### PR TITLE
Turn off sub-resolution parsing for SVS data

### DIFF
--- a/components/bio-formats/src/loci/formats/in/SVSReader.java
+++ b/components/bio-formats/src/loci/formats/in/SVSReader.java
@@ -69,6 +69,7 @@ public class SVSReader extends BaseTiffReader {
     super("Aperio SVS", new String[] {"svs"});
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
     suffixNecessary = true;
+    noSubresolutions = true;
   }
 
   // -- IFormatReader API methods --

--- a/components/scifio/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/scifio/src/loci/formats/in/MinimalTiffReader.java
@@ -98,6 +98,8 @@ public class MinimalTiffReader extends FormatReader {
 
   private int lastPlane = 0;
 
+  protected boolean noSubresolutions = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -431,7 +433,7 @@ public class MinimalTiffReader extends FormatReader {
           JPEG2000MetadataParser metadataParser =
             new JPEG2000MetadataParser(in, stripOffset + stripByteCounts[0]);
           resolutionLevels = metadataParser.getResolutionLevels();
-          if (resolutionLevels != null) {
+          if (resolutionLevels != null && !noSubresolutions) {
             if (LOGGER.isDebugEnabled()) {
               LOGGER.debug(String.format(
                   "Original resolution IFD Levels %d %dx%d Tile %dx%d",


### PR DESCRIPTION
Keeping sub-resolution parsing in place means that we can end up with
extra invalid images once the SVS reader has finished reworking the
CoreMetadata field.  This is not a permanent solution, but a temporary
measure until we can get the proper sub-resolution work merged into the
mainline.

See #9372.
