### PR TITLE
Fix channel count when exporting RGB images in ImageJ (rebased onto dev_5_0)

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -557,6 +557,10 @@ public class Exporter {
           System.arraycopy(pix[0], 0, plane, 0, x * y);
           System.arraycopy(pix[1], 0, plane, x * y, x * y);
           System.arraycopy(pix[2], 0, plane, 2 * x * y, x * y);
+
+          if (i == start) {
+            sizeC /= 3;
+          }
         }
 
         int fileIndex = 0;


### PR DESCRIPTION
This is the same as gh-1175 but rebased onto dev_5_0.

---

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12091 and http://trac.openmicroscopy.org.uk/ome/ticket/11569.

To test, verify that both test cases outlined in the tickets are now working.  It would also be helpful to verify that exporting a non-RGB image with multiple channels still works as expected.
