### PR TITLE
Inveon: ignore the absolute path to the image file

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -25,6 +25,7 @@
 
 package loci.formats.in;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -255,6 +256,11 @@ public class InveonReader extends FormatReader {
           value = value.substring(space + 1);
         }
         else if (key.equals("file_name")) {
+          // remove path from stored file name, if present
+          value = value.replaceAll("/", File.separator);
+          value = value.replace('\\', File.separatorChar);
+          value = value.substring(value.lastIndexOf(File.separator) + 1);
+
           Location header = new Location(currentId).getAbsoluteFile();
           datFile = new Location(header.getParent(), value).getAbsolutePath();
         }


### PR DESCRIPTION
This prevents an exception from being thrown when the absolute path is
stored, but does not match the true absolute path to the image file.

To test, verify that the dataset in `data_repo/from_skyking/inveon/samples` imports with the PR included; without this PR included, the same dataset should throw an exception due to the image file not being found.
