### PR TITLE
Build fix: Reintroduce import of loci.common.DataTools

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
@@ -29,6 +29,7 @@ import java.util.Hashtable;
 
 import loci.common.ByteArrayHandle;
 import loci.common.Constants;
+import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.common.xml.XMLTools;


### PR DESCRIPTION
This was accidentally removed while resolving merge conflicts in
50877b909417884cdfb5397a9b7e4ac8d217d515.  Resolves build failures.
