### PR TITLE
ND2: prevent alpha component from being set to 0

### DIFF
--- a/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
+++ b/components/bio-formats/src/loci/formats/in/NativeND2Reader.java
@@ -1654,12 +1654,12 @@ public class NativeND2Reader extends FormatReader {
         int red = colors[c] & 0xff;
         int green = (colors[c] & 0xff00) >> 8;
         int blue = (colors[c] & 0xff0000) >> 16;
-        int alpha = (colors[c] & 0xff000000) >> 24;
 
         // do not set the channel color if the recorded color is black
         // doing so can prevent the image from displaying correctly
         if (red != 0 || green != 0 || blue != 0) {
-          store.setChannelColor(new Color(red, green, blue, alpha), i, c);
+          // always set the alpha to 255, otherwise the colors may not appear
+          store.setChannelColor(new Color(red, green, blue, 255), i, c);
         }
       }
     }


### PR DESCRIPTION
If the alpha is set to 0, the color will not show up correctly in
Insight.  This forces alpha to be set to 255 so that the color always
appears correctly.

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/10646
