### PR TITLE
Allow for a >1 count increment in B&H .sdt Files.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -209,7 +209,10 @@ public class SDTReader extends FormatReader {
         output += oLineSize;
       }
       
-      // allow for non-zero count increments
+      // allow for >1 count increments
+      // the count increment is the amount by which the data is incremented for each event detected
+      // normally this is 1 so each bit represents a photon
+      // where it is >1 then divide the 16 bit data to get an answer in photon units
       if (info.incr > 1) {
         short incr = info.incr;
        


### PR DESCRIPTION
Only implemented for pre-loading mode. Do we want to retain the older mode now this is the default & should intensity mode be fixed or deleted ?
