### PR TITLE
Buffer overrun defensive coding (rebased onto develop)

### DIFF
--- a/components/scifio/src/loci/formats/tiff/TiffCompression.java
+++ b/components/scifio/src/loci/formats/tiff/TiffCompression.java
@@ -296,7 +296,7 @@ public enum TiffCompression implements CodedEnum {
       if (planarConfig == 2 || bitsPerSample[len - 1] == 0) len = 1;
       len *= bytes;
 
-      for (int b=0; b<input.length; b+=bytes) {
+      for (int b=0; b<=input.length-bytes; b+=bytes) {
         if (b / len % width == 0) continue;
         int value = DataTools.bytesToInt(input, b, bytes, little);
         value += DataTools.bytesToInt(input, b - len, bytes, little);


### PR DESCRIPTION
This is the same as gh-362 but rebased onto develop.

---

See issue #357.
