### PR TITLE
Changing Maia Scientific web link which is down (rebased onto develop)

### DIFF
--- a/docs/sphinx/formats/mias-maia-scientific.txt
+++ b/docs/sphinx/formats/mias-maia-scientific.txt
@@ -6,7 +6,7 @@ MIAS (Maia Scientific)
 
 Extensions: .tif 
 
-Developer: `Maia Scientific <http://www.maia-scientific.com/>`_
+Developer: `Maia Scientific <http://www.selectscience.net/supplier/maia-scientific/?compID=6088>`_
 
 
 **Support**


### PR DESCRIPTION
This is the same as gh-793 but rebased onto develop.

---

http://www.maia-scientific.com is down so this changes the link in the BF docs to the company listing on SelectScience, which has a link to the original company website for if it starts working again. (I haven't been able to find an email address for them and various contact forms have proved unhelpful)

Should make the BF docs build green again.
