### PR TITLE
SEQ: do not automatically pick up files with the .seq suffix

### DIFF
--- a/components/bio-formats/src/loci/formats/in/SEQReader.java
+++ b/components/bio-formats/src/loci/formats/in/SEQReader.java
@@ -56,6 +56,8 @@ public class SEQReader extends BaseTiffReader {
   /** Frame rate. */
   private static final int IMAGE_PRO_TAG_2 = 40105;
 
+  private static final int IMAGE_PRO_TAG_3 = 40100;
+
   // -- Constructor --
 
   /** Constructs a new Image-Pro SEQ reader. */
@@ -73,8 +75,11 @@ public class SEQReader extends BaseTiffReader {
     parser.setDoCaching(false);
     IFD ifd = parser.getFirstIFD();
     if (ifd == null) return false;
-    Object tag = ifd.get(IMAGE_PRO_TAG_1);
-    return tag != null && (tag instanceof short[]);
+    parser.fillInIFD(ifd);
+    Object tag1 = ifd.get(IMAGE_PRO_TAG_1);
+    Object tag3 = ifd.get(IMAGE_PRO_TAG_3);
+    return (tag1 != null && (tag1 instanceof short[])) || (tag3 != null &&
+      (tag3 instanceof int[]));
   }
 
   // -- Internal BaseTiffReader API methods --


### PR DESCRIPTION
Reported by Stéphane Dallongeville.

To test, copy any TIFF file to `test.seq`.  With this PR, the reader used for `test.seq` should match the reader used for the original TIFF.  Without this PR, `test.seq` should be read using `SEQReader`.  The name of the used reader can be checked using `showinf`.
