### PR TITLE
Autogen: prevent ClassNotFoundException from being needlessly thrown

### DIFF
--- a/components/autogen/src/MetaSupportList.java
+++ b/components/autogen/src/MetaSupportList.java
@@ -162,11 +162,12 @@ public class MetaSupportList {
     try {
       r.exec("import loci.formats.in." + handlerName);
     }
-    catch (ReflectException exc) { }
-    try {
-      r.exec("import loci.formats.out." + handlerName);
+    catch (ReflectException exc) {
+      try {
+        r.exec("import loci.formats.out." + handlerName);
+      }
+      catch (ReflectException e) { }
     }
-    catch (ReflectException exc) { }
     try {
       handler = (IFormatHandler) r.exec("new " + handlerName + "()");
       return handler.getFormat();


### PR DESCRIPTION
Should fix metadata pages not being updated as in http://ci.openmicroscopy.org/job/BIOFORMATS-5.0-latest-docs-autogen/255/.
