### PR TITLE
Updating Aperio ImageScope weblink

### DIFF
--- a/docs/sphinx/formats/aperio-afi.txt
+++ b/docs/sphinx/formats/aperio-afi.txt
@@ -52,4 +52,4 @@ Notes:
 
 
 .. seealso:: 
-  `Aperio ImageScope <http://www.aperio.com/#imagescope-request>`_
+  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_

--- a/docs/sphinx/formats/aperio-svs-tiff.txt
+++ b/docs/sphinx/formats/aperio-svs-tiff.txt
@@ -56,4 +56,4 @@ Notes:
 format, we are not able to distribute them to third parties.**
 
 .. seealso:: 
-  `Aperio ImageScope <http://www.aperio.com/#imagescope-request>`_
+  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_


### PR DESCRIPTION
Aperio.com now redirects to Leica website so the anchors don't work any more and are making the builds unstable. This should make the docs builds green again.
