### PR TITLE
Add planeInfo=true support to FakeReader (rebased onto develop)

### DIFF
--- a/components/scifio/src/loci/formats/in/FakeReader.java
+++ b/components/scifio/src/loci/formats/in/FakeReader.java
@@ -467,7 +467,6 @@ public class FakeReader extends FormatReader {
       else if (key.equals("lutLength")) lutLength = intValue;
       else if (key.equals("scaleFactor")) scaleFactor = doubleValue;
       else if (key.equals("exposureTime")) exposureTime = (float) doubleValue;
-      else if (key.equals("planeInfo")) planeInfo = boolValue;
       else if (key.equals("plates")) plates = intValue;
       else if (key.equals("plateRows")) plateRows = intValue;
       else if (key.equals("plateCols")) plateCols = intValue;


### PR DESCRIPTION
This is the same as gh-795 but rebased onto develop.

---

In order to investigate recent connection lost issues, being able
to generate a large number of plane info objects and insert them
into OMERO would be useful.

See: https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7351&start=20
