### PR TITLE
fix link to Java Image I/O guide (rebased onto dev_4_4)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1012,7 +1012,7 @@ utilityRating = Poor
 reader = JPEGReader.java
 writer = JPEGWriter.java
 notes = Bio-Formats can save individual planes as JPEG. \n
-Bio-Formats uses the `Java Image I/O <http://java.sun.com/j2se/1.4.2/docs/guide/imageio/index.html>`_ API to read and write JPEG files. \n
+Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_ API to read and write JPEG files. \n
 JPEG stands for "Joint Photographic Experts Group". \n
 \n
 .. seealso:: \n
@@ -1766,7 +1766,7 @@ opennessRating = Outstanding
 presenceRating = Outstanding
 utilityRating = Poor
 reader = APNGReader.java
-notes = Bio-Formats uses the `Java Image I/O <http://java.sun.com/j2se/1.4.2/docs/guide/imageio/index.html>`_  \n
+notes = Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_  \n
 API to read and write PNG files. \n
 \n
 .. seealso:: \n

--- a/docs/sphinx/formats/jpeg.txt
+++ b/docs/sphinx/formats/jpeg.txt
@@ -55,7 +55,7 @@ Notes:
 
 
 Bio-Formats can save individual planes as JPEG. 
-Bio-Formats uses the `Java Image I/O <http://java.sun.com/j2se/1.4.2/docs/guide/imageio/index.html>`_ API to read and write JPEG files. 
+Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_ API to read and write JPEG files. 
 JPEG stands for "Joint Photographic Experts Group". 
 
 .. seealso:: 

--- a/docs/sphinx/formats/png.txt
+++ b/docs/sphinx/formats/png.txt
@@ -55,7 +55,7 @@ Source Code: :scifioreader:`APNGReader.java`
 Notes:
 
 
-Bio-Formats uses the `Java Image I/O <http://java.sun.com/j2se/1.4.2/docs/guide/imageio/index.html>`_  
+Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_  
 API to read and write PNG files. 
 
 .. seealso:: 


### PR DESCRIPTION
This is the same as gh-801 but rebased onto dev_4_4.

---

current Bio-Formats minimum requirement is Java 6
