### PR TITLE
Standardize case of "Fiji"

### DIFF
--- a/docs/sphinx/users/bf-features-imagej.txt
+++ b/docs/sphinx/users/bf-features-imagej.txt
@@ -1,4 +1,4 @@
-Bio-Formats features in ImageJ and FIJI
+Bio-Formats features in ImageJ and Fiji
 =======================================
 
 When you select Bio-Formats under the Plugin menu, you will see the
@@ -6,7 +6,7 @@ following features:
 
 The **Bio-Formats Importer** is a plugin for :doc:`loading
 images <load-images>` into ImageJ or
-FIJI. It can over 100 of proprietary life sciences formats and
+Fiji. It can over 100 of proprietary life sciences formats and
 standardizes their acquisition metadata into the common
 :doc:`OME data model </about>`. It will also extract and set basic
 metadata values such as `spatial

--- a/docs/sphinx/users/bug-reporting.txt
+++ b/docs/sphinx/users/bug-reporting.txt
@@ -6,7 +6,7 @@ Before filing a bug report
 
 If you think you have found a bug in Bio-Formats, the first thing to do is
 update your version of Bio-Formats to the latest trunk version. It is
-possible that the problem has already been addressed. For both FIJI and
+possible that the problem has already been addressed. For both Fiji and
 ImageJ users, select Update LOCI Plugins under the LOCI menu. Select
 Trunk Build.
 

--- a/docs/sphinx/users/fiji.txt
+++ b/docs/sphinx/users/fiji.txt
@@ -20,9 +20,9 @@ checks for updates every time it is launched, so you will always be
 notified when new versions of Bio-Formats (or any other bundled plugin)
 are available.
 
-Updates in the FIJI updater are not always Bio-Formats’ most recent
+Updates in the Fiji updater are not always Bio-Formats’ most recent
 trunk build or stable release; they are versions that are known to
 remain compatible with other plugins that depend upon Bio-Formats. You
-should use the FIJI updater if you use other plugins that might use
+should use the Fiji updater if you use other plugins that might use
 Bio-Formats.  However, if you encounter a bug within Bio-Formats, use
 Bio-Formats’ own updater to see if the latest trunk build fixes it.

--- a/docs/sphinx/users/installing-bf-imagej.txt
+++ b/docs/sphinx/users/installing-bf-imagej.txt
@@ -2,8 +2,8 @@ Installing Bio-Formats in ImageJ
 ================================
 
 
-*(Since FIJI is essentially ImageJ with plugins like Bio-Formats already
-built in, people who install FIJI can skip this section.)*
+*(Since Fiji is essentially ImageJ with plugins like Bio-Formats already
+built in, people who install Fiji can skip this section.)*
 
 Once you `download <http://rsbweb.nih.gov/ij/download.html>`__ and
 install ImageJ, you can install the Bio-Formats plugin by going to the

--- a/docs/sphinx/users/load-images.txt
+++ b/docs/sphinx/users/load-images.txt
@@ -30,7 +30,7 @@ see a screen like this:
     :alt: Bio-Formats' Import Options Screen
 
 If you used the File > Open command and did not see the Bio-Formats
-Import Options screen, ImageJ / FIJI probably used another plugin
+Import Options screen, ImageJ/Fiji probably used another plugin
 instead of Bio-Formats to open the file.   If this happens and you want
 to open a file using Bio-Formats, use one of the other two methods
 instead. 
@@ -84,7 +84,7 @@ Data <http://www.loci.wisc.edu/software/sample-data>`_ page.  You will
 notice that it is a large dataset: each of the 85 files shows the
 specimen at 33 optical sections along the z-plane at a specific time. 
 
-If you open just one file in ImageJ / FIJI using the Bio-Formats
+If you open just one file in ImageJ/Fiji using the Bio-Formats
 Importer, you will get an image incorporating three dimensions (x, y,
 z).  However, if you select “Group files with similar names” from the
 Bio-Formats Import Options screen, you will be able to create a 4-D
@@ -208,6 +208,6 @@ data set.  This means if the highest value in your dataset is close to
 maximum display value, Autoscale’s adjusting may be undetectable to the
 eye. 
 
-ImageJ / Fiji also has its own tools for adjusting the image, which are
+ImageJ/Fiji also has its own tools for adjusting the image, which are
 available by selecting Brightness / Contrast, which is under the Adjust
 option in the Image menu. 

--- a/docs/sphinx/users/managing-memory.txt
+++ b/docs/sphinx/users/managing-memory.txt
@@ -16,7 +16,7 @@ load all the images.  If you have a very large data set, you may have to
 -  Crop the view area
 -  Open only a subset of images
 -  Use Virtual Stack
--  Increase ImageJ / FIJI’s memory.
+-  Increase ImageJ/Fiji’s memory.
 
  
 
@@ -75,20 +75,20 @@ Use Virtual Stack
 necessary. Note that unlike Data Browser, Virtual Stack does not contain
 a buffer and may produce choppy animations.
 
-**Increasing ImageJ /FIJI’s memory**
+**Increasing ImageJ/Fiji’s memory**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Finally, can also increase the amount of the computer memory devoted to
-ImageJ/ FIJI by selecting Memory & Threads under the Edit menu.
+ImageJ/Fiji by selecting Memory & Threads under the Edit menu.
 
 .. image:: /images/IncreaseMemory.jpg
    :align: center
-   :alt: FIJI's Memory Allocation Menu
+   :alt: Fiji's Memory Allocation Menu
 
 Generally, allocating more than 75% of the computer’s total memory will
-cause ImageJ / FIJI to become slow and unstable.
+cause ImageJ/Fiji to become slow and unstable.
 
-Please note that unlike the other three features, ImageJ / FIJI itself
+Please note that unlike the other three features, ImageJ/Fiji itself
 provides this feature and not Bio-Formats.  You can find out more about
 this feature by looking at ImageJ’s
 `documentation <http://rsbweb.nih.gov/ij/docs/menus/edit.html#options>`_.

--- a/docs/sphinx/users/user-info.txt
+++ b/docs/sphinx/users/user-info.txt
@@ -23,11 +23,11 @@ For information about what extensions to choose to import files, see
     /dataset-structure-table
 
 
-Using Bio-Formats with ImageJ and FIJI
+Using Bio-Formats with ImageJ and Fiji
 ======================================
 
 The following sections explain the features of Bio-Formats and how to use 
-it within ImageJ and FIJI:
+it within ImageJ and Fiji:
 
 
 .. toctree::


### PR DESCRIPTION
The Fiji project, despite being an acronym ("Fiji Is Just ImageJ"), uses normal case rather than capital case. Weird, I know.
