### PR TITLE
Add the series index to the default image name

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -128,6 +128,10 @@ public final class MetadataTools {
       if (doImageName) {
         Location f = new Location(r.getCurrentFile());
         imageName = f.getName();
+
+        if (r.getSeriesCount() > 1) {
+          imageName += " #" + (i + 1);
+        }
       }
       String pixelType = FormatTools.getPixelTypeString(r.getPixelType());
 


### PR DESCRIPTION
This prevents confusion when importing multi-series datasets that do not
override the image name.

/cc @imunro
