### PR TITLE
Add planeInfo=true support to FakeReader

### DIFF
--- a/components/scifio/src/loci/formats/in/FakeReader.java
+++ b/components/scifio/src/loci/formats/in/FakeReader.java
@@ -87,8 +87,8 @@ public class FakeReader extends FormatReader {
 
   // -- Fields --
 
-  /** whether or not to generate planeInfo elements **/
-  private boolean planeInfo = false;
+  /** exposure time per plane info */
+  private Float exposureTime = null;
 
   /** Scale factor for gradient, if any. */
   private double scaleFactor = 1;
@@ -307,7 +307,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("series")) seriesCount = intValue;
       else if (key.equals("lutLength")) lutLength = intValue;
       else if (key.equals("scaleFactor")) scaleFactor = doubleValue;
-      else if (key.equals("planeInfo")) planeInfo = boolValue;
+      else if (key.equals("exposureTime")) exposureTime = (float) doubleValue;
     }
 
     // do some sanity checks
@@ -364,8 +364,10 @@ public class FakeReader extends FormatReader {
     }
 
     // populate OME metadata
+    boolean planeInfo = (exposureTime != null);
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, planeInfo);
+    fillExposureTime(store);
     for (int s=0; s<seriesCount; s++) {
       String imageName = s > 0 ? name + " " + (s + 1) : name;
       store.setImageName(imageName, s);
@@ -405,7 +407,19 @@ public class FakeReader extends FormatReader {
     }
   }
 
-  // -- Helper methods --
+  private void fillExposureTime(MetadataStore store) {
+    if (exposureTime == null) return;
+    int oldSeries = getSeries();
+    for (int s=0; s<getSeriesCount(); s++) {
+      setSeries(s);
+      for (int i=0; i<getImageCount(); i++) {
+        store.setPlaneExposureTime(exposureTime.doubleValue(), s, i);
+      }
+      setSeries(oldSeries);
+    }
+  }
+
+// -- Helper methods --
 
   /** Creates a mapping between indices and color values. */
   private void createIndexMap(int num) {


### PR DESCRIPTION
In order to investigate recent connection lost issues, being able
to generate a large number of plane info objects and insert them
into OMERO would be useful.

See: https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7351&start=20
