### PR TITLE
NDPI: prevent potential NPE when checking the type

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NDPIReader.java
+++ b/components/bio-formats/src/loci/formats/in/NDPIReader.java
@@ -99,6 +99,9 @@ public class NDPIReader extends BaseTiffReader {
           return false;
         }
         IFD ifd = parser.getFirstIFD();
+        if (ifd == null) {
+          return false;
+        }
         return ifd.containsKey(MARKER_TAG);
       }
       catch (IOException e) {


### PR DESCRIPTION
Fixes NPEs noticed by @rleigh-dundee when testing .lsm files (see #461).  Not to be rebased onto dev_4_4.
