### PR TITLE
Fix Analyze 7.5 specification link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -114,7 +114,7 @@ extensions = .img, .hdr
 developer = `Mayo Foundation Biomedical Imaging Resource <http://www.mayo.edu/bir>`_
 bsd = no
 export = no
-weHave = * `an Analyze 7.5 specification document <http://analyzedirect.com/support/10.0Documents/Analyze_Resource_01.pdf>`_ \n
+weHave = * `an Analyze 7.5 specification document <http://web.archive.org/web/20070927191351/http://www.mayo.edu/bir/PDF/ANALYZE75.pdf>`_ \n
 * several Analyze 7.5 datasets
 pixelsRating = Very good
 metadataRating = Good

--- a/docs/sphinx/formats/analyze-75.txt
+++ b/docs/sphinx/formats/analyze-75.txt
@@ -24,7 +24,7 @@ Supported Metadata Fields: :doc:`Analyze 7.5 <analyze-75-metadata>`
 
 We currently have:
 
-* `an Analyze 7.5 specification document <http://analyzedirect.com/support/10.0Documents/Analyze_Resource_01.pdf>`_ 
+* `an Analyze 7.5 specification document <http://web.archive.org/web/20070927191351/http://www.mayo.edu/bir/PDF/ANALYZE75.pdf>`_ 
 * several Analyze 7.5 datasets
 
 We would like to have:


### PR DESCRIPTION
The BF docs builds have been yellow since 24th Oct because this link is broken. Analyze Direct appear to have removed this resource from hunting around their website so I found a new archive copy - seems to come from the original developers and looks legit to me.
