### PR TITLE
Fix bfGetReader for empty input (rebased onto develop)

### DIFF
--- a/components/formats-gpl/matlab/bfGetReader.m
+++ b/components/formats-gpl/matlab/bfGetReader.m
@@ -72,7 +72,7 @@ if (~isFake && ~isFile)
 end
 
 % set LuraWave license code, if available
-if exist('lurawaveLicense')
+if exist('lurawaveLicense', 'var')
     path = fullfile(fileparts(mfilename('fullpath')), 'lwf_jsdk2.6.jar');
     javaaddpath(path);
     java.lang.System.setProperty('lurawave.license', lurawaveLicense);


### PR DESCRIPTION
This is the same as gh-1206 but rebased onto develop.

---

Convert isFake into anonymous function which is only called if an input argument is supplied.

To test this function, check all the signatures of `bfGetReader work as expected:

```
>> bfGetReader()  % should pop up dialog window
>> bfGetReader('non-existing-file')  % should pop up dialog window
>> bfGetReader('test.fake')  % should initialize reader
>> bfGetReader('path/to/file) % should initialize reader
```

/cc @carandraug
