### PR TITLE
multiple netpbm fixes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/PGMReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PGMReader.java
@@ -73,7 +73,9 @@ public class PGMReader extends FormatReader {
 
   /** Constructs a new PGMReader. */
   public PGMReader() {
-    super("Portable Gray Map", "pgm");
+    super("Portable Any Map",
+      new String[] {"pbm", "pgm", "ppm"});
+
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
     suffixNecessary = false;
   }


### PR DESCRIPTION
This pull request fixes a few bugs on this format.
- previously mentioned bug on openmicroscopy/bioformats#1263 about pgm files being incorrectly marked as non-interleaved;
- crash when whitespace other than newline (and equivalents) was used to separate the header values (the specs define whitespace for delimiter  as space, CR, LF, TAB, VT, or FF)
- crash when it failed find values due to comments at end of line (even right after a value without whitespace in between)

Just as an example, the following is a valid (albeit random) PGM image:

```
P2
12# feep.ppm
 10  # feep.ppm
15# feep.ppm


 0  0  0    0  0  0    0  0  0   15  0 15
 0  0  0    0 15  7    0  0  0    0  0  0
 0  0  0    0  0  0    0 15  7    0  0  0
15  0 15    0  0  0    0  0  0    0  0  0
 0  0  0    0  0  0    0  0  0   15  0 15
 0  0  0    0 15  7    0  0  0    0  0  0
 0  0  0    0  0  0    0 15  7    0  0  0
15  0 15    0  0  0    0  0  0    0  0  0
 0  0  0    0  0  0    0  0  0   15  0 15
 0  0  0    0 15  7    0  0  0    0  0  0
```

Lastly, the file is named PGMReader but it's actually trying to handle ppm, pgm, and pbm. Since the collective of this 3 formats is [PNM](http://netpbm.sourceforge.net/doc/pnm.html), I'd suggest renaming it to PNMReader.
