### PR TITLE
Update POMs to point to mirror of the cppwrap plugin

### DIFF
--- a/components/scifio/pom.xml
+++ b/components/scifio/pom.xml
@@ -378,8 +378,8 @@
 
   <pluginRepositories>
     <pluginRepository>
-      <id>imagej.releases</id>
-      <url>http://maven.imagej.net/content/repositories/releases</url>
+      <id>ome.external</id>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -388,8 +388,8 @@
       </snapshots>
     </pluginRepository>
     <pluginRepository>
-      <id>imagej.releases</id>
-      <url>http://maven.imagej.net/content/repositories/releases</url>
+      <id>ome.external</id>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
This removes the dependency on maven.imagej.net, which has been causing
problems for Travis and Jenkins.

See gh-834.
