### PR TITLE
Permit cppwrap failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
   - BUILD=cppwrap
   - BUILD=sphinx
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: "BUILD=cppwrap"
+
 before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ raring main universe"
   - sudo apt-get -qq update


### PR DESCRIPTION
Since so much of https://travis-ci.org/openmicroscopy/bioformats/pull_requests
is red, permitting failure of cppwrap for the moment.
