### PR TITLE
Fixing IDL links (rebased onto dev_5_0)

### DIFF
--- a/docs/sphinx/users/idl/index.txt
+++ b/docs/sphinx/users/idl/index.txt
@@ -13,8 +13,10 @@ Bio-Formats to read in image files to IDL.
 Installation
 ------------
 
-Download the `ij_read_bio_formats.pro <http://www.helmholtz-muenchen.de/ibb/homepage/karsten.rodenacker/IDL/_pro/ij_read_bio_formats.pro>`_ script
-from Karsten Rodenacker's `IDL goodies (?) <http://www.helmholtz-muenchen.de/ibb/homepage/karsten.rodenacker/IDL/index.php>`_ web site.
+Download the `ij_read_bio_formats.pro
+<http://karo03.bplaced.net/karo/IDL/_pro/ij_read_bio_formats.pro>`_ script
+from Karsten Rodenacker's `IDL goodies (?)
+<http://karo03.bplaced.net/karo/ro_embed.php?file=IDL/index.html>`_ web site.
 See the comments at the top of the script for installation instructions
 and caveats.
 


### PR DESCRIPTION
This is the same as gh-936 but rebased onto dev_5_0.

---

Karsten Rodenacker has moved his IDL goodies page to his own website rather than it being hosted on his institutions site. This updates the links and will be rebased to all active branches.

To test, check the BF docs merge builds are green after rebuilding.
