### PR TITLE
Analyze: set littleEndian flag correctly

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
@@ -280,6 +280,7 @@ public class AnalyzeReader extends FormatReader {
 
     CoreMetadata m = core.get(0);
 
+    m.littleEndian = little;
     m.sizeX = x;
     m.sizeY = y;
     m.sizeZ = z;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12471.  To test, verify that the fileset from QA 9414 is detected as being little-endian.
