### PR TITLE
Update JPEGTurboServiceImpl.java (rebased onto dev_5_0)

### DIFF
--- a/components/scifio/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/scifio/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -232,11 +232,11 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     Region tileBoundary = new Region(0, 0, 0, 0);
     byte[] tile = null;
     for (int row=0; row<yTiles; row++) {
-      tileBoundary.height = row < yTiles - 1 ? tileDim : imageHeight % tileDim;
+      tileBoundary.height = row < yTiles - 1 ? tileDim : imageHeight - (tileDim*row);
       tileBoundary.y = row * tileDim;
       for (int col=0; col<xTiles; col++) {
         tileBoundary.x = col * tileDim;
-        tileBoundary.width = col < xTiles - 1 ? tileDim : imageWidth % tileDim;
+        tileBoundary.width = col < xTiles - 1 ? tileDim : imageWidth - (tileDim*col);
         if (tileBoundary.intersects(image)) {
           intersection = image.intersection(tileBoundary);
           tile = getTile(col, row);


### PR DESCRIPTION
This is the same as gh-836 but rebased onto dev_5_0.

---

Correct calculation of last row/col size similar to http://lists.openmicroscopy.org.uk/pipermail/ome-users/2013-September/003940.html
