### PR TITLE
Fix logback.xml XML header

### DIFF
--- a/ant/logback.xml
+++ b/ant/logback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"/>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
`mvn` without this commit complained about
the logback.xml file (loudly).
