### PR TITLE
Removing dead visiquest link (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1132,8 +1132,6 @@ opennessRating = Poor
 presenceRating = Poor
 utilityRating = Poor
 reader = KhorosReader.java
-notes = .. seealso:: \n
-  `VisiQuest software overview (formerly known as KhorosPro) <http://www.accusoft.com/products/visiquest/>`_
 
 [Kodak BIP]
 extensions = .bip

--- a/docs/sphinx/formats/khoros-viff-bitmap.txt
+++ b/docs/sphinx/formats/khoros-viff-bitmap.txt
@@ -55,5 +55,3 @@ Source Code: :bfreader:`KhorosReader.java`
 Notes:
 
 
-.. seealso:: 
-  `VisiQuest software overview (formerly known as KhorosPro) <http://www.accusoft.com/products/visiquest/>`_


### PR DESCRIPTION
This is the same as gh-1403 but rebased onto dev_5_0.

---

Visiquest seems to have been discontinued, it's not listed on the accusoft website anymore and as such the link is broken.

(Re: the other broken link in the current builds - I'm hoping the jpeg2000 link will start working again because the official specification docs aren't free so I could only link to intro page) 
