### PR TITLE
Add kryo-2.21-shaded.jar to loci_tools.jar

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -10,6 +10,7 @@
 
 merged-docs.classpath = ${lib.dir}/forms-1.3.0.jar:\
                         ${lib.dir}/ij.jar:\
+                        ${lib.dir}/kryo-2.21-shaded.jar:\
                         ${lib.dir}/log4j-1.2.15.jar:\
                         ${lib.dir}/native-lib-loader-2.0-SNAPSHOT.jar:\
                         ${lib.dir}/netcdf-4.0.jar:\
@@ -53,6 +54,7 @@ loci-tools.dir       = loci-tools
 loci-tools.libraries = bio-formats.jar \
                        forms-1.3.0.jar \
                        jai_imageio.jar \
+                       kryo-2.21-shaded.jar \
                        loci-legacy.jar \
                        loci_plugins.jar \
                        mdbtools-java.jar \


### PR DESCRIPTION
This should fix classpath issues when using loci_tools.jar by itself.

Noticed by @pwalczysko and @rleigh-dundee in #491.
