### PR TITLE
Ignore text nodes when parsing XMLAnnotation's value (rebased onto dev_5_0)

### DIFF
--- a/components/xsd-fu/templates-java/Pojo_XMLAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-java/Pojo_XMLAnnotation_update_Value.template
@@ -27,12 +27,15 @@
 				NodeList childNodeList = Value_nodeList.get(0).getChildNodes();
 				for (int i = 0; i < childNodeList.getLength(); i++)
 				{
-					try {
-						t.transform(new javax.xml.transform.dom.DOMSource(
-							childNodeList.item(i)), sr);
-					}
-					catch (javax.xml.transform.TransformerException te) {
-						LOGGER.warn("Failed to transform node #" + i, te);
+					// some parsers will pick up text nodes here, which we can ignore
+					if (childNodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
+					  try {
+						  t.transform(new javax.xml.transform.dom.DOMSource(
+								childNodeList.item(i)), sr);
+					  }
+					  catch (javax.xml.transform.TransformerException te) {
+							LOGGER.warn("Failed to transform node #" + i, te);
+					  }
 					}
 				}
 				setValue(sw.toString().trim());


### PR DESCRIPTION
This is the same as gh-853 but rebased onto dev_5_0.

---

This fixes an error parsing Modulo annotations (e.g. FLIM-modulo-sample.ome.tiff) in Matlab.

This does not fix the problem noted when viewing in Insight, namely that the sliders and do not correctly update the image indices (which I believe is an Insight bug).

/cc @imunro, @sbesson
