### PR TITLE
Metamorph: fix double value parsing for locales that use a comma separator

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -465,9 +465,7 @@ public class MetamorphReader extends BaseTiffReader {
           creationTime = value;
         }
         else if (key.equals("ZStepSize")) {
-          char separator = new DecimalFormatSymbols().getDecimalSeparator();
-          value = value.replace('.', separator);
-          value = value.replace(',', separator);
+          value = value.replace(',', '.');
           stepSize = Double.parseDouble(value);
         }
         else if (key.equals("NStagePositions")) {
@@ -1178,9 +1176,7 @@ public class MetamorphReader extends BaseTiffReader {
               value = value.substring(0, value.indexOf(" "));
             }
             try {
-              char separator = new DecimalFormatSymbols().getDecimalSeparator();
-              value = value.replace('.', separator);
-              value = value.replace(',', separator);
+              value = value.replace(',', '.');
               double exposure = Double.parseDouble(value);
               exposureTime = new Double(exposure / 1000);
             }


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-November/004864.html

Double.parseDouble does not account for locale, and assumes that the
decimal separator is '.'.  Without this PR, the stack trace shown in the above thread should be reproduceable by adding `-Duser.country=FR -Duser.language=fr` to the `BF_FLAGS` variable in `tools/bf.sh` (or `tools/bf.bat` if testing on Windows).  With this PR, the dataset from the thread should be readable with or without the country/language change.

It's also worth just double-checking that the Z step and exposure times are indeed present in the original metadata and OME-XML, again regardless of the country/language.
