### PR TITLE
Re-order plugin repositories in format-bsd/pom.xml

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -312,16 +312,12 @@
       <layout>default</layout>
     </pluginRepository>
     <pluginRepository>
-      <id>loci.releases</id>
-      <url>http://dev.loci.wisc.edu/maven2/releases</url>
+      <id>ome.external</id>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
     </pluginRepository>
     <pluginRepository>
       <id>imagej.thirdparty</id>
       <url>http://maven.imagej.net/content/repositories/thirdparty</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>ome.external</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
Since we have cppwrap_plugin deployed to our artifactory, we can directly use it for Travis.

--no-rebase
