### PR TITLE
Fix missing bioformats_package.jar in bftools.zip

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -132,7 +132,7 @@ bftools.files = bfconvert \
                 bfconvert.bat \
                 bfview \
                 bfview.bat \
-                bioformats_package.jar \
+                ${artifact.dir}/bioformats_package.jar \
                 config.bat \
                 config.sh \
                 domainlist \


### PR DESCRIPTION
The jar was only present locally in the tools directory
since I had a symlink for testing. In the vanilla builds,
this change is necessary to prevent:

```
-rw-r--r-- 1 jamoore jamoore 16277709 Feb 10 20:36 artifacts/bioformats_package.jar
(ome1)jamoore@blue:/opt/ome3/components/bioformats$ ant dist-bftools
Buildfile: /opt/ome3/components/bioformats/build.xml

dist-bftools:
     [echo] ----------=========== bftools ===========----------
     [exec]     zip warning: name not matched: bioformats_package.jar
...

BUILD SUCCESSFUL
Total time: 0 seconds
```
