### PR TITLE
OME-TIFF: close helper readers when working with single-plane files (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -263,9 +263,9 @@ public class OMETiffReader extends FormatReader {
     p.getSamples(ifd, buf, x, y, w, h);
     s.close();
 
-    // reasonably safe to close the reader if the entire plane from
-    // a single plane file has been read
-    if (r.getImageCount() == 1 && w == getSizeX() && h == getSizeY()) {
+    // reasonably safe to close the reader if the entire plane or
+    // lower-right-most tile from a single plane file has been read
+    if (r.getImageCount() == 1 && w + x == getSizeX() && h + y == getSizeY()) {
       r.close();
     }
     return buf;


### PR DESCRIPTION
This is the same as gh-1183 but rebased onto develop.

---

The reader will be left open if only a tile was read, but if the full
plane from a single plane file is read then the helper reader will be
closed.  This reduces the memory usage for datasets that consist of many
single plane files.

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12219.  To verify, import the dataset in `/ome/team/ejrozbicki/Series1` and verify that import succeeds with standard memory settings (no additional configuration should be necessary).
