### PR TITLE
Correcting using git doc link

### DIFF
--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -16,7 +16,8 @@ files likely to be affected by that commit. If you want to run these
 tests, you will need to do the following:
 
 Clone bioformats.git and checkout the appropriate branch (by following
-the directions on the :omerodoc:`Git usage <developers/using-git.html>`
+the directions on the `Git usage
+<http://www.openmicroscopy.org/site/support/contributing/using-git.html>`_
 page). Run this command to build all of the JAR files:
 
 ::


### PR DESCRIPTION
This docs page has been removed on the dev_4_4 branch of OMERO (now in the new contributing docs section on the develop branch only), so this changes the link to a hard-coded one to avoid linking across branches. Should make the bf-docs-merge-stable build green again.

May need rebasing to dev_5_0 (I need to check) but will NOT need rebasing to develop.
