### PR TITLE
Allow a directory of OME-XML files to be specified for testEqualOMEXML

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -108,6 +108,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -133,6 +134,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -166,6 +168,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -191,6 +194,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -216,6 +220,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -241,6 +246,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -266,6 +272,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -291,6 +298,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory-list" value="${testng.directory-list}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
+      <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -108,6 +108,7 @@ public class FormatReaderTest {
   private String id;
   private boolean skip = false;
   private Configuration config;
+  private String omexmlDir = System.getProperty("testng.omexmlDirectory");
 
   /**
    * Multiplier for use adjusting timing values. Slower machines take longer to
@@ -1249,11 +1250,26 @@ public class FormatReaderTest {
       if (!success) msg = TestTools.shortClassName(store);
 
       String file = reader.getCurrentFile() + ".ome.xml";
-      if (success && new File(file).exists()) {
-        String xml = DataTools.readFile(file);
-        OMEXMLMetadata base = omexmlService.createOMEXMLMetadata(xml);
+      if (success) {
+        if (!new File(file).exists() && omexmlDir != null &&
+          new File(omexmlDir).exists())
+        {
+          String dir = System.getProperty("testng.directory");
+          if (dir != null) {
+            file = reader.getCurrentFile().replace(dir, omexmlDir) + ".ome.xml";
 
-        success = omexmlService.isEqual(base, (OMEXMLMetadata) store);
+            if (!new File(file).exists()) {
+              file = reader.getCurrentFile().replace(dir, omexmlDir);
+              file = file.substring(0, file.lastIndexOf(".")) + ".ome.xml";
+            }
+          }
+        }
+        if (new File(file).exists()) {
+          String xml = DataTools.readFile(file);
+          OMEXMLMetadata base = omexmlService.createOMEXMLMetadata(xml);
+
+          success = omexmlService.isEqual(base, (OMEXMLMetadata) store);
+        }
       }
     }
     catch (Throwable t) {


### PR DESCRIPTION
This is intended to be used like this:

ant -Dtestng.omexmlDirectory=/path/to/samples -Dtestng.directory=/path/to/data test-automated

or:

ant -Dtestng.omexmlDirectory=/path/to/samples/leica/ -Dtestng.directory=/path/to/data/leica/ test-automated

where /path/to/samples/ is a clone of samples.git.

Fixes ticket #9403.
