### PR TITLE
Add section about JVM memory settings under MATLAB (rebased onto dev_4_4)

### DIFF
--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -8,6 +8,26 @@ This section assumes that you have installed the M-files and
 :doc:`MATLAB user information page </users/matlab/index>`.
 Note the minimum supported MATLAB version is R2007b (7.5).
 
+Increasing JVM memory settings
+------------------------------
+
+The default JVM settings in MATLAB can result in
+``java.lang.OutOfMemoryError: Java heap space`` exceptions when opening large
+image files using Bio-Formats. Information about the Java heap space usage in
+MATLAB can be retrieved using::
+
+	java.lang.Runtime.getRuntime.maxMemory
+
+Default JVM settings can be increased by creating a :file:`java.opts` file in
+the startup directory and overriding the default memory settings. We recommend
+using ``-Xmx512m`` in your :file:`java.opts` file.
+
+.. seealso::
+
+	http://www.mathworks.com/matlabcentral/answers/92813
+		How do I increase the heap space for the Java VM in MATLAB 6.0 (R12)
+		and later versions?
+
 Opening an image file
 ---------------------
 


### PR DESCRIPTION
This is the same as gh-830 but rebased onto dev_4_4.

---

Default JVM settings in MATLAB are fairly low (max heap size 196M for most recent 64-bit version) and easily result in OOM when opening large files. This PR adds a section to the MATLAB developer documentation page documenting how to increase the maximum heap space and proposing a default value of 512M.
