### PR TITLE
cppwrap: update includes to reference 4.4.10-SNAPSHOT headers

### DIFF
--- a/components/scifio/cppwrap/minimum_writer.cpp
+++ b/components/scifio/cppwrap/minimum_writer.cpp
@@ -42,8 +42,8 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.4.9.h"
-#include "ome-xml-4.4.9.h"
+#include "scifio-4.4.10-SNAPSHOT.h"
+#include "ome-xml-4.4.10-SNAPSHOT.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Boolean;

--- a/components/scifio/cppwrap/showinf.cpp
+++ b/components/scifio/cppwrap/showinf.cpp
@@ -42,8 +42,8 @@
 #include "javaTools.h"
 
 // for Bio-Formats C++ bindings
-#include "scifio-4.4.9.h"
-#include "loci-common-4.4.9.h"
+#include "scifio-4.4.10-SNAPSHOT.h"
+#include "loci-common-4.4.10-SNAPSHOT.h"
 using jace::JNIException;
 using jace::proxy::java::io::IOException;
 using jace::proxy::java::lang::Object;


### PR DESCRIPTION
This should fix recent Travis build failures, as the header versions and POM versions now match.
