### PR TITLE
Removing jpeg 2000 broken link (rebased onto develop)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1054,7 +1054,7 @@ developer = `Independent JPEG Group <http://www.ijg.org/>`_
 bsd = yes
 export = yes
 software = `JJ2000 (JPEG 2000 library for Java) <http://code.google.com/p/jj2000/>`_
-weHave = * a `JPEG 2000 specification document <http://www.jpeg.org/jpeg2000/CDs15444.html>`_ (final draft, from 2000, in PDF) \n
+weHave = * a JPEG 2000 specification document (free draft from 2000, no longer available online) \n
 * a few .jp2 files
 pixelsRating = Very good
 metadataRating = Poor

--- a/docs/sphinx/formats/jpeg-2000.txt
+++ b/docs/sphinx/formats/jpeg-2000.txt
@@ -27,7 +27,7 @@ Freely Available Software:
 
 We currently have:
 
-* a `JPEG 2000 specification document <http://www.jpeg.org/jpeg2000/CDs15444.html>`_ (final draft, from 2000, in PDF) 
+* a JPEG 2000 specification document (free draft from 2000, no longer available online) 
 * a few .jp2 files
 
 We would like to have:


### PR DESCRIPTION
This is the same as gh-1408 but rebased onto develop.

---

Fed up of this link being dead so removing it - lots of other people use similar ones but the official jpeg website has no links to it so I'm assuming it's been taken down.
