### PR TITLE
CZI: restrict dimension adjustment

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -550,11 +550,14 @@ public class ZeissCZIReader extends FormatReader {
       if ((planes.size() % (seriesCount * getSizeZ())) == 0) {
         ms0.sizeT = 1;
       }
-      else if ((planes.size() % (seriesCount * getSizeT())) == 0) {
-        ms0.sizeZ = 1;
-      }
       ms0.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();
-      seriesCount = planes.size() / ms0.imageCount;
+
+      int newCount = planes.size() / ms0.imageCount;
+      if (planes.size() - (ms0.imageCount * newCount) <
+        ms0.imageCount * seriesCount - planes.size() && (planes.size() % seriesCount) != 0)
+      {
+        seriesCount = newCount;
+      }
     }
 
     if (seriesCount > 1) {


### PR DESCRIPTION
SizeZ is no longer altered, and the series count is only changed if the
plane count is not a multiple of the original series count.

This should fix issues with reading various SPIM datasets.

/cc @chris-allan, @emilroz
