### PR TITLE
Update ome_tools.jar to include almost everything that loci_tools.jar does

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -91,7 +91,31 @@ ome-tools.libraries = commons-httpclient-2.0-rc2.jar \
                       ome-java.jar \
                       ome_plugins.jar \
                       omero_client.jar \
-                      xmlrpc-1.2-b1.jar
+                      xmlrpc-1.2-b1.jar \
+                      bio-formats.jar \
+                      forms-1.3.0.jar \
+                      jai_imageio.jar \
+                      joda-time-2.2.jar \
+                      kryo-2.21-shaded.jar \
+                      loci-legacy.jar \
+                      loci_plugins.jar \
+                      mdbtools-java.jar \
+                      metakit.jar \
+                      native-lib-loader-2.0-SNAPSHOT.jar \
+                      netcdf-4.3.19.jar \
+                      ome-xml.jar \
+                      perf4j-0.9.13.jar \
+                      poi-loci.jar \
+                      serializer-2.7.1.jar \
+                      scifio.jar \
+                      scifio-devel.jar \
+                      specification.jar \
+                      turbojpeg.jar \
+                      xalan-2.7.1.jar \
+                      xercesImpl-2.6.2.jar \
+                      slf4j-api-${slf4j.version}.jar \
+                      scifio-tools.jar \
+                      JWlz-1.4.0.jar
 
 ### Bio-Formats command line tools bundle ###
 

--- a/components/ome-tools/assembly.xml
+++ b/components/ome-tools/assembly.xml
@@ -11,31 +11,6 @@
     <dependencySet>
       <excludes>
         <!-- exclude things included in loci_tools.jar -->
-        <exclude>ome:bio-formats</exclude>
-        <exclude>ome:loci_plugins</exclude>
-        <exclude>ome:ome-xml</exclude>
-        <exclude>ome:loci-legacy</exclude>
-        <exclude>ome:scifio</exclude>
-        <exclude>ome:lwf-stubs</exclude>
-        <exclude>gov.nih.imagej:imagej</exclude>
-        <exclude>com.esotericsoftware.kryo:kryo</exclude>
-        <exclude>com.jgoodies:forms</exclude>
-        <exclude>ome:jai_imageio</exclude>
-        <exclude>ome:poi-loci</exclude>
-        <exclude>ome:mdbtools-java</exclude>
-        <exclude>ome:turbojpeg</exclude>
-        <exclude>ome:metakit</exclude>
-        <exclude>ome:scifio-devel</exclude>
-        <exclude>ome:specification</exclude>
-        <exclude>xalan:xalan</exclude>
-        <exclude>xalan:serializer</exclude>
-        <exclude>xerces:xercesImpl</exclude>
-        <exclude>joda-time:joda-time</exclude>
-        <exclude>org.perf4j:perf4j</exclude>
-        <exclude>org.scijava:native-lib-loader</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>edu.ucar:netcdf</exclude>
-        <exclude>woolz:JWlz</exclude>
         <exclude>org.springframework:spring*</exclude>
         <exclude>aopalliance:aopalliance</exclude>
         <exclude>org.aspectj:aspectj*</exclude>


### PR DESCRIPTION
Only slfj4-log4j and log4j are removed.  See ticket #11955.
