### PR TITLE
Removing dead link from Minolta-MRW format page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1380,8 +1380,6 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = MRWReader.java
-notes = .. seealso:: \n
-  `Description of MRW format <http://www.dalibor.cz/files/MRW%20File%20Format.txt>`_
 
 [MNG (Multiple-image Network Graphics)]
 pagename = mng

--- a/docs/sphinx/formats/minolta-mrw.txt
+++ b/docs/sphinx/formats/minolta-mrw.txt
@@ -54,5 +54,3 @@ Source Code: :bfreader:`MRWReader.java`
 Notes:
 
 
-.. seealso:: 
-  `Description of MRW format <http://www.dalibor.cz/files/MRW%20File%20Format.txt>`_


### PR DESCRIPTION
Broken link was making the docs build unstable and it looks like everything has been deleted from that address so I'm assuming it's not a temporary failure.
