### PR TITLE
Update CI build names to point at the latest Bio-Formats jobs (rebased onto develop)

### DIFF
--- a/components/loci-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/loci-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -74,7 +74,7 @@ public class LociFunctions extends MacroFunctions {
 
   /** URL for LOCI Software Javadocs. */
   public static final String URL_LOCI_SOFTWARE_JAVADOCS =
-    "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1/javadoc/";
+    "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/javadoc/";
 
   // -- Fields --
 

--- a/components/scifio/src/loci/formats/UpgradeChecker.java
+++ b/components/scifio/src/loci/formats/UpgradeChecker.java
@@ -80,13 +80,13 @@ public class UpgradeChecker {
    * Location of the JAR artifacts for Bio-Formats' trunk build.
    */
   public static final String TRUNK_BUILD =
-    CI_SERVER + "/job/BIOFORMATS-trunk/lastSuccessfulBuild/artifact/artifacts/";
+    CI_SERVER + "/job/BIOFORMATS-5.1-latest/lastSuccessfulBuild/artifact/artifacts/";
 
   /**
    * Location of the JAR artifacts for Bio-Formats' daily build.
    */
   public static final String DAILY_BUILD =
-    CI_SERVER + "/job/BIOFORMATS-daily/lastSuccessfulBuild/artifact/artifacts/";
+    CI_SERVER + "/job/BIOFORMATS-5.1-daily/lastSuccessfulBuild/artifact/artifacts/";
 
   /**
    * Location of the JAR artifacts for the stable releases.

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -132,7 +132,7 @@ bf_github_branch = bf_github_root + 'blob/' + source_branch + '/'
 if "JENKINS_JOB" in os.environ:
     jenkins_job = os.environ.get('JENKINS_JOB')
 else:
-    jenkins_job = 'BIOFORMATS-trunk'
+    jenkins_job = 'BIOFORMATS-5.1-latest'
 
 jenkins_root = 'http://ci.openmicroscopy.org'
 jenkins_job_root = jenkins_root + '/job'


### PR DESCRIPTION
This is the same as gh-869 but rebased onto develop.

---

This PR follows recent renaming of the latest Bio-Formats jobs and updates the corresponding URLs in the code.
