### PR TITLE
OME-TIFF: return blank planes if the corresponding file does not exist

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -715,7 +715,9 @@ public class OMETiffReader extends FormatReader {
 
           if (!new Location(filename).exists()) {
             filename = currentId;
-            exists = false;
+            // if only one file is defined, we have to assume that it
+            // corresponds to the current file
+            exists = fileSet.size() == 1;
           }
         }
 


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12447.

Without this change, unzipping the datasets attached to the ticket, removing one .ome.tif file from each and importing should result in the missing file's well containing non-zero pixel data (as in the screenshot attached to the ticket).  The same test with this change should result in the missing file's well containing all-zero pixel data.

The "inversion" mentioned in the ticket is a result of the pixel type being set to int8 in the OME-XML stored in the original OME-TIFF files.  Setting the pixel type to uint8 in the OME-XML would solve this, but it's not a reader issue and so is not addressed here.
