### PR TITLE
Restrict ImageJ version to < 1.47o (rebased onto dev_4_4)

### DIFF
--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId>
-      <version>[1.45s,)</version>
+      <version>[1.45s,1.47o)</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId>
-      <version>[1.45s,)</version>
+      <version>[1.45s,1.47o)</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is the same as gh-502 but rebased onto dev_4_4.

---

This prevents us from running into a bug in ImageStack introduced in
1.47o.
