### PR TITLE
Fix source code links moved to the scifio-tools foder

### DIFF
--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -57,4 +57,4 @@ the JARs in your :envvar:`CLASSPATH` (individual JARs or just loci_tools.jar):
     bfconvert test&pixelType=uint8&sizeX=8192&sizeY=8192.fake test.tiff
 
 If you do not have the command line tools installed, substitute
-:source:`loci.formats.tools.ImageConverter <components/scifio/src/loci/formats/tools/ImageConverter.java>` for `bfconvert`.
+:source:`loci.formats.tools.ImageConverter <components/scifio-tools/src/loci/formats/tools/ImageConverter.java>` for `bfconvert`.

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -62,10 +62,10 @@ all be found in our :source:`Git repository <jar>`.
 Examples of usage
 -----------------
 
-:source:`ImageConverter <components/scifio/src/loci/formats/tools/ImageConverter.java>` - 
+:source:`ImageConverter <components/scifio-tools/src/loci/formats/tools/ImageConverter.java>` - 
 A simple command line tool for converting between formats.
 
-:source:`ImageInfo <components/scifio/src/loci/formats/tools/ImageInfo.java>` - 
+:source:`ImageInfo <components/scifio-tools/src/loci/formats/tools/ImageInfo.java>` - 
 A more involved command line utility for thoroughly reading an input file, 
 printing some information about it, and displaying the pixels
 onscreen using the Bio-Formats viewer.

--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -197,7 +197,7 @@ Other useful things
   the images in the file.  :source:`ImageReader <components/scifio/src/loci/formats/ImageReader.java>` can take additional 
   parameters; a brief listing is provided below for reference, but it is  
   recommended that you take a look at the contents of 
-  :source:`loci.formats.tools.ImageInfo <components/scifio/src/loci/formats/tools/ImageInfo.java>` to see 
+  :source:`loci.formats.tools.ImageInfo <components/scifio-tools/src/loci/formats/tools/ImageInfo.java>` to see 
   exactly what each one does.
 
 +--------------+----------------------------------------------------------+

--- a/docs/sphinx/developers/using-bioformats.txt
+++ b/docs/sphinx/developers/using-bioformats.txt
@@ -156,7 +156,7 @@ the same writer and output settings (compression, frames per second, etc.),
 and is especially useful for formats that do not support multiple images per
 file.
 
-Please see :source:`loci.formats.tools.ImageConverter <components/scifio/src/loci/formats/tools/ImageConverter.java>` and 
+Please see :source:`loci.formats.tools.ImageConverter <components/scifio-tools/src/loci/formats/tools/ImageConverter.java>` and 
 :doc:`this guide to exporting to OME-TIFF files <export2>` for examples of how 
 to write files.
 


### PR DESCRIPTION
This is the same doc fixing commit as #376 rebased onto force pushed origin/dev_4_4.

Merging #376 into `dev_4_4` caused the [BIOFORMATS-docs-release-stable#22](http://hudson.openmicroscopy.org.uk/view/Docs/job/BIOFORMATS-docs-release-stable/22) job to fail. So `origin/dev_4_4` was force pushed excluding #376 and this doc fixing PR was reopened separately.

[BIOFORMATS-doc-merge-stable](http://hudson.openmicroscopy.org.uk/view/Docs/job/BIOFORMATS-docs-merge-stable/) shouldn't fail because of files moved in #368. 

:warning: DO NOT MERGE BEFORE 4.4.7 is tagged
