### PR TITLE
Zeiss TIFF: fix used file list when expected files are missing

### DIFF
--- a/components/formats-common/src/loci/common/CaseInsensitiveLocation.java
+++ b/components/formats-common/src/loci/common/CaseInsensitiveLocation.java
@@ -93,7 +93,7 @@ public class CaseInsensitiveLocation extends Location {
     // The file we're looking for doesn't exist, so look for it in the
     // same directory in a case-insensitive manner.  Note that this will
     // throw an exception if multiple copies are found.
-    return cache.lookup(name).getAbsolutePath();
+    return cache.lookup(name.getAbsoluteFile()).getAbsolutePath();
   }
 
   // Helper class

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -374,17 +374,15 @@ public class ZeissTIFFReader extends BaseZeissReader {
       info.basedir = b.getAbsolutePath();
       l = b;
     }
-    String basename = l.getParent() + "/" + info.prefix + ".tif";
-    l = new CaseInsensitiveLocation (basename);
-    if (l.exists())
-      info.origname = l.getAbsolutePath();
+    l = new CaseInsensitiveLocation (l.getParent(), info.prefix + ".tif");
+    info.origname = l.getAbsolutePath();
 
     return info;
   }
   protected void initFile(String id) throws FormatException, IOException {
     CaseInsensitiveLocation.invalidateCache();
     TIFFInfo info = evalFile(id);
-    if (new CaseInsensitiveLocation(info.origname).exists()) {
+    if (new CaseInsensitiveLocation(info.origname).getAbsoluteFile().exists()) {
       super.initFile(info.origname);
     }
     else {


### PR DESCRIPTION
The top-level .tif file in particular can be missing without causing any
other problems.  This prevents any files that do not exist from
appearing on the used file list, as that would cause import into OMERO
to fail.

To test, copy one of the datasets from the `zeiss-tiff` directory and remove the top-level .tif file.  Without this change, `showinf` on the .xml file will show the removed file in the used file list.  With this change, the removed file will not appear.
