### PR TITLE
Remove "Download from OMERO" from the plugin menu

### DIFF
--- a/components/ome-plugins/src/plugins.config
+++ b/components/ome-plugins/src/plugins.config
@@ -1,4 +1,4 @@
-Plugins>OME, "Download from OMERO", loci.plugins.LociImporter("location=[OMERO]")
+#Plugins>OME, "Download from OMERO", loci.plugins.LociImporter("location=[OMERO]")
 #Plugins>OME, "Upload to OME", loci.plugins.ome.LociUploader("")
 
 Help>About Plugins, "OME Plugins...", loci.plugins.ome.About("")


### PR DESCRIPTION
See ticket #10770.  Corresponds to gh-698, though it's not a true rebase.

To test, build the branch (or download the merge build artifacts), copy loci_tools.jar and ome_tools.jar to ImageJ's plugins folder, and verify that there is no `Download from OMERO` entry in the `Plugins > OME` menu.
