### PR TITLE
Maven: add Wagon extension to fix deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,13 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-webdav-jackrabbit</artifactId>
+        <version>1.0</version>
+      </extension>
+    </extensions>
   </build>
 
   <reporting>


### PR DESCRIPTION
This should hopefully fix the `BIOFORMATS-maven` job.
