### PR TITLE
Attempt to correct invalid metadata in OME-XML/OME-TIFF files

### DIFF
--- a/components/bio-formats/src/loci/formats/in/OMETiffReader.java
+++ b/components/bio-formats/src/loci/formats/in/OMETiffReader.java
@@ -237,6 +237,7 @@ public class OMETiffReader extends FormatReader {
     }
 
     String currentUUID = meta.getUUID();
+    MetadataTools.ensureValidOMEXML(meta);
     MetadataTools.convertMetadata(meta, metadataStore);
 
     // determine series count from Image and Pixels elements

--- a/components/bio-formats/src/loci/formats/in/OMEXMLReader.java
+++ b/components/bio-formats/src/loci/formats/in/OMEXMLReader.java
@@ -336,6 +336,7 @@ public class OMEXMLReader extends FormatReader {
     // contents of the internal OME-XML metadata object
     MetadataStore store = getMetadataStore();
 
+    MetadataTools.ensureValidOMEXML(omexmlMeta);
     MetadataTools.convertMetadata(omexmlMeta, store);
   }
 


### PR DESCRIPTION
This fills in commonly missing required values with defaults, in the hope of making invalid OME-XML and OME-TIFF files importable by OMERO.

Similar pull requests will be filed on dev_4_4 and develop once this is merged.
