### PR TITLE
Update FileHandleTest to skip /usr/lib64/*

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -93,7 +93,7 @@ public class FileHandleTest {
       String s = finalHandles.get(i);
       if (s.endsWith("libnio.so") || s.endsWith("resources.jar") ||
         s.startsWith("/usr/lib") || s.startsWith("/opt/") ||
-        s.startsWith("/usr/share/locale") ||
+        s.startsWith("/usr/share/locale") || s.startsWith("/lib") ||
         s.indexOf("/jre/") > 0)
       {
         finalHandles.remove(s);


### PR DESCRIPTION
This is necessary for running the `FileHandleTest` on JPEG files with Java 1.7, as `/usr/lib64/libjpeg*.so*` is used.  This should allow `BIOFORMATS-merge-stable` to progress.
