### PR TITLE
AVI: fix array index calculation for tile reading (rebased onto dev_4_4)

### DIFF
--- a/components/scifio/src/loci/formats/in/AVIReader.java
+++ b/components/scifio/src/loci/formats/in/AVIReader.java
@@ -241,7 +241,7 @@ public class AVIReader extends FormatReader {
     int pad = (bmpScanLineSize / getRGBChannelCount()) - getSizeX() * bytes;
     int scanline = w * bytes * (isInterleaved() ? getRGBChannelCount() : 1);
 
-    in.skipBytes((getSizeX() + pad) * bytes * (getSizeY() - h - y));
+    in.skipBytes((getSizeX() + pad) * (bmpBitsPerPixel / 8) * (getSizeY() - h - y));
 
     if (getSizeX() == w && pad == 0) {
       for (int row=0; row<h; row++) {


### PR DESCRIPTION
This is the same as gh-667 but rebased onto dev_4_4.

---

Fixes ticket #11100.

To test, please verify that the .avi files from QA 7336 and QA 7560 both import into OMERO (after unzipping, if needed) and that all of the develop builds are green.

/cc @gusferguson
