### PR TITLE
ND2: fix size calculation for lossless compressed data

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
@@ -926,9 +926,7 @@ public class NativeND2Reader extends FormatReader {
         LOGGER.debug("Correcting SizeC: was {}", getSizeC());
         LOGGER.debug("plane size = {}", planeSize);
         LOGGER.debug("available bytes = {}", availableBytes);
-        if (isLossless) {
-          planeSize *= 2;
-        }
+
         core[0].sizeC = (int) (availableBytes / (planeSize / getSizeC()));
         if (getSizeC() == 0) {
           core[0].sizeC = 1;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11386

To test, verify that the file from QA 7572 opens correctly, and that builds are green.
