### PR TITLE
Close IFormatReader copy if not to be used (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -675,6 +675,9 @@ public class Memoizer extends ReaderWrapper {
       } catch (RuntimeException rt) {
         copy.close();
         throw rt;
+      } catch (Error err) {
+        copy.close();
+        throw err;
       }
 
       if (!equal) {


### PR DESCRIPTION
This is the same as gh-1196 but rebased onto develop.

---

The generated copy from Memoizer's loadReader logic
was in some cases not being used. When the null was
returned, a RandomAccessFile held by the reader was
left open.

Attn: @zeb @manics

With this commit, a long-running CLI or insight import (say 1000 PNGs or TIFFs) should not lead to constantly increasing file handles on the server. Testing with 1000 .fake files did _not_ show the error.
