### PR TITLE
Cellomics: fix getSeriesUsedFiles to return the current series' files

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellomicsReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellomicsReader.java
@@ -120,7 +120,11 @@ public class CellomicsReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    return files;
+
+    int nFiles = files.length / getSeriesCount();
+    String[] seriesFiles = new String[nFiles];
+    System.arraycopy(files, getSeries() * nFiles, seriesFiles, 0, nFiles);
+    return seriesFiles;
   }
 
   /* @see loci.formats.IFormatReader#fileGroupOption(String) */


### PR DESCRIPTION
Previously, all of the files in the dataset were returned by getSeriesUsedFiles().  In the case of large plates, calls to getUsedFiles() would then attempt to iterate over several thousand files for each series, which is quite slow.

/cc @manics
