### PR TITLE
Add ome-io and ome-java jars to bioformats_package.jar

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -64,6 +64,8 @@ package.libraries = bio-formats.jar \
                   metakit.jar \
                   native-lib-loader-2.0-SNAPSHOT.jar \
                   netcdf-4.3.19.jar \
+                  ome-io.jar \
+                  ome-java.jar \
                   ome-xml.jar \
                   perf4j-0.9.13.jar \
                   poi-loci.jar \

--- a/components/bioformats_package/pom.xml
+++ b/components/bioformats_package/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>loci_plugins</artifactId>
+      <artifactId>ome_plugins</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
`bioformats_package.jar` as built from this PR's branch should fix `ClassNotFoundException` issues in the Insight ImageJ plugin.  See https://github.com/openmicroscopy/openmicroscopy/pull/2074
