### PR TITLE
Removing 'in transition' banner from docs

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -192,10 +192,6 @@ extlinks = {
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')
     }
 
-rst_prolog = """
-**This documentation is in transition. Please refer to the** :products_plone:`OME5 <ome5>` **products page for more information**.
-"""
-
 rst_epilog = """
 .. _Hibernate: http://www.hibernate.org
 .. _ZeroC: http://www.zeroc.com


### PR DESCRIPTION
Banner no longer needed, docs are as up-to-date & extensive as 4.4.9 and we are leaving beta.
