### PR TITLE
DICOM: fix file grouping so that path names are normalized

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1129,6 +1129,14 @@ public class DicomReader extends FormatReader {
     String[] patternFiles = pattern.getFiles();
     if (patternFiles == null) patternFiles = new String[0];
     Arrays.sort(patternFiles);
+
+    // make sure that the file names are normalized
+    // this prevents files from being missed on Windows if the
+    // path separator normalization is inconsistent
+    for (int i=0; i<patternFiles.length; i++) {
+      patternFiles[i] = new Location(patternFiles[i]).getAbsolutePath();
+    }
+
     String[] files = dir.list(true);
     if (files == null) return;
     Arrays.sort(files);


### PR DESCRIPTION
On Windows in particular, the list of pattern files often has extra path separator escaping, which prevents the
pattern files from being matched with the files from the directory listing.

To test, verify that selecting a single file from a multi-file DICOM dataset (e.g. dicom/johnh/PATIENT4728) on Windows without this fix results in an image with a single Z and T.  With this fix, selecting the same file should result in a Z stack.  Mac OS X and Linux should be unaffected, so please do make sure to test on Windows specifically.
