### PR TITLE
AVI: fix array index calculation for tile reading

### DIFF
--- a/components/scifio/src/loci/formats/in/AVIReader.java
+++ b/components/scifio/src/loci/formats/in/AVIReader.java
@@ -245,8 +245,8 @@ public class AVIReader extends FormatReader {
     in.skipBytes((getSizeX() + pad) * bytes * (getSizeY() - h - y));
 
     if (getSizeX() == w && pad == 0) {
-      for (int row=0; row<getSizeY(); row++) {
-        int outputRow = bmpCompression == Y8 ? row : getSizeY() - row - 1;
+      for (int row=0; row<h; row++) {
+        int outputRow = bmpCompression == Y8 ? row : h - row - 1;
         in.read(buf, outputRow * scanline, scanline);
       }
 
@@ -266,7 +266,7 @@ public class AVIReader extends FormatReader {
       }
       for (int i=h - 1; i>=0; i--) {
         in.skipBytes(x * (bmpBitsPerPixel / 8));
-        in.read(buf, (i - y)*scanline, scanline);
+        in.read(buf, i*scanline, scanline);
         if (bmpBitsPerPixel == 24) {
           for (int j=0; j<w; j++) {
             byte r = buf[i*scanline + j*3 + 2];


### PR DESCRIPTION
Fixes ticket #11100.

To test, please verify that the .avi files from QA 7336 and QA 7560 both import into OMERO (after unzipping, if needed) and that all of the develop builds are green.

/cc @gusferguson
