### PR TITLE
Zeiss ZVI: use coordinates to retrieve the correct plane (rebased onto dev_4_4)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/bio-formats/src/loci/formats/in/ZeissZVIReader.java
@@ -101,20 +101,21 @@ public class ZeissZVIReader extends BaseZeissReader {
     options.littleEndian = isLittleEndian();
     options.interleaved = isInterleaved();
 
-    int index = 0;
+    int index = no;
 
-    int[] coords = getZCTCoords(no);
-    int seriesCount = -1;
-    for (int q=0; q<coordinates.length; q++) {
-      if (coordinates[q][0] == coords[0] && coordinates[q][1] == coords[1] &&
-        coordinates[q][2] == coords[2])
-      {
-        index = q;
-        seriesCount++;
-        if (seriesCount == getSeries()) {
+    if (getSeriesCount() == 1) {
+      int[] coords = getZCTCoords(no);
+      for (int q=0; q<coordinates.length; q++) {
+        if (coordinates[q][0] == coords[0] && coordinates[q][1] == coords[1] &&
+          coordinates[q][2] == coords[2])
+        {
+          index = q;
           break;
         }
       }
+    }
+    else {
+      index += getSeries() * getImageCount();
     }
 
     if (index >= imageFiles.length) {


### PR DESCRIPTION
This is the same as gh-393 but rebased onto dev_4_4.

---

In some cases, the stored plane index will have nothing to do with the
stored ZCT coordinates.  The coordinates are more reliable, so we now
use those to retrieve the plane stream.

This will need to go on dev_4_4 and develop as well.
