### PR TITLE
Only add a MetadataOnly element if no TiffData elements are present (rebased onto dev_5_0)

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -149,7 +149,9 @@ public final class MetadataTools {
             OMEXMLMetadata omeMeta;
             try {
               omeMeta = service.getOMEMetadata(service.asRetrieve(baseStore));
-              service.addMetadataOnly(omeMeta, i);
+              if (omeMeta.getTiffDataCount(i) == 0) {
+                service.addMetadataOnly(omeMeta, i);
+              }
             }
             catch (ServiceException e) {
               LOGGER.warn("Failed to add MetadataOnly", e);


### PR DESCRIPTION
This is the same as gh-991 but rebased onto dev_5_0.

---

This prevents validation errors for most OME-TIFF files; noticed by @qidane.
