### PR TITLE
Add acquisition date to fake reader.

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -44,6 +44,7 @@ import java.util.StringTokenizer;
 import java.util.UUID;
 
 import loci.common.DataTools;
+import loci.common.DateTools;
 import loci.common.IniList;
 import loci.common.IniParser;
 import loci.common.IniTable;
@@ -64,6 +65,7 @@ import ome.specification.XMLMockObjects;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.OME;
 import ome.xml.model.primitives.Color;
+import ome.xml.model.primitives.Timestamp;
 
 /**
  * FakeReader is the file format reader for faking input data.
@@ -407,6 +409,8 @@ public class FakeReader extends FormatReader {
     int seriesCount = 1;
     int lutLength = 3;
 
+    String acquisitionDate = null;
+
     int plates = 0;
     int plateRows = 0;
     int plateCols = 0;
@@ -504,6 +508,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("lutLength")) lutLength = intValue;
       else if (key.equals("scaleFactor")) scaleFactor = doubleValue;
       else if (key.equals("exposureTime")) exposureTime = (float) doubleValue;
+      else if (key.equals("acquisitionDate")) acquisitionDate = value;
       else if (key.equals("plates")) plates = intValue;
       else if (key.equals("plateRows")) plateRows = intValue;
       else if (key.equals("plateCols")) plateCols = intValue;
@@ -610,6 +615,11 @@ public class FakeReader extends FormatReader {
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
       String imageName = currentImageIndex > 0 ? name + " " + (currentImageIndex + 1) : name;
       store.setImageName(imageName, currentImageIndex);
+      if (acquisitionDate != null) {
+        if(DateTools.getTime(acquisitionDate, DateTools.FILENAME_FORMAT) != -1) {
+          store.setImageAcquisitionDate(new Timestamp(DateTools.formatDate(acquisitionDate, DateTools.FILENAME_FORMAT)), currentImageIndex);
+        }
+      }
 
       for (int c=0; c<getEffectiveSizeC(); c++) {
         Color channel = defaultColor == null ? null: new Color(defaultColor);


### PR DESCRIPTION
Due to changes in https://github.com/openmicroscopy/openmicroscopy/pull/2847 making the image acquisition date optional one test using a fake file is now failing, see [1]. The best solution here would be to allow fake files to optionally have an acquisition date. This PR adds that facility and would seem to provide more generally useful functionality.

I have used the `FILENAME_FORMAT` as this offers the simplest way of adding a date to the filename but it doesn't deal with either milliseconds or timezone. I don't think that is too much of hindrance given the scope of this PR - and not wanting to touch DateTools!

I have not added a unit test as not all values are tested but as the code deals with a couple of conditions but I am happy to add tests if the PR is otherwise acceptable.

To test import some fake images:

```
bin/omero import FAKE_NO_DATE.fake
bin/omero import FAKE_WITH_DATE\&acquisitionDate\=2014-07-08_12-00-00.fake
bin/omero import FAKE_WITH_BROKEN_DATE\&acquisitionDate\=2014-NO-Se-ne-.fake

bin/omero hql "from Image"
 # | Class  | Id | details         | name                                                      | fileset    | acquisitionDate          
---+--------+----+-----------------+-----------------------------------------------------------+------------+--------------------------
 0 | ImageI | 1  | owner=2;group=3 | FAKE_NO_DATE.fake                                         | FilesetI:1 |                          
 1 | ImageI | 2  | owner=2;group=3 | FAKE_WITH_DATE&acquisitionDate=2014-07-08_12-00-00.fake   | FilesetI:2 | Tue Jul  8 13:00:00 2014 
 2 | ImageI | 3  | owner=2;group=3 | FAKE_WITH_BROKEN_DATE&acquisitionDate=2014-NO-Se-ne-.fake | FilesetI:3 | None                     
(3 rows)
```

/cc @mtbc @sbesson @joshmoore
1. http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-python/201/testReport/test.integration.clitest.test_search/TestSearch/test_search_dates_data2_/ 
