### PR TITLE
Fix the copyright statement on generated Javadocs

### DIFF
--- a/ant/global.properties
+++ b/ant/global.properties
@@ -17,7 +17,7 @@ testng.jar   = ${lib.dir}/testng-5.11-jdk15.jar
 
 # copyright strings to use when generating javadocs
 copyright.begin = <i>Copyright &#169;
-copyright.end   = Laboratory for Optical and Computational Instrumentation</i>
+copyright.end   = Open Microscopy Environment</i>
 
 domain.prefix = edu.wisc.loci
 


### PR DESCRIPTION
Noticed by @sbesson.
