### PR TITLE
AIM: fix offset calculation for > 4GB files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AIMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AIMReader.java
@@ -69,7 +69,7 @@ public class AIMReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    in.seek(pixelOffset + FormatTools.getPlaneSize(this) * no);
+    in.seek(pixelOffset + FormatTools.getPlaneSize(this) * (long) no);
     readPlane(in, x, y, w, h, buf);
     return buf;
   }


### PR DESCRIPTION
See http://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7637 and QA 9541.  Without this change, the file would have thrown an exception on import when reading past the offset 4294967296.  With this change, the file should import and all planes should be read without an exception.
