### PR TITLE
Improve OMEXMLMetadata

### DIFF
--- a/components/scifio/src/loci/formats/MetadataTools.java
+++ b/components/scifio/src/loci/formats/MetadataTools.java
@@ -48,9 +48,8 @@ import loci.common.services.ServiceFactory;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
-import loci.formats.ome.OMEXMLMetadataImpl;
+import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
-
 import ome.xml.model.BinData;
 import ome.xml.model.OME;
 import ome.xml.model.enums.DimensionOrder;
@@ -145,7 +144,14 @@ public final class MetadataTools {
         if (service.isOMEXMLRoot(store.getRoot())) {
           MetadataStore baseStore = r.getMetadataStore();
           if (service.isOMEXMLMetadata(baseStore)) {
-            ((OMEXMLMetadataImpl) baseStore).resolveReferences();
+            OMEXMLMetadata omeMeta;
+            try {
+              omeMeta = service.getOMEMetadata(service.asRetrieve(baseStore));
+              omeMeta.resolveReferences();
+            }
+            catch (ServiceException e) {
+              LOGGER.warn("Failed to resolve references", e);
+            }
           }
 
           OME root = (OME) store.getRoot();

--- a/components/scifio/src/loci/formats/ome/OMEXMLMetadata.java
+++ b/components/scifio/src/loci/formats/ome/OMEXMLMetadata.java
@@ -55,4 +55,6 @@ public interface OMEXMLMetadata extends IMetadata {
    */
   String dumpXML();
 
+  int resolveReferences();
+
 }

--- a/components/scifio/src/loci/formats/out/OMETiffWriter.java
+++ b/components/scifio/src/loci/formats/out/OMETiffWriter.java
@@ -237,12 +237,10 @@ public class OMETiffWriter extends TiffWriter {
     ServiceFactory factory = new ServiceFactory();
     service = factory.getInstance(OMEXMLService.class);
     OMEXMLMetadata originalOMEMeta = service.getOMEMetadata(retrieve);
-    if (originalOMEMeta instanceof OMEXMLMetadataImpl) {
-      ((OMEXMLMetadataImpl) originalOMEMeta).resolveReferences();
+    originalOMEMeta.resolveReferences();
 
-      String omexml = service.getOMEXML(originalOMEMeta);
-      omeMeta = service.createOMEXMLMetadata(omexml);
-    }
+    String omexml = service.getOMEXML(originalOMEMeta);
+    omeMeta = service.createOMEXMLMetadata(omexml);
   }
 
   private String getOMEXML(String file) throws FormatException, IOException {

--- a/components/scifio/src/loci/formats/services/OMEXMLService.java
+++ b/components/scifio/src/loci/formats/services/OMEXMLService.java
@@ -115,7 +115,7 @@ public interface OMEXMLService extends Service {
   /**
    * Checks whether the given object is an OME-XML metadata object.
    * @return True if the object is an instance of
-   *   {@link loci.formats.ome.AbstractOMEXMLMetadata}.
+   *   {@link loci.formats.ome.OMEXMLMetadata}.
    */
   public boolean isOMEXMLMetadata(Object o);
 

--- a/components/scifio/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/scifio/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -542,7 +542,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   public void populateOriginalMetadata(OMEXMLMetadata omexmlMeta,
     Hashtable<String, Object> metadata)
   {
-    ((OMEXMLMetadataImpl) omexmlMeta).resolveReferences();
+    omexmlMeta.resolveReferences();
     OME root = (OME) omexmlMeta.getRoot();
     StructuredAnnotations annotations = root.getStructuredAnnotations();
     if (annotations == null) annotations = new StructuredAnnotations();
@@ -567,7 +567,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   public void populateOriginalMetadata(OMEXMLMetadata omexmlMeta,
     String key, String value)
   {
-    ((OMEXMLMetadataImpl) omexmlMeta).resolveReferences();
+    omexmlMeta.resolveReferences();
     OME root = (OME) omexmlMeta.getRoot();
     StructuredAnnotations annotations = root.getStructuredAnnotations();
     if (annotations == null) annotations = new StructuredAnnotations();
@@ -618,7 +618,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
 
   /** @see OMEXMLService#removeBinData(OMEXMLMetadata) */
   public void removeBinData(OMEXMLMetadata omexmlMeta) {
-    ((OMEXMLMetadataImpl) omexmlMeta).resolveReferences();
+    omexmlMeta.resolveReferences();
     OME root = (OME) omexmlMeta.getRoot();
     List<Image> images = root.copyImageList();
     for (Image img : images) {
@@ -633,7 +633,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
 
   /** @see OMEXMLService#removeChannels(OMEXMLMetadata, int, int) */
   public void removeChannels(OMEXMLMetadata omexmlMeta, int image, int sizeC) {
-    ((OMEXMLMetadataImpl) omexmlMeta).resolveReferences();
+    omexmlMeta.resolveReferences();
     OME root = (OME) omexmlMeta.getRoot();
     Pixels img = root.getImage(image).getPixels();
     List<Channel> channels = img.copyChannelList();
@@ -649,7 +649,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
 
   /** @see OMEXMLService#addMetadataOnly(OMEXMLMetadata, int) */
   public void addMetadataOnly(OMEXMLMetadata omexmlMeta, int image) {
-    ((OMEXMLMetadataImpl) omexmlMeta).resolveReferences();
+    omexmlMeta.resolveReferences();
     MetadataOnly meta = new MetadataOnly();
     OME root = (OME) omexmlMeta.getRoot();
     Pixels pix = root.getImage(image).getPixels();
@@ -659,8 +659,8 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
 
   /** @see OMEXMLService#isEqual(OMEXMLMetadata, OMEXMLMetadata) */
   public boolean isEqual(OMEXMLMetadata src1, OMEXMLMetadata src2) {
-    ((OMEXMLMetadataImpl) src1).resolveReferences();
-    ((OMEXMLMetadataImpl) src2).resolveReferences();
+    src1.resolveReferences();
+    src2.resolveReferences();
 
     OME omeRoot1 = (OME) src1.getRoot();
     OME omeRoot2 = (OME) src2.getRoot();


### PR DESCRIPTION
This branch moves the OMEXMLMetadataImpl#resolveReferences method into the OMEXMLMetadata interface proper. Once the interface itself declares the method, the various explicit casts to OMEXMLMetadataImpl are no longer needed, and interface-driven design works to keep the codebase extensible.
