### PR TITLE
Leica LIF: 'C' goes before other dimensions if SizeC and SizeT > 1

### DIFF
--- a/components/bio-formats/src/loci/formats/in/LIFReader.java
+++ b/components/bio-formats/src/loci/formats/in/LIFReader.java
@@ -1821,6 +1821,9 @@ public class LIFReader extends FormatReader {
     Long[] bytes = bytesPerAxis.keySet().toArray(new Long[0]);
     Arrays.sort(bytes);
     ms.dimensionOrder = "XY";
+    if (getSizeC() > 1 && getSizeT() > 1) {
+      ms.dimensionOrder += "C";
+    }
     for (Long nBytes : bytes) {
       String axis = bytesPerAxis.get(nBytes);
       if (ms.dimensionOrder.indexOf(axis) == -1) {


### PR DESCRIPTION
This fixes QA 7724 as reported here:

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-November/004084.html
