### PR TITLE
Photoshop TIFF: fix offset to first layer (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/PhotoshopTiffReader.java
+++ b/components/bio-formats/src/loci/formats/in/PhotoshopTiffReader.java
@@ -260,7 +260,9 @@ public class PhotoshopTiffReader extends BaseTiffReader {
               codec.decompress(tag, null);
             }
             else if (compression[layer] == PACKBITS) {
-              if (layer == 0) tag.skipBytes(256);
+              if (layer == 0) {
+                tag.skipBytes(256 * 6 + 36);
+              }
               else tag.skipBytes(192);
               layerOffset[nextOffset] = tag.getFilePointer();
               PackbitsCodec codec = new PackbitsCodec();


### PR DESCRIPTION
This is the same as gh-345 but rebased onto develop.

---

Fixes #10203.
