### PR TITLE
Prevent false positives in open file handle test

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -93,7 +93,7 @@ public class FileHandleTest {
       String s = finalHandles.get(i);
       if (s.endsWith("libnio.so") || s.endsWith("resources.jar") ||
         s.startsWith("/usr/lib/") || s.startsWith("/opt/") ||
-        s.indexOf("turbojpeg") > 0)
+        s.indexOf("turbojpeg") > 0 || s.indexOf("/jre/") > 0)
       {
         finalHandles.remove(s);
         i--;
@@ -125,6 +125,9 @@ public class FileHandleTest {
         if (line == null) {
           break;
         }
+      }
+      catch (IllegalThreadStateException e) {
+        LOGGER.trace("", e);
       }
       catch (Exception e) {
         LOGGER.warn("", e);


### PR DESCRIPTION
Noticed by Jenkins (BIOFORMATS-merge-develop) when using Java 1.5.
