### PR TITLE
DICOM: expand sequence reading to include known sequences

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1052,7 +1052,7 @@ public class DicomReader extends FormatReader {
 
     // "Undefined" element length.
     // This is a sort of bracket that encloses a sequence of elements.
-    if (elementLength == -1 || (TYPES.containsKey(tag) &&
+    if (elementLength == -1 || (tag != 0x00180020 && TYPES.containsKey(tag) &&
       TYPES.get(tag).endsWith("Sequence")))
     {
       elementLength = 0;


### PR DESCRIPTION
See QA 9184.  With this PR, more original metadata entries should be present, including multiple entries for tag (0008, 0104).  See also http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-April/004336.html.
