### PR TITLE
Set POM versions to 5.1.0-SNAPSHOT

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats/pom.xml
+++ b/components/bio-formats/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/loci-common/pom.xml
+++ b/components/loci-common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-legacy/pom.xml
+++ b/components/loci-legacy/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/loci-tools/pom.xml
+++ b/components/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/native/bf-itk/pom.xml
+++ b/components/native/bf-itk/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio-native</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pom-scifio-native-bf-itk</artifactId>

--- a/components/native/pom.xml
+++ b/components/native/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-io/pom.xml
+++ b/components/ome-io/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-tools/pom.xml
+++ b/components/ome-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-devel/pom.xml
+++ b/components/scifio-devel/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio-tools/pom.xml
+++ b/components/scifio-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/turbojpeg/pom.xml
+++ b/components/turbojpeg/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/xsd-fu/pom.xml
+++ b/components/xsd-fu/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-scifio</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>pom-scifio</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>
@@ -44,7 +44,7 @@
     <maven.build.timestamp.format>d MMMMM yyyy</maven.build.timestamp.format>
 
     <vcs.revision>${revision}</vcs.revision>
-    <release.version>5.0.0-SNAPSHOT</release.version>
+    <release.version>5.1.0-SNAPSHOT</release.version>
     <date>${maven.build.timestamp}</date>
     <year>2013</year>
     <project.rootdir>${basedir}</project.rootdir>


### PR DESCRIPTION
This PR must go in before anything else on develop (otherwise we will have multiple `5.0.0-rc1` builds).
