### PR TITLE
ImageConverter: only call setSeries on non-negative values

### DIFF
--- a/components/scifio-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/scifio-tools/src/loci/formats/tools/ImageConverter.java
@@ -342,7 +342,11 @@ public final class ImageConverter {
 
     boolean dimensionsSet = true;
     if (width == 0 || height == 0) {
-      reader.setSeries(series);
+      // only switch series if the '-series' flag was used;
+      // otherwise default to series 0
+      if (series >= 0) {
+        reader.setSeries(series);
+      }
       width = reader.getSizeX();
       height = reader.getSizeY();
       dimensionsSet = false;


### PR DESCRIPTION
This was introduced in 370dfdf2b4b6e072ff3a20264bbcb8a722ec8c37 (i.e. gh-728).
Without this change, bfconvert will throw an IllegalArgumentException
unless the '-series' flag is used.

To test, verify that the tests from gh-728 pass, in addition to `bfconvert input-file output-file.tiff`
