### PR TITLE
Update version history for 5.0.2 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.0.2 (2014 June 2)
+5.0.2 (2014 May 28)
 -------------------
 
 * Many bug fixes for Zeiss .czi files


### PR DESCRIPTION
This is the same as gh-1114 but rebased onto develop.

---

The release date probably needs changing, but I can do that once we know for sure.
