### PR TITLE
Final .nd2 fixes for 5.0.3

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -328,7 +328,9 @@ public class NativeND2Reader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
-    in = new RandomAccessInputStream(id);
+    // using a 32KB buffer instead of the default 1MB gives
+    // better performance with the seek/skip pattern used here
+    in = new RandomAccessInputStream(id, 32 * 1024);
 
     channelColors = new Hashtable<String, Integer>();
 


### PR DESCRIPTION
Addresses two issues:
- http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-July/004589.html, files for which are in `nd2/karsten`; without this change both files should show 104 series, with varying numbers of timepoints.  With this change, there should be 105 series and no timepoints as shown in NIS Elements.
- Performance with large files.  I was testing with `nd2/sara/Ex9 ALADIN WT KO KI 31_07_2013.nd2` (the largest file we have), and setId time has now gone from ~1300s to ~500s.  See  https://trello.com/c/1ZClsqPU/42-nd2-performance.

/cc @sbesson
