### PR TITLE
Imspector: always set the modulo TypeDescription to "TCSPC"

### DIFF
--- a/components/bio-formats/src/loci/formats/in/ImspectorReader.java
+++ b/components/bio-formats/src/loci/formats/in/ImspectorReader.java
@@ -418,6 +418,7 @@ public class ImspectorReader extends FormatReader {
       m.moduloT.step = timeBase / m.sizeT;
       m.moduloT.end = m.moduloT.step * (m.sizeT - 1);
       m.moduloT.unit = "ps";
+      m.moduloT.typeDescription = "TCSPC";
     }
     else {
       if (uniquePMTs.size() <= pixelsOffsets.size()) {


### PR DESCRIPTION
This should prevent any problems with empty `TypeDescriptions` in FLIMfit.

/cc @imunro
