### PR TITLE
Fix the OME-XML writer to write valid files

### DIFF
--- a/components/scifio/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/scifio/src/loci/formats/out/OMEXMLWriter.java
@@ -92,6 +92,9 @@ public class OMEXMLWriter extends FormatWriter {
 
   /* @see loci.formats.IFormatHandler#setId(String) */
   public void setId(String id) throws FormatException, IOException {
+    if (id.equals(currentId)) {
+      return;
+    }
     super.setId(id);
 
     MetadataRetrieve retrieve = getMetadataRetrieve();


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/246 and
https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=3499

Testing involves everything from PR #246, but also verifying that `xmlvalid` on the converted file shows no errors.
