### PR TITLE
Add parameter to control source code branch on Github

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -113,6 +113,12 @@ if "OMERODOC_URI" in os.environ:
 else:
     omerodoc_uri = 'http://www.openmicroscopy.org/site/support/omero4/'
 
+
+if "SOURCE_BRANCH" in os.environ:
+    source_branch = os.environ.get('SOURCE_BRANCH')
+else:
+    source_branch = 'develop'
+
 extlinks = {
     'wiki' : ('http://trac.openmicroscopy.org.uk/ome/wiki/'+ '%s', ''),
     'ticket' : ('http://trac.openmicroscopy.org.uk/ome/ticket/'+ '%s', '#'),
@@ -120,7 +126,7 @@ extlinks = {
     'plone' : ('http://www.openmicroscopy.org/site/'+ '%s', ''),
     'oo' : ('http://www.openmicroscopy.org/' + '%s', ''),
     'doi' : ('http://dx.doi.org/' + '%s', ''),
-    'source' : ('https://github.com/openmicroscopy/bioformats/blob/develop/' + '%s', ''),
+    'source' : ('https://github.com/openmicroscopy/bioformats/blob/' + source_branch + '/' + '%s', ''),
     'javadoc' : ('http://hudson.openmicroscopy.org.uk/job/OMERO/javadoc/' + '%s', ''),
     'jenkins' : ('http://hudson.openmicroscopy.org.uk/' + '%s', ''),
     'mailinglist' : ('http://lists.openmicroscopy.org.uk/mailman/listinfo/' + '%s', ''),


### PR DESCRIPTION
Since we have different development branches, we need to point at different branches for the source code
- OMERO-docs-merge-4.4 should set `SOURCE_BRANCH=dev_4_4`
- OMERO-docs-merge-develop should set `SOURCE_BRANCH=develop`
- OMERO-docs-relase should set `SOURCE_BRANCH=(sha1 of the release tag)`

This should fix the failing BIOFORMATS-docs-merge-4.4 builds for now (due to scifio refactoring). 

Future goal are:
- allowing to point at merge branches created on `ome-bot` account
- automatically detecting the sha1 if not in a merge_build
- implementing the same strategy in ome-documentation

Opened in #171 against `origin/develop`
