### PR TITLE
Fixing & adding links to contributing devs docs

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -183,7 +183,8 @@ extlinks = {
     'faq_plone' : (oo_site_root + '/support/faq/%s', ''),
     'training_plone' : (oo_site_root + '/support/training/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
-    'omerodoc': (omerodoc_uri + '/%s', ''),
+    'omerodoc' : (omerodoc_uri + '/%s', ''),
+    'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/bio-formats/%s', ''),
     # Miscellaneous links

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -16,7 +16,7 @@ files likely to be affected by that commit. If you want to run these
 tests, you will need to do the following:
 
 Clone bioformats.git and checkout the appropriate branch (by following
-the directions on the :omerodoc:`Git usage <developers/using-git.html>`
+the directions on the :devs_doc:`Git usage <using-git.html>`
 page). Run this command to build all of the JAR files:
 
 ::

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -97,5 +97,8 @@ Contributing to Bio-Formats
     service
     xsd-fu
 
-See `open Trac tickets for Bio-Formats <https://trac.openmicroscopy.org.uk/ome/report/44>`_ for information on work currently planned or in progress.
+See `open Trac tickets for Bio-Formats <https://trac.openmicroscopy.org.uk/ome/report/44>`_ 
+for information on work currently planned or in progress.
 
+For more general guidance about how to contribute to OME projects, see the 
+:devs_doc:`Contributing developers documentation <index.html>`.


### PR DESCRIPTION
This fixes the bf-docs-merge-develop build by updating the 'using git' doc link to the new contributing developers documentation, and also adds a link to these docs on the BF developers index page.
