### PR TITLE
Adding kryo jar to classpath for 10.7 compile

### DIFF
--- a/components/bio-formats/build.properties
+++ b/components/bio-formats/build.properties
@@ -18,6 +18,7 @@ component.classpath      = ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/scifio-devel.jar:\
                            ${artifact.dir}/turbojpeg.jar:\
                            ${lib.dir}/forms-1.3.0.jar:\
+                           ${lib.dir}/kryo-2.21-shaded.jar:\
                            ${lib.dir}/netcdf-4.0.jar:\
                            ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-6.8.jar

--- a/components/loci-legacy/build.properties
+++ b/components/loci-legacy/build.properties
@@ -11,6 +11,7 @@ component.jar            = loci-legacy.jar
 component.version        = 4.5-DEV
 component.classpath      = ${artifact.dir}/scifio-devel.jar:\
                            ${lib.dir}/forms-1.3.0.jar:\
+                           ${lib.dir}/kryo-2.21-shaded.jar:\
                            ${lib.dir}/log4j-1.2.15.jar:\
                            ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-6.8.jar


### PR DESCRIPTION
'ant compile' fails under Mac OS 10.7 but works under 10.8
This adds the kryo jar to the two components that use it.
