### PR TITLE
Flatten path to bioformats_package.jar in bftools.zip (see gh-901)

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -132,7 +132,6 @@ bftools.files = bfconvert \
                 bfconvert.bat \
                 bfview \
                 bfview.bat \
-                ${artifact.dir}/bioformats_package.jar \
                 config.bat \
                 config.sh \
                 domainlist \

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -1037,6 +1037,11 @@ Type "ant -p" for a list of targets.
       <arg value="${artifact.dir}/bftools.zip"/>
       <arg line="${bftools.files}"/>
     </exec>
+    <exec executable="zip" dir="${artifact.dir}">
+      <arg value="-r9"/>
+      <arg value="${artifact.dir}/bftools.zip"/>
+      <arg value="bioformats_package.jar"/>
+    </exec>
   </target>
 
   <!-- Matlab -->


### PR DESCRIPTION
Since this uses the native zip command, invoking from the
artifact.dir seems to be the most portable way to get the
unprefixed jar into the zip.

/cc @pwalczysko @melissalinkert
