### PR TITLE
Fix the CLASSPATHs for the command line tools

### DIFF
--- a/tools/scifio.bat
+++ b/tools/scifio.bat
@@ -39,7 +39,7 @@ if not "%SCIFIO_DEVEL%" == "" (
 
 rem Developer environment variable unset; add JAR libraries to classpath.
 if exist "%SCIFIO_JAR_DIR%\bio-formats.jar" (
-  set SCIFIO_CP=%SCIFIO_CP%;"%SCIFIO_JAR_DIR%\bio-formats.jar"
+  set SCIFIO_CP=%SCIFIO_CP%;"%SCIFIO_JAR_DIR%\bio-formats.jar";"%SCIFIO_JAR_DIR%\scifio-tools.jar"
 ) else if exist "%SCIFIO_JAR_DIR%\loci_tools.jar" (
   set SCIFIO_CP=%SCIFIO_CP%;"%SCIFIO_JAR_DIR%\loci_tools.jar"
 ) else (

--- a/tools/scifio.sh
+++ b/tools/scifio.sh
@@ -40,7 +40,7 @@ else
   # Developer environment variable unset; add JAR libraries to classpath.
   if [ -e "$SCIFIO_JAR_DIR/bio-formats.jar" ]
   then
-    SCIFIO_CP="$SCIFIO_JAR_DIR/bio-formats.jar:$SCIFIO_CP"
+    SCIFIO_CP="$SCIFIO_JAR_DIR/bio-formats.jar:$SCIFIO_JAR_DIR/scifio-tools.jar:$SCIFIO_CP"
   elif [ -e "$SCIFIO_JAR_DIR/loci_tools.jar" ]
   then
     SCIFIO_CP="$SCIFIO_JAR_DIR/loci_tools.jar:$SCIFIO_CP"


### PR DESCRIPTION
Many of the classes for the command line tools are now in
scifio-tools.jar (instead of bio-formats.jar), so when the
'SCIFIO_DEVEL' environment variable is set we need to have
scifio-tools.jar on the CLASSPATH.

Noticed by Curtis Rueden.
