### PR TITLE
OME build hooks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -308,9 +308,17 @@ Apache XML-RPC
     License:   Apache
 -->
 
-<project name="Bio-Formats" default="jars" basedir=".">
+<project name="Bio-Formats" default="jars" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
   <description>
     Master build file for all Java software projects at LOCI
   </description>
   <import file="ant/toplevel.xml"/>
+
+  <!-- OME-compatibility layer -->
+  <target name="dist" description="Hook for OME build to call Bio-Formats">
+    <ant target="tools"/>
+    <ant target="tools-ome"/>
+    <ant antfile="ome.xml" inheritRefs="false" inheritAll="false"/>
+  </target>
+
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,28 @@
+<ivy-module version="1.0">
+  <info organisation="ome" module="bio-formats" revision="4.3.3-DEV-ice33" status="integration" publication="20120228143140"/>
+  <configurations>
+    <conf name="build"/>
+    <conf name="runtime"/>
+  </configurations>
+  <publications>
+    <artifact name="bio-formats"/>
+    <artifact name="jai_imageio"/>
+    <artifact name="loci-common"/>
+    <artifact name="mdbtools-java"/>
+    <artifact name="metakit"/>
+    <artifact name="ome-io"/>
+    <artifact name="ome-xml"/>
+    <artifact name="poi-loci"/>
+    <artifact name="scifio"/>
+  </publications>
+  <dependencies defaultconfmapping="build,runtime->default">
+    <!-- Internal -->
+    <dependency name="specification" rev="4.3.3-DEV-ice33" changing="true" conf="build,runtime->build"/>
+    <!-- Deps -->
+    <dependency org="bf-deps" name="xalan" rev="2.7.1"/>
+    <dependency org="bf-deps" name="serializer" rev="2.7.1"/>
+    <dependency org="bf-deps" name="bufr" rev="1.1.00"/>
+    <dependency org="bf-deps" name="grib" rev="5.1.03"/>
+    <dependency org="bf-deps" name="netcdf" rev="4.0"/>
+  </dependencies>
+</ivy-module>

--- a/ome.xml
+++ b/ome.xml
@@ -1,0 +1,15 @@
+<project name="OME-Bio-Formats-Build" default="dist" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
+  <description>
+    OME build file for Bio-Formats jars.
+  </description>
+
+  <property name="import.dir" value="${basedir}/../antlib/resources"/>
+  <import file="${import.dir}/global.xml"/>
+  <import file="${import.dir}/lifecycle.xml"/>
+
+  <target name="dist" depends="generate" description="Hook for OME build to call Bio-Formats">
+    <installIvy/>
+    <publishArtifact pattern="artifacts/[artifact].[ext]"/>
+  </target>
+
+</project>


### PR DESCRIPTION
build.xml is called by the OME ./build.py-based build
system. The only two targets that are currently supported
are "dist" and "clean". "test" etc. will also need hooks.

"dist" calls the regular Bio-Formats build and then calls
out to ome.xml which re-distributes the jars basd on the
ivy.xml specification.

This logic can't sit in the build.xml file itself because
of at least one naming conflict (root.dir)
