### PR TITLE
FileHandleTest: remove trailing slash from /usr/lib/

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -93,7 +93,7 @@ public class FileHandleTest {
       String s = finalHandles.get(i);
       if (s.endsWith("libnio.so") || s.endsWith("resources.jar") ||
         s.startsWith("/usr/lib") || s.startsWith("/opt/") ||
-        s.startsWith("/usr/share/locale") ||
+        s.startsWith("/usr/share/locale") || s.startsWith("/lib") ||
         s.indexOf("turbojpeg") > 0 || s.indexOf("/jre/") > 0)
       {
         finalHandles.remove(s);


### PR DESCRIPTION
Same as gh-656, rebased onto develop.

This allows the test to match /usr/lib/ and /usr/lib64/, so that
necessary native libraries aren't detected as file handles that have
incorrectly been left open.

Conflicts:

```
components/test-suite/src/loci/tests/testng/FileHandleTest.java
```
