### PR TITLE
CellSens: do not set the resolution count

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellSensReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellSensReader.java
@@ -404,10 +404,6 @@ public class CellSensReader extends FormatReader {
     for (int s=0; s<core.length; s++) {
       tileMap[s] = new HashMap<TileCoordinate, Integer>();
 
-      if (s == 0 && !hasFlattenedResolutions()) {
-        core[s].resolutionCount = ifds.size() + (files.size() == 1 ? 0 : 1);
-      }
-
       if (s < files.size() - 1) {
         setSeries(s);
         parseETSFile(files.get(s), s);


### PR DESCRIPTION
Rebase of https://github.com/openmicroscopy/bioformats/pull/369 onto dev_4_4.

The images in the .vsi file are not proper sub-resolutions of the images
in the .ets file(s), so let's not tell the reader that they are.  While
the aspect ratio may be the same, the channel counts (and/or Z/T sizes)
are frequently different.

Fixes ticket #10354.

Conflicts:

```
components/bio-formats/src/loci/formats/in/CellSensReader.java
```
