### PR TITLE
Fix memo file path creation on Windows (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -562,6 +562,9 @@ public class Memoizer extends ReaderWrapper {
       }
 
       // this serves to strip off the drive letter on Windows
+      // since we're using the absolute path, 'id' will either start with
+      // File.separator (as on UNIX), or a drive letter (as on Windows)
+      id = new File(id).getAbsolutePath();
       id = id.substring(id.indexOf(File.separator) + 1);
 
       f = new File(directory, id);


### PR DESCRIPTION
This is the same as gh-1095 but rebased onto develop.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12271.
