### PR TITLE
SVS: store the PhysicalSizeX and PhysicalSizeY attributes (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -46,6 +46,7 @@ import loci.formats.tiff.IFD;
 import loci.formats.tiff.PhotoInterp;
 import loci.formats.tiff.TiffIFDEntry;
 import loci.formats.tiff.TiffParser;
+import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 


### PR DESCRIPTION
This is the same as gh-1053 but rebased onto dev_5_0.

---

/cc @aleksandra-tarkowska

Pixel sizes should now be populated when SVS files are imported into OMERO.
