### PR TITLE
ND2: remove correction for lossless plane sizes (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
@@ -929,9 +929,7 @@ public class NativeND2Reader extends FormatReader {
         LOGGER.debug("Correcting SizeC: was {}", getSizeC());
         LOGGER.debug("plane size = {}", planeSize);
         LOGGER.debug("available bytes = {}", availableBytes);
-        if (isLossless) {
-          planeSize *= 2;
-        }
+
         core.get(0).sizeC = (int) (availableBytes / (planeSize / getSizeC()));
         if (getSizeC() == 0) {
           core.get(0).sizeC = 1;


### PR DESCRIPTION
We now decompress a single lossless plane in setId to get the exact byte
count, so there is no need to adjust the plane size based upon the
compressed byte count.

Conflicts:

```
components/bio-formats/src/loci/formats/in/NativeND2Reader.java
```
