### PR TITLE
Split out main doc sections with bullets

### DIFF
--- a/docs/sphinx/index.txt
+++ b/docs/sphinx/index.txt
@@ -2,31 +2,31 @@
 Bio-Formats Documentation
 #########################
 
-The following documentation is split into four parts. :doc:`about/index` explains 
-the goal of the software, discusses how it processes metadata, and provides other useful information such as version history and how to report bugs. 
-:doc:`users/index` focusses on how to use Bio-Formats as a plugin for 
-ImageJ and Fiji, and also gives details of other software packages which can 
-use Bio-Formats to read and write microscopy formats. 
-:doc:`developers/index` covers more indepth information on using 
-Bio-Formats as a Java library and how to interface from non-Java codes. 
-Finally, :doc:`formats/index` is a guide to all the file formats currently 
-supported by Bio-Formats.
- 
-.. only:: html
+The following documentation is split into four parts:
 
-    - :doc:`about/index`
-    - :doc:`users/index`
-    - :doc:`developers/index`
-    - :doc:`formats/index`
+- :doc:`about/index` explains the goal of the software, discusses how it
+  processes metadata, and provides other useful information such as
+  version history and how to report bugs.
 
+- :doc:`users/index` focuses on how to use Bio-Formats as a plugin for
+  ImageJ and Fiji, and also gives details of other software packages
+  which can use Bio-Formats to read and write microscopy formats.
+
+- :doc:`developers/index` covers more in-depth information on using
+  Bio-Formats as a Java library and how to interface from non-Java
+  codes.
+
+- :doc:`formats/index` is a guide to all the file formats currently
+  supported by Bio-Formats.
 
 .. toctree::
     :maxdepth: 1
     :hidden:
- 
+
     about/index
     users/index
     developers/index
     formats/index
 
-The version *4* releases use the *June 2012* release of the :model_doc:`OME-Model <>`
+The version *4* releases use the *June 2012* release of the
+:model_doc:`OME-Model <>`.


### PR DESCRIPTION
We were already listing them as bullets, but then we also redundantly
linked to them in the introductory paragraph above as well.

Bulleted lists are often much easier to read and digest
(http://www.contentious.com/2004/09/17/bulleted-lists/), so let's just
stick to a single list with the description inline per bullet point.
