### PR TITLE
Add Matlab utility functions

### DIFF
--- a/components/bio-formats/utils/bfGetPlane.m
+++ b/components/bio-formats/utils/bfGetPlane.m
@@ -1,0 +1,107 @@
+function I = bfGetPlane(r,iPlane)
+% Get the plane data from a dataset reader using bioformats tools
+% 
+% SYNOPSIS I=bfGetPlane(r,iPlane)
+%
+% Input 
+%    r - the reader object (obtained from bfGetReader)
+%
+%    iPlane - the index of the plane(s) to be retrieved.
+%
+% Output
+%
+%    I - an array of size (width x height) containing the plane
+%
+% Adapted from bfopen.m
+% See also bfGetReader
+
+% Input check
+ip=inputParser;
+ip.addRequired('r',@(x)isa(x,'loci.formats.ChannelSeparator'));
+ip.addRequired('iPlane',@isscalar);
+ip.parse(r,iPlane);
+
+% check MATLAB version, since typecast function requires MATLAB 7.1+
+canTypecast = versionCheck(version, 7, 1);
+bioFormatsVersion = char(loci.formats.FormatTools.VERSION);
+isBioFormatsTrunk = versionCheck(bioFormatsVersion, 5, 0);
+
+width = r.getSizeX();
+height = r.getSizeY();
+pixelType = r.getPixelType();
+bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
+fp = loci.formats.FormatTools.isFloatingPoint(pixelType);
+sgn = loci.formats.FormatTools.isSigned(pixelType);
+bppMax = power(2, bpp * 8);
+little = r.isLittleEndian();
+
+plane = r.openBytes(iPlane - 1);
+    
+% convert byte array to MATLAB image
+if isBioFormatsTrunk && (sgn || ~canTypecast)
+    % can get the data directly to a matrix
+    arr = loci.common.DataTools.makeDataArray2D(plane, ...
+        bpp, fp, little, height);
+else
+    % get the data as a vector, either because makeDataArray2D
+    % is not available, or we need a vector for typecast
+    arr = loci.common.DataTools.makeDataArray(plane, ...
+        bpp, fp, little);
+end
+%     if ~strcmp(class(I),class(arr)), I= cast(I,['u' class(arr)]); end
+
+% Java does not have explicitly unsigned data types;
+% hence, we must inform MATLAB when the data is unsigned
+if ~sgn
+    if canTypecast
+        % TYPECAST requires at least MATLAB 7.1
+        % NB: arr will always be a vector here
+        switch class(arr)
+            case 'int8'
+                arr = typecast(arr, 'uint8');
+            case 'int16'
+                arr = typecast(arr, 'uint16');
+            case 'int32'
+                arr = typecast(arr, 'uint32');
+            case 'int64'
+                arr = typecast(arr, 'uint64');
+        end
+    else
+        % adjust apparent negative values to actual positive ones
+        % NB: arr might be either a vector or a matrix here
+        mask = arr < 0;
+        adjusted = arr(mask) + bppMax / 2;
+        switch class(arr)
+            case 'int8'
+                arr = uint8(arr);
+                adjusted = uint8(adjusted);
+            case 'int16'
+                arr = uint16(arr);
+                adjusted = uint16(adjusted);
+            case 'int32'
+                arr = uint32(arr);
+                adjusted = uint32(adjusted);
+            case 'int64'
+                arr = uint64(arr);
+                adjusted = uint64(adjusted);
+        end
+        adjusted = adjusted + bppMax / 2;
+        arr(mask) = adjusted;
+    end
+end
+
+if isvector(arr)
+    % convert results from vector to matrix
+    shape = [width height];
+    I = reshape(arr, shape)';
+end
+
+
+function [result] = versionCheck(v, maj, min)
+
+tokens = regexp(v, '[^\d]*(\d+)[^\d]+(\d+).*', 'tokens');
+majToken = tokens{1}(1);
+minToken = tokens{1}(2);
+major = str2double(majToken{1});
+minor = str2double(minToken{1});
+result = major > maj || (major == maj && minor >= min);

--- a/components/bio-formats/utils/bfGetReader.m
+++ b/components/bio-formats/utils/bfGetReader.m
@@ -1,0 +1,36 @@
+function r = bfGetReader(id,varargin)
+% Get the reader associated with a given dataset using Bio-Formats
+% 
+% SYNOPSIS r=bfGetReader(path)
+%
+% Input 
+%
+%    id - the path of a proprietary file
+%
+%    stichFiles - Optional. Toggle the grouping of similarly
+%    named files into a single dataset based on file numbering.
+%    Default: false;
+%
+% Output
+%
+%    r - object of class loci.formats.ChannelSeparator
+%
+% Adapted from bfopen.m
+
+% Input check
+ip=inputParser;
+ip.addRequired('id',@ischar);
+ip.addOptional('stitchFiles',false,@isscalar);
+ip.parse(id,varargin{:});
+
+% initialize logging
+loci.common.DebugTools.enableLogging('INFO');
+
+r = loci.formats.ChannelFiller();
+r = loci.formats.ChannelSeparator(r);
+if ip.Results.stitchFiles
+    r = loci.formats.FileStitcher(r);
+end
+
+r.setMetadataStore(loci.formats.MetadataTools.createOMEXMLMetadata());
+r.setId(id);

--- a/components/bio-formats/utils/bfopen.m
+++ b/components/bio-formats/utils/bfopen.m
@@ -97,9 +97,9 @@ stitchFiles = 0;
 
 % -- Main function - no need to edit anything past this point --
 
-if exist('id') == 0
-  [path,file] = uigetfile(getFileExtensions, 'Choose a file to open');
-  id = fullfile(path, file);
+if exist('id','file') == 0
+  [file,path] = uigetfile(getFileExtensions, 'Choose a file to open');
+  id = [path file];
   if isequal(path,0) || isequal(file,0), return; end
 end
 
@@ -116,38 +116,18 @@ if exist('lurawaveLicense')
     java.lang.System.setProperty('lurawave.license', lurawaveLicense);
 end
 
-% check MATLAB version, since typecast function requires MATLAB 7.1+
-canTypecast = versionCheck(version, 7, 1);
+% Get the channel filler
+r=bfGetReader(id,stitchFiles);
 
-% check Bio-Formats version, since makeDataArray2D function requires trunk
-bioFormatsVersion = char(loci.formats.FormatTools.VERSION);
-isBioFormatsTrunk = versionCheck(bioFormatsVersion, 5, 0);
 
-% initialize logging
-loci.common.DebugTools.enableLogging('INFO');
-
-r = loci.formats.ChannelFiller();
-r = loci.formats.ChannelSeparator(r);
-if stitchFiles
-    r = loci.formats.FileStitcher(r);
-end
-
-tic
-r.setMetadataStore(loci.formats.MetadataTools.createOMEXMLMetadata());
-r.setId(id);
 numSeries = r.getSeriesCount();
 result = cell(numSeries, 2);
 for s = 1:numSeries
     fprintf('Reading series #%d', s);
     r.setSeries(s - 1);
-    width = r.getSizeX();
-    height = r.getSizeY();
     pixelType = r.getPixelType();
     bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
-    fp = loci.formats.FormatTools.isFloatingPoint(pixelType);
-    sgn = loci.formats.FormatTools.isSigned(pixelType);
     bppMax = power(2, bpp * 8);
-    little = r.isLittleEndian();
     numImages = r.getImageCount();
     imageList = cell(numImages, 2);
     colorMaps = cell(numImages);
@@ -156,7 +136,7 @@ for s = 1:numSeries
             fprintf('\n    ');
         end
         fprintf('.');
-        plane = r.openBytes(i - 1);
+        arr=bfGetPlane(r,i);
 
         % retrieve color map data
         if bpp == 1
@@ -164,6 +144,7 @@ for s = 1:numSeries
         else
             colorMaps{s, i} = r.get16BitLookupTable()';
         end
+        
         warning off
         if ~isempty(colorMaps{s, i})
             newMap = colorMaps{s, i};
@@ -173,63 +154,6 @@ for s = 1:numSeries
         end
         warning on
 
-        % convert byte array to MATLAB image
-        if isBioFormatsTrunk && (sgn || ~canTypecast)
-            % can get the data directly to a matrix
-            arr = loci.common.DataTools.makeDataArray2D(plane, ...
-                bpp, fp, little, height);
-        else
-            % get the data as a vector, either because makeDataArray2D
-            % is not available, or we need a vector for typecast
-            arr = loci.common.DataTools.makeDataArray(plane, ...
-                bpp, fp, little);
-        end
-
-        % Java does not have explicitly unsigned data types;
-        % hence, we must inform MATLAB when the data is unsigned
-        if ~sgn
-            if canTypecast
-                % TYPECAST requires at least MATLAB 7.1
-                % NB: arr will always be a vector here
-                switch class(arr)
-                    case 'int8'
-                        arr = typecast(arr, 'uint8');
-                    case 'int16'
-                        arr = typecast(arr, 'uint16');
-                    case 'int32'
-                        arr = typecast(arr, 'uint32');
-                    case 'int64'
-                        arr = typecast(arr, 'uint64');
-                end
-            else
-                % adjust apparent negative values to actual positive ones
-                % NB: arr might be either a vector or a matrix here
-                mask = arr < 0;
-                adjusted = arr(mask) + bppMax / 2;
-                switch class(arr)
-                    case 'int8'
-                        arr = uint8(arr);
-                        adjusted = uint8(adjusted);
-                    case 'int16'
-                        arr = uint16(arr);
-                        adjusted = uint16(adjusted);
-                    case 'int32'
-                        arr = uint32(arr);
-                        adjusted = uint32(adjusted);
-                    case 'int64'
-                        arr = uint64(arr);
-                        adjusted = uint64(adjusted);
-                end
-                adjusted = adjusted + bppMax / 2;
-                arr(mask) = adjusted;
-            end
-        end
-
-        if isvector(arr)
-            % convert results from vector to matrix
-            shape = [width height];
-            arr = reshape(arr, shape)';
-        end
 
         % build an informative title for our figure
         label = id;
@@ -287,24 +211,25 @@ toc
 
 % -- Helper functions --
 
-function [result] = versionCheck(v, maj, min)
-
-tokens = regexp(v, '[^\d]*(\d+)[^\d]+(\d+).*', 'tokens');
-majToken = tokens{1}(1);
-minToken = tokens{1}(2);
-major = str2num(majToken{1});
-minor = str2num(minToken{1});
-result = major > maj || (major == maj && minor >= min);
-
-
 function fileExt = getFileExtensions
-% Get the supported extensions (see loci.formats.tools.PrintFormatTable
+% List all supported extensions
 
+% Get all readers and create cell array with suffixes and names
 readers=loci.formats.ImageReader().getReaders;
 fileExt=cell(numel(readers),2);
 for i=1:numel(readers)
     suffixes=readers(i).getSuffixes();
-    s=arrayfun(@(x) ['*.' char(x.toString) ';'],suffixes,'Unif',false);
-    fileExt{i,1} = horzcat(s{:});
+    fileExt{i,1}=arrayfun(@char,suffixes,'Unif',false);
     fileExt{i,2} = char(readers(i).getFormat().toString);
+end
+
+% Concatenate all unique formats
+allExt=unique(vertcat(fileExt{:,1}));
+allExt=allExt(~cellfun(@isempty,allExt));
+fileExt=vertcat({allExt,'All formats'},fileExt);
+
+% Format file extensions
+for i=1:size(fileExt,1)
+    fileExt{i,1} = sprintf('*.%s;',fileExt{i,1}{:});
+    fileExt{i,1}(end)=[];
 end


### PR DESCRIPTION
It makes sense for Matlab users to be able to read only the metadata and/or the data for a given plane from a microscopy image. bfopen still loads all the contents of a file but now calls two functions (bfGetReader/bfGetPlane) which can be used independently.

Also, a subfunction of bfopen now parses supported formats for opening the dialog box. Basically, this is a cheap copy of the printSupportedFormats methods in PrintFormatTable.java with a Matlab-specific format (cell array). There may be a smarter way to call the methods of the java class.
