### PR TITLE
Memoizer: use Location instead of File to represent 'id'

### DIFF
--- a/components/scifio/src/loci/formats/Memoizer.java
+++ b/components/scifio/src/loci/formats/Memoizer.java
@@ -388,7 +388,7 @@ public class Memoizer extends ReaderWrapper {
   public void setId(String id) throws FormatException, IOException {
     StopWatch sw = stopWatch();
     try {
-      realFile = new Location(id); // TODO: Can likely fail.
+      realFile = new Location(id);
       memoFile = getMemoFile(id);
 
       if (memoFile == null) {


### PR DESCRIPTION
This is consistent with other readers, in that it does not assume that
'id' is a file on disk.
