### PR TITLE
Fix ImageScope links to match the committed documentation (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -175,7 +175,7 @@ presenceRating = Good
 utilityRating = Good
 reader = AFIReader.java
 notes = .. seealso:: \n
-  `Aperio ImageScope <http://www.aperio.com/#imagescope-request>`_
+  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
 
 [Aperio SVS TIFF]
 extensions = .svs
@@ -194,7 +194,7 @@ utilityRating = Good
 privateSpecification = true
 reader = SVSReader.java
 notes = .. seealso:: \n
-  `Aperio ImageScope <http://www.aperio.com/#imagescope-request>`_
+  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
 
 [Applied Precision CellWorX]
 extensions = .htd, .pnl


### PR DESCRIPTION
This is the same as gh-953 but rebased onto develop.

---

See gh-947; this just updates the autogeneration text to match the current format pages.
