### PR TITLE
Catch SecurityExceptions

### DIFF
--- a/components/bio-formats/src/loci/formats/in/LegacyND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/LegacyND2Reader.java
@@ -70,6 +70,9 @@ public class LegacyND2Reader extends FormatReader {
       LOGGER.trace(NO_NIKON_MSG, e);
       libraryFound = false;
     }
+    catch (SecurityException e) {
+      LOGGER.warn("Insufficient permission to load native library", e);
+    }
   }
 
   // -- Constructor --

--- a/components/scifio/src/loci/formats/gui/LegacyQTTools.java
+++ b/components/scifio/src/loci/formats/gui/LegacyQTTools.java
@@ -99,18 +99,24 @@ public class LegacyQTTools {
     }
 
     // case for Windows
-    String windir = System.getProperty("java.library.path");
-    StringTokenizer st = new StringTokenizer(windir, ";");
+    try {
+      String windir = System.getProperty("java.library.path");
+      StringTokenizer st = new StringTokenizer(windir, ";");
 
-    while (st.hasMoreTokens()) {
-      Location f = new Location(st.nextToken(), "QTJava.zip");
-      if (f.exists()) {
-        try {
-          paths = new URL[] {f.toURL()};
+      while (st.hasMoreTokens()) {
+        Location f = new Location(st.nextToken(), "QTJava.zip");
+        if (f.exists()) {
+          try {
+            paths = new URL[] {f.toURL()};
+          }
+          catch (MalformedURLException exc) { LOGGER.info("", exc); }
+          return paths == null ? null : new URLClassLoader(paths);
         }
-        catch (MalformedURLException exc) { LOGGER.info("", exc); }
-        return paths == null ? null : new URLClassLoader(paths);
       }
+    }
+    catch (SecurityException e) {
+      // this is common when using Bio-Formats within an applet
+      LOGGER.warn("Cannot read value of 'java.library.path'", e);
     }
 
     return null;


### PR DESCRIPTION
When using Bio-Formats within an applet, it is common for
System.getProperty("java.library.path") and System.loadLibrary(...) to
fail as a result of insufficient permissions.  We now catch and log
these exceptions, as the majority of Bio-Formats' functionality can be
used without the native libraries in question.

See:
http://www.openmicroscopy.org/community/viewtopic.php?f=6&t=942&start=10#p3594
