### PR TITLE
Flex: fix support for new file naming scheme

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -550,11 +550,14 @@ public class ZeissCZIReader extends FormatReader {
       if ((planes.size() % (seriesCount * getSizeZ())) == 0) {
         ms0.sizeT = 1;
       }
-      else if ((planes.size() % (seriesCount * getSizeT())) == 0) {
-        ms0.sizeZ = 1;
-      }
       ms0.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();
-      seriesCount = planes.size() / ms0.imageCount;
+
+      int newCount = planes.size() / ms0.imageCount;
+      if (planes.size() - (ms0.imageCount * newCount) <
+        ms0.imageCount * seriesCount - planes.size() && (planes.size() % seriesCount) != 0)
+      {
+        seriesCount = newCount;
+      }
     }
 
     if (seriesCount > 1) {


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2014-March/002721.html and https://trac.openmicroscopy.org.uk/ome/ticket/11382.

Recently acquired plates use one file per field, where previously fields were typically stored within the file.  To test, verify that the dataset listed in the ticket has 4 wells, 6 fields, and 30 planes per field - the planes should also visually look as though they all belong in the same field.
