### PR TITLE
TIFF: adjust optimal tile height if tiles have height of 1

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -397,7 +397,9 @@ public class MinimalTiffReader extends FormatReader {
       {
         return super.getOptimalTileHeight();
       }
-      return height;
+      if (height > 1) {
+        return height;
+      }
     }
     catch (FormatException e) {
       LOGGER.debug("Could not retrieve tile height", e);


### PR DESCRIPTION
This prevents callers that rely on the optimal tile height from reading
one row at a time from small images.  If the images are sufficiently
wide that only 1 row of pixels will fit in memory, then the optimal
height will still be 1.

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11850
