### PR TITLE
Use chunkmap for Nikon ND2 files to speed up processing (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -414,6 +414,8 @@ public class NativeND2Reader extends FormatReader {
           long chunkMapLength = in.readLong();
 
           chunkMapPosition += 16 + tmpLenTwo;
+          in.seek(chunkMapPosition);
+
           long chunkMapEnd = chunkMapPosition + chunkMapLength;
 
           while(in.getFilePointer() + 1 + 16 < chunkMapEnd) {


### PR DESCRIPTION
This is the same as gh-1233 but rebased onto dev_5_0.

---

This builds on @csachs gh-1232 to modify the logging behavior. Discussion should continue on 1232.
