### PR TITLE
Update parent POM reference to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.github.scijava</groupId>
     <artifactId>pom-scijava</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </parent>
 
   <groupId>loci</groupId>


### PR DESCRIPTION
I updated the toplevel SciJava POM. It now lists explicit version numbers for all Maven plugins, enables the versions-maven-plugin, and declares a minimum Maven version of 2.2.1.

See: https://github.com/scijava/scijava-common/commit/cbb90669d946c976613b2075a1e524a338ed3d6c

This branch updates the Bio-Formats toplevel POM to reference the new version of the SciJava POM. It should result in more reproducible builds (less variability in which plugin versions are used). It will also enable painless use of the versions plugin for analysis such as "mvn versions:display-dependency-updates".
