### PR TITLE
LogbackTools: silence ClassCastException traces

### DIFF
--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -105,7 +105,10 @@ public final class LogbackTools {
     Appender<ILoggingEvent> appender) {
     try {
 
-      Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+      Object logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+      if (!(logger instanceof Logger)) return;
+
+      Logger root = (Logger) logger;
 
       if (debug) {
         root.setLevel(Level.DEBUG);


### PR DESCRIPTION
Change suggested by @ctrueden after seeing the following stack trace with log4j on the classpath:

```
java.lang.ClassCastException: org.slf4j.impl.Log4jLoggerAdapter cannot be cast to ch.qos.logback.classic.Logger
    at loci.common.LogbackTools.enableIJLogging(LogbackTools.java:108)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at loci.common.ReflectedUniverse.exec(ReflectedUniverse.java:315)
    at loci.common.DebugTools.enableIJLogging(DebugTools.java:114)
    at loci.plugins.in.ImportProcess.createBaseReader(ImportProcess.java:667)
    at loci.plugins.in.ImportProcess.initializeReader(ImportProcess.java:484)
    at loci.plugins.in.ImportProcess.execute(ImportProcess.java:140)
    at loci.plugins.in.Importer.showDialogs(Importer.java:141)
    at loci.plugins.in.Importer.run(Importer.java:79)
    at loci.plugins.LociImporter.run(LociImporter.java:81)
    at ij.IJ.runUserPlugIn(IJ.java:201)
    at ij.IJ.runPlugIn(IJ.java:165)
    at ij.Executer.runCommand(Executer.java:131)
    at ij.Executer.run(Executer.java:64)
    at java.lang.Thread.run(Thread.java:695)
```
