### PR TITLE
Matlab bug fix

### DIFF
--- a/components/bio-formats/utils/bfopen.m
+++ b/components/bio-formats/utils/bfopen.m
@@ -124,7 +124,6 @@ end
 % Get the channel filler
 r=bfGetReader(id,stitchFiles);
 
-
 numSeries = r.getSeriesCount();
 result = cell(numSeries, 2);
 for s = 1:numSeries
@@ -212,7 +211,7 @@ for s = 1:numSeries
     fprintf('\n');
 end
 r.close();
-toc
+
 
 % -- Helper functions --
 
@@ -220,7 +219,8 @@ function fileExt = getFileExtensions
 % List all supported extensions
 
 % Get all readers and create cell array with suffixes and names
-readers=loci.formats.ImageReader().getReaders;
+imageReader=loci.formats.ImageReader();
+readers = imageReader.getReaders();
 fileExt=cell(numel(readers),2);
 for i=1:numel(readers)
     suffixes=readers(i).getSuffixes();


### PR DESCRIPTION
These modifications fix bugs in the Matlab bfopen utility function (mostly reated to library loading).

Note that this PR will conflict will PR #34 and should be reviewed/merged after PR #34 is merged into develop.
