### PR TITLE
ScanR: fix exposure time units (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -657,7 +657,13 @@ public class ScanrReader extends FormatReader {
             store.setPlaneTheT(new NonNegativeInteger(0), i, image);
             store.setPlanePositionX(fieldPositionX[field], i, image);
             store.setPlanePositionY(fieldPositionY[field], i, image);
-            store.setPlaneExposureTime(exposures.get(c), i, image);
+
+            // exposure time is stored in milliseconds
+            // convert to seconds before populating MetadataStore
+            Double time = exposures.get(c);
+            time /= 1000;
+
+            store.setPlaneExposureTime(time, i, image);
             if (deltaT != null) {
               store.setPlaneDeltaT(deltaT, i, image);
             }


### PR DESCRIPTION
This is the same as gh-1187 but rebased onto dev_5_0.

---

See http://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7554.

To test, verify that exposure times are smaller with this change.  I was using `data/from_skyking/scanr/nadine` to test, where the original exposure time was `50.0` and the new time is `0.05`.  Other datasets should produce similar results.
