### PR TITLE
Do not attempt to retrieve an entire image plane

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/bio-formats/src/loci/formats/in/ImarisHDFReader.java
@@ -149,7 +149,7 @@ public class ImarisHDFReader extends FormatReader {
 
     // pixel data is stored in XYZ blocks
 
-    Object image = getImageData(no);
+    Object image = getImageData(no, x, y, w, h);
 
     boolean big = !isLittleEndian();
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
@@ -157,36 +157,36 @@ public class ImarisHDFReader extends FormatReader {
       int base = row * w * bpp;
       if (image instanceof byte[][]) {
         byte[][] data = (byte[][]) image;
-        byte[] rowData = data[row + y];
-        System.arraycopy(rowData, x, buf, row*w, w);
+        byte[] rowData = data[row];
+        System.arraycopy(rowData, 0, buf, row*w, w);
       }
       else if (image instanceof short[][]) {
         short[][] data = (short[][]) image;
-        short[] rowData = data[row + y];
+        short[] rowData = data[row];
         for (int i=0; i<w; i++) {
-          DataTools.unpackBytes(rowData[x + i], buf, base + 2*i, 2, big);
+          DataTools.unpackBytes(rowData[i], buf, base + 2*i, 2, big);
         }
       }
       else if (image instanceof int[][]) {
         int[][] data = (int[][]) image;
-        int[] rowData = data[row + y];
+        int[] rowData = data[row];
         for (int i=0; i<w; i++) {
-          DataTools.unpackBytes(rowData[x + i], buf, base + i*4, 4, big);
+          DataTools.unpackBytes(rowData[i], buf, base + i*4, 4, big);
         }
       }
       else if (image instanceof float[][]) {
         float[][] data = (float[][]) image;
-        float[] rowData = data[row + y];
+        float[] rowData = data[row];
         for (int i=0; i<w; i++) {
-          int v = Float.floatToIntBits(rowData[x + i]);
+          int v = Float.floatToIntBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i*4, 4, big);
         }
       }
       else if (image instanceof double[][]) {
         double[][] data = (double[][]) image;
-        double[] rowData = data[row + y];
+        double[] rowData = data[row];
         for (int i=0; i<w; i++) {
-          long v = Double.doubleToLongBits(rowData[x + i]);
+          long v = Double.doubleToLongBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i * 8, 8, big);
         }
       }
@@ -278,7 +278,7 @@ public class ImarisHDFReader extends FormatReader {
 
     int type = -1;
 
-    Object pix = getImageData(0);
+    Object pix = getImageData(0, 0, 0, 1, 1);
     if (pix instanceof byte[][]) type = FormatTools.UINT8;
     else if (pix instanceof short[][]) type = FormatTools.UINT16;
     else if (pix instanceof int[][]) type = FormatTools.UINT32;
@@ -390,13 +390,25 @@ public class ImarisHDFReader extends FormatReader {
 
   // -- Helper methods --
 
-  private Object getImageData(int no) throws FormatException {
+  private Object getImageData(int no, int x, int y, int width, int height)
+    throws FormatException
+  {
     int[] zct = getZCTCoords(no);
     String path = "/DataSet/ResolutionLevel_" + series + "/TimePoint_" +
       zct[2] + "/Channel_" + zct[1] + "/Data";
     Object image = null;
-    int[] dimensions = new int[] {1, getSizeY(), getSizeX()};
-    int[] indices = new int[] {zct[0], 0, 0};
+
+    // the width and height cannot be 1, because then netCDF will give us a
+    // singleton instead of an array
+    if (height == 1) {
+      height++;
+    }
+    if (width == 1) {
+      width++;
+    }
+
+    int[] dimensions = new int[] {1, height, width};
+    int[] indices = new int[] {zct[0], y, x};
     try {
       image = netcdf.getArray(path, indices, dimensions);
     }


### PR DESCRIPTION
Retrieving a whole image plane causes all sorts of problems for very
large images.  So now we only attempt to retrieve the piece of the image
required by openBytes.

Noticed by MIchael Adams.
