### PR TITLE
Eclipse: ignore gmaven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,39 @@
         <version>1.0</version>
       </extension>
     </extensions>
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>
+                      org.codehaus.gmaven
+                    </groupId>
+                    <artifactId>
+                      gmaven-plugin
+                    </artifactId>
+                    <versionRange>[1.4,)</versionRange>
+                    <goals>
+                      <goal>execute</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <reporting>


### PR DESCRIPTION
Added configuration to ignore gmaven in eclipse by default, as it currently causes an error. I couldn't find a connector, and got more exceptions when trying to tell m2e to execute the gmaven script. It doesn't look necessary for code development in Eclipse, so it seems safe to ignore.

To test:
- Import Bio-Formats into Eclipse as a maven project.
- Verify it currently fails due to lacking a lifecycle mapping.
- Update to use this patch.
- Verify there are no more errors in Eclipse.
