### PR TITLE
fix SimplePCI links in documentation (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1942,7 +1942,7 @@ reader = SeikoReader.java
 
 [SimplePCI & HCImage TIFF]
 extensions = .tiff
-developer = `Hamamatsu <http://hcimage.com/simplepci.htm>`_
+developer = `Hamamatsu <http://hcimage.com/simple-pci-legacy/>`_
 scifio = no
 export = no
 weHave = * a few SimplePCI TIFF datasets
@@ -1970,7 +1970,7 @@ notes = Bio-Formats uses a modified version of the `Apache Jakarta \n
 POI library <http://jakarta.apache.org/poi/>`_ to read CXD files. \n
 \n
 .. seealso:: \n
-  `SimplePCI software overview <http://hcimage.com/simplepci.htm>`_
+  `SimplePCI software overview <http://hcimage.com/simple-pci-legacy/>`_
 
 [SM Camera]
 scifio = no

--- a/docs/sphinx/formats/simplepci-hcimage-tiff.txt
+++ b/docs/sphinx/formats/simplepci-hcimage-tiff.txt
@@ -6,7 +6,7 @@ SimplePCI & HCImage TIFF
 
 Extensions: .tiff 
 
-Developer: `Hamamatsu <http://hcimage.com/simplepci.htm>`_
+Developer: `Hamamatsu <http://hcimage.com/simple-pci-legacy/>`_
 
 
 **Support**

--- a/docs/sphinx/formats/simplepci-hcimage.txt
+++ b/docs/sphinx/formats/simplepci-hcimage.txt
@@ -55,4 +55,4 @@ Bio-Formats uses a modified version of the `Apache Jakarta
 POI library <http://jakarta.apache.org/poi/>`_ to read CXD files. 
 
 .. seealso:: 
-  `SimplePCI software overview <http://hcimage.com/simplepci.htm>`_
+  `SimplePCI software overview <http://hcimage.com/simple-pci-legacy/>`_


### PR DESCRIPTION
This is the same as gh-719 but rebased onto develop.

---

The previous SimplePCI URL appears to have moved.
