### PR TITLE
DICOM: fix units for physical sizes (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -730,8 +730,10 @@ public class DicomReader extends FormatReader {
       for (int i=0; i<core.size(); i++) {
         store.setImageDescription(imageType, i);
 
+        // all physical sizes were stored in mm, so must be converted to um
         if (pixelSizeX != null) {
           Double sizeX = new Double(pixelSizeX);
+          sizeX *= 1000;
           PositiveFloat x = FormatTools.getPhysicalSizeX(sizeX);
           if (x != null) {
             store.setPixelsPhysicalSizeX(x, i);
@@ -739,14 +741,18 @@ public class DicomReader extends FormatReader {
         }
         if (pixelSizeY != null) {
           Double sizeY = new Double(pixelSizeY);
+          sizeY *= 1000;
           PositiveFloat y = FormatTools.getPhysicalSizeY(sizeY);
           if (y != null) {
             store.setPixelsPhysicalSizeY(y, i);
           }
         }
-        PositiveFloat z = FormatTools.getPhysicalSizeZ(pixelSizeZ);
-        if (z != null) {
-          store.setPixelsPhysicalSizeZ(z, i);
+        if (pixelSizeZ != null) {
+          pixelSizeZ *= 1000;
+          PositiveFloat z = FormatTools.getPhysicalSizeZ(pixelSizeZ);
+          if (z != null) {
+            store.setPixelsPhysicalSizeZ(z, i);
+          }
         }
       }
     }


### PR DESCRIPTION
This is the same as gh-1192 but rebased onto dev_5_0.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12307 (QA 9219).  Physical pixel sizes should now be 1000 times larger, as the values stored in the file are in millimeters not micrometers.
