### PR TITLE
SCIFIO link (rebased onto develop)

### DIFF
--- a/docs/sphinx/developers/scifio.txt
+++ b/docs/sphinx/developers/scifio.txt
@@ -29,4 +29,4 @@ license (though individual modules can fall under any licensing
 framework, and Bio-Formats will continue to have a dual GPL + commercial
 license).
 
-For further information, see the `SCIFIO home page <http://loci.wisc.edu/software/scifio>`_.
+For further information, see the `SCIFIO home page <http://scif.io/>`_.


### PR DESCRIPTION
This is the same as gh-632 but rebased onto develop.

---

Updating the BF SCIFIO docs to link to the SCIFIO page at LOCI so we don't need to reproduce Mark & Curtis' updates to keep this up-to-date and everyone can find the latest SCIFIO documentation etc.

cc: @ctrueden @hinerm

N.B. Done this way rather than removing the file completely because we link to it throughout the supported formats table which is autogenerated.

To be rebased once merged.
