### PR TITLE
Fixing imglib scifio github link (rebased onto develop)

### DIFF
--- a/docs/sphinx/users/imglib/index.txt
+++ b/docs/sphinx/users/imglib/index.txt
@@ -10,4 +10,4 @@ source of the pixel data (arrays in memory, files on disk, etc.).
 The `SCIFIO <http://scif.io/>`_ project provides an ImgOpener_ utility
 class for reading data into ImgLib2 data structures using Bio-Formats.
 
-.. _ImgOpener: https://github.com/scifio/scifio/blob/master/scifio/src/main/java/io/scif/img/ImgOpener.java
+.. _ImgOpener: https://github.com/scifio/scifio/blob/master/src/main/java/io/scif/img/ImgOpener.java


### PR DESCRIPTION
This is the same as gh-1184 but rebased onto develop.

N.B. 5.1 docs build will still be yellow because the doxygen docs don't exist yet.

---

This should make the BF doc builds green again by fixing the ImgOpener link on http://www.openmicroscopy.org/site/support/bio-formats5-staging/users/imglib/index.html
