### PR TITLE
Data tests: adjust memory calculations based upon thread count (rebased onto dev_4_4)

### DIFF
--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -147,6 +147,12 @@ public class TestTools {
   public static boolean canFitInMemory(long bufferSize) {
     Runtime r = Runtime.getRuntime();
     long mem = r.freeMemory() / 2;
+    int threadCount = 1;
+    try {
+      threadCount = Integer.parseInt(System.getProperty("testng.threadCount"));
+    }
+    catch (NumberFormatException e) { }
+    mem /= threadCount;
     return bufferSize < mem && bufferSize <= Integer.MAX_VALUE;
   }
 


### PR DESCRIPTION
This is the same as gh-718 but rebased onto dev_4_4.

---

This restricts the amount of memory each thread can use to open a single image (to `testng.memory / testng.threadCount`) in order to prevent OOMs if most of the threads are attempting to open large images at the same time.  As before, if an image is too large to be opened at once, the MD5 of the upper-left-most tile will still be checked.
