### PR TITLE
Permit cppwrap failure (rebased onto dev_5_0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
   - BUILD=cppwrap
   - BUILD=sphinx
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: "BUILD=cppwrap"
+
 before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ raring main universe"
   - sudo apt-get -qq update


### PR DESCRIPTION
This is the same as gh-834 but rebased onto dev_5_0.

---

Since so much of https://travis-ci.org/openmicroscopy/bioformats/pull_requests
is red, permitting failure of cppwrap for the moment.
