### PR TITLE
Fix source code links in the documentation using source extlinks

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1445,8 +1445,8 @@ library to read ND2 files compressed with JPEG-2000. \n
 There is also an ND2 reader that uses Nikon's native libraries.  To use \n
 it, you must be using Windows and have `Nikon's ND2 reader plugin for ImageJ \n
 <http://rsb.info.nih.gov/ij/plugins/nd2-reader.html>`_ installed. \n
-Additionally, you will need to download `LegacyND2Reader.dll \n
-<https://github.com/openmicroscopy/bioformats/raw/develop/lib/LegacyND2Reader.dll>`_ \n
+Additionally, you will need to download :source:`LegacyND2Reader.dll \n
+<lib/LegacyND2Reader.dll?raw=true>` \n
 and place it in your ImageJ plugin folder.
 
 [NRRD (Nearly Raw Raster Data)]

--- a/docs/sphinx/developers/developer-links.txt
+++ b/docs/sphinx/developers/developer-links.txt
@@ -29,9 +29,8 @@ Examples
     matlab-dev
     source-code
 
--  `More thorough examples of exporting images and
-   metadata
-   <http://github.com/openmicroscopy/bioformats/tree/develop/components/bio-formats/doc/export>`_
+-  :source:`More thorough examples of exporting images and
+   metadata <components/bio-formats/doc/export>`
 
 
 Interfacing from non-Java code

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -227,4 +227,4 @@ constructed like so:
 
 There is also a script that can save MATLAB arrays to supported formats:
 
-`bfsave.m <https://github.com/openmicroscopy/bioformats/blob/develop/components/bio-formats/matlab/bfsave.m>`_
+:source:`bfsave.m <components/bio-formats/matlab/bfsave.m>`

--- a/docs/sphinx/developers/non-java-code.txt
+++ b/docs/sphinx/developers/non-java-code.txt
@@ -154,9 +154,7 @@ C/C++
    native code.
 -  Raw JNI solutions are `time-consuming and
    error-prone <http://codemesh.com/technology.html#jni>`_ to implement.
--  We have coded `a simple
-   example
-   <http://github.com/openmicroscopy/bioformats/tree/develop/components/bio-formats/utils/showinfJNI.cpp>`_
+-  We have coded :source:`a simple example <components/bio-formats/utils/showinfJNI.cpp>`
    for calling Bio-Formats this way.
 -  We recommend a higher level integration solution such as Jace
    instead.

--- a/docs/sphinx/formats/nikon-nis-elements-nd2.txt
+++ b/docs/sphinx/formats/nikon-nis-elements-nd2.txt
@@ -69,6 +69,6 @@ library to read ND2 files compressed with JPEG-2000.
 There is also an ND2 reader that uses Nikon's native libraries.  To use 
 it, you must be using Windows and have `Nikon's ND2 reader plugin for ImageJ 
 <http://rsb.info.nih.gov/ij/plugins/nd2-reader.html>`_ installed. 
-Additionally, you will need to download `LegacyND2Reader.dll 
-<https://github.com/openmicroscopy/bioformats/raw/develop/lib/LegacyND2Reader.dll>`_ 
+Additionally, you will need to download :source:`LegacyND2Reader.dll 
+<lib/LegacyND2Reader.dll?raw=true>` 
 and place it in your ImageJ plugin folder.


### PR DESCRIPTION
Same as #220 rebased onto 'origin/develop`
