### PR TITLE
Photoshop TIFF: ignore layers if the channel count is wrong (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/PhotoshopTiffReader.java
+++ b/components/bio-formats/src/loci/formats/in/PhotoshopTiffReader.java
@@ -206,7 +206,9 @@ public class PhotoshopTiffReader extends BaseTiffReader {
           layerCore.littleEndian = isLittleEndian();
           layerCore.dimensionOrder = getDimensionOrder();
 
-          if (layerCore.sizeX == 0 || layerCore.sizeY == 0) {
+          if (layerCore.sizeX == 0 || layerCore.sizeY == 0 ||
+            (layerCore.sizeC > 1 && !isRGB()))
+          {
             // Set size to 1
             CoreMetadata ms0 = core.get(0);
             core.clear();


### PR DESCRIPTION
This is the same as gh-353 but rebased onto develop.

---
