### PR TITLE
Use ome.staging for Maven release deployment (rebased onto dev_5_0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,9 +693,9 @@
 
   <distributionManagement>
     <repository>
-      <id>ome.releases</id>
-      <name>OME Releases Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
+      <id>ome.staging</id>
+      <name>OME Staging Repository</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
     </repository>
     <snapshotRepository>
       <id>ome.snapshots</id>


### PR DESCRIPTION
This is the same as gh-1329 but rebased onto dev_5_0.

---

This should allow the http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest-maven/ job to deploy release versions to ome.staging instead of ome.releases on our artifactory. Promotion of Maven artifacts to ome.releases should follow release acceptance (like the OMERO jobs)
