### PR TITLE
Avoid throwing exception when parsing URL in Location constructor

### DIFF
--- a/components/common/src/loci/common/Location.java
+++ b/components/common/src/loci/common/Location.java
@@ -102,11 +102,17 @@ public class Location {
 
   public Location(String pathname) {
     LOGGER.trace("Location({})", pathname);
-    try {
-      url = new URL(getMappedId(pathname));
-    }
-    catch (MalformedURLException e) {
-      LOGGER.trace("Location is not a URL", e);
+    if (pathname.contains("://")) {
+      // Avoid expensive exception handling in case when path is obviously not an URL
+      try {
+        url = new URL(getMappedId(pathname));
+      }
+      catch (MalformedURLException e) {
+        LOGGER.trace("Location is not a URL", e);
+        isURL = false;
+      }
+    } else {
+      LOGGER.trace("Location is not a URL");
       isURL = false;
     }
     if (!isURL) file = new File(getMappedId(pathname));


### PR DESCRIPTION
The constructor of a Location class is checking if the path is URL. This is done by try / catch block and calling an URL constructor. If the exception is being thrown, that this is the most time-consuming part of the constructor.

This can be avoided by doing a simple check if the path contains "://", which is one of the things that URL checks. In this case no exception is thrown if the path is a simple file.
