### PR TITLE
Correct use of asterisk in docs. (rebased onto dev_4_4)

### DIFF
--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -263,7 +263,7 @@ Other useful things
 | -format      | read file with a particular reader (e.g., ZeissZVI)      |
 +--------------+----------------------------------------------------------+
 
-* = may result in loss of precision
+\* = may result in loss of precision
 
 - If you wish to test using TestNG, 
   :source:`loci.tests.testng.FormatReaderTest <components/test-suite/src/loci/tests/testng/FormatReaderTest.java>`


### PR DESCRIPTION
This is the same as gh-551 but rebased onto dev_4_4.

---

In the developer docs (Bio-Formats file format reader guide), the asterisk under the table at the end of the page was render as a bullet point. This corrects the issue.
