### PR TITLE
Only add a MetadataOnly element if no TiffData elements are present

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -153,7 +153,9 @@ public final class MetadataTools {
             OMEXMLMetadata omeMeta;
             try {
               omeMeta = service.getOMEMetadata(service.asRetrieve(baseStore));
-              service.addMetadataOnly(omeMeta, i);
+              if (omeMeta.getTiffDataCount(i) == 0) {
+                service.addMetadataOnly(omeMeta, i);
+              }
             }
             catch (ServiceException e) {
               LOGGER.warn("Failed to add MetadataOnly", e);


### PR DESCRIPTION
This prevents validation errors for most OME-TIFF files; noticed by @qidane.
