### PR TITLE
Adding OME 5 product menu (rebased onto develop)

### DIFF
--- a/docs/sphinx/themes/plonematch/layout.html
+++ b/docs/sphinx/themes/plonematch/layout.html
@@ -40,6 +40,9 @@
                                     <a href="/site/products/partner" accesskey="p" title="">Partner Projects</a>
                                 </li>
                                 <li>
+                                    <a href="/site/products/ome5" accesskey="5" title="">OME 5</a>
+                                </li>
+                                <li>
                                     <a href="/site/products/legacy" accesskey="l" title="">Legacy</a>
                                 </li>
                             </ul>


### PR DESCRIPTION
This is the same as gh-545 but rebased onto develop.

---

Adding OME 5 product page to menu shown from docs pages.
