### PR TITLE
ND2: fix tile reading when the X coordinate is > 0

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -284,9 +284,10 @@ public class NativeND2Reader extends FormatReader {
       int rowLength = getSizeX() * pixel + scanlinePad * bpp;
       int destLength = w * pixel;
 
-      in.skipBytes(rowLength * y + x * pixel);
+      in.skipBytes(rowLength * y);
       byte[] pix = new byte[destLength * h];
       for (int row=0; row<h; row++) {
+        in.skipBytes(x * pixel);
         in.read(pix, row * destLength, destLength);
         in.skipBytes(pixel * (getSizeX() - w - x) + scanlinePad * bpp);
       }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12454.  Importing the file from QA 7799 into OMERO should result in an image that looks identical to what is shown when opening the same file in ImageJ (or Matlab, or showinf).  The weird banding shown in the screenshot attached to the ticket should not be present.
