### PR TITLE
Fix for BH .Sdt meas mode 0 & 1 single pixel files & (unrelated) problem with dividing by increment count. (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTInfo.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTInfo.java
@@ -700,6 +700,12 @@ public class SDTInfo {
         if (adcRE > 0) timeBins = adcRE;
         if (scanRX > 0) channels = scanRX;
         
+        // measurement mode 0 and 1 are both single-point data
+        if (measMode == 0 || measMode == 1)  {
+          width = 1;
+          height = 1;
+        }  
+        
         // for measurement_mode 13 one channel is stored in each block 
         // & width & height are not in scanX & scanY
         if (measMode == 13)  {


### PR DESCRIPTION
This is the same as gh-1139 but rebased onto develop.

---

Arithmetic fixes for single-pixel images and images which must be divided by an increment count.
