### PR TITLE
Added VT_BOOL serialization support for ZVI tags (rebased onto dev_4_4)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/bio-formats/src/loci/formats/in/ZeissZVIReader.java
@@ -422,6 +422,8 @@ public class ZeissZVIReader extends BaseZeissReader {
       case 13:
         s.skipBytes(16);
         return "";
+      case 11:
+        return String.valueOf(s.readShort()!=0);
       case 63:
       case 65:
         len = s.readInt();


### PR DESCRIPTION
This is the same as gh-668 but rebased onto dev_4_4.

---

Hi all.
This pull request adds support for the VT_BOOL VARENUM for ZVI tags (see http://msdn.microsoft.com/en-us/library/windows/desktop/ms221170(v=vs.85).aspx). CellProfiler was running into problems when parsing the XML metadata for the file below because the XML contained invalid characters. I traced it through and ZeissZVIReader.getNextTag was getting a tag type of 11 which fell through to the default:

https://github.com/LeeKamentsky/bioformats/blob/develop/components/bio-formats/src/loci/formats/in/ZeissZVIReader.java#L435

The code managed to execute, but the string that it saved consisted of the unicode character 0xFFFF which isn't legal. A UTF-16 to UTF-8 translation in Python failed because of this:

CellProfiler/CellProfiler#771

Looking at the ZVI docs, I guessed that the format was being generated by COM serialization and it looks like the codes that you have match to the VARENUM documentation. The patch seems to pick up the metadata for several boolean fields.

ZVI file demonstrating the problem:

http://broadinstitute.org/~leek/u87.cells-0027_AB02_01.zvi

--Lee

---

This replaces gh-658
