### PR TITLE
Cellworx: fix off-by-one if all pixels files are missing

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellWorxReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellWorxReader.java
@@ -376,7 +376,7 @@ public class CellWorxReader extends FormatReader {
       if (planeIndex <  nTimepoints * wavelengths.length) {
         planeIndex++;
       }
-      else if (seriesIndex < seriesCount) {
+      else if (seriesIndex < seriesCount - 1) {
         planeIndex = 0;
         seriesIndex++;
       }


### PR DESCRIPTION
This won't allow .htd files without TIFFs to import, but it makes the
exception that is thrown more informative.

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/6332.  The QA dataset mentioned in the ticket should throw a `FileNotFoundException` with this PR, as all of the pixels files are missing from the dataset.  
