### PR TITLE
Fix licensing note in the SCIFIO legend (rebased onto develop)

### DIFF
--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -101,7 +101,7 @@ Bio-Formats currently supports **$count** formats
 
     SCIFIO 
         This indicates whether format is supported by the
-        :doc:`SCIFIO <developers/scifio>` core library (See the SCIFIO
+        :doc:`SCIFIO <developers/scifio>` core library (see the SCIFIO
         section of the :about_plone:`licensing page <licensing-attribution>`).
 
 .. toctree::

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1251,7 +1251,7 @@ Bio-Formats currently supports **130** formats
 
     SCIFIO 
         This indicates whether format is supported by the
-        :doc:`SCIFIO <developers/scifio>` core library (See the SCIFIO
+        :doc:`SCIFIO <developers/scifio>` core library (see the SCIFIO
         section of the :about_plone:`licensing page <licensing-attribution>`).
 
 .. toctree::


### PR DESCRIPTION
This is the same as gh-487 but rebased onto develop.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/10795.
Replace the SCIFIO licensing note at the bottom of the formats table in the docs.
/cc @hflynn
