### PR TITLE
Zeiss LSM: use the longer display channel name

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/bio-formats/src/loci/formats/in/ZeissLSMReader.java
@@ -170,7 +170,7 @@ public class ZeissLSMReader extends FormatReader {
 
   private int nextLaser = 0, nextDetector = 0;
   private int nextFilter = 0, nextDichroicChannel = 0, nextDichroic = 0;
-  private int nextDataChannel = 0, nextIllumChannel = 0, nextDetectChannel = 0;
+  private int nextIllumChannel = 0, nextDetectChannel = 0;
   private boolean splitPlanes = false;
   private double zoom;
   private Vector<String> imageNames;
@@ -179,6 +179,7 @@ public class ZeissLSMReader extends FormatReader {
   private int dimensionM, dimensionP;
   private Hashtable<String, Integer> seriesCounts;
   private String userName;
+  private String[][] channelNames;
 
   private double originX, originY, originZ;
 
@@ -249,7 +250,7 @@ public class ZeissLSMReader extends FormatReader {
       tiffParser = null;
       nextLaser = nextDetector = 0;
       nextFilter = nextDichroicChannel = nextDichroic = 0;
-      nextDataChannel = nextIllumChannel = nextDetectChannel = 0;
+      nextIllumChannel = nextDetectChannel = 0;
       splitPlanes = false;
       zoom = 0;
       imageNames = null;
@@ -268,6 +269,7 @@ public class ZeissLSMReader extends FormatReader {
       originX = originY = originZ = 0d;
       userName = null;
       acquiredDate.clear();
+      channelNames = null;
     }
   }
 
@@ -434,6 +436,7 @@ public class ZeissLSMReader extends FormatReader {
     lsmFilenames = validFiles.toArray(new String[validFiles.size()]);
 
     core = new CoreMetadata[seriesCount];
+    channelNames = new String[seriesCount][];
     ifdsList = new Vector<IFDList>();
     ifdsList.setSize(core.length);
 
@@ -1040,15 +1043,19 @@ public class ZeissLSMReader extends FormatReader {
         // read the name of each channel
 
         if (namesOffset > 0) {
-          in.seek(channelColorsOffset + namesOffset + 4);
+          in.seek(channelColorsOffset + namesOffset);
+
+          channelNames[series] = new String[getSizeC()];
 
           for (int i=0; i<getSizeC(); i++) {
             if (in.getFilePointer() >= in.length() - 1) break;
             // we want to read until we find a null char
-            String name = in.readCString();
+            int length = in.readInt();
+            String name = in.readString(length);
             if (name.length() <= 128) {
               addSeriesMeta("ChannelName" + i, name);
             }
+            channelNames[series][i] = name;
           }
         }
       }
@@ -1098,7 +1105,7 @@ public class ZeissLSMReader extends FormatReader {
 
         nextLaser = nextDetector = 0;
         nextFilter = nextDichroicChannel = nextDichroic = 0;
-        nextDataChannel = nextDetectChannel = nextIllumChannel = 0;
+        nextDetectChannel = nextIllumChannel = 0;
 
         Vector<SubBlock> blocks = new Vector<SubBlock>();
 
@@ -1233,6 +1240,9 @@ public class ZeissLSMReader extends FormatReader {
 
       for (int i=0; i<getSizeC(); i++) {
         store.setChannelColor(channelColor[i], series, i);
+        if (channelNames[series] != null) {
+          store.setChannelName(channelNames[series][i], series, i);
+        }
       }
 
       int stampIndex = 0;
@@ -1322,14 +1332,6 @@ public class ZeissLSMReader extends FormatReader {
       Track track = (Track) block;
       if (track.acquire) {
         store.setPixelsTimeIncrement(track.timeIncrement, series);
-      }
-    }
-    else if (block instanceof DataChannel) {
-      DataChannel channel = (DataChannel) block;
-      if (channel.name != null && nextDataChannel < getSizeC() &&
-        channel.acquire)
-      {
-        store.setChannelName(channel.name, series, nextDataChannel++);
       }
     }
     else if (block instanceof DetectionChannel) {


### PR DESCRIPTION
...instead of the shorter data channel name.
