### PR TITLE
CZI: prevent NumberFormatExceptions on missing/invalid position values (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2157,9 +2157,21 @@ public class ZeissCZIReader extends FormatReader {
         String y = position.getAttribute("Y");
         String z = position.getAttribute("Z");
 
-        Double xPos = x == null ? null : new Double(x);
-        Double yPos = y == null ? null : new Double(y);
-        Double zPos = z == null ? null : new Double(z);
+        Double xPos = null;
+        try {
+          xPos = new Double(x);
+        }
+        catch (NumberFormatException e) { }
+        Double yPos = null;
+        try {
+          yPos = new Double(y);
+        }
+        catch (NumberFormatException e) { }
+        Double zPos = null;
+        try {
+          zPos = new Double(z);
+        }
+        catch (NumberFormatException e) { }
 
         for (int tile=0; tile<tilesX * tilesY; tile++) {
           int index = i * tilesX * tilesY + tile;


### PR DESCRIPTION
This is the same as gh-1186 but rebased onto develop.

---

Fixes QA 9382.  The file should open/import without error with this change, and show a stack trace similar to what is listed in the QA issue without this change.
