### PR TITLE
Exclude log4j and packages from target-test-runner (rebased onto develop)

### DIFF
--- a/components/test-suite/target-test-runner
+++ b/components/test-suite/target-test-runner
@@ -165,7 +165,8 @@ if __name__ == '__main__':
         pass
     classpath = "%s:./build/classes" % classpath
     for f in glob.glob("../../artifacts/*.jar"):
-        classpath += ":%s" % f
+        if not f.endswith("bioformats_package.jar") and not f.endswith("loci_tools.jar") and f.find("log4j") == -1:
+            classpath += ":%s" % f
 
     revision = None
     try:


### PR DESCRIPTION
This is the same as gh-1080 but rebased onto develop.

---

This is intended to fix https://trac.openmicroscopy.org.uk/ome/ticket/12114.  Running `ant clean jars tools` and then `cd components/test-suite && ./target-test-runner loci.tests.testng.OpenBytesPerformanceTest /path/to/test/file` should produce more `*.log` files in `components/test-suite` than the same command without this PR merged.

It's also important to verify that the performance builds remain green with this PR included.
