### PR TITLE
Replace BigTiff sample link (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2102,7 +2102,7 @@ developer = Aldus and Microsoft
 bsd = yes
 export = yes
 samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ \n
-`Big TIFF <http://tiffcentral.com/>`_
+`Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 weHave = * a `TIFF specification document <http://partners.adobe.com/asn/developer/PDFS/TN/TIFF6.pdf>`_ (v6.0, from 1992 June 3, in PDF) \n
 * many TIFF datasets \n
 * a few BigTIFF datasets

--- a/docs/sphinx/formats/tiff.txt
+++ b/docs/sphinx/formats/tiff.txt
@@ -25,7 +25,7 @@ Supported Metadata Fields: :doc:`TIFF (Tagged Image File Format) <tiff-metadata>
 Sample Datasets:
 
 - `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ 
-- `Big TIFF <http://tiffcentral.com/>`_
+- `Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 
 We currently have:
 


### PR DESCRIPTION
This is the same as gh-1377 but rebased onto dev_5_0.

---

The tiffcentral.com link has been broken since 15th Oct so I found a new link - this is the only sample set I could find that didn't say 'send us a hard drive to give you the data' and we do link to the same page in the 'see also' section so I'm going to assume it is safe to point people at downloading a zip from them. If not, I can just delete the link instead.
