### PR TITLE
Leica LIF: do not set Channel.Color for RGB images (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -828,8 +828,11 @@ public class LIFReader extends FormatReader {
           }
         }
 
+        // channel coloring is implicit if the image is stored as RGB
         Color channelColor = getChannelColor(realChannel[index][c]);
-        store.setChannelColor(channelColor, i, c);
+        if (!isRGB()) {
+          store.setChannelColor(channelColor, i, c);
+        }
 
         if (channelColor.getValue() != -1 && nextFilter >= 0) {
           if (nextDetector - firstDetector != getSizeC() &&


### PR DESCRIPTION
This is the same as gh-1193 but rebased onto dev_5_0.

---

The stored color for RGB images will usually (always?) be 0xffffffff, which causes the
displayed colors to be inaccurate (since the 'R' component will be shown as white).

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12214 (QA 9185).  The `Color` attribute on `Channel` should not be set at all for this file; there should be no other change in behavior.
