### PR TITLE
Add 32-bit only note to QTJava (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1935,9 +1935,9 @@ reader = NativeQTReader.java
 writer = QTWriter.java
 notes = Bio-Formats has two modes of operation for QuickTime: \n
 \n
-  * QTJava mode requires `QuickTime <http://www.apple.com/quicktime/download/>`_ to be \n
-    installed (32-bit JVM only, not supported with 64-bit). \n
-  * Native mode works on systems with no QuickTime (e.g. Linux). \n
+* QTJava mode requires `QuickTime <http://www.apple.com/quicktime/download/>`_ to be \n
+  installed (32-bit JVM only, not supported with 64-bit). \n
+* Native mode works on systems with no QuickTime (e.g. Linux). \n
 \n
 Bio-Formats can save image stacks as QuickTime movies. \n
 The following table shows supported codecs: \n


### PR DESCRIPTION
This is the same as gh-1310 but rebased onto dev_5_0.

---

See https://trello.com/c/XKTVuOSn/49-quicktime-64bit
Note that the autogeneration will need to be run for this to be pushed to the staging docs.
