### PR TITLE
Zeiss LSM: fix offset calculation for > 4GB files with SizeT > 1 (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -490,7 +490,11 @@ public class ZeissLSMReader extends FormatReader {
     long[] previousStripOffsets = null;
 
     for (int series=0; series<ifdsList.size(); series++) {
-      if (series > 0 && lsmFilenames.length > 1) {
+      // IFD ordering is ZPT, so reset state if we have multiple timepoints
+      // this prevents offsets from being confused when the first offset in
+      // the next series is legitimately smaller than the last offset in
+      // the previous series
+      if (series > 0 && getSizeT() > 1) {
         previousStripOffsets = null;
       }
 


### PR DESCRIPTION
This is the same as gh-1210 but rebased onto dev_5_0.

---

See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7560.  The file referenced in the thread is in `zeiss-lsm/dave/`; without this change, images in series beyond the first should look mixed up, as in the screenshots posted to the forum.  With this change, all images in all series should look reasonable (i.e. similar to the first series) when opened in ImageJ or imported into OMERO.  If in doubt, the images can also be checked with Zeiss Zen (http://www.zeiss.com/microscopy/en_us/products/microscope-software/zen-lite.html).

Due to the size of the file, if opening in ImageJ you will likely not be able to open all planes in memory at once; either choose one series at a time, or select the `Use virtual stack` option before opening all series.

This should only affect Zeiss LSM files larger than 4GB, and I would not expect there to be any test failures as a result of this PR.
