### PR TITLE
Update version numbers to 4.4.8

### DIFF
--- a/ant/common.xml
+++ b/ant/common.xml
@@ -52,7 +52,7 @@ Type "ant -p" for a list of targets.
     </if>
 
     <!-- set release version from repository URL -->
-    <property name="release.version" value="4.4.7"/>
+    <property name="release.version" value="4.4.8"/>
   </target>
 
 </project>

--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats/build.properties
+++ b/components/bio-formats/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = bio-formats
 component.jar            = bio-formats.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/mdbtools-java.jar:\
                            ${artifact.dir}/metakit.jar:\

--- a/components/bio-formats/pom.xml
+++ b/components/bio-formats/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/common/build.properties
+++ b/components/common/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = loci-common
 component.jar            = loci-common.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-5.11-jdk15.jar
 component.java-version   = 1.5

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/legacy/ome-editor/pom.xml
+++ b/components/legacy/ome-editor/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/legacy/ome-notes/pom.xml
+++ b/components/legacy/ome-notes/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/loci-plugins/build.properties
+++ b/components/loci-plugins/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = loci_plugins
 component.jar            = loci_plugins.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/bio-formats.jar:\
                            ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/ome-xml.jar:\

--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-tools/pom.xml
+++ b/components/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/metakit/build.properties
+++ b/components/metakit/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = metakit
 component.jar            = metakit.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/loci-common.jar:\
                            ${lib.dir}/testng-5.11-jdk15.jar
 component.java-version   = 1.5

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/native/benchmark/pom.xml
+++ b/components/native/benchmark/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
   </parent>
 
   <artifactId>pom-scifio-native-benchmark</artifactId>

--- a/components/native/bf-itk-jace/pom.xml
+++ b/components/native/bf-itk-jace/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-jace</artifactId>

--- a/components/native/bf-itk-jni/pom.xml
+++ b/components/native/bf-itk-jni/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-jni</artifactId>

--- a/components/native/bf-itk-pipe/pom.xml
+++ b/components/native/bf-itk-pipe/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-pipe</artifactId>

--- a/components/native/pom.xml
+++ b/components/native/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-io/build.properties
+++ b/components/ome-io/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome-io
 component.jar            = ome-io.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/ome-xml.jar:\
                            ${artifact.dir}/scifio.jar:\

--- a/components/ome-io/pom.xml
+++ b/components/ome-io/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-plugins/build.properties
+++ b/components/ome-plugins/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome_plugins
 component.jar            = ome_plugins.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/scifio.jar:\
                            ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/loci_plugins.jar:\

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-tools/pom.xml
+++ b/components/ome-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-xml/build.properties
+++ b/components/ome-xml/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome-xml
 component.jar            = ome-xml.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-5.11-jdk15.jar
 component.java-version   = 1.5

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-tools/build.properties
+++ b/components/scifio-tools/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = scifio-tools
 component.jar            = scifio-tools.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/jai_imageio.jar:\
                            ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/lwf-stubs.jar:\

--- a/components/scifio-tools/pom.xml
+++ b/components/scifio-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/build.properties
+++ b/components/scifio/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = scifio
 component.jar            = scifio.jar
-component.version        = 4.4.7
+component.version        = 4.4.8
 component.classpath      = ${artifact.dir}/jai_imageio.jar:\
                            ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/lwf-stubs.jar:\

--- a/components/scifio/cppwrap/minimum_writer.cpp
+++ b/components/scifio/cppwrap/minimum_writer.cpp
@@ -42,8 +42,8 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.4.7.h"
-#include "ome-xml-4.4.7.h"
+#include "scifio-4.4.8.h"
+#include "ome-xml-4.4.8.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Boolean;

--- a/components/scifio/cppwrap/showinf.cpp
+++ b/components/scifio/cppwrap/showinf.cpp
@@ -42,8 +42,8 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.4.7.h"
-#include "loci-common-4.4.7.h"
+#include "scifio-4.4.8.h"
+#include "loci-common-4.4.8.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Object;

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/src/loci/formats/FormatTools.java
+++ b/components/scifio/src/loci/formats/FormatTools.java
@@ -173,7 +173,7 @@ public final class FormatTools {
   public static final String DATE = "@date@";
 
   /** Version number of this release. */
-  public static final String VERSION = "4.4.7";
+  public static final String VERSION = "4.4.8";
 
   // -- Constants - domains --
 

--- a/components/scifio/src/loci/formats/UpgradeChecker.java
+++ b/components/scifio/src/loci/formats/UpgradeChecker.java
@@ -71,7 +71,7 @@ public class UpgradeChecker {
   // -- Constants --
 
   /** Version number of the latest stable release. */
-  public static final String STABLE_VERSION = "4.4.7";
+  public static final String STABLE_VERSION = "4.4.8";
 
   /** Location of the OME continuous integration server. */
   public static final String CI_SERVER = "http://hudson.openmicroscopy.org.uk";

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.7</version>
+    <version>4.4.8</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>loci</groupId>
   <artifactId>pom-scifio</artifactId>
-  <version>4.4.7</version>
+  <version>4.4.8</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>


### PR DESCRIPTION
Bump the version number of Bio-Formats to 4.4.8 even though there are no code changes. This maintains the version synchronization, but it should not be necessary (or even useful) for users to upgrade.
