### PR TITLE
Fix link to Homebrew Github repository (rebased onto dev_4_4)

### DIFF
--- a/docs/sphinx/developers/BF-CPP-macosx.txt
+++ b/docs/sphinx/developers/BF-CPP-macosx.txt
@@ -4,7 +4,7 @@ Building C++ bindings in Mac OS X
 Compile-time dependencies -- Mac OS X
 -------------------------------------
 
-To install dependencies on Mac OS X, we advise using `Homebrew <http://mxcl.github.com/homebrew/>`_:
+To install dependencies on Mac OS X, we advise using `Homebrew <https://github.com/mxcl/homebrew/>`_:
 
 ::
 


### PR DESCRIPTION
This is the same as gh-778 but rebased onto dev_4_4.

---
