### PR TITLE
Prevent false positives in open file handle test (rebased onto dev_4_4)

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -92,7 +92,8 @@ public class FileHandleTest {
     for (int i=0; i<finalHandles.size(); i++) {
       String s = finalHandles.get(i);
       if (s.endsWith("libnio.so") || s.endsWith("resources.jar") ||
-        s.startsWith("/usr/lib/") || s.startsWith("/opt/"))
+        s.startsWith("/usr/lib/") || s.startsWith("/opt/") ||
+        s.indexOf("/jre/") > 0)
       {
         finalHandles.remove(s);
         i--;
@@ -124,6 +125,9 @@ public class FileHandleTest {
         if (line == null) {
           break;
         }
+      }
+      catch (IllegalThreadStateException e) {
+        LOGGER.trace("", e);
       }
       catch (Exception e) {
         LOGGER.warn("", e);


### PR DESCRIPTION
See gh-504.  This PR should make this job green again: http://hudson.openmicroscopy.org.uk/view/Bio-Formats/job/BIOFORMATS-merge-stable/
