### PR TITLE
AVI: fix byte count when skipping rows

### DIFF
--- a/components/scifio/src/loci/formats/in/AVIReader.java
+++ b/components/scifio/src/loci/formats/in/AVIReader.java
@@ -242,7 +242,7 @@ public class AVIReader extends FormatReader {
     int pad = (bmpScanLineSize / getRGBChannelCount()) - getSizeX() * bytes;
     int scanline = w * bytes * (isInterleaved() ? getRGBChannelCount() : 1);
 
-    in.skipBytes((getSizeX() + pad) * bytes * (getSizeY() - h - y));
+    in.skipBytes((getSizeX() + pad) * (bmpBitsPerPixel / 8) * (getSizeY() - h - y));
 
     if (getSizeX() == w && pad == 0) {
       for (int row=0; row<h; row++) {


### PR DESCRIPTION
Contains the last commit from gh-672.  This fixes offsets when reading tiles from certain types of AVI files.
