### PR TITLE
Add SCIFIO component to Javadoc generation

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -27,6 +27,7 @@ merged-docs.source    = ${root.dir}/components/bio-formats/build/src:\
                         ${root.dir}/components/ome-io/build/src:\
                         ${root.dir}/components/ome-plugins/build/src:\
                         ${root.dir}/components/ome-xml/build/src:\
+                        ${root.dir}/components/scifio/build/src:\
                         ${root.dir}/components/stubs/lwf-stubs/build/src:\
                         ${root.dir}/components/test-suite/build/src:\
                         ${root.dir}/components/forks/jai/build/src:\


### PR DESCRIPTION
The "ant docs" target leaves out the scifio component, so many classes are now missing (e.g., MetadataStore) from the online javadoc. This branch fixes the problem.
