### PR TITLE
Create an ant target to distribute Matlab functions

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -928,7 +928,7 @@ Type "ant -p" for a list of targets.
   </target>
 
   <!-- HACK - limit OS to *nix due to file permission issues -->
-  <target name="dist-bftools" if="isUnix">
+  <target name="dist-bftools" if="isUnix" description="zip the command line tools bundle">
     <echo>----------=========== bftools ===========----------</echo>
     <!--
     <zip destfile="${artifact.dir}/bftools.zip"


### PR DESCRIPTION
Rather than pointing at our tagged source code on Github, we may want to create a bundle of our Matlab functions for distribution (meaning including a link in the downloads page).

This PR adds an extra `dist-matlab` ant target that is archiving the Matlab functions (without the `loci_tools.jar` like for the command line tools bundle)
