### PR TITLE
Matlab developer documentation page update (rebased onto develop)

### DIFF
--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -112,18 +112,16 @@ Retrieving metadata
 
 There are two kinds of metadata:
 
--  :ref:`original-metadata` is a set of key/value pairs specific to the
-   input format of the data. It is stored in the ``data{s, 2}`` element of the
-   data structure returned by ``bfopen``.
+-  **Original metadata** is a set of key/value pairs specific to the input
+   format of the data. It is stored in the ``data{s, 2}`` element of the data
+   structure returned by ``bfopen``.
 
--  :ref:`ome-metadata` is a standardized metadata structure, which is the
+-  **OME metadata** is a standardized metadata structure, which is the
    same regardless of input file format. It is stored in the ``data{s, 4}``
    element of the data structure returned by ``bfopen``, and contains common
    metadata values such as physical pixel sizes, instrument settings,
-   and much more. See the :model_doc:`OME Model and Formats <>` pages for full
-   details.
-
-.. _original-metadata:
+   and much more. See the :model_doc:`OME Model and Formats <>` documentation
+   for full details.
 
 Original metadata
 """""""""""""""""
@@ -186,7 +184,9 @@ To convert the OME metadata into a string, use the ``dumpXML()`` method:
 Reading from an image file
 --------------------------
 
-The main inconvenience of the :source:`bfopen.m <components/bio-formats/matlab/bfopen.m>` function is that it loads all the content of an image independently of its size.
+The main inconvenience of the
+:source:`bfopen.m <components/bio-formats/matlab/bfopen.m>` function is that
+it loads all the content of an image regardless of its size.
 
 To access the file reader without loading all the data, use the low-level 
 :source:`bfGetReader.m <components/bio-formats/matlab/bfGetReader.m>` 
@@ -203,7 +203,8 @@ method:
 
     omeMeta = reader.getMetadataStore();
 
-Individual planes can be queried using the :source:`bfGetPlane.m <components/bio-formats/matlab/bfGetPlane.m>` function:
+Individual planes can be queried using the
+:source:`bfGetPlane.m <components/bio-formats/matlab/bfGetPlane.m>` function:
 
 ::
 


### PR DESCRIPTION
This is the same as gh-666 but rebased onto develop.

---

This PR reviews the `Using Bio-Formats in Matlab` documentation page:
- restructure the page into 3 sections based on the M files: `Opening image files` describes the usage of `bfopen`, `Reading from image files` describes the usage of `bfGetReader` and `Saving files` describes the usage of `bfsave`
- reviews the description of the `bfopen` complex cell array output
- verify and fix the code snippets
- simplify the `Saving files` section to use examples based upon `bfsave`
- add additional internal link as well as a link to the Javadocs for the OME metadata section
- highlight code blocks using Matlab pigments

Given this proposed restructuration, does it make sense to call `data = bfopen('/path/to/data/file');` at the beginning of each code snippet in the first section?
