### PR TITLE
First round of Nikon ND2 fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -415,7 +415,7 @@ public class ND2Handler extends BaseHandler {
           v = 1;
         }
 
-        if (ms0.sizeT == 0) {
+        if (ms0.sizeT == 0 || (ms0.sizeT * ms0.sizeZ > nImages && v < ms0.sizeT)) {
           ms0.sizeT = v;
         }
         else if (qName.equals("no_name") && v > 0 && core.size() == 1) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -885,7 +885,9 @@ public class NativeND2Reader extends FormatReader {
 
       if ((getSizeZ() == imageOffsets.size() || (extraZDataCount > 1 && getSizeZ() == 1) || (handler.getXPositions().size() == 0 && (xOffset == 0 && getSizeZ() != getSeriesCount()))) && getSeriesCount() > 1) {
         CoreMetadata ms0 = core.get(0);
-        ms0.sizeZ = getSeriesCount();
+        if (getSeriesCount() > ms0.sizeZ) {
+          ms0.sizeZ = getSeriesCount();
+        }
         core = new ArrayList<CoreMetadata>();
         core.add(ms0);
       }


### PR DESCRIPTION
This should fix the problems described in http://trac.openmicroscopy.org.uk/ome/ticket/11998 and http://trac.openmicroscopy.org.uk/ome/ticket/10939.

For ticket 11998, the relevant files are in QA 7906 (apache_repo/7906 or data_repo/from_skyking/nd2/qa-7906).  I would expect all of them to open and/or import with no error, and be single planes with 3 channels.

For ticket 10939, the relevant file is in data_repo/from_skyking/nd2/cameron.  I would expect this to have 8 Z sections and 4 channels.

For this and subsequent .nd2 PRs, imports can also be verified by checking what the file looks like in Nikon's software: http://www.nikoninstruments.com/Products/Software/NIS-Elements-Viewer/.
