### PR TITLE
Fixing imaris file spec FAQ link (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -349,7 +349,7 @@ owner = `Bitplane <http://www.bitplane.com/>`_
 bsd = no
 export = no
 versions = 2.7, 3.0, 5.5
-weHave = * an `Imaris (RAW) specification document <http://flash.bitplane.com/support/faqs/faqsview.cfm?inCat=6&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) \n
+weHave = * an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) \n
 * an Imaris 5.5 (HDF) specification document \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n

--- a/components/formats-gpl/src/loci/formats/in/ImarisReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisReader.java
@@ -40,7 +40,7 @@ import ome.xml.model.primitives.PositiveFloat;
 /**
  * ImarisReader is the file format reader for Bitplane Imaris files.
  * Specifications available at
- * http://flash.bitplane.com/support/faqs/faqsview.cfm?inCat=6&inQuestionID=104
+ * http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104
  *
  * <dl><dt><b>Source code:</b></dt>
  * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/in/ImarisReader.java">Trac</a>,

--- a/docs/sphinx/formats/bitplane-imaris.txt
+++ b/docs/sphinx/formats/bitplane-imaris.txt
@@ -24,7 +24,7 @@ Supported Metadata Fields: :doc:`Bitplane Imaris <bitplane-imaris-metadata>`
 
 We currently have:
 
-* an `Imaris (RAW) specification document <http://flash.bitplane.com/support/faqs/faqsview.cfm?inCat=6&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) 
+* an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) 
 * an Imaris 5.5 (HDF) specification document 
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) 
 * several older Imaris (RAW) datasets 


### PR DESCRIPTION
This is the same as gh-1189 but rebased onto develop.

N.B. this won't make the 5.1 merge build green because the doxygen links don't exist yet.

---

This link was showing as broken in the merge build this morning - hopefully this fixes it, I had a bit of trouble getting a link that works in isolation rather than just if you've clicked through from the main FAQ page! 
