### PR TITLE
CZI: prevent AIOOB exception when populating position metadata (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2187,9 +2187,12 @@ public class ZeissCZIReader extends FormatReader {
               String y = getFirstNode(region, "Y").getTextContent();
               String z = getFirstNode(region, "Z").getTextContent();
 
-              positionsX[i] = x == null ? null : new Double(x);
-              positionsY[i] = y == null ? null : new Double(y);
-              positionsZ[i] = z == null ? null : new Double(z);
+              // safe to assume all 3 arrays have the same length
+              if (i < positionsX.length) {
+                positionsX[i] = x == null ? null : new Double(x);
+                positionsY[i] = y == null ? null : new Double(y);
+                positionsZ[i] = z == null ? null : new Double(z);
+              }
             }
           }
         }


### PR DESCRIPTION
This is the same as gh-1153 but rebased onto develop.

---

See gh-1148.  Without this change, opening the file referenced in gh-1148 should throw an exception as described in that issue.  With this change, the referenced file should open without an error (I would expect 12 small planes).
