### PR TITLE
Update version history for 5.0.5 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,12 @@
 Version history
 ===============
 
+5.0.5 (2014 September 23)
+-------------------------
+
+* Documentation improvements
+* Support for non-spectral Prairie 5.2 datasets
+
 5.0.4 (2014 September 3)
 ------------------------
 


### PR DESCRIPTION
This is the same as gh-1345 but rebased onto develop.

---

Release date is a best guess - might need updating.
