### PR TITLE
Use fork=true for javac in build

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -26,7 +26,7 @@ Type "ant -p" for a list of targets.
   <!-- Main build targets -->
 
   <target name="compile" depends="copy-source" description="compile classes">
-    <javac debug="true" includeantruntime="false"
+    <javac debug="true" includeantruntime="false" fork="true"
       deprecation="${component.deprecation}"
       source="${component.java-version}"
       target="${component.java-version}"
@@ -39,7 +39,7 @@ Type "ant -p" for a list of targets.
 
   <target name="compile-tests" depends="compile, copy-test-source"
     description="compile test classes" if="doTests">
-    <javac debug="true" includeantruntime="false"
+    <javac debug="true" includeantruntime="false" fork="true"
       deprecation="${component.deprecation}"
       source="${component.java-version}"
       target="${component.java-version}"
@@ -172,7 +172,7 @@ your FindBugs installation's lib directory. E.g.:
     <delete>
       <fileset dir="${utils.dir}" includes="*.class"/>
     </delete>
-    <javac debug="true" includeantruntime="false"
+    <javac debug="true" includeantruntime="false" fork="true"
       deprecation="true" source="1.5" target="1.5"
       srcdir="${utils.dir}" includes="*.java"
       classpath="${component.classpath}:${artifact.dir}/${component.jar}">


### PR DESCRIPTION
The hudson.openmicroscopy.org.uk/job/OMERO-trunk-components build has been failing since we moved to submodules, since the build on Windows was failing with:

```
compile:
Compiling 47 source files to <http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\components\bioformats\components\common\build\classes>

BUILD FAILED
<http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\build.xml>:167: The following error occurred while executing this line:
<http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\components\antlib\resources\global.xml>:364: The following error occurred while executing this line:
<http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\components\bioformats\build.xml>:312: The following error occurred while executing this line:
<http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\components\bioformats\ant\toplevel.xml>:205: The following error occurred while executing this line:
<http://hudson.openmicroscopy.org.uk/job/OMERO-trunk-components/./component=start,label=x86-windows/ws/src\components\bioformats\ant\java.xml>:35: Unable to find a javac compiler;
com.sun.tools.javac.Main is not on the classpath.
Perhaps JAVA_HOME does not point to the JDK.
It is currently set to "C:\Program Files\Java\jre6"

Total time: 30 seconds
Failed 1
```

Part of the program is having a space in the JAVA_HOME setting (`C:\Program Files\Java\jdk1.6.0_21` versus `c:\progra~1\Java\jdk1.6.0_21`), but correcting that is not enough.

The only two solutions I've found so far (for the bioformats build) are:
- use `java omero` rather than `build.bat`
- adding fork to javac.

If there are no concrete reasons for omitting fork, I'd vote for the latter.
