### PR TITLE
Fixing broken OME docs link & adding git hyperlink (rebased onto develop)

### DIFF
--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -16,7 +16,7 @@ files likely to be affected by that commit. If you want to run these
 tests, you will need to do the following:
 
 Clone bioformats.git and checkout the appropriate branch (by following
-the directions on the :omerodoc:`Git usage <developers/Development/UsingGit.html>`
+the directions on the :omerodoc:`Git usage <developers/using-git.html>`
 page). Run this command to build all of the JAR files:
 
 ::

--- a/docs/sphinx/developers/source-code.txt
+++ b/docs/sphinx/developers/source-code.txt
@@ -7,9 +7,8 @@ repository path:
 
 ``git@github.com:openmicroscopy/bioformats.git``
 
-You can also browse the Bio-Formats source on GitHub:
-
-``https://github.com/openmicroscopy/bioformats``
+You can also browse the 
+`Bio-Formats source on GitHub <https://github.com/openmicroscopy/bioformats>`_
 
 To build the code, you can use our Ant build script—try "``ant -p``\ "
 for a list of targets.  In general, "ant jars" or "ant tools" is the


### PR DESCRIPTION
This is the same as gh-348 but rebased onto develop.

---

Fixing the link to the OME developer Using Git page which has moved, and adding hyperlink to BF git repository as requested by Simon a while back.
