### PR TITLE
Redirect links to new Bio-Formats downloads page

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -131,7 +131,8 @@ extlinks = {
     'jenkins' : ('http://hudson.openmicroscopy.org.uk/' + '%s', ''),
     'mailinglist' : ('http://lists.openmicroscopy.org.uk/mailman/listinfo/' + '%s', ''),
     'forum' : ('http://www.openmicroscopy.org/community/' + '%s', ''),
-    'omerodoc': (omerodoc_uri + '%s', '')
+    'omerodoc': (omerodoc_uri + '%s', ''),
+    'bf_plone' : ('http://www.openmicroscopy.org/site/products/bio-formats/%s/', ''),
     }
 
 rst_epilog = """

--- a/docs/sphinx/developers/c-bindings.txt
+++ b/docs/sphinx/developers/c-bindings.txt
@@ -27,7 +27,7 @@ You can use BF-CPP from a pre-compiled binary, or you can generate the
 code and compile it yourself:
 
 -  Binary builds for several common platforms are available on our
-   `Bio-Formats downloads page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_.
+   :bf_plone:`Bio-Formats downloads page <downloads>`.
 -  See the :source:`build instructions <components/scifio/cppwrap/readme.txt>`
    (:source:`Windows </components/scifio/cppwrap/readme-windows.txt>`,
    :source:`Mac OS X <components/scifio/cppwrap/readme-macosx.txt>`,

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -2,11 +2,10 @@ Bio-Formats as a Java Library
 =============================
 
 If you wish to make use of Bio-Formats within your own software, you can
-`download bio-formats.jar <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
-to use it as a library. Just add **bio-formats.jar** to your CLASSPATH or
-build path. You will also need **loci-common.jar** for common I/O
-functions, **ome-xml.jar** for metadata standardization, and
-`**SLF4J** <http://slf4j.org/>`_ for logging. 
+:bf_plone:`download bio-formats.jar <downloads>` to use it as a library. Just 
+add **bio-formats.jar** to your CLASSPATH or build path. You will also need 
+**loci-common.jar** for common I/O functions, **ome-xml.jar** for metadata 
+standardization, and `**SLF4J** <http://slf4j.org/>`_ for logging. 
 
 Beyond **bio-formats.jar**, **loci-common.jar**, **ome-xml.jar**, and
 `**SLF4J** <http://slf4j.org/>`_, no additional libraries are required.

--- a/docs/sphinx/index.txt
+++ b/docs/sphinx/index.txt
@@ -16,7 +16,7 @@ formats.
     - :doc:`supported-formats`
 
 
-Installation information is available on the :doc:`user information page <users/user-info>`. Download Bio-Formats from `the Bio-Formats downloads page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
+Installation information is available on the :doc:`user information page <users/user-info>`. Download Bio-Formats from :bf_plone:`the Bio-Formats downloads page <downloads>`.
 
 
 For help, see the

--- a/docs/sphinx/users/bug-reporting.txt
+++ b/docs/sphinx/users/bug-reporting.txt
@@ -10,8 +10,8 @@ possible that the problem has already been addressed. For both FIJI and
 ImageJ users, select Update LOCI Plugins under the LOCI menu. Select
 Trunk Build.
 
-You can also download the `newest version of Bio-Formats <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_. If you
-are not sure which version you need, select the Trunk Build under LOCI
+You can also download the :bf_plone:`newest version of Bio-Formats <downloads>`. 
+If you are not sure which version you need, select the Trunk Build under LOCI 
 Tools complete bundle.
 
 Sending a bug report

--- a/docs/sphinx/users/command-line-tools.txt
+++ b/docs/sphinx/users/command-line-tools.txt
@@ -7,9 +7,9 @@ line.
 Installation
 ------------
 
-`Download **bftools.zip** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_,
-unzip it into a new folder, then `download **loci\_tools.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
-and place it in the same folder.
+:bf_plone:`Download **bftools.zip** <downloads>`, unzip it into a new folder, 
+then :bf_plone:`download **loci\_tools.jar** <downloads>` and place it in the 
+same folder.
 
 The zip file contains both Unix scripts and Windows batch files.
 Currently available tools include:

--- a/docs/sphinx/users/endrov.txt
+++ b/docs/sphinx/users/endrov.txt
@@ -17,8 +17,7 @@ Upgrading
 ---------
 
 It should be possible to use a newer version of Bio-Formats by
-`downloading the latest
-**bio-formats.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`
+:bf_plone:`downloading the latest **bio-formats.jar** <downloads>`
 and putting it into the ``libs`` folder of the EV distribution,
 overwriting the old file.
 

--- a/docs/sphinx/users/focalpoint.txt
+++ b/docs/sphinx/users/focalpoint.txt
@@ -17,9 +17,8 @@ necessary.
 Upgrading
 ---------
 
-It should be possible to use a `newer version of
-Bio-Formats <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ by
-overwriting the old **loci\_tools.jar** within the FocalPoint
+It should be possible to use a :bf_plone:`newer version of Bio-Formats <downloads>` 
+by overwriting the old **loci\_tools.jar** within the FocalPoint
 distribution. For Mac OS X, you'll have to control click the FocalPoint
 program icon, choose "Show Package Contents" and navigate into
 Contents/Resources/Java to find the **loci\_tools.jar** file.

--- a/docs/sphinx/users/idl.txt
+++ b/docs/sphinx/users/idl.txt
@@ -24,4 +24,4 @@ Upgrading
 ---------
 
 To use a newer version of Bio-Formats, overwrite the requisite JAR files
-with the `newer version <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and restart IDL.
+with the :bf_plone:`newer version <downloads>` and restart IDL.

--- a/docs/sphinx/users/imagej.txt
+++ b/docs/sphinx/users/imagej.txt
@@ -10,7 +10,8 @@ formats it supports.
 Installation
 ------------
 
-`Download **loci\_tools.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and drop it into your **ImageJ/plugins** folder. Next time you run ImageJ, a new
+:bf_plone:`Download **loci\_tools.jar** <downloads>` and drop it into your 
+**ImageJ/plugins** folder. Next time you run ImageJ, a new
 LOCI submenu with several plugins will appear in the Plugins menu,
 including the Bio-Formats Importer and Bio-Formats Exporter.
 
@@ -40,8 +41,8 @@ Fiji wiki.
 Upgrading
 ---------
 
-To upgrade, just overwrite the old **loci\_tools.jar** with the `latest
-one <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_.
+To upgrade, just overwrite the old **loci\_tools.jar** with the 
+:bf_plone:`latest one <downloads>`.
 Step-by-step upgrade instructions for Windows are available
 :doc:`here <upgrading-importer-imagej>`.
 You may want to download the latest version of ImageJ first, to take

--- a/docs/sphinx/users/installing-bf-imagej.txt
+++ b/docs/sphinx/users/installing-bf-imagej.txt
@@ -7,7 +7,7 @@ built in, people who install FIJI can skip this section.)*
 
 Once you `download <http://rsbweb.nih.gov/ij/download.html>`__ and
 install ImageJ, you can install the Bio-Formats plugin by going to the
-Bio-Formats `download page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_.  
+Bio-Formats :bf_plone:`download page <downloads>`.  
 For most end-users, we recommend downloading the LOCI Tools complete bundle. 
 However, you must decide which version of it you want to install. There
 are three primary versions of Bio-Formats: the trunk build, the daily
@@ -43,9 +43,9 @@ report. Rather than using the stable release until you find a bug that
 requires you to upgrade and reproduce it, why not just use the trunk
 build to begin with?
 
-Once you decide which version you need, go to the Bio-Formats `download
-page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and save the
-appropriate loci\_tools.jar to the Plugins directory within ImageJ.
+Once you decide which version you need, go to the Bio-Formats 
+:bf_plone:`download page <downloads>` and save the appropriate loci\_tools.jar 
+to the Plugins directory within ImageJ.
 
 .. figure:: /images/PluginDirectory.png
     :align: center

--- a/docs/sphinx/users/matlab.txt
+++ b/docs/sphinx/users/matlab.txt
@@ -25,13 +25,13 @@ overhead from copying arrays.
 Installation
 ------------
 
-To use the script, download **bfopen.m** (above) and `**loci\_tools.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and place them in your MATLAB work directory.
+To use the script, download **bfopen.m** (above) and :bf_plone:`**loci\_tools.jar** <downloads>` and place them in your MATLAB work directory.
 
 Upgrading
 ---------
 
 To use a newer version of Bio-Formats, overwrite **loci\_tools.jar**
-with the `newer version <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and restart MATLAB.
+with the :bf_plone:`newer version <downloads>` and restart MATLAB.
 
 More information
 ----------------

--- a/docs/sphinx/users/mipav.txt
+++ b/docs/sphinx/users/mipav.txt
@@ -14,7 +14,7 @@ Installation
 
 Follow these steps to install the Bio-Formats plugin for MIPAV:
 
-#. `Download **loci\_tools.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
+#. :bf_plone:`Download **loci\_tools.jar** <downloads>`
    and drop it into your MIPAV folder.
 #. Download the :source:`plugin source code <components/scifio/utils/mipav/PlugInBioFormatsImporter.java>`
    into your user ``mipav/plugins`` folder.
@@ -37,6 +37,6 @@ Follow these steps to install the Bio-Formats plugin for MIPAV:
 See the :source:`readme file <components/scifio/utils/mipav/readme.txt>`
 for more information.
 
-To upgrade, just overwrite the old **loci\_tools.jar** with the `latest
-one <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_. You may want to download the latest version of MIPAV first, to take advantage of new
+To upgrade, just overwrite the old **loci\_tools.jar** with the 
+:bf_plone:`latest one <downloads>`. You may want to download the latest version of MIPAV first, to take advantage of new
 features and bug-fixes.

--- a/docs/sphinx/users/ome-server.txt
+++ b/docs/sphinx/users/ome-server.txt
@@ -68,7 +68,8 @@ Upgrading
 ---------
 
 You can upgrade your OME server installation to take advantage of a
-`new Bio-Formats release <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ by overwriting the old **loci\_tools.jar** with the new one.
+:bf_plone:`new Bio-Formats release <downloads>` by overwriting the old 
+**loci\_tools.jar** with the new one.
 
 Source Code
 -----------

--- a/docs/sphinx/users/omero.txt
+++ b/docs/sphinx/users/omero.txt
@@ -19,4 +19,5 @@ Upgrading
 The OMERO clients are currently distributed with a static version of
 Bio-Formats bundled within the **jar\_0.jar** or **omero.importer.jar**
 file, and cannot be easily upgraded using the latest **loci\_tools.jar**
-on the `Bio-Formats downloads page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_. You should upgrade to the latest version of the OMERO.importer client instead.
+on the :bf_plone:`Bio-Formats downloads page <downloads>`. You should upgrade 
+to the latest version of the OMERO.importer client instead.

--- a/docs/sphinx/users/upgrading-importer-imagej.txt
+++ b/docs/sphinx/users/upgrading-importer-imagej.txt
@@ -1,7 +1,8 @@
 Upgrading the Bio-Formats importer for ImageJ to the latest trunk build
 =======================================================================
 
-1) Download the latest trunk build of loci\_tools.jar from `bio-formats downloads <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
+1) Download the latest trunk build of loci\_tools.jar from 
+:bf_plone:`bio-formats downloads <downloads>`
 
 .. image:: /images/imagej-upgrade_01.png
     :align: center

--- a/docs/sphinx/users/user-info.txt
+++ b/docs/sphinx/users/user-info.txt
@@ -6,7 +6,8 @@ User Information
 Installation
 ============
 
-Download one of the files from `the Bio-Formats downloads page <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ and place it in an appropriate directory. Specific installation instructions
+Download one of the files from :bf_plone:`the Bio-Formats downloads page <downloads>` 
+and place it in an appropriate directory. Specific installation instructions
 depend upon the application you are using - see below.
 
 

--- a/docs/sphinx/users/visad.txt
+++ b/docs/sphinx/users/visad.txt
@@ -16,8 +16,7 @@ Upgrading
 ---------
 
 It should be possible to use a newer version of Bio-Formats by putting
-the `latest **loci\_tools.jar** or
-**bio-formats.jar** <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_
+the :bf_plone:`latest **loci\_tools.jar** or **bio-formats.jar** <downloads>`
 before **visad.jar** in the class path. Alternately, you can create a
 "VisAD Lite" using the ``make lite`` command from VisAD source, and use
 the resultant **visad-lite.jar**, which is a stripped down version of

--- a/docs/sphinx/users/visbio.txt
+++ b/docs/sphinx/users/visbio.txt
@@ -16,8 +16,8 @@ necessary.
 Upgrading
 ---------
 
-It should be possible to use a `newer version of Bio-Formats <http://www.openmicroscopy.org/site/products/bio-formats/bio-formats-downloads>`_ by
-overwriting the old **bio-formats.jar** and optional libraries within
+It should be possible to use a :bf_plone:`newer version of Bio-Formats <downloads>` 
+by overwriting the old **bio-formats.jar** and optional libraries within
 the VisBio distribution. For Mac OS X, you'll have to control click the
 VisBio program icon, choose "Show Package Contents" and navigate into
 Contents/Resources/Java to find the JAR files.


### PR DESCRIPTION
This PR redirects the Bio-Formats downloads links in the documentation to the new page, namely https://www.openmicroscopy.org/site/products/bio-formats/downloads
