### PR TITLE
ICSReader.java fix for Paul Barber

### DIFF
--- a/components/scifio/src/loci/formats/in/ICSReader.java
+++ b/components/scifio/src/loci/formats/in/ICSReader.java
@@ -678,6 +678,14 @@ public class ICSReader extends FormatReader {
         }
       }
     }
+    else if (lifetime && isInterleaved(0)) {
+        byte[] pixelBytes = new byte[bpp];
+        for (int i = 0; i < w * h; ++i) {
+            in.seek(offset + (long)(bpp * (no + i * w)));
+            in.read(pixelBytes);
+            System.arraycopy(pixelBytes, 0, buf, i * bpp, bpp);
+        } 
+    }
     else if (gzip) {
       RandomAccessInputStream s = new RandomAccessInputStream(data);
       readPlane(s, x, y, w, h, buf);
@@ -1380,6 +1388,12 @@ public class ICSReader extends FormatReader {
         core[0].sizeC = binCount;
         core[0].cLengths = new int[] {binCount};
         core[0].cTypes = new String[] {FormatTools.LIFETIME};
+        
+        // fix local vector variables also
+        channelTypes.clear();
+        channelTypes.add(FormatTools.LIFETIME);
+        channelLengths.clear();
+        channelLengths.add(binCount);
       }
     }
 


### PR DESCRIPTION
Paul Barber reported that the LOCI SLIM Plugin was unable to read his data files.

I uploaded SPC1.ics and SPC1_compressed.ics to ics/paul at smb://dev.loci.wisc.edu/data.  With this patch at least the first version is readable (second isn't).

I found two problems:

The lifetime channel dimension name and size weren't being reported properly because the channelTypes and channelLengths were not updated.

The file was not getting read properly because of interleave issues:

In this case there is an ICS metadata tag "history labels t x y".  This means all of the lifetime data for x=0, y=0 comes first, followed by x=1, y=0 etc.  The lifetime dimension t becomes the channel in BioFormats.  So this is handled by specifying "XYCZT" order and setting interleaved to be true.

Unfortunately the openBytes method was ignoring the interleaved setting.  My fix is to detect if this is a lifetime interleaved situation and handle the interleaving.

Both of these fixes are very specific to the Paul Barber/Gray Institute-specific lifetime case.

My fix for interleaving leaves a lot to be desired.  As each plane is requested in the openBytes method I seek to each x, y pixel and read in each two byte lifetime value at a time.  So for SPC1.ics, a 256x256 image with 256 lifetime bins there are 256x256x256 seeks and the same number of two-byte reads!

The BioFormats openBytes concept that channels have to be planes doesn't really work very well for lifetime data since we'd like to deal with all of the lifetime data for a given x, y at a time.  I think an interleaved internal storage would be more efficient for processing.

As a speed-up openBytes could load the entire file at once upon first call.  Subsequent calls would just System.arrayCopy lifetime data into place.  This would also make reading compressed files easy.  In this case 256x256x256x2 is around 34MB; the lifetime files I've seen are fairly small.

How to tell it works:

If you load a lifetime file in ImageJ it should have a channel slider.  Early channels are mostly dark, then there should be a peak with many pixels lit up, followed by an exponential decay.  With the bug the X and C dimensions were swapped so you'd see a small dark vertical band on the left followed by a large lighter band that fades to black towards the right.

If you load a lifetime file with the SLIM Plugin it sums up the lifetime values and puts up a grayscale image.  With the fix you can see cellular structures in SPC1.ics.  See http://loci.wisc.edu/software/slim-plugin .
