### PR TITLE
Comstat2 link

### DIFF
--- a/docs/sphinx/users/comstat2/index.txt
+++ b/docs/sphinx/users/comstat2/index.txt
@@ -9,5 +9,3 @@ Comstat2 uses the :doc:`Bio-Formats Importer plugin for
 ImageJ </users/imagej/index>` to read files in TIFF and Leica LIF
 formats.
 
-.. seealso::
-    `Comstat2 - a modern 3D image analysis environment for biofilms <http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=5628>`_


### PR DESCRIPTION
This old link is now asking for a log-in so making the docs builds unstable. All the relevant info is available from the page still linked anyway and the project isn't being actively developed anymore.
