### PR TITLE
KodakReader: Bugfix and file info metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -53,6 +53,7 @@ public class KodakReader extends FormatReader {
   private static final String MAGIC_STRING = "DTag";
   private static final String PIXELS_STRING = "BSfD";
   private static final String DIMENSIONS_STRING = "GBiH";
+  private static final String FILEINFO_STRING = "DLFi";
 
   private static final String DATE_FORMAT = "HH:mm:ss 'on' MM/dd/yyyy";
 
@@ -129,6 +130,7 @@ public class KodakReader extends FormatReader {
     MetadataTools.populatePixels(store, this, true);
 
     readExtraMetadata(store);
+    readFileInfoMetadata(store);
   }
 
   // -- Helper methods --
@@ -231,4 +233,35 @@ public class KodakReader extends FormatReader {
     }
   }
 
+  private void readFileInfoMetadata(MetadataStore store) throws IOException {
+    in.seek(0);
+    findString(FILEINFO_STRING);
+
+    int tagLength = FILEINFO_STRING.length();
+
+    if (in.length() - in.getFilePointer() < tagLength + 20) {
+      return;
+    }
+
+    in.skipBytes(tagLength + 16);
+    int dataLength = in.readInt() - tagLength - 20;
+
+    if (in.length() - in.getFilePointer() < dataLength) {
+      return;
+    }
+
+    byte[] data = new byte[dataLength];
+    if (in.read(data) != dataLength) {
+      return;
+    }
+
+    String info = new String(data, Constants.ENCODING);
+    info = info.trim().replaceAll("(\\r|\\n)+", " | ");
+
+    if (info.isEmpty()) {
+      return;
+    }
+
+    addGlobalMeta("FileInfo", info);
+  }
 }


### PR DESCRIPTION
This patch fixes a bug in KodakReader.findString(String marker) and provides file information text extraction.
1. Bugfix
   KodakReader.findString(String marker) fails if marker lies within the last 8192 byte of the file. Fix: Take into account that file size is not necessarily a multiple of 8192.
2. Extracting file information text
   BIP files can contain an user-defined information text. In order to have this text availiable when using BioFormats, I reverse-engineered the file format a little. Here's what I found:
- "DLFi" marks the beginning of a data chunk containing the information text
- At 20 bytes offset, a 4 byte big endian integer encodes the overall chunk size (including "DLFi")
- At 24 bytes offset, the actual text begins
- The text is padded by lots of leading and trailing zero bytes.

We successfully tested this implementation while analyzing a set of about 50 BIP images using ImageJ. I just uploaded an example image file via your QA system.

I'm still unsure about a few things, though:
- Is using MetadataStore.addGlobalMeta() the way to go?
- In absence of an "DLFi" tag: Should I export "FileInfo" with an empty string or export nothing at all?
- Should I call getMetadataOptions().getMetadataLevel() as seen in KodakReader.readExtraMetadata()?
