### PR TITLE
CellWorx: populate StartTime/EndTime on PlateAcquisition

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellWorxReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellWorxReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
 
@@ -79,6 +80,9 @@ public class CellWorxReader extends FormatReader {
 
   private String lastFile;
   private IFormatReader lastReader;
+
+  private HashMap<Integer, Timestamp> timestamps =
+    new HashMap<Integer, Timestamp>();
 
   // -- Constructor --
 
@@ -210,6 +214,7 @@ public class CellWorxReader extends FormatReader {
       }
       lastReader = null;
       doChannels = false;
+      timestamps.clear();
     }
   }
 
@@ -454,6 +459,11 @@ public class CellWorxReader extends FormatReader {
       for (int well=0; well<wellCount; well++) {
         parseWellLogFile(well, store);
       }
+      if (timestamps.size() > 0) {
+        store.setPlateAcquisitionStartTime(timestamps.get(0), 0, 0);
+        store.setPlateAcquisitionEndTime(
+          timestamps.get(timestamps.size() - 1), 0, 0);
+      }
       for (int i=0; i<core.length; i++) {
         for (int c=0; c<getSizeC(); c++) {
           if (c < wavelengths.length) {
@@ -545,8 +555,10 @@ public class CellWorxReader extends FormatReader {
         String date = DateTools.formatDate(value, DATE_FORMAT);
         for (int field=0; field<fieldCount; field++) {
           if (date != null) {
+            int imageIndex = seriesIndex + field;
+            timestamps.put(imageIndex, new Timestamp(date));
             store.setImageAcquisitionDate(
-              new Timestamp(date), seriesIndex + field);
+              timestamps.get(imageIndex), imageIndex);
           }
         }
       }


### PR DESCRIPTION
These values are just taken from the AcquisitionDate on the first and
lates Images.

`showinf -nopix -omexml` on any of the datasets in `cellworx` should show the `StartTime` and `EndTime` attributes correctly populated.
