### PR TITLE
LZW: prevent reading beyond the end of the stream (rebased onto develop)

### DIFF
--- a/components/scifio/src/loci/formats/codec/LZWCodec.java
+++ b/components/scifio/src/loci/formats/codec/LZWCodec.java
@@ -402,7 +402,7 @@ public class LZWCodec extends BaseCodec {
             currCodeLength = 12;
             break;
         }
-      } while(currOutPos < output.length);
+      } while (currOutPos < output.length && in.getFilePointer() < in.length());
     }
     catch (ArrayIndexOutOfBoundsException e) {
       throw new FormatException("Invalid LZW data", e);


### PR DESCRIPTION
This is the same as gh-419 but rebased onto develop.

---

Fixes #10525.
