### PR TITLE
No log4j in loci tools

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -75,8 +75,6 @@ loci-tools.libraries = bio-formats.jar \
                        xalan-2.7.1.jar \
                        xercesImpl-2.6.2.jar \
                        slf4j-api-${slf4j.version}.jar \
-                       slf4j-log4j12-${slf4j.version}.jar \
-                       log4j-${log4j.version}.jar \
                        scifio-tools.jar \
                        JWlz-1.4.0.jar
 


### PR DESCRIPTION
This was discovered while testing openmicroscopy/openmicroscopy#2043. Putting both `loci_tools.jar` and `OMERO.insight-ij` into ImageJ causes:

```
java.lang.ClassCastException: org.slf4j.impl.Log4jLoggerFactory cannot be cast to ch.qos.logback.classic.LoggerContext
    at org.openmicroscopy.shoola.env.log.LoggerImpl.<init>(LoggerImpl.java:88)
    at org.openmicroscopy.shoola.env.log.LoggerFactory.makeNew(LoggerFactory.java:104)
    at org.openmicroscopy.shoola.env.init.LoggerInit.execute(LoggerInit.java:82)
    at org.openmicroscopy.shoola.env.init.Initializer.doInit(Initializer.java:276)
    at org.openmicroscopy.shoola.env.Container.startupInPluginMode(Container.java:478)
    at org.openmicroscopy.shoola.env.Container.startupInPluginMode(Container.java:421)
    at org.openmicroscopy.shoola.MainIJPlugin.run(MainIJPlugin.java:247)
    at ij.IJ.runUserPlugIn(IJ.java:195)
    at ij.IJ.runPlugIn(IJ.java:160)
    at ij.Executer.runCommand(Executer.java:128)
    at ij.Executer.run(Executer.java:64)
    at java.lang.Thread.run(Thread.java:695)
```

due to

```
err > SLF4J: Class path contains multiple SLF4J bindings.
err >SLF4J: Found binding in [jar:file:/Users/cblackburn/Desktop/ImageJ/plugins/loci_tools.jar!/org/slf4j/impl/StaticLoggerBinder.class]
err >SLF4J: Found binding in [jar:file:/Users/cblackburn/Desktop/ImageJ/plugins/OMERO.insight-ij-5.0.0-rc1-DEV-ice33/libs/logback-classic.jar!/org/slf4j/impl/StaticLoggerBinder.class]
err >SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
err >SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
```
