### PR TITLE
AFI: only initialize internal SVS readers once per file

### DIFF
--- a/components/bio-formats/src/loci/formats/in/AFIReader.java
+++ b/components/bio-formats/src/loci/formats/in/AFIReader.java
@@ -65,7 +65,7 @@ public class AFIReader extends FormatReader {
   // -- Fields --
 
   private ArrayList<String> pixels = new ArrayList<String>();
-  private ChannelSeparator reader = new ChannelSeparator(new SVSReader());
+  private ChannelSeparator[] reader;
 
   // -- Constructor --
 
@@ -93,12 +93,12 @@ public class AFIReader extends FormatReader {
 
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   public int getOptimalTileWidth() {
-    return reader.getOptimalTileWidth();
+    return reader[0].getOptimalTileWidth();
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   public int getOptimalTileHeight() {
-    return reader.getOptimalTileHeight();
+    return reader[0].getOptimalTileHeight();
   }
 
   /* @see loci.formats.IFormatReader#openThumbBytes(int) */
@@ -106,9 +106,8 @@ public class AFIReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader.setId(pixels.get(0));
-      reader.setCoreIndex(getCoreIndex());
-      return reader.openThumbBytes(no);
+      reader[0].setCoreIndex(getCoreIndex());
+      return reader[0].openThumbBytes(no);
     }
 
     int coreIndex = getCoreIndex();
@@ -128,18 +127,16 @@ public class AFIReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader.setId(pixels.get(0));
-      reader.setCoreIndex(getCoreIndex());
-      return reader.openBytes(no, buf, x, y, w, h);
+      reader[0].setCoreIndex(getCoreIndex());
+      return reader[0].openBytes(no, buf, x, y, w, h);
     }
 
     int[] coords = getZCTCoords(no);
     int channel = coords[1];
     int index = getIndex(coords[0], 0, coords[2]);
 
-    reader.setId(pixels.get(channel));
-    reader.setCoreIndex(getCoreIndex());
-    return reader.openBytes(index, buf, x, y, w, h);
+    reader[channel].setCoreIndex(getCoreIndex());
+    return reader[channel].openBytes(index, buf, x, y, w, h);
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -167,7 +164,14 @@ public class AFIReader extends FormatReader {
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
     if (!fileOnly) {
-      reader.close();
+      if (reader != null) {
+        for (ChannelSeparator r : reader) {
+          if (r != null) {
+            r.close();
+          }
+        }
+      }
+      reader = null;
       pixels.clear();
     }
   }
@@ -191,6 +195,7 @@ public class AFIReader extends FormatReader {
 
     String parent = new Location(id).getAbsoluteFile().getParent();
     String[] channelNames = new String[pixels.size()];
+    reader = new ChannelSeparator[pixels.size()];
 
     for (int i=0; i<pixels.size(); i++) {
       String file = pixels.get(i);
@@ -202,12 +207,13 @@ public class AFIReader extends FormatReader {
       }
 
       pixels.set(i, new Location(parent, file).getAbsolutePath());
+
+      reader[i] = new ChannelSeparator(new SVSReader());
+      reader[i].setFlattenedResolutions(hasFlattenedResolutions());
+      reader[i].setId(pixels.get(i));
     }
 
-    reader.setFlattenedResolutions(hasFlattenedResolutions());
-    reader.setId(pixels.get(0));
-
-    core = reader.getCoreMetadataList();
+    core = reader[0].getCoreMetadataList();
 
     for (int i=0; i<core.size() - EXTRA_IMAGES; i++) {
       CoreMetadata c = core.get(i);
@@ -238,8 +244,7 @@ public class AFIReader extends FormatReader {
       Timestamp[] datestamp = new Timestamp[pixels.size()];
 
       for (int c=0; c<pixels.size(); c++) {
-        reader.setId(pixels.get(c));
-        SVSReader baseReader = (SVSReader) reader.getReader();
+        SVSReader baseReader = (SVSReader) reader[c].getReader();
         emission[c] = baseReader.getEmission();
         excitation[c] = baseReader.getExcitation();
         exposure[c] = baseReader.getExposureTime();


### PR DESCRIPTION
This prevents us from having to re-initialize the internal reader on every call to openBytes.
