### PR TITLE
Metamorph: fix description delimiter to account for XML sanitization

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -125,7 +125,7 @@ public class MetamorphHandler extends BaseHandler {
   {
     String id = attributes.getValue("id");
     String value = attributes.getValue("value");
-    String delim = "&#13;&#10;";
+    String delim = " #13; #10;";
     if (id != null && value != null) {
       if (id.equals("Description")) {
         if (metadata != null) metadata.remove("Comment");


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/12633.

To test, verify that the dataset in `data_repo/from_skyking/metamorph/sebastien-besson/A._WTChlor.2.nd_[Stage1__Position52_]/` has some original metadata entries that begin with `#10;`, as noted in the ticket.  Without this change, there should not be any entries that begin with `#10;`, and e.g. `Binning` and `Temperature` should be in the original metadata table.

/cc @sbesson 
