### PR TITLE
Added eclipse support for maven-exec:exec plugin

### DIFF
--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -210,6 +210,36 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>exec</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <developers>

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -113,6 +113,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
 	<executions>
 	  <!-- Generate the metadata interfaces -->
 	  <execution>
@@ -321,6 +322,36 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>exec</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <developers>


### PR DESCRIPTION
This change assumes use of the M2Eclipse plugin for maven integration with eclipse:
http://www.eclipse.org/m2e/download/

With the automated xsd-fu invocation through maven-exec:exec, M2E didn't know how to run the exec goal, which prevents Eclipse use.

This commit adds a pluginManagement specification which allows M2E to handle the exec target.

To test:

Pre-merge:
- In Eclipse, try importing Bio-Formats
  (import -> Maven -> Existing Maven projects -> bio-formats top-level).
- Eclipse should complain about maven-exec-plugin:1.2.1:exec. If you continue the import, there will be compile errors.

Post-merge:
- Import Bio-Formats in Eclipse as before.
- Eclipse may request downloading a plugin at this point. Allow it to do so. Restart Eclipse after the plugin is installed.
- If the build is still red after restarting and rebuilding, do a Maven -> update project -> Force update of snapshots/releases.
- After updating maven dependencies & rebuilding, everything should be green.

Tested in Eclipse Juno, service release 2 (OSX)
