### PR TITLE
Adjust logging of setId

### DIFF
--- a/components/scifio/src/loci/formats/FormatReader.java
+++ b/components/scifio/src/loci/formats/FormatReader.java
@@ -1328,7 +1328,7 @@ public abstract class FormatReader extends FormatHandler
 
   /* @see IFormatHandler#setId(String) */
   public void setId(String id) throws FormatException, IOException {
-    LOGGER.info("{} initializing {}", this.getClass().getSimpleName(), id);
+    LOGGER.debug("{} initializing {}", this.getClass().getSimpleName(), id);
     if (!id.equals(currentId)) {
       initFile(id);
 

--- a/components/scifio/src/loci/formats/ImageReader.java
+++ b/components/scifio/src/loci/formats/ImageReader.java
@@ -756,7 +756,10 @@ public class ImageReader implements IFormatReader {
 
   /* @see IFormatHandler#setId(String) */
   public void setId(String id) throws FormatException, IOException {
-    getReader(id).setId(id);
+    IFormatReader currentReader = getReader(id);
+    LOGGER.info("{} initializing {}",
+      currentReader.getClass().getSimpleName(), id);
+    currentReader.setId(id);
   }
 
   /* @see IFormatHandler#close() */


### PR DESCRIPTION
ImageReader now logs setId at INFO, while FormatReader logs setId at
DEBUG.  This means that the top-level call to setId should show up by
default, but setId on any constituent files (e.g. TIFFs in a plate) will
only show up if the log level is changed to DEBUG or TRACE.

This should substantially clean up the INFO-level logs for multi-file datasets.
