### PR TITLE
Switch from net.imagej:ij to gov.nih.imagej:imagej (rebased onto develop)

### DIFF
--- a/components/loci-plugins/pom.xml
+++ b/components/loci-plugins/pom.xml
@@ -54,8 +54,8 @@
       <version>1.2.1</version>
     </dependency>
     <dependency>
-      <groupId>net.imagej</groupId>
-      <artifactId>ij</artifactId>
+      <groupId>gov.nih.imagej</groupId>
+      <artifactId>imagej</artifactId>
       <version>[1.45s,1.47o),[1.47q,)</version>
     </dependency>
     <dependency>

--- a/components/loci-tools/assembly.xml
+++ b/components/loci-tools/assembly.xml
@@ -11,7 +11,7 @@
     <dependencySet>
       <excludes>
         <exclude>ome:lwf-stubs</exclude>
-        <exclude>net.imagej:ij</exclude>
+        <exclude>gov.nih.imagej:imagej</exclude>
         <!-- exclude testing dependencies -->
         <exclude>org.testng:testng</exclude>
         <exclude>junit:junit</exclude>

--- a/components/ome-plugins/pom.xml
+++ b/components/ome-plugins/pom.xml
@@ -54,8 +54,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>net.imagej</groupId>
-      <artifactId>ij</artifactId>
+      <groupId>gov.nih.imagej</groupId>
+      <artifactId>imagej</artifactId>
       <version>[1.45s,1.47o),[1.47q,)</version>
     </dependency>
   </dependencies>

--- a/components/ome-tools/assembly.xml
+++ b/components/ome-tools/assembly.xml
@@ -17,7 +17,7 @@
         <exclude>ome:loci-legacy</exclude>
         <exclude>ome:scifio</exclude>
         <exclude>ome:lwf-stubs</exclude>
-        <exclude>net.imagej:ij</exclude>
+        <exclude>gov.nih.imagej:imagej</exclude>
         <exclude>com.esotericsoftware.kryo:kryo</exclude>
         <exclude>com.jgoodies:forms</exclude>
         <exclude>ome:jai_imageio</exclude>


### PR DESCRIPTION
This is the same as gh-873 but rebased onto develop.

---

This prevents one more indirect dependency on maven.imagej.net.  With this branch, I can now successfully do this locally:

```
rm -rf ~/.m2/repository/*
mvn clean
mvn
```

after adding `127.0.0.1 maven.imagej.net` to my `/etc/hosts` file; I'd expect Travis and Jenkins to be happy as well.
