### PR TITLE
Detect multi-channel data

### DIFF
--- a/components/bio-formats/src/loci/formats/in/AmiraReader.java
+++ b/components/bio-formats/src/loci/formats/in/AmiraReader.java
@@ -119,8 +119,6 @@ public class AmiraReader extends FormatReader {
     parameters = new AmiraParameters(in);
     offsetOfFirstStream = in.getFilePointer();
 
-    // TODO: handle multiple streams
-
     LOGGER.info("Populating metadata hashtable");
 
     addGlobalMeta("Image width", parameters.width);
@@ -130,14 +128,19 @@ public class AmiraReader extends FormatReader {
 
     LOGGER.info("Populating core metadata");
 
+    int channelIndex = 1;
+    while (parameters.getStreams().get("@" + channelIndex) != null) {
+      channelIndex++;
+    }
+
     core[0].sizeX = parameters.width;
     core[0].sizeY = parameters.height;
     core[0].sizeZ = parameters.depth;
     core[0].sizeT = 1;
-    core[0].sizeC = 1;
-    core[0].imageCount = getSizeZ();
+    core[0].sizeC = channelIndex - 1;
+    core[0].imageCount = getSizeZ() * getSizeC();
     core[0].littleEndian = parameters.littleEndian;
-    core[0].dimensionOrder = "XYCZT";
+    core[0].dimensionOrder = "XYZCT";
 
     String streamType = parameters.streamTypes[0].toLowerCase();
     if (streamType.equals("byte")) {


### PR DESCRIPTION
Pixel data is stored contiguously, but each channel is identified by a
spearate stream.  So it is simply a matter of counting the streams to
determine the correct channel count.
