### PR TITLE
Adding partner projects to menu

### DIFF
--- a/docs/sphinx/themes/plonematch/layout.html
+++ b/docs/sphinx/themes/plonematch/layout.html
@@ -37,6 +37,9 @@
                                     <a href="/site/products/bio-formats" accesskey="b" title="">Bio-Formats</a>
                                 </li>
                                 <li>
+                                    <a href="/site/products/partner" accesskey="p" title="">Partner Projects</a>
+                                </li>
+                                <li>
                                     <a href="/site/products/legacy" accesskey="l" title="">Legacy</a>
                                 </li>
                             </ul>
@@ -52,6 +55,9 @@
                                 </li>
                                 <li>
                                     <a href="/site/support/ome-model" accesskey="f" title="">OME Model and Formats</a>
+                                </li>
+                                <li>
+                                    <a href="/site/support/partner" accesskey="p" title="">Partner Projects</a>
                                 </li>
                                 <li>
                                     <a href="/site/support/legacy" accesskey="l" title="">Legacy</a>


### PR DESCRIPTION
Now that the FLIMfit stuff is live in the website, partner projects links need adding to the menu so it matches the plone menu on the main site when that is updated.
