### PR TITLE
CellWorx: ignore thumbnails and missing channel names (rebased onto develop)

### DIFF
--- a/components/bio-formats/src/loci/formats/in/CellWorxReader.java
+++ b/components/bio-formats/src/loci/formats/in/CellWorxReader.java
@@ -503,7 +503,7 @@ public class CellWorxReader extends FormatReader {
       }
       for (int i=0; i<core.size(); i++) {
         for (int c=0; c<getSizeC(); c++) {
-          if (c < wavelengths.length) {
+          if (c < wavelengths.length && wavelengths[c] != null) {
             store.setChannelName(wavelengths[c], i, c);
           }
         }
@@ -769,7 +769,7 @@ public class CellWorxReader extends FormatReader {
       for (String f : list) {
         if (checkSuffix(f, new String [] {"tif", "tiff", "pnl"})) {
           String path = new Location(parent, f).getAbsolutePath();
-          if (path.startsWith(base)) {
+          if (path.startsWith(base) && path.indexOf("_thumb_") < 0) {
             files[nextFile++] = path;
           }
         }


### PR DESCRIPTION
This is the same as gh-746 but rebased onto develop.

---

Any TIFF files with `_thumb_` in the name are now ignored, so that
thumbnails are not inadvertently picked up.  If channel names are
missing from the .htd file, then the channel names stored in the
.pnl/.tif files will be used instead.

/cc @chris-allan
