### PR TITLE
Add license headers to Matlab functions (rebased onto develop)

### DIFF
--- a/components/bio-formats/matlab/bfCheckJavaPath.m
+++ b/components/bio-formats/matlab/bfCheckJavaPath.m
@@ -18,6 +18,27 @@ function [status, version] = bfCheckJavaPath(varargin)
 %    version - String specifying the current version of Bio-Formats if 
 %    loci_tools.jar is in the Java class path. Empty string else.
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % Input check
 ip = inputParser;
 ip.addOptional('autoloadBioFormats', true, @isscalar);

--- a/components/bio-formats/matlab/bfGetFileExtensions.m
+++ b/components/bio-formats/matlab/bfGetFileExtensions.m
@@ -12,6 +12,27 @@ function fileExt = bfGetFileExtensions
 %      format.
 %      This cell array is formatted to be used with uigetfile funciton.
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % Get all readers and create cell array with suffixes and names
 imageReader = loci.formats.ImageReader();
 readers = imageReader.getReaders();

--- a/components/bio-formats/matlab/bfGetPlane.m
+++ b/components/bio-formats/matlab/bfGetPlane.m
@@ -26,6 +26,27 @@ function I = bfGetPlane(r, iPlane, varargin)
 %
 % See also bfGetReader
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % Input check
 ip = inputParser;
 ip.addRequired('r', @(x) isa(x, 'loci.formats.ReaderWrapper'));

--- a/components/bio-formats/matlab/bfGetReader.m
+++ b/components/bio-formats/matlab/bfGetReader.m
@@ -18,6 +18,27 @@ function r = bfGetReader(varargin)
 %
 % Adapted from bfopen.m
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % Input check
 ip = inputParser;
 ip.addOptional('id', '', @ischar);

--- a/components/bio-formats/matlab/bfOpen3DVolume.m
+++ b/components/bio-formats/matlab/bfOpen3DVolume.m
@@ -14,6 +14,27 @@ function volume = bfOpen3DVolume(filename)
 %
 %   volume - 3D array containing all images in the file.
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % load the Bio-Formats library into the MATLAB environment
 status = bfCheckJavaPath();
 assert(status, ['Missing Bio-Formats library. Either add loci_tools.jar '...

--- a/components/bio-formats/matlab/bfUpgradeCheck.m
+++ b/components/bio-formats/matlab/bfUpgradeCheck.m
@@ -13,6 +13,26 @@ function bfUpgradeCheck(varargin)
 % Output
 %    none
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 % Check input
 ip = inputParser;
 ip.addOptional('autoDownload', false, @isscalar);

--- a/components/bio-formats/matlab/bfopen.m
+++ b/components/bio-formats/matlab/bfopen.m
@@ -47,6 +47,27 @@ function [result] = bfopen(id, varargin)
 % For many examples of how to use the bfopen function, please see:
 %     http://trac.openmicroscopy.org.uk/ome/wiki/BioFormats-Matlab
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2007 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 % -- Configuration - customize this section to your liking --
 
 % Toggle the autoloadBioFormats flag to control automatic loading

--- a/components/bio-formats/matlab/bfsave.m
+++ b/components/bio-formats/matlab/bfsave.m
@@ -10,11 +10,32 @@ function bfsave(I, outputPath, varargin)
 %       outputPath - a string containing the location of the path where to
 %       save the resulting OME-TIFF
 %
-%       dimensionOrder - optional. A string representing the dimension 
+%       dimensionOrder - optional. A string representing the dimension
 %       order, Default: XYZCT.
 %
 % OUTPUT
-% 
+%
+
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 % Check loci-tools jar is in the Java path
 bfCheckJavaPath();
@@ -102,10 +123,10 @@ switch class(I)
     case 'double'
         getBytes = @(x) loci.common.DataTools.doublesToBytes(x(:), 0);
 end
-        
+
 % Save planes to the writer
 nPlanes = sizeZ * sizeC * sizeT;
-for index = 1 : nPlanes 
+for index = 1 : nPlanes
     [i, j, k] = ind2sub([size(I, 3) size(I, 4) size(I, 5)],index);
     plane = I(:, :, i, j, k)';
     writer.saveBytes(index-1, getBytes(plane));

--- a/components/bio-formats/test/matlab/TestBfGetPlane.m
+++ b/components/bio-formats/test/matlab/TestBfGetPlane.m
@@ -3,6 +3,27 @@
 % Require MATLAB xUnit Test Framework to be installed
 % http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 classdef TestBfGetPlane < TestCase
     
     properties

--- a/components/bio-formats/test/matlab/TestBfsave.m
+++ b/components/bio-formats/test/matlab/TestBfsave.m
@@ -3,6 +3,27 @@
 % Require MATLAB xUnit Test Framework to be installed
 % http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 classdef TestBfsave < TestCase
     
     properties

--- a/components/bio-formats/test/matlab/TestCheckJavaPath.m
+++ b/components/bio-formats/test/matlab/TestCheckJavaPath.m
@@ -3,6 +3,28 @@
 % Require MATLAB xUnit Test Framework to be installed
 % http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
 
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2013 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
 classdef TestCheckJavaPath < TestCase
     
     properties


### PR DESCRIPTION
This is the same as gh-428 but rebased onto develop.

---
