### PR TITLE
Remove unnecessary array allocation

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2762,7 +2762,6 @@ public class ZeissCZIReader extends FormatReader {
     // -- SubBlock API methods --
 
     public byte[] readPixelData() throws FormatException, IOException {
-      byte[] data = new byte[(int) dataSize];
       RandomAccessInputStream s = new RandomAccessInputStream(filename);
       try {
         return readPixelData(s);


### PR DESCRIPTION
This should fix the Findbugs warning in http://ci.openmicroscopy.org/job/BIOFORMATS-5.0-merge-daily/840/findbugsResult/new/?  Nothing else is expected to change.
