### PR TITLE
Fix single plane ND2 line scan (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -938,11 +938,13 @@ public class NativeND2Reader extends FormatReader {
       else if (planeSize > 0 &&
         availableBytes > DataTools.safeMultiply64(planeSize, 3))
       {
-        core.get(0).sizeC = 3;
-        core.get(0).rgb = true;
-        if (getPixelType() == FormatTools.INT8) {
-          core.get(0).pixelType = availableBytes > planeSize * 5 ?
-            FormatTools.UINT16 : FormatTools.UINT8;
+        if (availableBytes < DataTools.safeMultiply64(planeSize, 6)) {
+          core.get(0).sizeC = 3;
+          core.get(0).rgb = true;
+          if (getPixelType() == FormatTools.INT8) {
+            core.get(0).pixelType = availableBytes > planeSize * 5 ?
+              FormatTools.UINT16 : FormatTools.UINT8;
+          }
         }
       }
       else if (((planeSize > 0 &&


### PR DESCRIPTION
This is the same as gh-1085 but rebased onto develop.

---

This should resolve the issue in https://trac.openmicroscopy.org.uk/ome/ticket/12222; no other files should be affected.  Verifying that the QA image when opened in ImageJ or imported into OMERO matches the description in the ticket is sufficient.
