### PR TITLE
Moved OME-TIFF reader to top of priority list for tiff-based readers

### DIFF
--- a/components/scifio/src/loci/formats/readers.txt
+++ b/components/scifio/src/loci/formats/readers.txt
@@ -145,6 +145,7 @@ loci.formats.in.JPKReader             # jpk
 loci.formats.in.NDPIReader            # ndpi
 
 # TIFF-based readers with slow isThisType
+loci.formats.in.OMETiffReader         # tif
 loci.formats.in.MIASReader            # tif
 loci.formats.in.TCSReader             # xml, tif
 loci.formats.in.LeicaReader           # lei, tif
@@ -156,7 +157,6 @@ loci.formats.in.MicromanagerReader    # txt, tif
 loci.formats.in.ImprovisionTiffReader # tif
 loci.formats.in.MetamorphTiffReader   # tif
 loci.formats.in.NikonTiffReader       # tif
-loci.formats.in.OMETiffReader         # tif
 loci.formats.in.PhotoshopTiffReader   # tif
 loci.formats.in.FEITiffReader         # tif
 loci.formats.in.SimplePCITiffReader   # tif


### PR DESCRIPTION
Made OME-TIFF the first tiff-based file type that bioformats checks for. Since OME-TIFF is a preferred bioformats output format, this change also makes it a preferred input format over other tiff-based files.

This will need testing to see if checking for OME-TIFF files first affects performance.
