### PR TITLE
Do not use IOException(Exception) constructor

### DIFF
--- a/components/bio-formats/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/bio-formats/src/loci/formats/in/LeicaSCNReader.java
@@ -265,7 +265,7 @@ public class LeicaSCNReader extends BaseTiffReader {
         XMLTools.parseXML(imageDescription, handler);
       }
       catch (Exception se) {
-        throw new IOException(se);
+        throw new FormatException("Failed to parse XML", se);
       }
     }
 


### PR DESCRIPTION
This is not part of the Java 1.5 API, so it causes all of the 1.5-based
builds to fail.  Better to use the FormatException(String, Exception)
constructor, so that we can preserve the full stack trace without
compile errors.
