### PR TITLE
Fix off-by-one in LZW decoding (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
@@ -351,11 +351,15 @@ public class LZWCodec extends BaseCodec {
           int outLength = lengths[currCode];
           int i = currOutPos + outLength;
           int tablePos = currCode;
-          if (i > output.length) break;
+          while (i > output.length) {
+            tablePos = anotherCodes[tablePos];
+            i--;
+          }
           while (i > currOutPos) {
             output[--i] = newBytes[tablePos];
             tablePos = anotherCodes[tablePos];
           }
+          if (i >= output.length) break;
           currOutPos += outLength;
           // 2) Add string[old_code]+firstByte(string[curr_code]) to the table
           if (nextCode >= anotherCodes.length) break; 


### PR DESCRIPTION
This is the same as gh-1200 but rebased onto dev_5_0.

---

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-July/004566.html.

The file listed in the thread should now open as it does with imread/libtiff.  I would expect several jobs to fail though due to a handful of filesets having changed pixels hashes.  It would probably be a good idea to verify anything that fails with this PR against imread or libtiff as well, just to make sure this doesn't break images that were correct before.
