### PR TITLE
Updated ITK build instructions

### DIFF
--- a/docs/sphinx/users/itk/index.txt
+++ b/docs/sphinx/users/itk/index.txt
@@ -18,83 +18,51 @@ used). Secondly, the architecture provides a distribution method for
 open source software, like Bio-Formats, which have licenses that might
 otherwise exclude them from being used with other software suites.
 
-The Bio-Formats ITK plug-in provides an ImageIO plug-in for ITK that uses
-`Bio-Formats <http://farsight-toolkit.org/wiki/Bio-Formats>`_ to read
-and write supported life sciences file formats. This plug-in allows any
-program built on ITK to read any of the image types supported by
-Bio-Formats.
+The `SCIFIO ImageIO <https://github.com/scifio/scifio-imageio>`_ plugin provides an for ITK imageIO base that uses `Bio-Formats <http://farsight-toolkit.org/wiki/Bio-Formats>`_ to read and write supported life sciences file formats. This plugin allows any program built on ITK to read any of the image types supported by Bio-Formats.
 
 Prerequisites
 -------------
 
-If you have not done so already, `download <http://itk.org/ITK/resources/software.html>`_ and build ITK.
-Note that BF-ITK requires ITK 3.20.0 or newer. It should also work with the latest
-`ITK source from git <http://www.itk.org/Wiki/ITK/Git>`_. BF-ITK also requires ITK to be built with the following
-flags set:
-
-* ITK_USE_REVIEW = ON
-* BUILD_SHARED_LIBS = ON
-
-You will also need `Git <http://git-scm.com/>`_, `Ant <http://ant.apache.org/>`_ and
-`CMake <http://www.cmake.org/>`_ for the installation
-tutorial.
+You should have `CMake <http://www.cmake.org/>`_ installed, to allow the configuration of ITK builds. If you want the latest ITK development build, you will need `Git <http://git-scm.com/>`_ as well.
 
 Installation
 ------------
 
-#. Clone the :doc:`Bio-Formats source
-   code </developers/source-code>`::
+Simply download ITK from the `Kitware software page <http://www.itk.org/ITK/resources/software.html>`_. Using CMake, set the following configuration flag:
 
-        git clone git://github.com/openmicroscopy/bioformats.git
+(NOTE: this flag is only visible in "advanced" mode within CMake)
 
-#. Compile the Bio-Formats tools bundle::
+* Fetch_SCIFIO = ON
 
-        cd bioformats
-        ant tools
+If you would like to use the utility classes included with the SCIFIO imageIO, also set the flag:
 
-#. Configure your BF-ITK build::
+* BUILD_TESTING = ON
 
-        mkdir ../bf-itk-build && cd ../bf-itk-build
-        ccmake ../bioformats/components/native/bf-itk
-
-   If you prefer, you can use cmake-gui rather than ccmake to configure
-   the project. If you receive a configuration error stating that the
-   location of ITK cannot be found, then set ``ITK_DIR`` to your binary
-   build of ITK.
-
-#. Compile BF-ITK:
-
-   On Linux and OSX, simply run ``make``, or on Windows ``start BioFormatsImageIO.sln``.
-
-   This will open the solution in Visual Studio. Select ``Debug`` or
-   ``Release`` from the drop-down menu, as appropriate. Press ``F7``
-   to compile, or select ``Build Solution`` from the Build menu.
-
-
-#. Package BF-ITK build (optional):
-
-   By default, all necessary libraries including ``loci_tools.jar`` will
-   be copied to ``dist/bf-itk`` inside the BF-ITK build folder.
-
-   If desired, everything can be packaged into a single archive by running:
-
-   On Linux and OSX, ``make package`` or on Windows, click on the ``PACKAGE`` target in the Visual Studio interface.
-   Then choose ``Build PACKAGE`` from the Build menu.
-
+Then build ITK as normal. It will automatically download and build the latest SCIFIO imageIO plugin.
 Usage
------
 
-To use BF-ITK, you must set your ``ITK_AUTOLOAD_PATH`` to point to the
-folder containing the BF-ITK binaries (including the **BioFormatsIO**
-and **BioFormatsIOPlugin** shared libraries, and the **loci_tools.jar**
-Java library). For example::
+Applications using the installed ITK should automatically defer to the SCIFIO ImageIO, and thus Bio-Formats, when reading or saving images not natively supported by ITK.
 
-     export ITK_AUTOLOAD_PATH=~/bf-itk-build/dist/bf-itk
+To use the SCIFIO test utility, run::
 
-Once this variable is set, ITK's ImageIO routines will automatically use
-Bio-Formats as needed to read and write supported file formats.
+   ITKIOSCIFIOTestDriver
 
-If you build ITK with examples, you can test using various programs::
+from your *${ITK_BUILD}/bin* directory. This program has four separate applications that can be directly invoked using the syntax::
 
-     cd ~/itk-build/bin
-     ./ImageReadWrite ~/data/inputFile.ics ~/data/outputFile.mha
+   ITKIOSCIFIOTestDriver [Program to run] [Program arguments]
+
+The programs are as follows:
+
+* itkSCIFIOImageInfoTest - Displays basic information to verify the SCIFIO imageIO works, using .fake images.
+* itkSCIFIOImageIOTest - Reads an input image, and writes it out as a specified type
+* itkRGBSCIFIOImageTest - Same as itkSCIFIOImageIOTest but for `RGB <http://www.itk.org/Doxygen/html/classitk_1_1RGBPixel.html>`_ types
+* itkVectorImageSCIFIOImageIOTest - Same as itkSCIFIOImageIOTest but for `VectorImage <http://www.itk.org/Doxygen/html/classitk_1_1VectorImage.html>`_ type
+
+For example, to convert a .czi image to a .tif, you would use::
+
+   ITKIOSCIFIOTestDriver itkSCIFIOImageIOTest in.czi out.tif
+
+Troubleshooting
+---------------
+
+Please send any issues, suggestions or requests to the `insight users mailing list <http://www.itk.org/ITK/help/mailing.html>`_.


### PR DESCRIPTION
Changed the ITK build and usage instructions to reflect that a SCIFIO
ImageIO plugin can now be automatically fetched by the latest ITK
builds.
