### PR TITLE
Log the expected and actual values in failed metadata tests (rebased onto develop)

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -658,7 +658,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getSizeX() != config.getSizeX()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getSizeX() + ", actual " + reader.getSizeX() + ")");
       }
     }
     result(testName, true);
@@ -675,7 +675,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getSizeY() != config.getSizeY()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getSizeY() + ", actual " + reader.getSizeY() + ")");
       }
     }
     result(testName, true);
@@ -692,7 +692,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getSizeZ() != config.getSizeZ()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getSizeZ() + ", actual " + reader.getSizeZ() + ")");
       }
     }
     result(testName, true);
@@ -709,7 +709,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getSizeC() != config.getSizeC()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getSizeC() + ", actual " + reader.getSizeC() + ")");
       }
     }
     result(testName, true);
@@ -726,7 +726,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getSizeT() != config.getSizeT()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getSizeT() + ", actual " + reader.getSizeT() + ")");
       }
     }
     result(testName, true);
@@ -764,7 +764,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.isInterleaved() != config.isInterleaved()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.isInterleaved() + ", actual " + reader.isInterleaved() + ")");
       }
     }
     result(testName, true);
@@ -781,7 +781,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.isIndexed() != config.isIndexed()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.isIndexed() + ", actual " + reader.isIndexed() + ")");
       }
     }
     result(testName, true);
@@ -798,7 +798,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.isFalseColor() != config.isFalseColor()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.isFalseColor() + ", actual " + reader.isFalseColor() + ")");
       }
     }
     result(testName, true);
@@ -815,7 +815,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.isRGB() != config.isRGB()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.isRGB() + ", actual " + reader.isRGB() + ")");
       }
     }
     result(testName, true);
@@ -832,7 +832,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getThumbSizeX() != config.getThumbSizeX()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getThumbSizeX() + ", actual " + reader.getThumbSizeX() + ")");
       }
     }
     result(testName, true);
@@ -849,7 +849,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.getThumbSizeY() != config.getThumbSizeY()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getThumbSizeY() + ", actual " + reader.getThumbSizeY() + ")");
       }
     }
     result(testName, true);
@@ -868,7 +868,7 @@ public class FormatReaderTest {
       if (reader.getPixelType() !=
         FormatTools.pixelTypeFromString(config.getPixelType()))
       {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.getPixelType() + ", actual " + reader.getPixelType() + ")");
       }
     }
     result(testName, true);
@@ -885,7 +885,7 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       if (reader.isLittleEndian() != config.isLittleEndian()) {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + config.isLittleEndian() + ", actual " + reader.isLittleEndian() + ")");
       }
     }
     result(testName, true);
@@ -911,7 +911,7 @@ public class FormatReaderTest {
       if (!(expectedSize == null && realSize == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
     }
     result(testName, true);
@@ -936,7 +936,7 @@ public class FormatReaderTest {
       if (!(expectedSize == null && realSize == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
     }
     result(testName, true);
@@ -962,7 +962,7 @@ public class FormatReaderTest {
       if (!(expectedSize == null && realSize == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
     }
     result(testName, true);
@@ -984,7 +984,7 @@ public class FormatReaderTest {
       if (!(expectedIncrement == null && realIncrement == null) &&
         !expectedIncrement.equals(realIncrement))
       {
-        result(testName, false, "Series " + i);
+        result(testName, false, "Series " + i + " (expected " + expectedIncrement + ", actual " + realIncrement + ")");
       }
     }
     result(testName, true);
@@ -1011,7 +1011,7 @@ public class FormatReaderTest {
         if (!(expectedLightSource == null && realLightSource == null) &&
           !expectedLightSource.equals(realLightSource))
         {
-          result(testName, false, "Series " + i + " channel " + c);
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedLightSource + ", actual " + realLightSource + ")");
         }
       }
     }
@@ -1108,7 +1108,7 @@ public class FormatReaderTest {
         if (realWavelength == null || expectedWavelength == null ||
           !expectedWavelength.equals(realWavelength.getValue()))
         {
-          result(testName, false, "Series " + i + " channel " + c);
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }
       }
     }
@@ -1137,7 +1137,7 @@ public class FormatReaderTest {
         if (realWavelength == null || expectedWavelength == null ||
           !expectedWavelength.equals(realWavelength.getValue()))
         {
-          result(testName, false, "Series " + i + " channel " + c);
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }
       }
     }
@@ -1168,7 +1168,7 @@ public class FormatReaderTest {
             !expectedDetector.equals(realDetector)) && (realDetector == null ||
             !realDetector.equals(expectedDetector)))
           {
-            result(testName, false, "Series " + i + " channel " + c);
+            result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedDetector + ", actual " + realDetector + ")");
           }
         }
       }


### PR DESCRIPTION
This is the same as gh-943 but rebased onto develop.

---

This just needs verifying that the logs for failed tests (e.g. with https://github.com/openmicroscopy/bioformats/pull/881) are more informative.

/cc @qidane
