### PR TITLE
UpgradeChecker: fix the stable version number

### DIFF
--- a/components/scifio/src/loci/formats/UpgradeChecker.java
+++ b/components/scifio/src/loci/formats/UpgradeChecker.java
@@ -71,7 +71,7 @@ public class UpgradeChecker {
   // -- Constants --
 
   /** Version number of the latest stable release. */
-  public static final String STABLE_VERSION = "4.4.5";
+  public static final String STABLE_VERSION = "5.0.0-rc1";
 
   /** Location of the OME continuous integration server. */
   public static final String CI_SERVER = "http://ci.openmicroscopy.org";


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11865.
