### PR TITLE
Cellomics: a few fixes for single-file datasets (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -383,7 +383,7 @@ public class CellomicsReader extends FormatReader {
     final String name = new Location(filename).getName();
     if (cellomicsPattern == null) {
       Matcher m = PATTERN_O.matcher(name);
-      if (m.matches()) {
+      if (m.matches() && m.group(4) != null) {
         cellomicsPattern = PATTERN_O;
         return m;
       }


### PR DESCRIPTION
This is the same as gh-950 but rebased onto dev_5_0.

---

This allows the field to contain either 2 or 3 digits, and fixes the
image name setting so that field/well indices are not 0.
