### PR TITLE
Makefile

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    ?=
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
- Clean unused variable
- Allow the BIOFORMATS-docs-merge-4.4 job to set `SPHINXOPTS` as an environment variable and then to build the doc using

```
make clean html latexpdf
```

like the OMERO-docs-merge-\* jobs
