### PR TITLE
Add www.sbig.com to the list of URLs to ignore in the linkcheck (rebased onto develop)

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -364,4 +364,8 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ['http://www.openmicroscopy.org/site/support/faq', 'http://vaa3d.org']
+linkcheck_ignore = [
+    'http://www.openmicroscopy.org/site/support/faq',
+    'http://vaa3d.org',
+    'http://www.sbig.com',
+    ]


### PR DESCRIPTION
This is the same as gh-399 but rebased onto develop.

---
