### PR TITLE
Update pom-scijava to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.github.scijava</groupId>
     <artifactId>pom-scijava</artifactId>
-    <version>1.4</version>
+    <version>1.6</version>
   </parent>
 
   <groupId>loci</groupId>


### PR DESCRIPTION
This fixes a problem where no tests would run, due to a bug in the
specification of the minimum/maximum heap sizes.
