### PR TITLE
Metamorph: do not adjust the series index if there is 1 series

### DIFF
--- a/components/bio-formats/src/loci/formats/in/MetamorphReader.java
+++ b/components/bio-formats/src/loci/formats/in/MetamorphReader.java
@@ -485,7 +485,7 @@ public class MetamorphReader extends BaseTiffReader {
             if ((seriesCount != 1 && !validZ) ||
               (nstages == 0 && ((!validZ && cc > 1) || seriesCount > 1)))
             {
-              if (j > 0 && stks.length > 1) {
+              if (j > 0 && seriesNdx < seriesCount - 1) {
                 seriesNdx++;
               }
             }


### PR DESCRIPTION
This allows multi-channel single position datasets to be read correctly.
