### PR TITLE
do not insert acquisition dates by default unless from metadata

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -81,7 +81,7 @@ public final class MetadataTools {
 
   // -- Static fields --
 
-  private static boolean defaultDateEnabled = true;
+  private static boolean defaultDateEnabled = false;
 
   // -- Constructor --
 


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/2847 enables `null` acquisition dates and this PR is the remaining piece for http://trac.openmicroscopy.org.uk/ome/ticket/12465.
--no-rebase

Testing: with https://github.com/openmicroscopy/openmicroscopy/pull/2847 also merged, importing an image format like PNG that does not have acquisition dates, should create a resulting `Image` that has a `null` acquisition date.
