### PR TITLE
ND2: prevent NumberFormatExceptions when parsing text data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2133,7 +2133,12 @@ public class NativeND2Reader extends FormatReader {
             value = key.substring(8, end);
             key = key.substring(0, 8);
           }
-          trueSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
+          try {
+            trueSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
+          }
+          catch (NumberFormatException nfe) {
+            LOGGER.trace("Could not parse step", nfe);
+          }
         }
         else if (key.equals("Name")) {
           textChannelNames.add(value);
@@ -2142,12 +2147,22 @@ public class NativeND2Reader extends FormatReader {
           if (value.endsWith("Active")) {
             int first = key.lastIndexOf(":") + 1;
             int last = key.lastIndexOf(";");
-            textEmissionWavelengths.add(
-              new Integer(key.substring(first, last)) + 20);
+            try {
+              textEmissionWavelengths.add(
+                new Integer(key.substring(first, last)) + 20);
+            }
+            catch (NumberFormatException nfe) {
+              LOGGER.trace("Could not parse emission wavelength", nfe);
+            }
           }
         }
         else if (key.equals("Refractive Index")) {
-          refractiveIndex = Double.parseDouble(DataTools.sanitizeDouble(value));
+          try {
+            refractiveIndex = Double.parseDouble(DataTools.sanitizeDouble(value));
+          }
+          catch (NumberFormatException nfe) {
+            LOGGER.trace("Could not parse refractive index", nfe);
+          }
         }
 
         if (metadata.containsKey(key)) {


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12536.  To test, verify that the file from QA 9463 opens without throwing an exception.  There should be 201 Z sections and 3 channels, as in NIS Elements Viewer.
