### PR TITLE
Update Bio-Formats POMs to use scijava base POM

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>bf-autogen</artifactId>
@@ -93,7 +94,7 @@
     </developer>
   </developers>
 
-  <!-- NB: for bio-formats-base, in case of partial checkout -->
+  <!-- NB: for parent project, in case of partial checkout -->
   <repositories>
     <repository>
       <id>loci.releases</id>

--- a/components/bio-formats/pom.xml
+++ b/components/bio-formats/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>bio-formats</artifactId>

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>loci-common</artifactId>

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>jai_imageio</artifactId>

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>mdbtools-java</artifactId>

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>poi-loci</artifactId>

--- a/components/legacy/ome-editor/pom.xml
+++ b/components/legacy/ome-editor/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>ome-editor</artifactId>

--- a/components/legacy/ome-notes/pom.xml
+++ b/components/legacy/ome-notes/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>ome-notes</artifactId>

--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>loci_plugins</artifactId>

--- a/components/loci-tools/pom.xml
+++ b/components/loci-tools/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>loci_tools</artifactId>
@@ -81,7 +82,7 @@
     </developer>
   </developers>
 
-  <!-- NB: for bio-formats-base, in case of partial checkout -->
+  <!-- NB: for parent project, in case of partial checkout -->
   <repositories>
     <repository>
       <id>loci.releases</id>

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>metakit</artifactId>

--- a/components/ome-io/pom.xml
+++ b/components/ome-io/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>ome-io</artifactId>

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>ome_plugins</artifactId>

--- a/components/ome-tools/pom.xml
+++ b/components/ome-tools/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>ome_tools</artifactId>
@@ -81,7 +82,7 @@
     </developer>
   </developers>
 
-  <!-- NB: for bio-formats-base, in case of partial checkout -->
+  <!-- NB: for parent project, in case of partial checkout -->
   <repositories>
     <repository>
       <id>loci.releases</id>

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>ome-xml</artifactId>

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scifio</artifactId>

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../../..</relativePath>
   </parent>
 
   <artifactId>lwf-stubs</artifactId>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -7,8 +7,9 @@
 
   <parent>
     <groupId>loci</groupId>
-    <artifactId>bio-formats-base</artifactId>
+    <artifactId>pom-scifio</artifactId>
     <version>4.4-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>test-suite</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,20 @@
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>com.github.scijava</groupId>
+    <artifactId>pom-scijava</artifactId>
+    <version>1.3</version>
+  </parent>
+
   <groupId>loci</groupId>
-  <artifactId>bio-formats-base</artifactId>
+  <artifactId>pom-scifio</artifactId>
   <version>4.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>
-  <description>Umbrella project for Bio-Formats software projects.</description>
-  <url>http://loci.wisc.edu/software</url>
+  <description>Umbrella project for SCIFIO and Bio-Formats software projects.</description>
+  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <modules>
@@ -36,14 +42,7 @@
     <module>components/stubs/lwf-stubs</module>
   </modules>
 
-  <properties>
-    <!-- NB: Avoid platform encoding warning when copying resources. -->
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
-
   <build>
-    <defaultGoal>install</defaultGoal>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <testSourceDirectory>${project.basedir}/test</testSourceDirectory>
     <resources>
@@ -64,48 +63,12 @@
         </excludes>
       </testResource>
     </testResources>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-webdav</artifactId>
-        <version>1.0-beta-2</version>
-      </extension>
-    </extensions>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-assembly-plugin</artifactId>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.1</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <argLine>-Xms512m -Xmx512m</argLine>
         </configuration>
       </plugin>
     </plugins>
@@ -113,35 +76,28 @@
 
   <reporting>
     <plugins>
-      <!-- NB: Generate javadocs as part of site generation. -->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <javadocDirectory>${project.basedir}/src</javadocDirectory>
-          <maxmemory>1024m</maxmemory>
-          <!-- NB: Workaround for javadoc bug when classes in the default
-            package access classes from non-default packages. See:
-            http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5101868 -->
-          <use>false</use>
         </configuration>
       </plugin>
     </plugins>
   </reporting>
 
   <organization>
-    <name>UW-Madison LOCI</name>
-    <url>http://loci.wisc.edu/</url>
+    <name>Open Microscopy Environment</name>
+    <url>http://www.openmicroscopy.org/</url>
   </organization>
 
   <issueManagement>
     <system>Trac</system>
-    <url>http://dev.loci.wisc.edu/trac/bio-formats/</url>
+    <url>http://trac.openmicroscopy.org.uk/ome/wiki/BioFormats</url>
   </issueManagement>
 
   <ciManagement>
-    <system>Hudson</system>
-    <url>http://dev.loci.wisc.edu:8080/</url>
+    <system>Jenkins</system>
+    <url>http://hudson.openmicroscopy.org.uk/</url>
   </ciManagement>
 
   <mailingLists>
@@ -152,43 +108,39 @@
       <post>locisoftware@lists.wisc.edu</post>
       <archive>https://lists.wisc.edu/read/?forum=locisoftware</archive>
     </mailingList>
+    <mailingList>
+      <name>OME-users</name>
+      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
+      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
+      <post>ome-users@lists.openmicroscopy.org.uk</post>
+      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
+    </mailingList>
+    <mailingList>
+      <name>OME-devel</name>
+      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
+      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
+      <post>ome-devel@lists.openmicroscopy.org.uk</post>
+      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
+    </mailingList>
   </mailingLists>
 
   <scm>
-    <connection>scm:git:git://dev.loci.wisc.edu/bio-formats.git</connection>
-    <developerConnection>scm:git:git@dev.loci.wisc.edu:bio-formats.git</developerConnection>
+    <connection>scm:git://github.com/openmicroscopy/bioformats.git</connection>
+    <developerConnection>scm:git@github.com:openmicroscopy/bioformats.git</developerConnection>
     <tag>HEAD</tag>
-    <url>http://loci.wisc.edu/bio-formats/source-code</url>
+    <url>http://github.com/openmicroscopy/bioformats</url>
   </scm>
 
+  <!-- NB: for parent project -->
   <repositories>
-    <!-- NB: for loci projects -->
     <repository>
-      <id>loci.releases</id>
-      <url>http://dev.loci.wisc.edu/maven2/releases</url>
+      <id>imagej.releases</id>
+      <url>http://maven.imagej.net/content/repositories/releases</url>
     </repository>
     <repository>
-      <id>loci.snapshots</id>
-      <url>http://dev.loci.wisc.edu/maven2/snapshots</url>
-    </repository>
-    <!-- NB: for various dependencies -->
-    <repository>
-      <id>loci.thirdparty</id>
-      <url>http://dev.loci.wisc.edu/maven2/thirdparty</url>
+      <id>imagej.snapshots</id>
+      <url>http://maven.imagej.net/content/repositories/snapshots</url>
     </repository>
   </repositories>
-
-  <distributionManagement>
-    <repository>
-      <id>loci.releases</id>
-      <name>LOCI Releases Repository</name>
-      <url>dav:http://dev.loci.wisc.edu:8081/content/repositories/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>loci.snapshots</id>
-      <name>LOCI Snapshots Repository</name>
-      <url>dav:http://dev.loci.wisc.edu:8081/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
 </project>


### PR DESCRIPTION
This change cuts down on the amount of boilerplate required in the base Bio-Formats pom.xml file. It also allows Bio-Formats to share recommended configuration and dependency versions with other SciJava projects.

See also: http://github.com/scijava/scijava-common

I also updated the project metadata to reflect the latest links and information, and fixed a problem with the parent relative paths.
