### PR TITLE
Maven: add missing distributionManagement block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,4 +345,17 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <distributionManagement>
+    <repository>
+      <id>imagej.releases</id>
+      <name>ImageJ Releases Repository</name>
+      <url>dav:http://maven.imagej.net/content/repositories/releases</url>
+    </repository>
+    <snapshotRepository>
+      <id>imagej.snapshots</id>
+      <name>ImageJ Snapshots Repository</name>
+      <url>dav:http://maven.imagej.net/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
Without this, `mvn deploy` will fail.  Merging this should fix the `BIOFORMATS-maven`, `BIOFORMATS-trunk-cppwrap`, and `BIOFORMATS-cpp-daily` builds.
