### PR TITLE
Volocity: flag most files as being pixels files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VolocityReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VolocityReader.java
@@ -95,12 +95,14 @@ public class VolocityReader extends FormatReader {
 
     ArrayList<String> files = new ArrayList<String>();
     files.addAll(extraFiles);
-    Stack stack = stacks.get(getSeries());
-    for (int c=0; c<getEffectiveSizeC(); c++) {
-      files.add(stack.pixelsFiles[c]);
-    }
-    if (stack.timestampFile != null) {
-      files.add(stack.timestampFile);
+    if (!noPixels) {
+      Stack stack = stacks.get(getSeries());
+      for (int c=0; c<getEffectiveSizeC(); c++) {
+        files.add(stack.pixelsFiles[c]);
+      }
+      if (stack.timestampFile != null) {
+        files.add(stack.timestampFile);
+      }
     }
     return files.toArray(new String[files.size()]);
   }


### PR DESCRIPTION
This is the second part of the fix for https://trac.openmicroscopy.org.uk/ome/ticket/12485.  This should speed up import time and assist in preventing MemoryLimitExceptions for large Volocity filesets (e.g. QA 9407).

MemoryLimitException on import may be difficult to reproduce now, so the next best thing is to verify that fewer companion file annotations are created during import with this change.
