### PR TITLE
Fix the copyright statement on generated Javadocs (rebased onto dev_5_0)

### DIFF
--- a/ant/global.properties
+++ b/ant/global.properties
@@ -17,7 +17,7 @@ testng.jar   = ${lib.dir}/testng-6.8.jar
 
 # copyright strings to use when generating javadocs
 copyright.begin = <i>Copyright &#169;
-copyright.end   = Laboratory for Optical and Computational Instrumentation</i>
+copyright.end   = Open Microscopy Environment</i>
 
 domain.prefix = edu.wisc.loci
 


### PR DESCRIPTION
This is the same as gh-839 but rebased onto dev_5_0.

---

Noticed by @sbesson.
