### PR TITLE
Allow dist-matlab to run on Windows (rebased onto dev_5_0)

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -920,7 +920,7 @@ Type "ant -p" for a list of targets.
   </target>
 
   <!-- Matlab -->
-  <target name="dist-matlab" if="isUnix" description="zip the Matlab functions bundle" depends="tools">
+  <target name="dist-matlab" description="zip the Matlab functions bundle" depends="tools">
     <echo>----------=========== bfmatlab ===========----------</echo>
     <zip destfile="${artifact.dir}/bfmatlab.zip">
       <zipfileset dir="${root.dir}/components/formats-gpl/matlab" includes="**/*" prefix="bfmatlab"/>


### PR DESCRIPTION
This is the same as gh-1060 but rebased onto dev_5_0.

---

This should fix the archiving problems in `BIOFORMATS-5.1-merge-build-win`.  On Windows without this PR, `ant dist-matlab` should not produce a new artifact; with this PR, `artifacts/bfmatlab.zip` should be present.

/cc @rleigh-dundee
