### PR TITLE
Hiding header and menu when printing

### DIFF
--- a/docs/sphinx/themes/plonematch/static/plonematch.css_t
+++ b/docs/sphinx/themes/plonematch/static/plonematch.css_t
@@ -171,5 +171,9 @@ div.related {
 }
 
 @media print{
-	
+
+#portal-top {
+    display:none;
+}
+
 }


### PR DESCRIPTION
When you print sphinx html pages the header and menu should be hidden.
