### PR TITLE
Zeiss CZI: fix dimension calculations when expected planes are missing (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -187,7 +187,7 @@ public class ZeissCZIReader extends FormatReader {
       return null;
     }
     else if (noPixels) {
-      return new String[] {currentId};
+      return null;
     }
     String[] files = new String[pixels.size() + 1];
     files[0] = currentId;


### PR DESCRIPTION
This is the same as gh-1386 but rebased onto dev_5_0.

---

This should fix http://trac.openmicroscopy.org.uk/ome/ticket/12556.  The dimensions for the files in QA 9521 and 10301 should now match the expected dimensions listed in the ticket and QA issues.  I would not expect this to cause any test failures.

/cc @emilroz
