### PR TITLE
Ignore namespaces when filling in an XMLAnnotation's Value (rebased onto dev_5_0)

### DIFF
--- a/components/xsd-fu/templates-java/Pojo_XMLAnnotation_asXMLElement_Value.template
+++ b/components/xsd-fu/templates-java/Pojo_XMLAnnotation_asXMLElement_Value.template
@@ -3,7 +3,7 @@
 			{
 				javax.xml.parsers.DocumentBuilderFactory factory =
 					javax.xml.parsers.DocumentBuilderFactory.newInstance();
-				factory.setNamespaceAware(true);
+				factory.setNamespaceAware(false);
 				javax.xml.parsers.DocumentBuilder parser =
 					factory.newDocumentBuilder();
 				org.xml.sax.InputSource is = new org.xml.sax.InputSource();


### PR DESCRIPTION
This is the same as gh-981 but rebased onto dev_5_0.

---

This prevents the xmlns on Value from being set to an empty string.

See gh-980 and issues reported while testing gh-881.

/cc @qidane
