### PR TITLE
ScanR: clear the pixel buffer when an invalid TIFF is found

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ScanrReader.java
+++ b/components/bio-formats/src/loci/formats/in/ScanrReader.java
@@ -235,6 +235,7 @@ public class ScanrReader extends FormatReader {
       }
       catch (FormatException e) {
         reader.close();
+        Arrays.fill(buf, (byte) 0);
         return buf;
       }
 


### PR DESCRIPTION
This prevents `openBytes` from returning garbage data when the real pixel data is missing.

/cc @chris-allan
