### PR TITLE
Updating transform catalog for 2013-10-dev-1

### DIFF
--- a/components/specification/transforms/ome-transforms.xml
+++ b/components/specification/transforms/ome-transforms.xml
@@ -36,14 +36,14 @@
 		<upgrades/>
 		<downgrades>
 			<target schema="2003-FC" quality="poor" info="This is the format used by the Origional OME Server (c.2005)">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
 				<transform file="2010-06-to-2003-FC.xsl"/>
 			</target>
 			<target schema="2007-06" quality="poor">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
@@ -51,14 +51,14 @@
 				<transform file="2003-FC-to-2007-06.xsl"/>
 			</target>
 			<target schema="2008-02" quality="fair">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
 				<transform file="2010-06-to-2008-02.xsl"/>
 			</target>
 			<target schema="2008-09" quality="fair">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
@@ -66,7 +66,7 @@
 				<transform file="2008-02-to-2008-09.xsl"/>
 			</target>
 			<target schema="2009-09" quality="fair">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
@@ -75,7 +75,7 @@
 				<transform file="2008-09-to-2009-09.xsl"/>
 			</target>
 			<target schema="2010-04" quality="fair">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
@@ -85,22 +85,22 @@
 				<transform file="2009-09-to-2010-04.xsl"/>
 			</target>
 			<target schema="2010-06" quality="good">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
 			</target>
 			<target schema="2011-06" quality="good">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 			</target>
 			<target schema="2012-06" quality="good">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 			</target>
 			<target schema="2013-06" quality="good">
-				<transform file="2013-10-dev-1-to-2013-06.xsl.xsl"/>
+				<transform file="2013-10-dev-1-to-2013-06.xsl"/>
 			</target>
 		</downgrades>
 	</source>


### PR DESCRIPTION
This list the transforms used for upgrades and downgrades.

(Change is to Bio-formats, downgrade effect is seen in OMERO)
To test downgraded part run OMERO.insight and save files as ome-tiff. You should see 2013-10-dev-1 listed as current schema and the option to downgrade to the others.

Exported files should have chosen schema and be valid. (Check with bftools).
