### PR TITLE
Fixed scifio-tools pom.xml

### DIFF
--- a/components/scifio-tools/pom.xml
+++ b/components/scifio-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.6-SNAPSHOT</version>
+    <version>4.5-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>loci-common</artifactId>
+      <artifactId>loci-legacy</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -51,7 +51,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupid>
+      <groupId>${project.groupId}</groupId>
       <artifactId>scifio</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <module>components/ome-xml</module>
     <module>components/scifio</module>
     <module>components/scifio-devel</module>
+    <module>components/scifio-tools</module>
     <module>components/test-suite</module>
     <module>components/stubs/lwf-stubs</module>
   </modules>


### PR DESCRIPTION
Updated the scifio-tools pom.

To test:
run "mvn" components/scifio-tools and verify the "groupid" typo
run "mvn" from top-level and verify scifio-tools is not included in the build
import scifio-tools into eclipse and verify "missing loci-common" component error

You could also manually add scifio-tools as a module in the top-level pom to verify the version mis-match.

All the above should work after applying this patch.
