### PR TITLE
Properly populate metadata with Zeiss ROIs

### DIFF
--- a/components/bio-formats/src/loci/formats/in/BaseZeissReader.java
+++ b/components/bio-formats/src/loci/formats/in/BaseZeissReader.java
@@ -134,8 +134,8 @@ public abstract class BaseZeissReader extends FormatReader {
     fillMetadataPass5(store);
     fillMetadataPass6(store);
     MetadataTools.populatePixels(store, this, true);
-    fillMetadataPass7(store);
     storeROIs(store);
+    fillMetadataPass7(store);
   }
 
   protected void initVars(String id) throws FormatException, IOException {


### PR DESCRIPTION
`filterMetadataPass7` was trying to use data not yet noted by `storeROIs`. After this fix, the images should be properly linked to their ROIs.

Discovered in investigating http://trac.openmicroscopy.org.uk/ome/ticket/10097

In testing, take a look at `data_repo/test_images_roi/zvi/` and see if via OMERO.web you can see ROIs in images.
