### PR TITLE
Reduce the number of JAI ImageIO registrations (rebased onto dev_4_4)

### DIFF
--- a/components/scifio/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/scifio/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -204,7 +204,7 @@ public class JAIIIOServiceImpl extends AbstractService
   }
 
   /** Register the JPEG-2000 readers with the reader service. */
-  private IIORegistry registerServiceProviders() {
+  private static IIORegistry registerServiceProviders() {
     IIORegistry registry = IIORegistry.getDefaultInstance();
     Iterator<J2KImageReaderSpi> iter =
       ServiceRegistry.lookupProviders(J2KImageReaderSpi.class);


### PR DESCRIPTION
This is the same as gh-583 but rebased onto dev_4_4.

---

Fixes ticket #11034.
