### PR TITLE
Add external list of broken URLs to linkcheck_ignore

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -371,4 +371,8 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ['http://www.openmicroscopy.org/site/support/faq', 'http://vaa3d.org']
+linkcheck_ignore = ['http://www.openmicroscopy.org/site/support/faq',]
+
+import urllib
+brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
+linkcheck_ignore.extend(urllib.urlopen(brokenfiles_url).read().splitlines())


### PR DESCRIPTION
This PR delegates the management of the third-party websites to exclude from the `linkcheck` to the newly create openmicroscopy/sphinx-ignore-links repository.

The BIOFORMATS-docs-merge job should be green again after applying this PR.
