### PR TITLE
Update version numbers to 5.0.0-beta1

### DIFF
--- a/ant/common.xml
+++ b/ant/common.xml
@@ -53,7 +53,7 @@ Type "ant -p" for a list of targets.
     </if>
 
     <!-- set release version from repository URL -->
-    <property name="release.version" value="4.5-DEV"/>
+    <property name="release.version" value="5.0.0-beta1"/>
   </target>
 
 </project>

--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats/build.properties
+++ b/components/bio-formats/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = bio-formats
 component.jar            = bio-formats.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/mdbtools-java.jar:\
                            ${artifact.dir}/metakit.jar:\

--- a/components/bio-formats/pom.xml
+++ b/components/bio-formats/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/loci-common/pom.xml
+++ b/components/loci-common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-legacy/build.properties
+++ b/components/loci-legacy/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = loci-legacy
 component.jar            = loci-legacy.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/scifio-devel.jar:\
                            ${lib.dir}/forms-1.3.0.jar:\
                            ${lib.dir}/kryo-2.21-shaded.jar:\

--- a/components/loci-legacy/pom.xml
+++ b/components/loci-legacy/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-plugins/build.properties
+++ b/components/loci-plugins/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = loci_plugins
 component.jar            = loci_plugins.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/bio-formats.jar:\
                            ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/ome-xml.jar:\

--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-tools/pom.xml
+++ b/components/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/metakit/build.properties
+++ b/components/metakit/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = metakit
 component.jar            = metakit.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/scifio-devel.jar:\
                            ${lib.dir}/testng-6.8.jar

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/native/bf-itk/pom.xml
+++ b/components/native/bf-itk/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk</artifactId>

--- a/components/native/pom.xml
+++ b/components/native/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-io/build.properties
+++ b/components/ome-io/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome-io
 component.jar            = ome-io.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/ome-xml.jar:\
                            ${artifact.dir}/scifio.jar:\

--- a/components/ome-io/pom.xml
+++ b/components/ome-io/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-plugins/build.properties
+++ b/components/ome-plugins/build.properties
@@ -9,7 +9,7 @@
 component.name           = ome_plugins
 component.jar            = ome_plugins.jar
 <<<<<<< HEAD
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/loci_plugins.jar:\
                            ${artifact.dir}/ome-io.jar:\

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-tools/pom.xml
+++ b/components/ome-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-xml/bin/build.properties
+++ b/components/ome-xml/bin/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome-xml
 component.jar            = ome-xml.jar
-component.version        = 4.3.3-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-6.8.jar
 component.java-version   = 1.5

--- a/components/ome-xml/build.properties
+++ b/components/ome-xml/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = ome-xml
 component.jar            = ome-xml.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${lib.dir}/slf4j-api-1.5.10.jar:\
                            ${lib.dir}/testng-6.8.jar
 component.java-version   = 1.5

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-devel/build.properties
+++ b/components/scifio-devel/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = scifio-devel
 component.jar            = scifio-devel.jar
-component.version        = 4.4-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${lib.dir}/forms-1.3.0.jar:\
                            ${lib.dir}/kryo-2.21-shaded.jar:\
                            ${lib.dir}/log4j-1.2.15.jar:\

--- a/components/scifio-devel/pom.xml
+++ b/components/scifio-devel/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-tools/build.properties
+++ b/components/scifio-tools/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = scifio-tools
 component.jar            = scifio-tools.jar
-component.version        = 4.4.6-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/jai_imageio.jar:\
                            ${artifact.dir}/loci-common.jar:\
                            ${artifact.dir}/lwf-stubs.jar:\

--- a/components/scifio-tools/pom.xml
+++ b/components/scifio-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/build.properties
+++ b/components/scifio/build.properties
@@ -8,7 +8,7 @@
 
 component.name           = scifio
 component.jar            = scifio.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/jai_imageio.jar:\
                            ${artifact.dir}/loci-legacy.jar:\
                            ${artifact.dir}/lwf-stubs.jar:\

--- a/components/scifio/cppwrap/minimum_writer.cpp
+++ b/components/scifio/cppwrap/minimum_writer.cpp
@@ -42,8 +42,8 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.5-SNAPSHOT.h"
-#include "ome-xml-4.5-SNAPSHOT.h"
+#include "scifio-5.0.0-beta1.h"
+#include "ome-xml-5.0.0-beta1.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Boolean;

--- a/components/scifio/cppwrap/showinf.cpp
+++ b/components/scifio/cppwrap/showinf.cpp
@@ -42,9 +42,9 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.5-SNAPSHOT.h"
-#include "loci-legacy-4.5-SNAPSHOT.h"
-#include "scifio-devel-4.5-SNAPSHOT.h"
+#include "scifio-5.0.0-beta1.h"
+#include "loci-legacy-5.0.0-beta1.h"
+#include "scifio-devel-5.0.0-beta1.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Object;

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/src/loci/formats/FormatTools.java
+++ b/components/scifio/src/loci/formats/FormatTools.java
@@ -184,7 +184,7 @@ public final class FormatTools {
   public static final String DATE = "@date@";
 
   /** Version number of this release. */
-  public static final String VERSION = "4.5-DEV";
+  public static final String VERSION = "5.0.0-beta1";
 
   // -- Constants - domains --
 

--- a/components/specification/build.properties
+++ b/components/specification/build.properties
@@ -4,7 +4,7 @@
 
 component.name           = specification
 component.jar            = specification.jar
-component.version        = 4.5-DEV
+component.version        = 5.0.0-beta1
 component.classpath      = ${artifact.dir}/specification.jar:\
                            ${artifact.dir}/ome-xml.jar:\
                            ${lib.dir}/slf4j-api-1.5.10.jar

--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/turbojpeg/pom.xml
+++ b/components/turbojpeg/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/xsd-fu/pom.xml
+++ b/components/xsd-fu/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0.0-beta1</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>loci</groupId>
   <artifactId>pom-scifio</artifactId>
-  <version>4.5-SNAPSHOT</version>
+  <version>5.0.0-beta1</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>


### PR DESCRIPTION
Excluded for now.  This is the last thing to merge before tagging 5.0.0-beta1, and must be reverted immediately after merging.
