### PR TITLE
Fix channel count bug introduced in f8c4b76

### DIFF
--- a/components/scifio/src/loci/formats/ChannelFiller.java
+++ b/components/scifio/src/loci/formats/ChannelFiller.java
@@ -246,9 +246,9 @@ public class ChannelFiller extends ReaderWrapper {
   /* @see IFormatHandler#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
+    super.setId(id);
+    lutLength = getLookupTableComponentCount();
     if (!id.equals(getCurrentFile())) {
-      super.setId(id);
-      lutLength = getLookupTableComponentCount();
       MetadataStore store = getMetadataStore();
       MetadataTools.populatePixels(store, this, false, false);
     }


### PR DESCRIPTION
The lookup table component count needs to be reset on every call to
setId.  Since we only really care about not calling
MetadataTools.populatePixels(...) on files that have already been
initialized, there is no reason not to let everything else run on every
call to setId.

This should allow the tests to pass again.
