### PR TITLE
Deploy -sources JARs to Maven repository (rebased onto dev_4_4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
This is the same as gh-225 but rebased onto dev_4_4.

---

For a number of reasons, it is very useful to have these sources JARs
deployed. For example, in Eclipse, you can right-click on a Maven JAR
dependency and choose Maven > Download Sources, and it will then
automatically download the sources JAR and link them for debugging.
