### PR TITLE
BF-ITK build fix

### DIFF
--- a/components/native/bf-itk-pipe/CMakeLists.txt
+++ b/components/native/bf-itk-pipe/CMakeLists.txt
@@ -279,7 +279,7 @@ add_custom_command(
   TARGET BioFormatsIOPlugin
   DEPENDS "${BF_LOCI_TOOLS_JAR}"
   POST_BUILD
-  COMMAND "${Java_JAVA_EXECUTABLE}" -cp "${BF_LOCI_TOOLS_JAR}"
+  COMMAND "${JAVA_RUNTIME}" -cp "${BF_LOCI_TOOLS_JAR}"
   "loci.formats.tools.BioFormatsExtensionPrinter"
   VERBATIM
 )


### PR DESCRIPTION
This little change allows the BIOFORMATS-ITK\* builds on Jenkins to run.  Previously, the 'java' executable was not found, which caused the builds to fail.
