### PR TITLE
Complete revert of Image->Transform

### DIFF
--- a/components/specification/released-schema/2013-06/ROI.xsd
+++ b/components/specification/released-schema/2013-06/ROI.xsd
@@ -108,7 +108,7 @@
 					<xsd:element ref="Polygon" minOccurs="1" maxOccurs="1"/>
 					<xsd:element ref="Label" minOccurs="1" maxOccurs="1"/>
 				</xsd:choice>
-				<xsd:element name="Transform" type="OME:AffineTransform" minOccurs="0" maxOccurs="1">
+				<xsd:element name="Transform" type="AffineTransform" minOccurs="0" maxOccurs="1">
 					<xsd:annotation>
 						<xsd:documentation>
 							This is a matrix used to transform the shape.
@@ -532,6 +532,26 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+
+
+	<xsd:complexType name="AffineTransform">
+		<xsd:annotation>
+			<xsd:documentation>
+				This is a matrix used to transform the shape.
+				--             --
+				| A00, A01, A02 |
+				| A10, A11, A12 |
+				| 0,   0,   1   |
+				--             --
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="A00" use="required" type="xsd:float"/>
+		<xsd:attribute name="A10" use="required" type="xsd:float"/>
+		<xsd:attribute name="A01" use="required" type="xsd:float"/>
+		<xsd:attribute name="A11" use="required" type="xsd:float"/>
+		<xsd:attribute name="A02" use="required" type="xsd:float"/>
+		<xsd:attribute name="A12" use="required" type="xsd:float"/>
+	</xsd:complexType>
 
 	<xsd:simpleType name="ROIID"> <!-- top level definition -->
 		<xsd:restriction base="OME:LSID">

--- a/components/specification/released-schema/2013-06/ome.xsd
+++ b/components/specification/released-schema/2013-06/ome.xsd
@@ -266,18 +266,6 @@
 				<xsd:element ref="ObjectiveSettings" minOccurs="0" maxOccurs="1"/>
 				<xsd:element ref="ImagingEnvironment" minOccurs="0" maxOccurs="1"/>
 				<xsd:element ref="StageLabel" minOccurs="0" maxOccurs="1"/>
-				<xsd:element name="Transform" type="AffineTransform" minOccurs="0" maxOccurs="1">
-					<xsd:annotation>
-						<xsd:documentation>
-							This is a matrix used to transform the image. It can
-							be used by stitching, tracking or visualization tools.
-							The element has 6 xsd:float attributes. If the element
-							is present then all 6 values must be included.
-							e.g. this could record a field rotation, or a flip 
-							in the axes of an image.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:element>
 				<xsd:element ref="Pixels" minOccurs="1" maxOccurs="1"/>
 				<xsd:element ref="ROI:ROIRef" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>
@@ -1304,24 +1292,6 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-	</xsd:complexType>
-	<xsd:complexType name="AffineTransform">
-		<xsd:annotation>
-			<xsd:documentation>
-				This is a matrix used to transform a shape or image.
-				--             --
-				| A00, A01, A02 |
-				| A10, A11, A12 |
-				| 0,   0,   1   |
-				--             --
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:attribute name="A00" use="required" type="xsd:float"/>
-		<xsd:attribute name="A10" use="required" type="xsd:float"/>
-		<xsd:attribute name="A01" use="required" type="xsd:float"/>
-		<xsd:attribute name="A11" use="required" type="xsd:float"/>
-		<xsd:attribute name="A02" use="required" type="xsd:float"/>
-		<xsd:attribute name="A12" use="required" type="xsd:float"/>
 	</xsd:complexType>
 	<xsd:simpleType name="Hex40">
 		<xsd:annotation>


### PR DESCRIPTION
Additional changes needed to fully revert:
https://github.com/qidane/bioformats/commit/d3c2ceb9b607c40411f89e1e67ee24aad0e06f95
As the changes were copied into released-schema/2013-06 between the original
commit and the revert, so the changes ended up still in released-schema/2013-06
version.
