### PR TITLE
Update POM version numbers to 4.4.10-SNAPSHOT

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats/pom.xml
+++ b/components/bio-formats/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/legacy/ome-editor/pom.xml
+++ b/components/legacy/ome-editor/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/legacy/ome-notes/pom.xml
+++ b/components/legacy/ome-notes/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-tools/pom.xml
+++ b/components/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/native/benchmark/pom.xml
+++ b/components/native/benchmark/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>pom-scifio-native-benchmark</artifactId>

--- a/components/native/bf-itk-jace/pom.xml
+++ b/components/native/bf-itk-jace/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-jace</artifactId>

--- a/components/native/bf-itk-jni/pom.xml
+++ b/components/native/bf-itk-jni/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-jni</artifactId>

--- a/components/native/bf-itk-pipe/pom.xml
+++ b/components/native/bf-itk-pipe/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk-pipe</artifactId>

--- a/components/native/pom.xml
+++ b/components/native/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-io/pom.xml
+++ b/components/ome-io/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-tools/pom.xml
+++ b/components/ome-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-tools/pom.xml
+++ b/components/scifio-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>loci</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>4.4.9</version>
+    <version>4.4.10-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>loci</groupId>
   <artifactId>pom-scifio</artifactId>
-  <version>4.4.9</version>
+  <version>4.4.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>


### PR DESCRIPTION
This should be the first thing to go in after 4.4.9 is tagged.
