### PR TITLE
ND2: only populate the channel color if it is non-zero

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
@@ -1645,7 +1645,12 @@ public class NativeND2Reader extends FormatReader {
         int green = (colors[c] & 0xff00) >> 8;
         int blue = (colors[c] & 0xff0000) >> 16;
         int alpha = (colors[c] & 0xff000000) >> 24;
-        store.setChannelColor(new Color(red, green, blue, alpha), i, c);
+
+        // do not set the channel color if the recorded color is black
+        // doing so can prevent the image from displaying correctly
+        if (red != 0 || green != 0 || blue != 0) {
+          store.setChannelColor(new Color(red, green, blue, alpha), i, c);
+        }
       }
     }
 


### PR DESCRIPTION
Setting the channel color to 0 (i.e. black) can prevent the images from displaying correctly when the color-appropriate lookup tables are applied.

/cc @pwalczysko
