### PR TITLE
Delete temp files used by unit tests

### DIFF
--- a/components/loci-legacy/test/loci/common/utests/providers/BZip2HandleProvider.java
+++ b/components/loci-legacy/test/loci/common/utests/providers/BZip2HandleProvider.java
@@ -59,6 +59,7 @@ class BZip2HandleProvider implements IRandomAccessProvider {
   public IRandomAccess createMock(
       byte[] page, String mode, int bufferSize) throws IOException {
     File pageFile = File.createTempFile("page", ".dat");
+    pageFile.deleteOnExit();
     FileOutputStream out = new FileOutputStream(pageFile);
     out.write(page);
     out.close();
@@ -72,6 +73,7 @@ class BZip2HandleProvider implements IRandomAccessProvider {
     }
 
     pageFile = new File(pageFile.getAbsolutePath() + ".bz2");
+    pageFile.deleteOnExit();
     return new BZip2Handle(pageFile.getAbsolutePath());
   }
 

--- a/components/loci-legacy/test/loci/common/utests/providers/NIOFileHandleProvider.java
+++ b/components/loci-legacy/test/loci/common/utests/providers/NIOFileHandleProvider.java
@@ -60,6 +60,7 @@ class NIOFileHandleProvider implements IRandomAccessProvider {
   public IRandomAccess createMock(
       byte[] page, String mode, int bufferSize) throws IOException {
     File pageFile = File.createTempFile("page", ".dat");
+    pageFile.deleteOnExit();
     OutputStream stream = new FileOutputStream(pageFile);
     try {
       stream.write(page);

--- a/components/scifio-devel/test/ome/scifio/io/utests/providers/BZip2HandleProvider.java
+++ b/components/scifio-devel/test/ome/scifio/io/utests/providers/BZip2HandleProvider.java
@@ -60,6 +60,7 @@ class BZip2HandleProvider implements IRandomAccessProvider {
   public IRandomAccess createMock(
       byte[] page, String mode, int bufferSize) throws IOException {
     File pageFile = File.createTempFile("page", ".dat");
+    pageFile.deleteOnExit();
     FileOutputStream out = new FileOutputStream(pageFile);
     out.write(page);
     out.close();
@@ -73,6 +74,7 @@ class BZip2HandleProvider implements IRandomAccessProvider {
     }
 
     pageFile = new File(pageFile.getAbsolutePath() + ".bz2");
+    pageFile.deleteOnExit();
     return new BZip2Handle(pageFile.getAbsolutePath());
   }
 

--- a/components/scifio-devel/test/ome/scifio/io/utests/providers/NIOFileHandleProvider.java
+++ b/components/scifio-devel/test/ome/scifio/io/utests/providers/NIOFileHandleProvider.java
@@ -61,6 +61,7 @@ class NIOFileHandleProvider implements IRandomAccessProvider {
   public IRandomAccess createMock(
       byte[] page, String mode, int bufferSize) throws IOException {
     File pageFile = File.createTempFile("page", ".dat");
+    pageFile.deleteOnExit();
     OutputStream stream = new FileOutputStream(pageFile);
     try {
       stream.write(page);

--- a/components/scifio/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
+++ b/components/scifio/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
@@ -79,8 +79,9 @@ public class EightBitLosslessJPEG2000Test {
       pixels[index][0] = v;
 
       String file = index + ".jp2";
-      Location.mapId(
-        file, File.createTempFile("test", ".jp2").getAbsolutePath());
+      File tempFile = File.createTempFile("test", ".jp2");
+      tempFile.deleteOnExit();
+      Location.mapId(file, tempFile.getAbsolutePath());
       files.add(file);
 
       IMetadata metadata = MetadataTools.createOMEXMLMetadata();

--- a/components/scifio/test/loci/formats/utests/LosslessJPEG2000Test.java
+++ b/components/scifio/test/loci/formats/utests/LosslessJPEG2000Test.java
@@ -71,10 +71,12 @@ public class LosslessJPEG2000Test {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    Location.mapId(FILE_8,
-      File.createTempFile("test", ".jp2").getAbsolutePath());
-    Location.mapId(FILE_16,
-      File.createTempFile("test", ".jp2").getAbsolutePath());
+    File temp8 = File.createTempFile("test", ".jp2");
+    File temp16 = File.createTempFile("test", ".jp2");
+    temp8.deleteOnExit();
+    temp16.deleteOnExit();
+    Location.mapId(FILE_8, temp8.getAbsolutePath());
+    Location.mapId(FILE_16, temp16.getAbsolutePath());
 
     IMetadata metadata8 = MetadataTools.createOMEXMLMetadata();
     MetadataTools.populateMetadata(metadata8, 0, "foo", false, "XYCZT",


### PR DESCRIPTION
This can be tested by checking that the output of `ls /tmp/` is the same before and after running `ant clean jars test`.
