### PR TITLE
bfGetReader() returns empty reader

### DIFF
--- a/components/formats-gpl/matlab/bfGetReader.m
+++ b/components/formats-gpl/matlab/bfGetReader.m
@@ -57,12 +57,9 @@ isFake = strcmp(id(max(1, end - 4):end), '.fake');
 if ~isempty(id) && ~isFake
     % Check file existence using fileattrib
     [status, f] = fileattrib(id);
-    isFile = status && f.directory == 0;
-    if isFile
-        id = f.Name;
-    else
-        id = [];
-    end
+    assert(status && f.directory == 0, 'bfGetReader:FileNotFound',...
+        'No such file: %s', id);
+    id = f.Name;
 end
 
 % set LuraWave license code, if available

--- a/components/formats-gpl/test/matlab/TestBfGetReader.m
+++ b/components/formats-gpl/test/matlab/TestBfGetReader.m
@@ -55,6 +55,11 @@ classdef TestBfGetReader < ReaderTest
             assertEqual(char(self.reader.getCurrentFile()), 'test.fake');
         end
         
+        function testNonExistingInput(self)
+            assertExceptionThrown(@() bfGetReader('nonexistingfile'),...
+                'bfGetReader:FileNotFound');
+        end
+        
         function testFileInput(self)
             % Create fake file
             if isunix,


### PR DESCRIPTION
This PR adds some breaking changes to the `bfGetReader` signature to allow the creation of uninitialized readers.
- all the previous UI dialog logic called when no/empty input is passed is removed. This ui logic still exists in the top-level `bfopen` function but `bfGetReader` should be more easily used in batch mode
- `bfGetReader()` or `bfGetReader('')` now creates and returns an unitialized `ReaderWrapper`. This change should add some flexibility to the reader construction without complicating the function logic, e.g.
  
  ```
  r= bfGetReader();
  r=loci.format.Memoizer(r);
  r.setId(id);
  ```
- `bfGetReader('invalid_path`) should now throw an exception that can be handled in a `try.. catch` block
-  `bfGetReader('string.fake')` and `bfGetReader('valid_path')` should still work as previously and return an initialized reader
- corresponding tests are added to `TestBfGetReader`
- the function header should be modified to account for the changes describe above

--no-rebase
