### PR TITLE
change TeX Gyre font package so XeLaTeX can find it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - if [[ $BUILD == 'cpp' ]]; then sudo apt-get install -qq libgtest-dev libxerces-c-dev doxygen graphviz; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get install -qq python-sphinx; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended tex-gyre; fi
+  - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo fc-cache -rsfv; fi
 
 install:


### PR DESCRIPTION
`fonts-texgyre` supersedes earlier `tex-gyre` in including extra material that helps to make fonts findable by XeLaTeX; this PR makes the Travis configuration a better hint about what to install to build our documentation locally on systems like Debian jessie. Travis is the main tester here.
