### PR TITLE
Update version history for 5.0.6 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -4,7 +4,6 @@ Version history
 5.0.6 (2014 November 11)
 ------------------------
 
-* Documentation improvements
 * Several bug fixes, including:
     - Pixel sign for DICOM images
     - Image dimensions for Zeiss CZI and Nikon ND2


### PR DESCRIPTION
This is the same as gh-1405 but rebased onto develop.

---

As usual, the date is a guess and might need updating.
