### PR TITLE
Using correct redirect for 4 download page

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -176,15 +176,15 @@ extlinks = {
     'community_plone' : (oo_site_root + '/community/%s', ''),
     'feature_plone' : (oo_site_root + '/products/feature-list/%s', ''),
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
-    'legacy_plone' : (oo_site_root + '/support/legacy/%s', ''),
+    'legacy_plone' : (oo_site_root + '/support/previous/%s', ''),
     'about_plone' : (oo_site_root + '/about/%s', ''),
     'team_plone' : (oo_site_root + '/team/%s', ''),
     'faq_plone' : (oo_site_root + '/support/faq/%s', ''),
     'training_plone' : (oo_site_root + '/support/training/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats4/%s', ''),
     'omerodoc': (omerodoc_uri + '/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/bio-formats/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats4/%s', ''),
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,4 +1,4 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/bio-formats/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats4/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Mostly for completeness and consistency but I need to re-release these docs anyway when 5.0 goes out because the menu is changing.

Makes the 4.4 docs point at the latest 4.4.x release version downloads page rather than the top folder.
