### PR TITLE
bfopen: save individual series' original metadata

### DIFF
--- a/components/bio-formats/matlab/bfopen.m
+++ b/components/bio-formats/matlab/bfopen.m
@@ -205,12 +205,11 @@ for s = 1:numSeries
         imageList{i, 2} = label;
     end
 
-    % extract metadata table for this series
-    metadataList = r.getSeriesMetadata();
-
     % save images and metadata into our master series list
     result{s, 1} = imageList;
-    result{s, 2} = metadataList;
+
+    % extract metadata table for this series
+    result{s, 2} = r.getSeriesMetadata();
     result{s, 3} = colorMaps;
     result{s, 4} = r.getMetadataStore();
     fprintf('\n');


### PR DESCRIPTION
Previously the union of all series' original metadata was stored once
for each series.  This causes potentially substantially more memory to
be used, and makes it more difficult to read original metadata.

See: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-June/003816.html

/cc @sbesson
