### PR TITLE
9318 ome tiff

### DIFF
--- a/components/scifio/src/loci/formats/meta/MetadataConverter.java
+++ b/components/scifio/src/loci/formats/meta/MetadataConverter.java
@@ -1670,11 +1670,17 @@ public final class MetadataConverter {
       }
       catch (NullPointerException e) { }
 
+      // NB: plate name is required in OMERO
       try {
         String name = src.getPlateName(i);
+        if (name == null) {
+          name = "";
+        }
         dest.setPlateName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException e) {
+        dest.setPlateName("", i);
+      }
 
       try {
         NamingConvention rowConvention = src.getPlateRowNamingConvention(i);


### PR DESCRIPTION
Makes sure that Plate.Name and Screen.Name are set to something other than null when OME-XML/OME-TIFF files are imported.

See #9318.
