### PR TITLE
bfopen: colormap floating-point format

### DIFF
--- a/components/bio-formats/matlab/bfopen.m
+++ b/components/bio-formats/matlab/bfopen.m
@@ -99,7 +99,7 @@ for s = 1:numSeries
         
         warning off
         if ~isempty(colorMaps{s, i})
-            newMap = double(colorMaps{s, i});
+            newMap = single(colorMaps{s, i});
             newMap(newMap < 0) = newMap(newMap < 0) + bppMax;
             colorMaps{s, i} = newMap / (bppMax - 1);
         end


### PR DESCRIPTION
As suggested by @melissalinkert, now use single-precision floating-point number to cut colormap size in half for each series.

see also discussion on dfa433d9bc4fa22b4e5e20560c8925a778fd69f0
