### PR TITLE
Fix CLI tools when used from a source working copy

### DIFF
--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -38,8 +38,8 @@ if not "%BF_DEVEL%" == "" (
 )
 
 rem Developer environment variable unset; add JAR libraries to classpath.
-if exist "%BF_JAR_DIR%\bio-formats.jar" (
-  set BF_CP=%BF_CP%;"%BF_JAR_DIR%\bio-formats.jar";"%BF_JAR_DIR%\bio-formats-tools.jar"
+if exist "%BF_JAR_DIR%\formats-gpl.jar" (
+  set BF_CP=%BF_CP%;"%BF_JAR_DIR%\formats-gpl.jar";"%BF_JAR_DIR%\bio-formats-tools.jar"
 ) else if exist "%BF_JAR_DIR%\bioformats_package.jar" (
   set BF_CP=%BF_CP%;"%BF_JAR_DIR%\bioformats_package.jar"
 ) else if exist "%BF_JAR_DIR%\loci_tools.jar" (

--- a/tools/bf.sh
+++ b/tools/bf.sh
@@ -38,9 +38,9 @@ then
   java $BF_FLAGS $BF_PROG "$@"
 else
   # Developer environment variable unset; add JAR libraries to classpath.
-  if [ -e "$BF_JAR_DIR/bio-formats.jar" ]
+  if [ -e "$BF_JAR_DIR/formats-gpl.jar" ]
   then
-    BF_CP="$BF_JAR_DIR/bio-formats.jar:$BF_JAR_DIR/bio-formats-tools.jar:$BF_CP"
+    BF_CP="$BF_JAR_DIR/formats-gpl.jar:$BF_JAR_DIR/bio-formats-tools.jar:$BF_CP"
   elif [ -e "$BF_JAR_DIR/bioformats_package.jar" ]
   then
     BF_CP="$BF_JAR_DIR/bioformats_package.jar:$BF_CP"


### PR DESCRIPTION
There is no longer a bio-formats.jar. We can use formats-gpl.jar
instead, which references the others in its manifest Class-Path.
