### PR TITLE
Metamorph: fix erroneous channel counts

### DIFF
--- a/components/bio-formats/src/loci/formats/in/MetamorphReader.java
+++ b/components/bio-formats/src/loci/formats/in/MetamorphReader.java
@@ -1039,6 +1039,13 @@ public class MetamorphReader extends BaseTiffReader {
 
       if (getSizeC() == 1) {
         core[0].sizeC = uniqueWavelengths.size();
+
+        if (getSizeC() < getImageCount() &&
+          getSizeC() > (getImageCount() - getSizeC()) &&
+          (getImageCount() % getSizeC()) != 0)
+        {
+          core[0].sizeC = getImageCount();
+        }
       }
 
       IFDList tempIFDs = new IFDList();
@@ -1756,8 +1763,6 @@ public class MetamorphReader extends BaseTiffReader {
         }
         break;
     }
-
-    core[0].sizeC = index + 1;
   }
 
   private String getKey(int id) {


### PR DESCRIPTION
This is what edfc130ef90eb70cb1ad54a9e8450fcd7a84fbec should have done
in the first place.

Should fix the metamorph test failures introduced by PR #373.
