### PR TITLE
OME-XML writer: split up series using the "Pixels" tag

### DIFF
--- a/components/scifio/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/scifio/src/loci/formats/out/OMEXMLWriter.java
@@ -251,7 +251,7 @@ public class OMEXMLWriter extends FormatWriter {
 
     public void endElement(String uri, String localName, String qName) {
       currentFragment += "</" + qName + ">";
-      if (qName.equals("Channel")) {
+      if (qName.equals("Pixels")) {
         xmlFragments.add(currentFragment);
         currentFragment = "";
       }


### PR DESCRIPTION
Splitting on the "Channels" tag causes problems when there are multiple
channels per Image.

See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=3499

To test, convert a file with multiple Images (series) and multiple channels to OME-XML with and without this fix and verify that only the one converted with this fix contains the correct number of Images.  The command to use is `bfconvert input-file output-file.ome`.  The .oib file in fv1000/david/ (on squig) is a good test, but feel free to use any other file that meets the requirements.
