### PR TITLE
MRC: fix handling of mode 16 data (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -168,6 +168,7 @@ public class MRCReader extends FormatReader {
     }
 
     m.sizeC = 1;
+    m.rgb = false;
 
     int mode = in.readInt();
     switch (mode) {
@@ -191,7 +192,8 @@ public class MRCReader extends FormatReader {
         break;
       case 16:
         m.sizeC = 3;
-        m.pixelType = FormatTools.UINT16;
+        m.pixelType = FormatTools.UINT8;
+	m.rgb = true;
         break;
     }
 
@@ -291,9 +293,8 @@ public class MRCReader extends FormatReader {
     LOGGER.info("Populating metadata");
 
     m.sizeT = 1;
-    m.dimensionOrder = "XYZTC";
-    m.imageCount = getSizeZ();
-    m.rgb = false;
+    m.dimensionOrder = isRGB() ? "XYCZT" : "XYZTC";
+    m.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC());
     m.interleaved = true;
     m.indexed = false;
     m.falseColor = false;


### PR DESCRIPTION
This is the same as gh-1091 but rebased onto develop.

---

Mode 16 denotes 8-bit RGB data, not 16-bit data.  See
https://trello.com/c/guQdSW8V/235-follow-ups-with-joaquin.
