### PR TITLE
Fix links to source code moved to loci-legacy

### DIFF
--- a/docs/sphinx/service.txt
+++ b/docs/sphinx/service.txt
@@ -38,9 +38,9 @@ Writing a service
 
 -  **Interface** -- The basic form of a service is an interface which
    inherits from
-   :source:`loci.common.services.Service <components/common/src/loci/common/services/Service.java>`.
+   :source:`loci.common.services.Service <components/loci-legacy/src/loci/common/services/Service.java>`.
    Here is the very basic
-   :source:`OMENotesService <components/common/src/loci/common/services/OMENotesService.java>`
+   :source:`OMENotesService <components/loci-legacy/src/loci/common/services/OMENotesService.java>`
    from the initial implementation in r5894:
 
    ::
@@ -103,9 +103,9 @@ Writing a service
 
 -  **Registration** -- A service's interface and implementation must
    finally be *registered* with the
-   :source:`loci.common.services.ServiceFactory <components/common/src/loci/common/services/ServiceFactory.java>`
+   :source:`loci.common.services.ServiceFactory <components/loci-legacy/src/loci/common/services/ServiceFactory.java>`
    via the
-   :source:`services.properties <components/common/src/loci/common/services/Service.java>`
+   :source:`services.properties <components/loci-legacy/src/loci/common/services/Service.java>`
    file. Following the ``OMENotesService`` again, here is an example
    registration:
 


### PR DESCRIPTION
Eventually this documentation page will need to be rewritten for 4.5.0.
In the meantime, this PR should fix the `BIOFORMATS-docs-merge-develop` job.

Can also be tested locally with

```
make clean html linkcheck
grep 404 _build/linkcheck/output.txt
```
