### PR TITLE
Remove dead bitmap link (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2291,7 +2291,6 @@ notes = Compressed BMP files are currently not supported. \n
 \n
 .. seealso:: \n
   `Technical Overview <http://www.faqs.org/faqs/graphics/fileformats-faq/part3/section-18.html>`_ \n
-  `General Resources <http://people.sc.fsu.edu/~burkardt/data/bmp/bmp.html>`_
 
 [Woolz]
 extensions = .wlz

--- a/docs/sphinx/formats/windows-bitmap.txt
+++ b/docs/sphinx/formats/windows-bitmap.txt
@@ -57,5 +57,5 @@ Notes:
 Compressed BMP files are currently not supported. 
 
 .. seealso:: 
-  `Technical Overview <http://www.faqs.org/faqs/graphics/fileformats-faq/part3/section-18.html>`_ 
-  `General Resources <http://people.sc.fsu.edu/~burkardt/data/bmp/bmp.html>`_
+  `Technical Overview <http://www.faqs.org/faqs/graphics/fileformats-faq/part3/section-18.html>`_
+


### PR DESCRIPTION
This is the same as gh-1071 but rebased onto develop.

---

John Burkardt updated his data files website (http://people.sc.fsu.edu/~jburkardt/data/data.html) yesterday and obviously removed the bitmap examples we were linking to. This PR removes the broken links and should make BF 5.0 docs merge build green again.
