### PR TITLE
Try to discourage users from using "Standard ImageJ"

### DIFF
--- a/components/loci-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/loci-plugins/src/loci/plugins/in/MainDialog.java
@@ -182,7 +182,17 @@ public class MainDialog extends ImporterDialog
 
   /** Handles toggling of mutually exclusive options. */
   public void itemStateChanged(ItemEvent e) {
-    verifyOptions(e.getSource());
+    Object src = e.getSource();
+    verifyOptions(src);
+    if (src == stackFormatChoice) {
+      if (ImporterOptions.VIEW_STANDARD.equals(e.getItem().toString())) {
+        infoPane.setText("<html><font color=\"red\">Warning!</font>"
+          + "<i>Standard ImageJ</i> is deprecated; "
+          + "please use <i>Hyperstack</i> instead.</html>");
+      } else {
+        infoPane.setText("<html>" + infoTable.get(src));
+      }
+    }
   }
 
   // -- MouseListener methods --

--- a/components/loci-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/loci-plugins/src/loci/plugins/in/importer-options.txt
@@ -236,8 +236,9 @@ info = <b>View stack with</b> - \
   The type of image viewer to use when displaying the dataset.        \
   <br><br>Possible choices are:<ul>                                   \
   <li><b>Metadata only</b> - Display no pixels, only metadata.</li>   \
-  <li><b>Standard ImageJ</b> - Display the pixels in ImageJ's         \
-  built-in 2D viewer.</li>                                            \
+  <li><b>Standard ImageJ</b> - This option is deprecated (i.e.        \
+  intended for use by old macros only). Please use <i>Hyperstack</i>  \
+  instead.</li>                                                       \
   <li><b>Hyperstack</b> - Display the pixels in ImageJ's              \
   built-in 5D viewer.</li>                                            \
   <li><b>Data Browser</b> - Display the pixels in LOCI's              \


### PR DESCRIPTION
It is a pity that due to the way macros are handled, we cannot change the name of said option to "Deprecated" or "Legacy ImageJ". But at least we can give users a red warning when they choose that stack format in interactive mode.
