### PR TITLE
Fix licensing note in the SCIFIO legend

### DIFF
--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -101,7 +101,7 @@ Bio-Formats currently supports **$count** formats
 
     SCIFIO 
         This indicates whether format is supported by the
-        :doc:`SCIFIO <developers/scifio>` core library (See the SCIFIO
+        :doc:`SCIFIO <developers/scifio>` core library (see the SCIFIO
         section of the :about_plone:`licensing page <licensing-attribution>`).
 
 .. toctree::

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1224,7 +1224,7 @@ Bio-Formats currently supports **127** formats
 
     SCIFIO 
         This indicates whether format is supported by the
-        :doc:`SCIFIO <developers/scifio>` core library (See the SCIFIO
+        :doc:`SCIFIO <developers/scifio>` core library (see the SCIFIO
         section of the :about_plone:`licensing page <licensing-attribution>`).
 
 .. toctree::


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/10795.
Replace the SCIFIO licensing note at the bottom of the formats table in the docs.
/cc @hflynn
