### PR TITLE
CellWorx: do not assume that the first well/field file exists (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellWorxReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellWorxReader.java
@@ -376,7 +376,7 @@ public class CellWorxReader extends FormatReader {
       if (planeIndex <  nTimepoints * wavelengths.length) {
         planeIndex++;
       }
-      else if (seriesIndex < core.size()) {
+      else if (seriesIndex < seriesCount) {
         planeIndex = 0;
         seriesIndex++;
       }


### PR DESCRIPTION
This is the same as gh-680 but rebased onto develop.

---

If the first file that we're expecting (the one for the first well/field/channel/timepoint) is missing, then look for the first file that does exist and use that to determine the plane dimensions.  This prevents `setId` from throwing a `FileNotFoundException`.
