### PR TITLE
Metamorph image names (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/MetamorphReader.java
+++ b/components/bio-formats/src/loci/formats/in/MetamorphReader.java
@@ -1318,7 +1318,7 @@ public class MetamorphReader extends BaseTiffReader {
     String name = "";
     if (stageNames != null && stageNames.size() > 0) {
       int stagePosition = i / (getSeriesCount() / stageNames.size());
-      name += "Stage" + (i + 1) + " " + stageNames.get(stagePosition);
+      name += "Stage" + (stagePosition + 1) + " " + stageNames.get(stagePosition);
     }
 
     if (firstSeriesChannels != null &&


### PR DESCRIPTION
This is the same as gh-707 but rebased onto develop.

---

Fix image names used for plate data, so that they are more consistent.  Channel names are only included in the image name if different channels were acquired for different Z sections.
