### PR TITLE
Correct use of asterisk in docs.

### DIFF
--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -264,7 +264,7 @@ Other useful things
 | -format      | read file with a particular reader (e.g., ZeissZVI)      |
 +--------------+----------------------------------------------------------+
 
-* = may result in loss of precision
+\* = may result in loss of precision
 
 - If you wish to test using TestNG, 
   :source:`loci.tests.testng.FormatReaderTest <components/test-suite/src/loci/tests/testng/FormatReaderTest.java>`


### PR DESCRIPTION
In the developer docs (Bio-Formats file format reader guide), the asterisk under the table at the end of the page was render as a bullet point. This corrects the issue.
