### PR TITLE
Fix Eclipse AssumeNG errors (see #10238)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -24,5 +24,6 @@
     <dependency org="bf-deps" name="bufr" rev="1.1.00"/>
     <dependency org="bf-deps" name="grib" rev="5.1.03"/>
     <dependency org="bf-deps" name="netcdf" rev="4.0"/>
+    <dependency org="bf-deps" name="assumeng" rev="1.2.3-jdk15"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
This PR fixes the issue where errors are displayed in Eclipse indicating a missing AssumeNG package and related classes. This error can be seen when the top-level project is imported (ome.git) and not specific projects from under `/components`. It goes together with https://github.com/openmicroscopy/openmicroscopy/pull/642.
