### PR TITLE
bfconvert: fix conversion of individual series

### DIFF
--- a/components/scifio-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/scifio-tools/src/loci/formats/tools/ImageConverter.java
@@ -342,6 +342,7 @@ public final class ImageConverter {
 
     boolean dimensionsSet = true;
     if (width == 0 || height == 0) {
+      reader.setSeries(series);
       width = reader.getSizeX();
       height = reader.getSizeY();
       dimensionsSet = false;


### PR DESCRIPTION
This ensures that the image width and height are set correctly if only
one series is being converted.  Previously, attempting to convert a
series with dimensions different from series 0 would have resulted in a
FormatException.

To test, verify that `bfconvert -series 1 input-file output-file.tiff` works regardless of whether or not series 0 and series 1 have the same image dimensions.  Most HCS datasets should have the same dimensions; most pathology (e.g. SVS) datasets should have different dimensions.
