### PR TITLE
OME-XML: fix image name population

### DIFF
--- a/components/scifio/src/loci/formats/in/OMEXMLReader.java
+++ b/components/scifio/src/loci/formats/in/OMEXMLReader.java
@@ -306,7 +306,7 @@ public class OMEXMLReader extends FormatReader {
     // contents of the internal OME-XML metadata object
     MetadataStore store = getMetadataStore();
     service.convertMetadata(omexmlMeta, store);
-    MetadataTools.populatePixels(store, this);
+    MetadataTools.populatePixels(store, this, false, false);
   }
 
   // -- Helper class --


### PR DESCRIPTION
This prevents MetadataTools from overwriting the Image.Name that was
originally stored in the file.

Once merged, this should fix the failing BIOFORMATS-test_images_good job:

http://hudson.openmicroscopy.org.uk/view/Bio-Formats/job/BIOFORMATS-test_images_good/
