### PR TITLE
Deploy -sources JARs to Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
For a number of reasons, it is very useful to have these sources JARs
deployed. For example, in Eclipse, you can right-click on a Maven JAR
dependency and choose Maven > Download Sources, and it will then
automatically download the sources JAR and link them for debugging.
