### PR TITLE
CellSens: do not set the resolution count

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellSensReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellSensReader.java
@@ -406,9 +406,6 @@ public class CellSensReader extends FormatReader {
       tileMap[s] = new HashMap<TileCoordinate, Integer>();
 
       CoreMetadata ms = core.get(s);
-      if (s == 0) {
-        ms.resolutionCount = ifds.size() + (files.size() == 1 ? 0 : 1);
-      }
 
       if (s < files.size() - 1) {
         setSeries(s);


### PR DESCRIPTION
The images in the .vsi file are not proper sub-resolutions of the images
in the .ets file(s), so let's not tell the reader that they are.  While
the aspect ratio may be the same, the channel counts (and/or Z/T sizes)
are frequently different.

Fixes ticket #10354.
