### PR TITLE
Eliminate references to bioformats email alias

### DIFF
--- a/components/bio-formats/doc/reader-guide.txt
+++ b/components/bio-formats/doc/reader-guide.txt
@@ -220,7 +220,6 @@ These variables are:
   straightforward one).  loci.formats.in.LIFReader and InCellReader are also
   good references that show off some of the nicer features of Bio-Formats.
 
-If you have questions about Bio-Formats, please contact the Bio-Formats
-developers <bioformats@loci.wisc.edu>, or via one of the mailing lists:
+If you have questions about Bio-Formats, please contact the Bio-Formats team:
 
-http://loci.wisc.edu/software/mailing-lists
+  http://loci.wisc.edu/bio-formats/contact

--- a/components/native/bf-itk-jace/readme.txt
+++ b/components/native/bf-itk-jace/readme.txt
@@ -75,4 +75,5 @@ BUILDING AND TESTING THE PLUGIN ON LINUX AND MAC OS X
    example program on a TIFF file; c) optionally, clear ITK_AUTOLOAD_PATH and
    rerun to compare against the results with ITK's built-in TIFF reader.
 
-Please direct questions to the Bio-Formats team at bioformats@loci.wisc.edu.
+Please direct any questions to the Bio-Formats team:
+http://loci.wisc.edu/bio-formats/contact

--- a/components/native/bf-itk-pipe/readme.txt
+++ b/components/native/bf-itk-pipe/readme.txt
@@ -7,4 +7,5 @@ to read and write supported life sciences file formats.
 For details, including compilation and usage instructions, see:
   http://www.loci.wisc.edu/bio-formats/itk
 
-Please direct questions to the Bio-Formats team at bioformats@loci.wisc.edu.
+Please direct any questions to the Bio-Formats team:
+  http://loci.wisc.edu/bio-formats/contact

--- a/components/scifio/cppwrap/readme.txt
+++ b/components/scifio/cppwrap/readme.txt
@@ -107,4 +107,6 @@ individual JAR files as appropriate for your application. For details, see:
 
   http://www.loci.wisc.edu/bio-formats/bio-formats-java-library
 
-Please direct questions to the Bio-Formats team at bioformats@loci.wisc.edu.
+Please direct any questions to the Bio-Formats team:
+
+  http://loci.wisc.edu/bio-formats/contact


### PR DESCRIPTION
This branch eliminates references to the obsolete bioformats email alias in the documentation.
