### PR TITLE
Leica: prevent exception when linking EmissionFilter

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -1421,16 +1421,10 @@ public class LeicaReader extends FormatReader {
           store.setFilterID(filterID, series, channel);
 
           int index = activeChannelIndices.indexOf(new Integer(channel));
-          CoreMetadata ms = core.get(series);
-          if (index >= 0 && index < ms.sizeC) {
+          if (index >= 0 && index < getEffectiveSizeC()) {
             if (!filterRefPopulated[series][index]) {
-              try {
-                store.setLightPathEmissionFilterRef(filterID, series, index, 0);
-                filterRefPopulated[series][index] = true;
-              }
-              catch (IndexOutOfBoundsException e) {
-                LOGGER.trace("Could not link the EmissionFilter", e);
-              }
+              store.setLightPathEmissionFilterRef(filterID, series, index, 0);
+              filterRefPopulated[series][index] = true;
             }
 
             if (tokens[3].equals("0") && !cutInPopulated[series][index]) {


### PR DESCRIPTION
This prevents the reader from attempting to link an EmissionFilter to e.g. Channel:1 before Channel:0.

See QA 9255.  To test, verify that an IndexOutOfBoundsException occurs when the .lei file from the larger dataset is initialized (by opening in ImageJ, or `showinf -nopix -omexml`) without this PR's fix.  With this PR, the file should open normally and `showinf -nopix -omexml` should display metadata and OME-XML,
