### PR TITLE
Changed handling of empty series names in ND2 files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1718,7 +1718,7 @@ public class NativeND2Reader extends FormatReader {
       ArrayList<String> posNames = handler.getPositionNames();
       for (int i=0; i<getSeriesCount(); i++) {
         String suffix =
-          i < posNames.size() ? posNames.get(i) : "(series " + (i + 1) + ")";
+          (i < posNames.size() && !posNames.get(i).equals("")) ? posNames.get(i) : "(series " + (i + 1) + ")";
         String name = filename + " " + suffix;
         store.setImageName(name.trim(), i);
       }


### PR DESCRIPTION
We have observed that the NIS Elements software changes some metadata of ND2 files even if there is no explicit change to that specific metadata. Changing the LUT, for example, will set the series names/pPosNames to an empty string ("") where before no pPosNames were available.

This PR changes the series naming scheme such that the both situations (`"".equals(pPosName)` and pPosName is not available) are handled in the same way.
