### PR TITLE
CellSens: fix off-by-ones in subresolution tile calculations (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -757,13 +757,13 @@ public class CellSensReader extends FormatReader {
       ms.imageCount *= (maxC[0] + 1);
     }
 
-    if (maxY[0] > 1) {
+    if (maxY[0] >= 1) {
       rows.add(maxY[0] + 1);
     }
     else {
       rows.add(1);
     }
-    if (maxX[0] > 1) {
+    if (maxX[0] >= 1) {
       cols.add(maxX[0] + 1);
     }
     else {
@@ -789,17 +789,17 @@ public class CellSensReader extends FormatReader {
         nDimensions.add(nDimensions.get(nDimensions.size() - 1));
         tileOffsets.add(tileOffsets.get(tileOffsets.size() - 1));
 
-        if (maxX[i] > 1) {
+        if (maxX[i] >= 1) {
           newResolution.sizeX = tileX.get(tileX.size() - 1) * (maxX[i] + 1);
-          cols.add(maxX[i]);
+          cols.add(maxX[i] + 1);
         }
         else {
           newResolution.sizeX = tileX.get(tileX.size() - 1);
           cols.add(1);
         }
-        if (maxY[i] > 1) {
+        if (maxY[i] >= 1) {
           newResolution.sizeY = tileY.get(tileY.size() - 1) * (maxY[i] + 1);
-          rows.add(maxY[i]);
+          rows.add(maxY[i] + 1);
         }
         else {
           newResolution.sizeY = tileY.get(tileY.size() - 1);


### PR DESCRIPTION
This is the same as gh-1077 but rebased onto develop.

---

This is likely to fail data test builds for the moment, as I'll need to update various configuration files.  The lowest 2-3 resolutions in each pyramid should now be slightly larger, and the ubiquitous black bands on the right-hand and lower edges should now be gone.

/cc @chris-allan
