### PR TITLE
Disable file grouping in ImageJ remote import plugin

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -505,7 +505,7 @@ public class MainDialog extends ImporterDialog
     if (src == stackFormatChoice && isStackBrowser) {
       isGroupFiles = true;
     }
-    else if (options.isOMERO()) {
+    else if (!options.isLocal()) {
       isGroupFiles = false;
       groupFilesEnabled = false;
     }


### PR DESCRIPTION
This should fix https://trac.openmicroscopy.org.uk/ome/ticket/12158 by disabling the `Group files with similar names` option when the remote importer plugin is being used.  `Group files with similar names` should still be enabled when using `Plugins > Bio-Formats > Bio-Formats Importer`.
