### PR TITLE
Fix declaration of ConcurrentHashMap instance (rebased onto develop)

### DIFF
--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -40,6 +40,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
@@ -85,7 +86,7 @@ public class Location {
       this.time = time;
     }
   }
-  private static ConcurrentHashMap<String, ListingsResult> fileListings =
+  private static Map<String, ListingsResult> fileListings =
     new ConcurrentHashMap<String, ListingsResult>();
 
   // -- Fields --


### PR DESCRIPTION
This is the same as gh-1280 but rebased onto develop.

---

This should prevent issues with running 1.8-compiled classes on 1.6 or 1.7.

/cc @jburel
