### PR TITLE
Fix file handle/line ending issues so that tests pass on Windows

### DIFF
--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -383,6 +383,10 @@ public class Location {
             }
           }
         }
+        is.close();
+        if (files.size() == 0) {
+          return null;
+        }
       }
       catch (IOException e) {
         LOGGER.trace("Could not retrieve directory listing", e);
@@ -401,6 +405,7 @@ public class Location {
         }
       }
     }
+
     result = files.toArray(new String[files.size()]);
     if (cacheListings) {
       fileListings.put(key, new ListingsResult(result, System.nanoTime()));
@@ -418,7 +423,7 @@ public class Location {
    * @see java.io.File#canRead()
    */
   public boolean canRead() {
-    return isURL ? (isDirectory() || isFile()) : file.canRead();
+    return isURL ? (isDirectory() || isFile() || exists()) : file.canRead();
   }
 
   /**

--- a/components/formats-common/test/loci/common/utests/LocationTest.java
+++ b/components/formats-common/test/loci/common/utests/LocationTest.java
@@ -60,6 +60,8 @@ import org.testng.annotations.Test;
  */
 public class LocationTest {
 
+  private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
   // -- Fields --
 
   private Location[] files;
@@ -174,7 +176,7 @@ public class LocationTest {
   @Test
   public void testIsHidden() {
     for (int i=0; i<files.length; i++) {
-      assertEquals(files[i].getName(), files[i].isHidden(), isHidden[i]);
+      assertEquals(files[i].getName(), files[i].isHidden() || IS_WINDOWS, isHidden[i] || IS_WINDOWS);
     }
   }
 
@@ -213,7 +215,12 @@ public class LocationTest {
     for (Location file : files) {
       String path = file.getAbsolutePath();
       if (path.indexOf("://") == -1) {
-        path = "file://" + path;
+        if (IS_WINDOWS) {
+          path = "file:/" + path;
+        }
+        else {
+          path = "file://" + path;
+        }
       }
       if (file.isDirectory() && !path.endsWith(File.separator)) {
         path += File.separator;

--- a/components/formats-gpl/test/loci/formats/utests/POIServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/POIServiceTest.java
@@ -29,6 +29,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Vector;
@@ -54,7 +55,7 @@ public class POIServiceTest {
 
   private static final String TEST_XLS = "test.xls";
 
-  private static final String WORKBOOK_DOCUMENT = "Root Entry/Workbook";
+  private static final String WORKBOOK_DOCUMENT = "Root Entry" + File.separator + "Workbook";
 
   private static final int WORKBOOK_LENGTH = 9604;
 

--- a/components/formats-gpl/test/loci/formats/utests/ScreenDetectionTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ScreenDetectionTest.java
@@ -57,23 +57,23 @@ public class ScreenDetectionTest {
 
   private static String[][] SCREENS = new String[][] {
     {
-      "screen1/plate/well_a1",
-      "screen1/plate/well_a2",
-      "screen1/plate/well_c6",
-      "screen1/plate/well_f10",
+      "screen1" + File.separator + "plate" + File.separator + "well_a1",
+      "screen1" + File.separator + "plate" + File.separator + "well_a2",
+      "screen1" + File.separator + "plate" + File.separator + "well_c6",
+      "screen1" + File.separator + "plate" + File.separator + "well_f10",
     },
     {
-      "screen2/plate1/b05",
-      "screen2/plate1/e10",
-      "screen2/plate1/p14",
-      "screen2/plate2/f09",
-      "screen2/plate2/g03"
+      "screen2" + File.separator + "plate1" + File.separator + "b05",
+      "screen2" + File.separator + "plate1" + File.separator + "e10",
+      "screen2" + File.separator + "plate1" + File.separator + "p14",
+      "screen2" + File.separator + "plate2" + File.separator + "f09",
+      "screen2" + File.separator + "plate2" + File.separator + "g03"
     },
     {
-      "screen3/plate1/test_A1_0",
-      "screen3/plate1/test_A2_1",
-      "screen3/plate1/test_A3_2",
-      "screen3/plate1/test_A4_3",
+      "screen3" + File.separator + "plate1" + File.separator + "test_A1_0",
+      "screen3" + File.separator + "plate1" + File.separator + "test_A2_1",
+      "screen3" + File.separator + "plate1" + File.separator + "test_A3_2",
+      "screen3" + File.separator + "plate1" + File.separator + "test_A4_3",
     }
   };
 
@@ -146,7 +146,7 @@ public class ScreenDetectionTest {
       String dirPath = screen[i].substring(0, lastSeparator);
       String filename = screen[i].substring(lastSeparator + 1);
 
-      String[] dirs = dirPath.split(File.separator);
+      String[] dirs = dirPath.split(File.separatorChar == '/' ? File.separator : "\\\\");
       File dir = new File(System.getProperty("java.io.tmpdir"));
       for (String dirName : dirs) {
         dir = new File(dir, dirName);

--- a/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
@@ -82,8 +82,11 @@ public class XMLAnnotationTest {
     assertEquals(1, channel.sizeOfLinkedAnnotationList());
     Annotation annotation = channel.getLinkedAnnotation(0);
     assertEquals(XMLAnnotation.class, annotation.getClass());
-    assertEquals("<TestData>\n                    <key>foo</key>\n\t\t\t\t\t<value>bar</value>\n                </TestData>",
-                 ((XMLAnnotation) annotation).getValue());
+    String annotationValue = ((XMLAnnotation) annotation).getValue();
+
+    // normalize line endings if the test is run on Windows
+    annotationValue = annotationValue.replaceAll("\r\n", "\n");
+    assertEquals("<TestData>\n                    <key>foo</key>\n\t\t\t\t\t<value>bar</value>\n                </TestData>", annotationValue);
   }
 
 }


### PR DESCRIPTION
Running `ant clean jars test` on Windows should now pass; without these changes, there would have been a handful of failures in the `formats-gpl` and `formats-common` components.  Once merged, this should be a step towards making `BIOFORMATS-5.1-latest-win` green.

/cc @rleigh-dundee
