### PR TITLE
OME-XML package bug-fix (rebased onto develop)

### DIFF
--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -182,7 +182,7 @@
 		<argument>${xsdfu.script}</argument>
 		<argument>omexml_metadata</argument>
 		<argument>-p</argument>
-		<argument>ome.xml.ome</argument>
+		<argument>ome.xml.meta</argument>
 		<argument>-o</argument>
 		<argument>${xsdfu.metadatapath}/</argument>
 		<argument>${project.rootdir}/${xsdfu.ome}</argument>


### PR DESCRIPTION
This is the same as gh-1022 but rebased onto develop.

---

The class `OMEXMLMetadataImpl` used to live in `ome.xml.ome`, and the POM reflected that. But it has now moved to `ome.xml.meta` for consistency with other auto-generated classes; this change is necessary to reflect that.

Thanks to @rleigh-dundee for the solution!
