### PR TITLE
Use corrected download redirects for 5

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -186,7 +186,7 @@ extlinks = {
     'omerodoc' : (omerodoc_uri + '/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest-develop/bio-formats/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5/%s', ''),
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,4 +1,4 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest-develop/bio-formats/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats5/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
New redirects have been set up today to keep consistency with OMERO and the way we handle the docs in general. These links should redirect to the rc1 download page at the moment and will be updated to point at 5.0.0 when we release.

Not sure whether we need this on develop or not but I can rebase it for completeness unless anyone sees a reason not to.
