### PR TITLE
TIFF: fix header writing for big-endian BigTIFF files

### DIFF
--- a/components/scifio/src/loci/formats/tiff/TiffSaver.java
+++ b/components/scifio/src/loci/formats/tiff/TiffSaver.java
@@ -203,10 +203,15 @@ public class TiffSaver {
 
     // for vanilla TIFFs, 8 is the offset to the first IFD
     // for BigTIFFs, 8 is the number of bytes in an offset
-    out.writeInt(8);
     if (bigTiff) {
+      out.writeShort(8);
+      out.writeShort(0);
+
       // write the offset to the first IFD for BigTIFF files
       out.writeLong(16);
+    }
+    else {
+      out.writeInt(8);
     }
   }
 


### PR DESCRIPTION
Fix suggested by Matthias Baldauf:

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2012-November/003463.html

Same as #258, but against develop.
