### PR TITLE
CellProfiler issue 1207 - LSM files with zero-terminated channel names

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -1062,6 +1062,10 @@ public class ZeissLSMReader extends FormatReader {
             // we want to read until we find a null char
             int length = in.readInt();
             String name = in.readString(length);
+            while ((name.length() > 0) &&
+            	   (name.codePointAt(name.length()-1) == 0)) {
+            	name = name.substring(0, name.length()-1);
+            }
             if (name.length() <= 128) {
               addSeriesMetaList("ChannelName", name);
             }


### PR DESCRIPTION
This is to resolve a problem pointed out by a CP user with an LSM file. The details (stack trace) and the offending file can be found here:

https://github.com/CellProfiler/CellProfiler/issues/1207

This LSM file has several channel names which have a length, as recorded in the LSM file, of 7, but they are six bytes long and have a trailing zero. I think I've seen this problem in other LSM files, but since it means that you can't parse the metadata, I think we were able to continue on and just read the image planes. This patch removes trailing zeros from the names and solves the problem. In addition to the way to exercise the bug as reported in 1207, you can do the following using the javabridge and Python:

```
import javabridge
my_jar = r"<path-to>\bioformats_package_<version>.jar"
my_jars = javabridge.JARS + [my_jar]
javabridge.start_vm(class_path=my_jars)
path = r"<path-to>\DAY3WT1B.LSM"
rdr = javabridge.JClassWrapper("loci.formats.in.ZeissLSMReader")()
metadata = javabridge.JClassWrapper("loci.formats.ome.OMEXMLMetadataImpl")()
rdr.setMetadataStore(metadata)
rdr.setId(path)
print metadata.getChannelName(0, 0)
```

It should print "Ch2-T1" after the fix, will have garbage characters on the end before you fix.

The file was uploaded to our forum so it's in the public domain. The lines of code I added were after a comment that says "// we want to read until we find a null char", but mysteriously, it never did so.

--Lee
