### PR TITLE
Updating TILL Photonics website link (rebased onto develop)

### DIFF
--- a/docs/sphinx/formats/tillphotonics-tillvision.txt
+++ b/docs/sphinx/formats/tillphotonics-tillvision.txt
@@ -6,7 +6,7 @@ TillPhotonics TillVision
 
 Extensions: .vws 
 
-Developer: `TILL Photonics <http://www.till-photonics.com/>`_
+Developer: `TILL Photonics, now FEI Munich <http://www.fei.com>`_
 
 
 **Support**


### PR DESCRIPTION
This is the same as gh-877 but rebased onto develop.

---

TILL Photonics has been bought out and their website seems to have been taken down this week. This updates the link to the company they are now part of. Should make the BF docs green again, provided the NIH links aren't still being annoying!
