### PR TITLE
Fix the component retrieval methods in Index16ColorModel (rebased onto dev_4_4)

### DIFF
--- a/components/scifio/src/loci/formats/gui/Index16ColorModel.java
+++ b/components/scifio/src/loci/formats/gui/Index16ColorModel.java
@@ -59,7 +59,6 @@ public class Index16ColorModel extends ColorModel {
   private short[] redShort, greenShort, blueShort, alphaShort;
 
   private int pixelBits;
-  private boolean littleEndian;
 
   // -- Constructors --
 
@@ -67,8 +66,6 @@ public class Index16ColorModel extends ColorModel {
     boolean littleEndian) throws IOException
   {
     super(bits);
-
-    this.littleEndian = littleEndian;
 
     if (table == null) throw new IOException("LUT cannot be null");
     for (int i=0; i<table.length; i++) {
@@ -135,29 +132,31 @@ public class Index16ColorModel extends ColorModel {
 
   /* @see java.awt.image.ColorModel#getAlpha(int) */
   public int getAlpha(int pixel) {
-    if (alphaShort != null) return alphaShort[pixel] & 0xffff;
-    return 0xffff;
+    if (alphaShort != null) {
+      return (int) (((alphaShort[pixel] & 0xffff) / 65535.0) * 255.0);
+    }
+    return 0xff;
   }
 
   /* @see java.awt.image.ColorModel#getBlue(int) */
   public int getBlue(int pixel) {
     if (blueShort == null) return 0;
     int blue = blueShort[pixel] & 0xffff;
-    return littleEndian ? DataTools.swap(blue) : blue;
+    return (int) ((blue / 65535.0) * 255.0);
   }
 
   /* @see java.awt.image.ColorModel#getGreen(int) */
   public int getGreen(int pixel) {
     if (greenShort == null) return 0;
     int green = greenShort[pixel] & 0xffff;
-    return littleEndian ? DataTools.swap(green) : green;
+    return (int) ((green / 65535.0) * 255.0);
   }
 
   /* @see java.awt.image.ColorModel#getRed(int) */
   public int getRed(int pixel) {
     if (redShort == null) return 0;
     int red = redShort[pixel] & 0xffff;
-    return littleEndian ? DataTools.swap(red) : red;
+    return (int) ((red / 65535.0) * 255.0);
   }
 
 }


### PR DESCRIPTION
This is the same as gh-451 but rebased onto dev_4_4.

---

Byte-swapping the values is not correct, and getRed(int), getGreen(int),
and getBlue(int) should normalize the return values to 0-255, as per the
Javadoc for ColorModel:

http://docs.oracle.com/javase/1.5.0/docs/api/java/awt/image/ColorModel.html#getRed(int)

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-April/003654.html
