### PR TITLE
Update version history for 5.0.3 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.0.3 (2014 August 1)
+5.0.3 (2014 August 7)
 ---------------------
 
 * Many bug fixes for Nikon .nd2 files


### PR DESCRIPTION
This is the same as gh-1231 but rebased onto develop.

---

This can be merged at any time before tagging, provided the release date is acceptable.
