### PR TITLE
Release version fix

### DIFF
--- a/ant/common.xml
+++ b/ant/common.xml
@@ -94,7 +94,7 @@ Type "ant -p" for a list of targets.
         </if>
         <if>
           <or>
-            <equals arg1="0" arg2="git.describe.exact.rc"/>
+            <equals arg1="0" arg2="${git.describe.exact.rc}"/>
             <isset property="use.inexact.version"/>
           </or>
           <then>


### PR DESCRIPTION
This PR fixes the `init-version` target in the case of a tag match (preventing the `-DEV` suffix appending)

To test:
- in Hudson. check the artifacts of the [BIOFORMATS-trunk-release](http://hudson.openmicroscopy.org.uk/job/BIOFORMATS-trunk-release) job
- locally tag and build Bio-Formats, e.g.  `git tag vx.y.z -m "Release x.y.z" && ant clean tools` then check `loci.format.FormatsTools.VERSION` does not have any `-DEV` suffix

---

--rebased-to #636 
