### PR TITLE
Update autogen scripts and templates for restructuring

### DIFF
--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -23,7 +23,7 @@ Supported Formats
      - .. image:: images/header-presence.png
      - .. image:: images/header-utility.png
      - .. image:: images/header-export.png
-     - .. image:: images/header-bsd.png
+     - BSD
 
 #foreach ($format in $formats)
 #set ($pagename = $format.get("pagename"))

--- a/components/autogen/src/gen-meta-support.sh
+++ b/components/autogen/src/gen-meta-support.sh
@@ -34,7 +34,9 @@ HEADER='# This file documents the metadata support for each file format that\n# 
 rm $outputFile
 echo -e $HEADER >> $outputFile
 
-for reader in $baseDir/**/src/loci/formats/in/*Reader.java
+readers=`ls $baseDir/formats-gpl/**/src/loci/formats/in/*Reader.java && ls $baseDir/formats-bsd/**/src/loci/formats/in/*Reader.java`
+
+for reader in $readers
 do
   readername=$(echo $reader | sed -e 's/.*\///' -e 's/\.java//')
   echo "Parsing $readername"


### PR DESCRIPTION
The gen-formats-pages and gen-meta-support targets were also run, but
both resulted in no changes (since no new formats were introduced after
rc2).
