### PR TITLE
Make private class in DV reader public (see #12358) (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -45,6 +45,7 @@ import loci.formats.meta.MetadataStore;
 import ome.xml.model.enums.Correction;
 import ome.xml.model.enums.Immersion;
 import ome.xml.model.primitives.PositiveFloat;
+import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 
 /**


### PR DESCRIPTION
This is the same as gh-1145 but rebased onto dev_5_0.

---

In order to be able to handle the DVExtHdrFields as anything
other than a string, the object will either need to be made
public or be made to implement some public API (e.g. Map).
