### PR TITLE
Deltavision: do not warn if the ND is set to "BLANK"

### DIFF
--- a/components/bio-formats/src/loci/formats/in/DeltavisionReader.java
+++ b/components/bio-formats/src/loci/formats/in/DeltavisionReader.java
@@ -1121,7 +1121,11 @@ public class DeltavisionReader extends FormatReader {
             ndFilters[cIndex] = new Double(nd / 100);
           }
           catch (NumberFormatException exc) {
-            LOGGER.warn("Could not parse ND filter '{}'", value);
+            // "BLANK" is the default (e.g. for deconvolved data),
+            // so no need to log it explicitly
+            if (!value.equals("BLANK")) {
+              LOGGER.warn("Could not parse ND filter '{}'", value);
+            }
           }
           catch (IllegalArgumentException e) {
             LOGGER.debug("", e);


### PR DESCRIPTION
Noticed by @joshmoore.

This should prevent things like:

```
2013-10-28 10:07:51,499 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,499 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,499 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,499 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,500 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,500 WARN  [              loci.formats.FormatHandler] (l.Server-2) Could not parse ND filter 'BLANK'
2013-10-28 10:07:51,500 DEBUG [                   loci.formats.Memoizer] (l.Server-2) skipping save memo. elapsed millis: 25
2013-10-28 10:07:51,500 DEBUG [                   loci.formats.Memoizer] (l.Server-2) start[1382954871475] time[25] tag[loci.formats.Memoizer.setId]
2013-10-28 10:07:51,500 INFO  [                ome.io.nio.PixelsService] (l.Server-2) Creating BfPixelBuffer:
/OMERO/ManagedRepository/user-1_8/2013-09/18/10-05-41.286/IAGFP-Noc01_R3D.dv Series: 0
```
