### PR TITLE
ITK: Fix whitespace in package jar location definition

### DIFF
--- a/components/native/bf-itk/CMakeLists.txt
+++ b/components/native/bf-itk/CMakeLists.txt
@@ -265,7 +265,7 @@ install(FILES
 # has been generated using "ant tools" from the Bio-Formats base folder.
 
 set(BF_ARTIFACT_DIR "${PROJECT_SOURCE_DIR}/../../../artifacts")
-set(BF_PACKAGE_JAR"${BF_ARTIFACT_DIR}/bioformats_package.jar")
+set(BF_PACKAGE_JAR "${BF_ARTIFACT_DIR}/bioformats_package.jar")
 
 # --------------------------------------------------------------------------
 # Copy bioformats_package.jar to the distribution folder (dist/bf-itk).


### PR DESCRIPTION
Merging this is expected to fix http://ci.openmicroscopy.org/job/BIOFORMATS-5.0-daily-ITK4/650 and http://ci.openmicroscopy.org/job/BIOFORMATS-5.0-daily-ITK320/732
