### PR TITLE
Leica LIF: do not set the 'rgb' flag for 16-bit multi-channel data

### DIFF
--- a/components/scifio/src/loci/formats/ImageTools.java
+++ b/components/scifio/src/loci/formats/ImageTools.java
@@ -763,8 +763,8 @@ public final class ImageTools {
       for (int i=0; i<buf.length; i+=bpp*c) {
         for (int b=0; b<bpp; b++) {
           byte tmp = buf[i + b];
-          buf[i + b] = buf[i + bpp * 2];
-          buf[i + bpp * 2] = tmp;
+          buf[i + b] = buf[i + b + bpp * 2];
+          buf[i + b + bpp * 2] = tmp;
         }
       }
     }


### PR DESCRIPTION
Multi-channel images with more than 8 bits per pixel are not stored as
RGB images, even though the stored byte count suggests that they might
be.

See QA 7695 and
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-November/004051.html

To test, verify that the images in QA 7695 look correct and that the builds are green.
