### PR TITLE
Trestle: fix optimal tile sizes for subresolutions (rebased onto dev_4_4)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/TrestleReader.java
+++ b/components/bio-formats/src/loci/formats/in/TrestleReader.java
@@ -159,7 +159,7 @@ public class TrestleReader extends BaseTiffReader {
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
     try {
-      return (int) ifds.get(getSeries()).getTileWidth();
+      return (int) ifds.get(getCoreIndex()).getTileWidth();
     }
     catch (FormatException e) {
       LOGGER.debug("", e);
@@ -171,7 +171,7 @@ public class TrestleReader extends BaseTiffReader {
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
     try {
-      return (int) ifds.get(getSeries()).getTileLength();
+      return (int) ifds.get(getCoreIndex()).getTileLength();
     }
     catch (FormatException e) {
       LOGGER.debug("", e);


### PR DESCRIPTION
This is the same as gh-449 but rebased onto dev_4_4.

---

Tile sizes should now get progressively smaller with each smaller subresolution, instead of being 448x352 for all resolutions.
