### PR TITLE
Zeiss LSM 4.1: remove EmWave

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/bio-formats/src/loci/formats/in/ZeissLSMReader.java
@@ -1004,8 +1004,8 @@ public class ZeissLSMReader extends FormatReader {
     else if (block instanceof IlluminationChannel) {
       IlluminationChannel channel = (IlluminationChannel) block;
       if (channel.acquire && channel.wavelength != null) {
-        store.setLogicalChannelEmWave(
-          channel.wavelength, series, nextIllumChannel++);
+        //store.setLogicalChannelEmWave(
+        //  channel.wavelength, series, nextIllumChannel++);
       }
     }
   }


### PR DESCRIPTION
This allows the channel colors to be set correctly.
