### PR TITLE
Fixing broken links in BF doc build

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1322,7 +1322,7 @@ notes = .. seealso:: \n
 
 [Molecular Imaging]
 extensions = .stp
-owner = `Molecular Imaging <http://www.molecularimagingcorp.com>`_
+owner = Molecular Imaging Corp, San Diego CA (closed)
 scifio = no
 export = no
 weHave = * Pascal code that reads Molecular Imaging files (from ImageSXM) \n

--- a/docs/sphinx/formats/molecular-imaging.txt
+++ b/docs/sphinx/formats/molecular-imaging.txt
@@ -7,7 +7,7 @@ Molecular Imaging
 Extensions: .stp 
 
 
-Owner: `Molecular Imaging <http://www.molecularimagingcorp.com>`_
+Owner: Molecular Imaging Corp, San Diego CA (closed)
 
 **Support**
 

--- a/docs/sphinx/users/imaris/index.txt
+++ b/docs/sphinx/users/imaris/index.txt
@@ -13,5 +13,5 @@ As of `version
 7.2 <http://www.bitplane.com/go/releasenotes?product=Imaris&version=7.2&patch=0>`_,
 Imaris integrates with :doc:`/users/fiji/index`, which includes
 Bio-Formats. See `this
-page <http://www.bitplane.com/index.cfm?objectid=0D8067BB-B4BA-B42D-00D7454EF75DB9A8>`_
-for a detailed list of Imaris' features.
+page <http://www.bitplane.com/imaris/imaris>`_ for a detailed list of Imaris' 
+features.


### PR DESCRIPTION
Molecular Imaging Corp appears to have closed, explaining why their website doesn't exist anymore (delisted on stock exchange sites and reported closed on local business finder website, also investors forum posts saying it has gone bust).

Imaris link is the closest I can find to a current features page - you have to click on a 'Features' tab.

This PR should make the BF docs-merge-stable build green again.
