### PR TITLE
Fix for unit tests run with ant 1.9

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -63,7 +63,7 @@ Type "ant -p" for a list of targets.
     <if>
       <equals arg1="${component.junit}" arg2="true"/>
       <then>
-        <junit haltonfailure="true">
+        <junit haltonfailure="true" fork="true">
           <classpath>
             <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
             <pathelement location="${artifact.dir}/junit-4.8.2.jar"/>


### PR DESCRIPTION
If the test suite is run with ant 1.9 (tested with 1.9.3), the following error occurs:

```
[...]
jar:

copy-test-source:
    [mkdir] Created dir: /home/simleo/git/bioformats/components/bio-formats-plugins/build/test/classes
     [copy] Copied 3 empty directories to 3 empty directories under /home/simleo/git/bioformats/components/bio-formats-plugins/build/test/classes

compile-tests:
    [javac] Compiling 3 source files to /home/simleo/git/bioformats/components/bio-formats-plugins/build/test/classes

test:
    [junit] Testsuite: loci.plugins.in.AutoscaleTest
    [junit] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 sec
    [junit] 
    [junit] ------------- Standard Error -----------------
    [junit] SLF4J: Class path contains multiple SLF4J bindings.
    [junit] SLF4J: Found binding in [jar:file:/home/simleo/git/bioformats/artifacts/logback-classic-1.1.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
    [junit] SLF4J: Found binding in [jar:file:/home/simleo/git/bioformats/jar/logback-classic-1.1.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
    [junit] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
    [junit] SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
    [junit] ------------- ---------------- ---------------
    [junit] Null Test:  Caused an ERROR
    [junit] junit/framework/JUnit4TestAdapterCache
    [junit] java.lang.NoClassDefFoundError: junit/framework/JUnit4TestAdapterCache
    [junit]     at java.lang.ClassLoader.defineClass1(Native Method)
    [junit]     at java.lang.ClassLoader.defineClassCond(ClassLoader.java:631)
    [junit]     at java.lang.ClassLoader.defineClass(ClassLoader.java:615)
    [junit]     at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:141)
    [junit]     at java.net.URLClassLoader.defineClass(URLClassLoader.java:283)
    [junit]     at java.net.URLClassLoader.access$000(URLClassLoader.java:58)
    [junit]     at java.net.URLClassLoader$1.run(URLClassLoader.java:197)
    [junit]     at java.security.AccessController.doPrivileged(Native Method)
    [junit]     at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    [junit]     at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    [junit]     at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
    [junit]     at java.lang.Class.forName0(Native Method)
    [junit]     at java.lang.Class.forName(Class.java:169)
    [junit]     at net.sf.antcontrib.logic.IfTask.execute(IfTask.java:197)
    [junit]     at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    [junit]     at java.security.AccessController.doPrivileged(Native Method)
    [junit]     at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    [junit]     at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    [junit]     at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
    [junit] 
    [junit] 
```

This PR introduces a fix described [here](https://github.com/real-logic/simple-binary-encoding/issues/96)
