### PR TITLE
TIFF: correctly account for ```fakeBigTiff``` when reading IFD entries

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -476,6 +476,10 @@ public class TiffParser {
     }
 
     if (offset != in.getFilePointer()) {
+      if (fakeBigTiff && (offset < 0 || offset > in.getFilePointer())) {
+        offset &= 0xffffffffL;
+        offset += 0x100000000L;
+      }
       in.seek(offset);
     }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12367.  Easiest way to test is probably to import the files from `data_repo/from_skyking/hamamatsu/kristian` into OMERO, and verify that import is successful and there is nothing obviously wrong with the resulting images.  Checking these files in ImageJ or Matlab is going to be much trickier given their size.
