### PR TITLE
Scope test dependencies in specification component properly

### DIFF
--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -56,6 +56,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -68,6 +69,7 @@
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.8</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Without proper scoping the JUnit and TestNG dependencies leak into the
runtime CLASSPATH of downstream consumers of Bio-Formats.  As things
stand the dependency tree looks something like this at compile time and
runtime:

```
ome:formats-api:5.0.0-rc3
+--- ome:jai_imageio:5.0.0-rc3
+--- ome:formats-common:5.0.0-rc3 (*)
+--- ome:lwf-stubs:5.0.0-rc3
+--- ome:ome-xml:5.0.0-rc3 (*)
+--- ome:specification:5.0.0-rc3
|    +--- ome:ome-xml:5.0.0-rc3 (*)
|    +--- ome:formats-common:5.0.0-rc3 (*)
|    +--- joda-time:joda-time:2.2
|    +--- junit:junit:4.8.2 -> 4.10
|    |    \--- org.hamcrest:hamcrest-core:1.1
|    +--- org.slf4j:slf4j-api:1.7.2 -> 1.7.5
|    +--- org.testng:testng:6.8
|    |    +--- junit:junit:4.10 (*)
|    |    +--- org.beanshell:bsh:2.0b4
|    |    +--- com.beust:jcommander:1.27
|    |    \--- org.yaml:snakeyaml:1.6
|    \--- xerces:xercesImpl:2.6.2
+--- ome:turbojpeg:5.0.0-rc3
+--- org.scijava:native-lib-loader:2.0-SNAPSHOT
+--- com.jgoodies:forms:1.2.1
+--- joda-time:joda-time:2.2
+--- com.esotericsoftware.kryo:kryo:2.21
+--- org.perf4j:perf4j:0.9.13
+--- org.slf4j:slf4j-api:1.7.2 -> 1.7.5
+--- xalan:serializer:2.7.1 (*)
\--- xalan:xalan:2.7.1 (*)
```

That is at least seven needless JARs on the CLASSPATH and present in all
resultant downstream artifacts.  This commit should resolve that and
have no affect on the compile, test or package goals of the Bio-Formats
Maven build.
