### PR TITLE
Fix links to Zeiss image browser software

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1728,7 +1728,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = PCXReader.java
-notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.de/C12567BE00472A5C/EmbedTitelIntern/LSMImageBrowser/$File/INST_IB.EXE>`_.
+notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com.au/microscopy/en_au/downloads/lsm-5-series.html>`_.
 
 [PCORAW]
 extensions = .pcoraw, .rec
@@ -2375,7 +2375,7 @@ extensions = .lsm, .mdb
 owner = `Carl Zeiss MicroImaging GmbH <http://www.zeiss.com/micro>`_
 bsd = no
 export = no
-software = `Zeiss LSM Image Browser <http://www.zeiss.de/C12567BE00472A5C/EmbedTitelIntern/LSMImageBrowser/$File/INST_IB.EXE>`_ \n
+software = `Zeiss LSM Image Browser <http://www.zeiss.com.au/microscopy/en_au/downloads/lsm-5-series.html`_ \n
 `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ \n
 `LSM Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/lsm-reader.html>`_ \n
 `DIMIN <http://www.dimin.net/>`_

--- a/docs/sphinx/formats/pcx-pc-paintbrush.txt
+++ b/docs/sphinx/formats/pcx-pc-paintbrush.txt
@@ -52,4 +52,4 @@ Source Code: :bsd-reader:`PCXReader.java`
 Notes:
 
 
-Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.de/C12567BE00472A5C/EmbedTitelIntern/LSMImageBrowser/$File/INST_IB.EXE>`_.
+Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com.au/microscopy/en_au/downloads/lsm-5-series.html>`_.

--- a/docs/sphinx/formats/zeiss-lsm.txt
+++ b/docs/sphinx/formats/zeiss-lsm.txt
@@ -22,7 +22,7 @@ Supported Metadata Fields: :doc:`Zeiss LSM (Laser Scanning Microscope) 510/710 <
 
 Freely Available Software:
 
-- `Zeiss LSM Image Browser <http://www.zeiss.de/C12567BE00472A5C/EmbedTitelIntern/LSMImageBrowser/$File/INST_IB.EXE>`_ 
+- `Zeiss LSM Image Browser <http://www.zeiss.com.au/microscopy/en_au/downloads/lsm-5-series.html>`_ 
 - `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ 
 - `LSM Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/lsm-reader.html>`_ 
 - `DIMIN <http://www.dimin.net/>`_


### PR DESCRIPTION
This should make the 5.0 merge docs build green again. Link is broken because Zeiss now want you to fill in a form before downloading the software, and it looks like there is a new version.
