### PR TITLE
Remove deprecated Bfview from CL tools page (rebased onto develop)

### DIFF
--- a/docs/sphinx/users/comlinetools/index.txt
+++ b/docs/sphinx/users/comlinetools/index.txt
@@ -20,10 +20,6 @@ Currently available tools include:
         Prints information about a given image file to the console, and
         displays the image itself in the Bio-Formats image viewer.
 
-    bfview
-        Launches the Bio-Formats image viewer, displaying the given file (if
-        any).
-
     ijview
         Displays the given image file in ImageJ using the Bio-Formats Importer
         plugin (requires **ij.jar**).


### PR DESCRIPTION
This is the same as gh-703 but rebased onto develop.

---

Bfview is apparently now deprecated but was still listed on the http://www.openmicroscopy.org/site/support/bio-formats4/users/comlinetools/index.html - this PR removes reference to it (git grep shows Bfview is now only mentioned on the version history page).
