### PR TITLE
ND2: reset series count before allocating offset array

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1144,6 +1144,18 @@ public class NativeND2Reader extends FormatReader {
         numSeries = core.size();
       }
 
+      // reset the series count if we're confident that the image count
+      // covers all of the offsets; this prevents too much memory being used
+      // when the offsets array is allocated
+      if (getImageCount() == imageOffsets.size() && numSeries > 1 &&
+        getSizeC() == 1)
+      {
+        CoreMetadata first = core.get(0);
+        core.clear();
+        core.add(first);
+        numSeries = 1;
+      }
+
       offsets = new long[numSeries][getImageCount()];
 
       int[] lengths = new int[4];


### PR DESCRIPTION
This prevents extra memory from being used if the series count was too
high.  See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-September/004699.html and the file in `nd2/christophe/`.
