### PR TITLE
CellSens: sort arrays of pixels files (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellSensReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellSensReader.java
@@ -26,6 +26,7 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -368,10 +369,12 @@ public class CellSensReader extends FormatReader {
     Location pixelsDir = new Location(dir, "_" + name + "_");
     String[] stackDirs = pixelsDir.list(true);
     if (stackDirs != null) {
+      Arrays.sort(stackDirs);
       for (String f : stackDirs) {
         Location stackDir = new Location(pixelsDir, f);
         String[] pixelsFiles = stackDir.list(true);
         if (pixelsFiles != null) {
+          Arrays.sort(pixelsFiles);
           for (String pixelsFile : pixelsFiles) {
             if (checkSuffix(pixelsFile, "ets")) {
               files.add(new Location(stackDir, pixelsFile).getAbsolutePath());


### PR DESCRIPTION
This is the same as gh-586 but rebased onto develop.

---

This ensures that the pixel file ordering is consistent, and prevents
the errors seen in https://github.com/openmicroscopy/bioformats/pull/579
