### PR TITLE
Read internal pyramids from CellSens .vsi data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -406,6 +406,12 @@ public class CellSensReader extends FormatReader {
         ms.littleEndian = compressionType.get(index) == RAW;
         ms.interleaved = ms.rgb;
 
+        for (int q=1; q<ms.resolutionCount; q++) {
+          int res = core.size() - ms.resolutionCount + q;
+          core.get(res).littleEndian = ms.littleEndian;
+          core.get(res).interleaved = ms.interleaved;
+        }
+
         if (s == 0 && exifs.size() > 0) {
           IFD exif = exifs.get(0);
 


### PR DESCRIPTION
The main thing to test is that OMERO no longer generates pyramid files when .vsi files are imported (i.e. there should be no clock icon).  Resolutions are stored in the file(s) in order from largest to smallest, with each resolution expected to be 25% of the previous resolutions's size.  The smallest resolution is a single tile, typically 512x512.

/cc @chris-allan
