### PR TITLE
Add prefix to zip file produced by dist-bftools target

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -115,29 +115,29 @@ ome-tools.libraries = commons-httpclient-2.0-rc2.jar \
 
 ### Bio-Formats command line tools bundle ###
 
-bftools.dir = tools
-bftools.files = bfconvert \
-                bfconvert.bat \
-                config.bat \
-                config.sh \
-                domainlist \
-                domainlist.bat \
-                formatlist \
-                formatlist.bat \
-                ijview \
-                ijview.bat \
-                logback.xml \
-                mkfake \
-                mkfake.bat \
-                omeul \
-                omeul.bat \
-                bf.bat \
-                bf.sh \
-                showinf \
-                showinf.bat \
-                tiffcomment \
-                tiffcomment.bat \
-                xmlindent \
-                xmlindent.bat \
-                xmlvalid \
-                xmlvalid.bat
+bftools.dir       = tools
+bftools.execfiles = bfconvert \
+                    domainlist \
+                    formatlist \
+                    ijview \
+                    mkfake \
+                    omeul \
+                    bf.sh \
+                    showinf \
+                    tiffcomment \
+                    xmlindent \
+                    xmlvalid
+bftools.files     = bfconvert.bat \
+                    config.bat \
+                    config.sh \
+                    domainlist.bat \
+                    formatlist.bat \
+                    ijview.bat \
+                    logback.xml \
+                    mkfake.bat \
+                    omeul.bat \
+                    bf.bat \
+                    showinf.bat \
+                    tiffcomment.bat \
+                    xmlindent.bat \
+                    xmlvalid.bat

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -912,6 +912,8 @@ Type "ant -p" for a list of targets.
     <zip destfile="${artifact.dir}/bftools.zip">
       <zipfileset dir="${bftools.dir}" includes="${bftools.files}"
         prefix="bftools"/>
+      <zipfileset dir="${bftools.dir}" includes="${bftools.execfiles}"
+        prefix="bftools" filemode="751"/>
       <zipfileset file="${package.jar}" prefix="bftools"/>
     </zip>
 


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/12327

To test this PR, download the `bftools.zip` artifacts produced by the daily job and unzip it locally. The content of the zip should be unzipped within a folder called `bftools`.
