### PR TITLE
TIFF: attempt to correct incorrectly stored StripByteCounts values

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -664,6 +664,11 @@ public class TiffParser {
     {
       stripByteCounts[countIndex] *= pixel;
     }
+    else if (stripByteCounts[countIndex] < 0 && countIndex > 0) {
+      LOGGER.debug("byte count #{} was {}; correcting to {}", countIndex,
+        stripByteCounts[countIndex], stripByteCounts[countIndex - 1]);
+      stripByteCounts[countIndex] = stripByteCounts[countIndex - 1];
+    }
 
     long stripOffset = 0;
     long nStrips = 0;


### PR DESCRIPTION
If an entry in the StripByteCounts array is negative, this logs the
original value and attempts to set it to the previous entry in the
array.

Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12583.

To test, verify that the file from QA 9563 throws an exception as referenced in the ticket without this change.  With this change, the same file should open/import without throwing an exception, and the image should look "reasonable" - ImageMagick gives similar results, but leaves the last strip empty instead of correcting the byte count and reading the stored pixel values.

Builds should remain green, as I would not expect this to affect other files in the repository.
