### PR TITLE
bfGetPlane fix and hardcoded version removal

### DIFF
--- a/components/bio-formats/matlab/bfGetPlane.m
+++ b/components/bio-formats/matlab/bfGetPlane.m
@@ -57,6 +57,14 @@ ip.addOptional('width', r.getSizeX(), isValidX);
 ip.addOptional('height', r.getSizeY(), isValidY);
 ip.parse(r, iPlane, varargin{:});
 
+% Additional check for tile size
+assert(ip.Results.x - 1 + ip.Results.width <= r.getSizeX(),...
+     'MATLAB:InputParser:ArgumentFailedValidation',...
+     'Invalid tile size');
+assert(ip.Results.y - 1 + ip.Results.height <= r.getSizeY(),...
+     'MATLAB:InputParser:ArgumentFailedValidation',...
+     'Invalid tile size');
+
 % check MATLAB version, since typecast function requires MATLAB 7.1+
 canTypecast = versionCheck(version, 7, 1);
 

--- a/components/bio-formats/test/matlab/TestBfGetPlane.m
+++ b/components/bio-formats/test/matlab/TestBfGetPlane.m
@@ -118,6 +118,7 @@ classdef TestBfGetPlane < TestBfMatlab
             self.checkInvalidTileInput();
         end
         
+        
         function testZeroTileWidth(self)
             self.x = 1;
             self.y = 1;
@@ -129,6 +130,13 @@ classdef TestBfGetPlane < TestBfMatlab
             self.x = 1;
             self.y = 1;
             self.width = self.sizeX + 1;
+            self.checkInvalidTileInput();
+        end
+        
+        function testOversizedTileWidth2(self)
+            self.x = 2;
+            self.y = 1;
+            self.width = self.sizeX;
             self.checkInvalidTileInput();
         end
         
@@ -145,6 +153,14 @@ classdef TestBfGetPlane < TestBfMatlab
             self.y = 1;
             self.width = self.sizeX;
             self.height = self.sizeY + 1;
+            self.checkInvalidTileInput();
+        end
+        
+        function testOversizedTileHeight2(self)
+            self.x = 1;
+            self.y = 2;
+            self.width = self.sizeX;
+            self.height = self.sizeY;
             self.checkInvalidTileInput();
         end
         


### PR DESCRIPTION
The local merge of #627 into the daily merge build exposed an obvious bug in bfGetPlane() (which required the version number to be >= 5.0 to show up). This PR:
- removes the hardcoded version check from `bfGetPlane()`
- fixes the call to `makeDataArray2D` for signed pixelTypes
- add additional validator to the input check as well as corresponding unit tests

As an outcome of this PR, [BIOFORMATS-merge-matlab-develop](http://hudson.openmicroscopy.org.uk/job/BIOFORMATS-merge-matlab-develop/) is expected to turn green again.
