### PR TITLE
Fix Z and T size calculation for InCell 6000 data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -777,7 +777,10 @@ public class InCellReader extends FormatReader {
       else if (qName.equals("Wavelength")) {
         String fusion = attributes.getValue("fusion_wave");
         if (fusion.equals("false")) ms0.sizeC++;
-        doZ = attributes.getValue("imaging_mode").equals("3-D");
+        String mode = attributes.getValue("imaging_mode");
+        if (mode != null) {
+          doZ = mode.equals("3-D");
+        }
       }
       else if (qName.equals("AcqWave")) {
         nChannels++;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12416.  There is one .xdce file attached to the ticket which needs to be verified - there should be 96 wells with 16 fields per well and 1 Z section/timepoint.  Without this change, multiple Z sections were detected.  This is the only InCell 6000 dataset we have; I would not expect other datasets to be affected (so it's sufficient to verify that repository tests pass).

See as well https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7545#p14250.
