### PR TITLE
fix the ICS Opener plugin link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -716,7 +716,7 @@ scifio = yes
 export = yes
 versions = 1.0, 2.0
 software = `Libics (ICS reference library) <http://libics.sourceforge.net/>`_ \n
-`ICS Opener plugin for ImageJ <http://valelab.ucsf.edu/%7Enico/IJplugins/Ics_Opener.html>`_ \n
+`ICS Opener plugin for ImageJ <http://valelab.ucsf.edu/%7Enstuurman/IJplugins/Ics_Opener.html>`_ \n
 `IrfanView <http://www.irfanview.com/>`_
 weHave = * numerous ICS datasets
 pixelsRating = Outstanding

--- a/docs/sphinx/formats/ics.txt
+++ b/docs/sphinx/formats/ics.txt
@@ -23,7 +23,7 @@ Supported Metadata Fields: :doc:`ICS (Image Cytometry Standard) <ics-metadata>`
 Freely Available Software:
 
 - `Libics (ICS reference library) <http://libics.sourceforge.net/>`_ 
-- `ICS Opener plugin for ImageJ <http://valelab.ucsf.edu/%7Enico/IJplugins/Ics_Opener.html>`_ 
+- `ICS Opener plugin for ImageJ <http://valelab.ucsf.edu/%7Enstuurman/IJplugins/Ics_Opener.html>`_ 
 - `IrfanView <http://www.irfanview.com/>`_
 
 


### PR DESCRIPTION
The Vale lab's redirect of Nico's home directory is broken, this should prevent the problem from reoccurring and hopefully fix the BF docs builds.
