### PR TITLE
CellWorx: do not assume that the first well/field file exists

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellWorxReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellWorxReader.java
@@ -355,7 +355,22 @@ public class CellWorxReader extends FormatReader {
 
     core = new CoreMetadata[fieldCount * wellCount];
 
-    String file = getFile(0, 0);
+    int planeIndex = 0;
+    int seriesIndex = 0;
+    String file = getFile(seriesIndex, planeIndex);
+    while (!new Location(file).exists()) {
+      if (planeIndex <  nTimepoints * wavelengths.length) {
+        planeIndex++;
+      }
+      else if (seriesIndex < core.length) {
+        planeIndex = 0;
+        seriesIndex++;
+      }
+      else {
+        break;
+      }
+      file = getFile(seriesIndex, planeIndex);
+    }
     IFormatReader pnl = getReader(file);
 
     for (int i=0; i<core.length; i++) {


### PR DESCRIPTION
If the first file that we're expecting (the one for the first well/field/channel/timepoint) is missing, then look for the first file that does exist and use that to determine the plane dimensions.  This prevents `setId` from throwing a `FileNotFoundException`.
