### PR TITLE
ImportProcess: remove UI-level exception reporting

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -604,19 +604,7 @@ public class ImportProcess implements StatusReporter {
     if (options.isLocal() || options.isHTTP()) {
       BF.status(options.isQuiet(), "Identifying " + idName);
       imageReader = LociPrefs.makeImageReader();
-      try {
-        baseReader = imageReader.getReader(options.getId());
-      }
-      catch (FormatException exc) {
-        WindowTools.reportException(exc, options.isQuiet(),
-          "Sorry, there was an error reading the file.");
-        throw exc;
-      }
-      catch (IOException exc) {
-        WindowTools.reportException(exc, options.isQuiet(),
-          "Sorry, there was a I/O problem reading the file.");
-        throw exc;
-      }
+      baseReader = imageReader.getReader(options.getId());
     }
     else if (options.isOMERO()) {
       BF.status(options.isQuiet(), "Establishing server connection");


### PR DESCRIPTION
Since this is a private method that throws FormatException and
IOException, the caller is assumed to be responsible for any UI-level
logging of those exceptions.  In this case, Importer is the only class
that makes use of the method in question, and it already displays an
appropriate error message when an exception is thrown.

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/11866.  Without this change, opening ImageJ, selecting `Plugins > Bio-Formats > Bio-Formats Remote Importer`, and entering `http://test` in the URL box should result in two sets of error windows.  With this change, the same test should result in a single set of error windows (each set is the log window with a stack trace, and a short error message with an "OK" button).
