### PR TITLE
Make sure that the configuration file suffix is propagated to subdirs

### DIFF
--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -302,7 +302,7 @@ public class TestTools {
       }
       else if (file.isDirectory()) {
         LOGGER.info("\tdirectory");
-        getFiles(subs[i], files, config, null);
+        getFiles(subs[i], files, config, null, null, configFileSuffix);
       }
       else if (!subs[i].endsWith("readme.txt")) {
         if (typeTester.isThisType(subs[i])) {


### PR DESCRIPTION
This prevents alternate configuration files that aren't in the top-level
directory from being ignored.

This should also fix the `BIOFORMATS-5.0-merge-daily` job.
