### PR TITLE
Store the first plane's offset in the original metadata table

### DIFF
--- a/components/bio-formats/src/loci/formats/in/DeltavisionReader.java
+++ b/components/bio-formats/src/loci/formats/in/DeltavisionReader.java
@@ -62,6 +62,8 @@ public class DeltavisionReader extends FormatReader {
   public static final int DV_MAGIC_BYTES_1 = 0xa0c0;
   public static final int DV_MAGIC_BYTES_2 = 0xc0a0;
 
+  public static final String FIRST_PLANE_OFFSET = "Offset to first plane";
+
   public static final String DATE_FORMAT = "EEE MMM  d HH:mm:ss yyyy";
 
   private static final short LITTLE_ENDIAN = -16224;
@@ -467,6 +469,8 @@ public class DeltavisionReader extends FormatReader {
     // --- populate original metadata ---
 
     LOGGER.info("Populating original metadata");
+
+    addGlobalMeta(FIRST_PLANE_OFFSET, HEADER_LENGTH + extSize);
 
     addGlobalMeta("ImageWidth", sizeX);
     addGlobalMeta("ImageHeight", sizeY);


### PR DESCRIPTION
`reader.getMetadataValue(DeltavisionReader.FIRST_PLANE_OFFSET)` should now give the offset to the first plane.

Do note that planes will not necessarily be returned in the order in which they are stored in the file.  The series (tile) dimension always precedes T in the file, so if getDimensionOrder() returns XYZCT, the ordering in the file is actually XYZCST.
