### PR TITLE
Adding external PR guidance to CONTRIBUTING.md (rebased onto dev_5_0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,19 +13,39 @@ please ensure you read these.
 
 * Fork the GitHub repository.
 * Create a branch for your work based on the latest `dev_x` e.g. dev_5_0 or
-  `develop` branch.
+  `develop` branch. Unless you are targeting a specific release, it is
+  best to default to working against `develop`.
 * Make your commits, test your changes locally as per the README, and open a
   PR.
 * Make sure you include details of the problem you are fixing and how to test
   your changes.
 * We may need you to submit some test data
-  [via our QA system](http://qa.openmicroscopy.org.uk/qa/upload/). If the 
+  [via our QA system](http://qa.openmicroscopy.org.uk/qa/upload/). If the
   files are particularly large (> ~2 GB), contact the
   [mailing list](http://www.openmicroscopy.org/site/community/mailing-lists)
   and we will get back to you with secure upload details.
 
-We review all PRs as soon as we are able. Someone will comment whether
-the change is fine as-is or request you make changes before we merge it.
+## External Contributors
+
+* PRs submitted from outside OME will get an initial review to identify if
+  they are suitable to pass into our continuous integration system for
+  building and testing. We try to do this within 2 days of submission but
+  please be patient if we are busy and it takes longer.
+
+* If there are any obvious issues, we will comment and wait for you to fix
+  them. You can help this process by ensuring that the Travis build is passing
+  when you first submit the PR.
+
+* Once we are confident the PR contains no obvious errors, an "include" label
+  will be added which means the PR will be included in the merge build jobs
+  for the appropriate branch.
+
+* Build failures will then be noted on the PR and we will either submit a
+  patch or provide sufficient information for you to fix the problem yourself.
+  The "include" label will be removed until this is completed.
+
+* The PR will be merged once all the builds are green with the "include" label
+  added.
 
 ## Contributing to Bio-Formats Documentation
 


### PR DESCRIPTION
This is the same as gh-1364 but rebased onto dev_5_0.

---

See https://trello.com/c/NK9edzdd/205-add-handling-external-prs-to-contributing-doc-esp-for-bf

I will also add text to https://www.openmicroscopy.org/site/support/contributing/code-contributions.html in a PR against the docs repo.
