### PR TITLE
Remove Maven version detection (rebased onto dev_4_4)

### DIFF
--- a/components/scifio/cppwrap/build.sh
+++ b/components/scifio/cppwrap/build.sh
@@ -40,25 +40,8 @@
 #            which generates and builds the Bio-Formats C++ bindings.
 
 cd "$(dirname "$0")"/..
-
-# find Maven v2 executable
-VER=`mvn -v | head -1 | sed -e 's/Apache Maven //' | sed 's/\..*//'`
-if [ "$VER" = "2" ]
-then
-  MVN="mvn"
-else
-  VER=`mvn2 -v | head -1 | sed -e 's/Apache Maven //' | sed 's/\..*//'`
-  if [ "$VER" = "2" ]
-  then
-    MVN="mvn2"
-  else
-    echo "Maven v2.x is required to build."
-    exit 1
-  fi
-fi
-
 set -ex
-$MVN -DskipTests clean package cppwrap:wrap dependency:copy-dependencies
+mvn -DskipTests clean package cppwrap:wrap dependency:copy-dependencies
 cd target/cppwrap
 mkdir -p build
 cd build


### PR DESCRIPTION
This is the same as gh-180 but rebased onto dev_4_4.

---

This reverts commit
43a2e68f62269d136e743b9878bcdf362924d4eb.

It seems that cppwrap works properly with Maven 3.x now, so we simplify
the build script to just use "mvn" all the time, as you would expect.
