### PR TITLE
Add .mailmap for better "git shortlog" reports (rebased onto dev_4_4)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Chris Allan <callan@glencoesoftware.com> <callan@lifesci.dundee.ac.uk>
+Curtis Rueden <ctrueden@wisc.edu> <unknown@unknown>
+Jean-Marie Burel <j.burel@dundee.ac.uk>
+Johannes Schindelin <johannes.schindelin@gmx.de> <Johannes.Schindelin@gmx.de>
+Josh Moore <josh@glencoesoftware.com> <josh.moore@gmx.de>
+Kristin Briney <briney@wisc.edu>
+Mark Hiner <hiner@wisc.edu> <hinerm@gmail.com>
+Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
+Premysl Fiala <premysl.fiala@lim.cz>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>


### PR DESCRIPTION
This is the same as gh-308 but rebased onto dev_4_4.

---

None
