### PR TITLE
Leica link (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1174,7 +1174,7 @@ developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
 bsd = no
 export = no
 versions = 1.0, 2.0
-software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-imaging-software/life-sciences/las-af-advanced-fluorescence/>`_ (links at bottom of page)
+software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-af-4-advanced-fluorescence/>`_ (links at bottom of page)
 weHave = * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
 * a LIF specification document (version 1, from no later than 206 April 3, in PDF) \n
 * numerous LIF datasets


### PR DESCRIPTION
This is the same as gh-1125 but rebased onto develop.

---

Leica have released a new version of LAS AF software and helpfully changed the url without putting in any sort of redirect. This updates the autogeneration source so the actual doc page will be updated via that.

CC @sbesson

(link is on https://www.openmicroscopy.org/site/support/bio-formats5-staging/formats/leica-lif.html but won't be updated there until autogenerated build is updated)
