### PR TITLE
Adding 4.4.9 to version history (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -22,7 +22,6 @@ Version history
 * Many bug fixes including improvements to support for ND2 format
 * Java 1.6 is now the minimum supported version; Java 1.5 is no longer 
   supported
-* Bfview command line tool deprecated
 
 4.4.8 (2013 May 2)
 ------------------


### PR DESCRIPTION
This is the same as gh-739 but rebased onto develop.

---

Updating version history for 4.4.9 release
