### PR TITLE
Prevent an NPE when referencing Image.AcquisitionDate

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -417,7 +417,9 @@ public class LociFunctions extends MacroFunctions {
 
   public void getImageCreationDate(String[] creationDate) {
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
-    creationDate[0] = retrieve.getImageAcquisitionDate(r.getSeries()).getValue();
+    if (retrieve.getImageAcquisitionDate(r.getSeries()) != null) {
+      creationDate[0] = retrieve.getImageAcquisitionDate(r.getSeries()).getValue();
+    }
   }
 
   public void getPlaneTimingDeltaT(Double[] deltaT, Double no) {

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -54,6 +54,7 @@ import loci.formats.services.OMEXMLServiceImpl;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -871,15 +872,22 @@ public final class FormatTools {
 
     filename = filename.replaceAll(CHANNEL_NAME, channelName);
 
-    String date = retrieve.getImageAcquisitionDate(series).getValue();
+    Timestamp timestamp = retrieve.getImageAcquisitionDate(series);
     long stamp = 0;
-    if (retrieve.getPlaneCount(series) > image) {
-      Double deltaT = retrieve.getPlaneDeltaT(series, image);
-      if (deltaT != null) {
-        stamp = (long) (deltaT * 1000);
+    String date = null;
+    if (timestamp != null) {
+      date = timestamp.getValue();
+      if (retrieve.getPlaneCount(series) > image) {
+        Double deltaT = retrieve.getPlaneDeltaT(series, image);
+        if (deltaT != null) {
+          stamp = (long) (deltaT * 1000);
+        }
       }
+      stamp += DateTools.getTime(date, DateTools.ISO8601_FORMAT);
     }
-    stamp += DateTools.getTime(date, DateTools.ISO8601_FORMAT);
+    else {
+      stamp = System.currentTimeMillis();
+    }
     date = DateTools.convertDate(stamp, (int) DateTools.UNIX_EPOCH);
 
     filename = filename.replaceAll(TIMESTAMP, date);

--- a/components/formats-gpl/utils/PrintTimestamps.java
+++ b/components/formats-gpl/utils/PrintTimestamps.java
@@ -66,7 +66,10 @@ public class PrintTimestamps {
   /** Outputs global timing details. */
   public static void printGlobalTiming(IMetadata meta, int series) {
     String imageName = meta.getImageName(series);
-    String creationDate = meta.getImageAcquisitionDate(series).getValue();
+    String creationDate = null;
+    if (meta.getImageAcquisitionDate(series) != null) {
+      creationDate = meta.getImageAcquisitionDate(series).getValue();
+    }
     Double timeInc = meta.getPixelsTimeIncrement(series);
     System.out.println();
     System.out.println("Global timing information:");

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -47,6 +47,7 @@ import loci.formats.meta.IMetadata;
 
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.PositiveFloat;
+import ome.xml.model.primitives.Timestamp;
 
 /**
  * <dl><dt><b>Source code:</b></dt>
@@ -479,9 +480,12 @@ public class Configuration {
         seriesTable.put(TIME_INCREMENT, timeIncrement.toString());
       }
 
-      String date = retrieve.getImageAcquisitionDate(series).getValue();
-      if (date != null) {
-        seriesTable.put(DATE, date);
+      Timestamp acquisition = retrieve.getImageAcquisitionDate(series);
+      if (acquisition != null) {
+        String date = acquisition.getValue();
+        if (date != null) {
+          seriesTable.put(DATE, date);
+        }
       }
 
       for (int c=0; c<retrieve.getChannelCount(series); c++) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -615,7 +615,10 @@ public class FormatReaderTest {
         }
 
         // if CreationDate is before 1990, it's probably invalid
-        String date = retrieve.getImageAcquisitionDate(i).getValue();
+        String date = null;
+        if (retrieve.getImageAcquisitionDate(i) != null) {
+          date = retrieve.getImageAcquisitionDate(i).getValue();
+        }
         String configDate = config.getDate();
         if (date != null && !date.equals(configDate)) {
           date = date.trim();


### PR DESCRIPTION
The acquisition date is now optional, and so may be null.  Without this
commit, bfconvert threw an NPE when the acquisition date was missing,
and the automated data tests logged a warning for each missing date.

To test, verify that bfconvert succeeds on a dataset that does not have an acquisition date.  The logs from `BIOFORMATS-5.1-merge-full-repository` should also be cleaner; see http://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-5.1-merge-full-repository/214/console for comparison.
