### PR TITLE
Fuji: make carriage returns optional (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/FujiReader.java
+++ b/components/bio-formats/src/loci/formats/in/FujiReader.java
@@ -150,7 +150,7 @@ public class FujiReader extends FormatReader {
       infFile = pixelsFile.substring(0, pixelsFile.lastIndexOf(".")) + ".inf";
     }
 
-    String[] lines = DataTools.readFile(infFile).split("\r\n");
+    String[] lines = DataTools.readFile(infFile).split("\r{0,1}\n");
 
     int bits = Integer.parseInt(lines[5]);
 


### PR DESCRIPTION
This is the same as gh-776 but rebased onto develop.

---

This allows `.inf` files with either CRLF or LF line endings to be parsed correctly.

Nothing really to test other than that the builds are green.
