### PR TITLE
Multi-plane flex file with factor and no compression only reads first pl...

### DIFF
--- a/components/bio-formats/src/loci/formats/in/FlexReader.java
+++ b/components/bio-formats/src/loci/formats/in/FlexReader.java
@@ -226,56 +226,55 @@ public class FlexReader extends FormatReader {
       new int[] {fieldCount / effectiveFieldCount, wellCount, plateCount};
     int[] pos = FormatTools.rasterToPosition(lengths, getSeries());
 
-    int wellRow = wellNumber[pos[1]][0];
-    int wellCol = wellNumber[pos[1]][1];
-    if (wellCount == 1) {
-      wellRow = 0;
-      wellCol = 0;
-    }
-
     int imageNumber = file.offsets == null ? getImageCount() * pos[0] + no : 0;
-    IFD ifd = file.offsets == null ?
-      file.ifds.get(imageNumber) : firstFile.ifds.get(0);
 
     RandomAccessInputStream s = 
       new RandomAccessInputStream(getFileHandle(file.file));
 
+    IFD ifd;
+    double factor;
+    if (file.offsets == null) {
+    	ifd = file.ifds.get(imageNumber);
+    	factor = 1d;
+    } else {
+    	// Only the first IFD was read. Hack the IFD to adjust the offset.
+    	final IFD firstIFD = firstFile.ifds.get(0);
+    	ifd = new IFD(firstIFD);
+    	int tag = IFD.STRIP_OFFSETS;
+    	if (firstIFD.isTiled() && firstIFD.getIFDLongArray(IFD.TILE_OFFSETS) != null)
+    		tag =  IFD.TILE_OFFSETS;
+    	long [] offsets = ifd.getIFDLongArray(tag);
+
+    	final int planeSize = getSizeX() * getSizeY() * getRGBChannelCount() *
+    	ifd.getBitsPerSample()[0] / 8;
+    	final int index = getImageCount() * pos[0] + no;
+    	long offset = (index == file.offsets.length - 1 ?
+    			s.length() : file.offsets[index + 1]) - offsets[0] - planeSize;
+
+    	for (int i = 0; i < offsets.length; i++) {
+    		offsets[i] += offset;  
+    	}
+    	ifd.putIFDValue(tag, offsets);
+    }
     int nBytes = ifd.getBitsPerSample()[0] / 8;
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
-    int planeSize = getSizeX() * getSizeY() * getRGBChannelCount() * nBytes;
-    double factor = 1d;
 
     // read pixels from the file
-    if (ifd.getCompression() != TiffCompression.UNCOMPRESSED || nBytes != bpp ||
-      file.offsets == null)
-    {
-      TiffParser tp = new TiffParser(s);
-      tp.getSamples(ifd, buf, x, y, w, h);
-      factor = file.factors[imageNumber];
-      tp.getStream().close();
-    }
-    else {
-      int index = getImageCount() * pos[0] + no;
-      long offset = index == file.offsets.length - 1 ?
-        s.length() : file.offsets[index + 1];
-      s.seek(offset - planeSize);
-      readPlane(s, x, y, w, h, buf);
-      factor = firstFile.factors[index];
-    }
-    if (wellRow != 0 || wellCol != 0) s.close();
+    TiffParser tp = new TiffParser(s);
+    tp.getSamples(ifd, buf, x, y, w, h);
+    factor = file.factors[imageNumber];
+    tp.getStream().close();
 
     // expand pixel values with multiplication by factor[no]
     int num = buf.length / bpp;
 
     if (factor != 1d || nBytes != bpp) {
-      for (int i=num-1; i>=0; i--) {
-        int q = nBytes == 1 ? buf[i] & 0xff :
-          DataTools.bytesToInt(buf, i * bpp, bpp, isLittleEndian());
-        if (q != 0) {
-          q = (int) (q * factor);
-          DataTools.unpackBytes(q, buf, i * bpp, bpp, isLittleEndian());
-        }
-      }
+    	for (int i=num-1; i>=0; i--) {
+    		int q = nBytes == 1 ? buf[i] & 0xff :
+    			DataTools.bytesToInt(buf, i * nBytes, nBytes, isLittleEndian());
+    		q = (int) (q * factor);
+    		DataTools.unpackBytes(q, buf, i * bpp, bpp, isLittleEndian());
+    	}
     }
 
     s.close();


### PR DESCRIPTION
Hi all,
Another problem here, involving the flex file below:
https://svn.broadinstitute.org/CellProfiler/trunk/TestImages/RLM1%20SSN3%20300308%20008015000.flex

This is an 8-plane .tif which has some multiplication factors in it that exercise some of the more hairy code paths in FlexReader.java. You can see the problem if you run ImageInfo.java with the arguments:

-autoscale -fast -no-upgrade -no-group "RLM SSN3 20300308 2000801500.flex"

and

-format Tiff -autoscale -fast -no-upgrade -no-group "RLM SSN3 20300308 2000801500.flex"

The first will display two planes and they are identical whereas the second displays 8 planes all of which are different. You can use the -series switch to display series 0-3 and see that the planes are identical. The problem is that the multiplication factor is 3, which means that the FlexReader outputs an image of type UINT16 and it uses the first IFD to read all 8 planes.

I've simplified the code a bit (I hope) and I hope what I've done isn't too much more of a hack than what's there already. The idea is to use the first IFD as a template for reading the remaining planes by adjusting the strip or tile offsets. I also corrected some logical errors in the section that expands pixel values.

--Lee
