### PR TITLE
Leica LIF: fix support for new files with 0 padding (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -145,6 +145,7 @@ public class LIFReader extends FormatReader {
   private double[] acquiredDate;
 
   private int[] tileCount;
+  private long endPointer;
 
   // -- Constructor --
 
@@ -294,7 +295,7 @@ public class LIFReader extends FormatReader {
 
     long planeSize = (long) getSizeX() * getSizeY() * bpp;
     long nextOffset = index + 1 < offsets.size() ?
-      offsets.get(index + 1).longValue() : in.length();
+      offsets.get(index + 1).longValue() : endPointer;
     int bytesToSkip = (int) (nextOffset - offset - planeSize * getImageCount());
     bytesToSkip /= getSizeY();
     if ((getSizeX() % 4) == 0) bytesToSkip = 0;
@@ -370,6 +371,7 @@ public class LIFReader extends FormatReader {
       tileCount = null;
       fieldPosX.clear();
       fieldPosY.clear();
+      endPointer = 0;
     }
   }
 
@@ -413,6 +415,11 @@ public class LIFReader extends FormatReader {
         in.getFilePointer(), offsets.size());
       int check = in.readInt();
       if (check != LIF_MAGIC_BYTE) {
+        if (check == 0 && offsets.size() > 0) {
+          // newer .lif file; the remainder of the file is all 0s
+          endPointer = in.getFilePointer();
+          break;
+        }
         throw new FormatException("Invalid Memory Block: found magic bytes " +
           check + ", expected " + LIF_MAGIC_BYTE);
       }
@@ -445,6 +452,10 @@ public class LIFReader extends FormatReader {
     }
     initMetadata(xml);
     xml = null;
+
+    if (endPointer == 0) {
+      endPointer = in.length();
+    }
 
     // correct offsets, if necessary
     if (offsets.size() > getSeriesCount()) {


### PR DESCRIPTION
This is the same as gh-1382 but rebased onto dev_5_0.

---

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12144.  With this change, files in `leica-lif/fabrice/new`, `leica-lif/ron/`, and QA 9457 should all open/import without throwing an exception, and there should be nothing obviously wrong with the images and metadata.

All other files should not be affected, so builds should remain green.
