### PR TITLE
Add support for multi-channel Volocity Clipping datasets

### DIFF
--- a/components/bio-formats/src/loci/formats/in/VolocityClippingReader.java
+++ b/components/bio-formats/src/loci/formats/in/VolocityClippingReader.java
@@ -225,7 +225,7 @@ public class VolocityClippingReader extends FormatReader {
       firstOffset = in.getFilePointer() + 65;
     }
     else {
-      firstOffset -= 59;
+      firstOffset -= 69;
     }
 
     if (getSizeX() * getSizeY() * 100 >= in.length()) {
@@ -244,6 +244,10 @@ public class VolocityClippingReader extends FormatReader {
         in.seek(firstOffset);
       }
     }
+
+    in.seek(firstOffset);
+    while (in.readShort() == 0);
+    firstOffset = in.getFilePointer() - 2;
 
     pixelOffsets.add(firstOffset);
 


### PR DESCRIPTION
To test, just verify that all of the builds are green.  Merged RGB channels are not supported by this PR, but rather "real" acquisition channels that are stored separately.
