### PR TITLE
DICOM: also use the pixel sign tag to detect the pixel type (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -79,6 +79,7 @@ public class DicomReader extends FormatReader {
   private static final Hashtable<Integer, String> TYPES = buildTypes();
 
   private static final int PIXEL_REPRESENTATION = 0x00280103;
+  private static final int PIXEL_SIGN = 0x00281041;
   private static final int TRANSFER_SYNTAX_UID = 0x00020010;
   private static final int SLICE_SPACING = 0x00180088;
   private static final int SAMPLES_PER_PIXEL = 0x00280002;
@@ -547,6 +548,7 @@ public class DicomReader extends FormatReader {
           addInfo(tag, bitsPerPixel);
           break;
         case PIXEL_REPRESENTATION:
+        case PIXEL_SIGN:
           short ss = in.readShort();
           signed = ss == 1;
           addInfo(tag, ss);


### PR DESCRIPTION
This is the same as gh-1378 but rebased onto dev_5_0.

---

Closes http://trac.openmicroscopy.org.uk/ome/ticket/12568.

To test, verify that the files from QA 9532 and QA 9552 have pixel type int16, and have a black background/white artifact when imported.  Without this change, the pixel type should have been uint16, and the images had a white background/black artifact.
