### PR TITLE
Reduce memory needed to open PNG images

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -32,13 +32,12 @@
 
 package loci.formats.in;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.Vector;
 import java.util.zip.InflaterInputStream;
 
-import loci.common.ByteArrayHandle;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -141,39 +140,23 @@ public class APNGReader extends FormatReader {
       RandomAccessInputStream s = new RandomAccessInputStream(lastImage);
       readPlane(s, x, y, w, h, buf);
       s.close();
+      s = null;
       return buf;
     }
 
     if (no == 0) {
-      ByteArrayOutputStream s = new ByteArrayOutputStream();
-      int readIDATs = 0;
+      lastImage = null;
 
-      for (PNGBlock block : blocks) {
-        if (block.type.equals("IDAT")) {
-          in.seek(block.offset);
-          byte[] tmp = new byte[block.length];
-          in.read(tmp);
-          s.write(tmp);
-          tmp = null;
-
-          readIDATs++;
-        }
-        if (readIDATs == idatCount) {
-          break;
-        }
-      }
-
-      s.close();
-
-      LOGGER.warn("height = " + (y + h));
-
-      lastImage = decode(s.toByteArray(), getSizeX(), y + h);
+      PNGInputStream stream = new PNGInputStream("IDAT");
+      lastImage = decode(stream, getSizeX(), y + h);
+      stream.close();
       lastImageIndex = 0;
       lastImageRow = y + h;
 
       RandomAccessInputStream pix = new RandomAccessInputStream(lastImage);
       readPlane(pix, x, y, w, h, buf);
       pix.close();
+      pix = null;
 
       if (y + h < getSizeY()) {
         lastImage = null;
@@ -181,50 +164,14 @@ public class APNGReader extends FormatReader {
       return buf;
     }
 
-    ByteArrayOutputStream s = new ByteArrayOutputStream();
-    int readIDATs = 0;
 
-    for (PNGBlock block : blocks) {
-      if (block.type.equals("IDAT")) {
-        in.seek(block.offset);
-        byte[] tmp = new byte[block.length];
-        in.read(tmp);
-        s.write(tmp);
-        tmp = null;
-
-        readIDATs++;
-      }
-      if (readIDATs == idatCount) {
-        break;
-      }
-    }
-
-    boolean fdatValid = false;
-    int fctlCount = 0;
     int[] coords = frameCoordinates.get(no);
 
-    s = new ByteArrayOutputStream();
-
-    for (PNGBlock block : blocks) {
-      if (block.type.equals("fcTL")) {
-        fdatValid = fctlCount == no;
-        fctlCount++;
-      }
-      else if (block.type.equals("fdAT")) {
-        in.seek(block.offset + 4);
-        if (fdatValid) {
-          byte[] tmp = new byte[block.length - 4];
-          in.read(tmp);
-          s.write(tmp);
-          tmp = null;
-        }
-      }
-    }
-
-    s.close();
     lastImage = openBytes(0);
     lastImageRow = getSizeY();
-    byte[] newImage = decode(s.toByteArray(), coords[2], coords[3]);
+    PNGInputStream stream = new PNGInputStream("fdAT", no);
+    byte[] newImage = decode(stream, coords[2], coords[3]);
+    stream.close();
 
     // paste current image onto first image
 
@@ -394,11 +341,11 @@ public class APNGReader extends FormatReader {
     MetadataTools.populatePixels(store, this);
   }
 
-  private byte[] decode(byte[] bytes) throws FormatException, IOException {
+  private byte[] decode(PNGInputStream bytes) throws FormatException, IOException {
     return decode(bytes, getSizeX(), getSizeY());
   }
 
-  private byte[] decode(byte[] bytes, int width, int height)
+  private byte[] decode(PNGInputStream bytes, int width, int height)
     throws FormatException, IOException
   {
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
@@ -425,11 +372,11 @@ public class APNGReader extends FormatReader {
       byte[] filters = new byte[height];
       image = new byte[rowLen * height];
 
-      InflaterInputStream decompressor =
-        new InflaterInputStream(new ByteArrayInputStream(bytes));
+      InflaterInputStream decompressor = new InflaterInputStream(bytes);
       try {
+        int n = 0;
         for (int row=0; row<height; row++) {
-          int n = 0;
+          n = 0;
           while (n < 1) {
             n = decompressor.read(filters, row, 1);
           }
@@ -441,6 +388,7 @@ public class APNGReader extends FormatReader {
       }
       finally {
         decompressor.close();
+        decompressor = null;
       }
 
       // perform any necessary unfiltering
@@ -465,8 +413,7 @@ public class APNGReader extends FormatReader {
 
       image = new byte[FormatTools.getPlaneSize(this)];
 
-      InflaterInputStream decompressor =
-        new InflaterInputStream(new ByteArrayInputStream(bytes));
+      InflaterInputStream decompressor = new InflaterInputStream(bytes);
       try {
         for (int i=0; i<passImages.length; i++) {
           int passWidth = PASS_WIDTHS[i] * nColBlocks;
@@ -494,6 +441,7 @@ public class APNGReader extends FormatReader {
       }
       finally {
         decompressor.close();
+        decompressor = null;
       }
 
       int chunk = bpp * getRGBChannelCount();
@@ -545,8 +493,7 @@ public class APNGReader extends FormatReader {
 
     if (getBitsPerPixel() < 8) {
       byte[] expandedImage = new byte[FormatTools.getPlaneSize(this)];
-      RandomAccessInputStream bits = new RandomAccessInputStream(
-        new ByteArrayHandle(image));
+      RandomAccessInputStream bits = new RandomAccessInputStream(image);
 
       int skipBits = rowLen * 8 - getSizeX() * getBitsPerPixel();
       for (int row=0; row<getSizeY(); row++) {
@@ -558,6 +505,7 @@ public class APNGReader extends FormatReader {
         bits.skipBits(skipBits);
       }
       bits.close();
+      bits = null;
 
       image = expandedImage;
     }
@@ -623,6 +571,123 @@ public class APNGReader extends FormatReader {
     public long offset;
     public int length;
     public String type;
+  }
+
+  /**
+   * InputStream implementation that stitches together IDAT blocks into
+   * a seamless zlib stream.  This allows us to decompress the image data
+   * without reading the entire compressed stream into a byte array.
+   */
+  class PNGInputStream extends InputStream {
+    private int currentBlock = -1;
+    private int blockPointer = 0;
+    private int blockLength = 0;
+    private String blockType;
+    private int imageNumber;
+    private int fctlCount = 0;
+    private boolean fdatValid = false;
+
+    public PNGInputStream(String blockType) throws IOException {
+      this(blockType, 0);
+    }
+
+    public PNGInputStream(String blockType, int imageNumber) throws IOException {
+      this.imageNumber = imageNumber;
+      this.blockType = blockType;
+      fctlCount = 0;
+      fdatValid = false;
+      advanceBlock();
+    }
+
+    public int available() throws IOException {
+      if (blockPointer == blockLength) {
+        advanceBlock();
+      }
+      if (currentBlock < 0 || in.getFilePointer() == in.length()) {
+        return -1;
+      }
+      return (int) Math.min(blockLength - blockPointer, in.length() - in.getFilePointer());
+    }
+
+    public int read() throws IOException {
+      if (blockPointer < blockLength) {
+        blockPointer++;
+        return in.read();
+      }
+      advanceBlock();
+      if (currentBlock < 0) {
+        throw new EOFException();
+      }
+      blockPointer++;
+      return in.read();
+    }
+
+    public byte readByte() throws IOException {
+      if (blockPointer < blockLength) {
+        blockPointer++;
+        return in.readByte();
+      }
+      advanceBlock();
+      if (currentBlock < 0) {
+        throw new EOFException();
+      }
+      blockPointer++;
+      return in.readByte();
+    }
+
+    public int read(byte[] b, int off, int len) throws IOException {
+      int read = 0;
+      for (int i=0; i<len; i++) {
+        if (available() > 0) {
+          b[off + i] = readByte();
+          read++;
+        }
+        else {
+          break;
+        }
+      }
+      return read;
+    }
+
+    private void advanceBlock() throws IOException {
+      if (currentBlock < blocks.size() - 1) {
+        while (currentBlock < blocks.size()) {
+          currentBlock++;
+          if (currentBlock == blocks.size()) {
+            currentBlock = -1;
+            break;
+          }
+          if (blockType.equals("fdAT") && blocks.get(currentBlock).type.equals("fcTL")) {
+            fdatValid = fctlCount == imageNumber;
+            fctlCount++;
+            if (fctlCount > imageNumber + 1) {
+              currentBlock = -1;
+              break;
+            }
+          }
+          else if (blockType.equals(blocks.get(currentBlock).type)) {
+            if (fdatValid || !blockType.equals("fdAT")) {
+              break;
+            }
+          }
+        }
+        if (currentBlock >= 0) {
+          blockPointer = 0;
+          blockLength = blocks.get(currentBlock).length;
+          in.seek(blocks.get(currentBlock).offset);
+          if (blocks.get(currentBlock).type.equals("fdAT")) {
+            blockLength -= 4;
+            in.skipBytes(4);
+          }
+        }
+      }
+      else {
+        currentBlock = -1;
+        blockPointer = 0;
+        blockLength = 0;
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12274.

To test, change the `BF_MAX_MEM` variable in `tools/bf.sh` or `tools/bf.bat` to `768m`.  Verify that the following two commands on the file in `from_skyking/png/james` result in an OutOfMemoryError without this change:

`showinf -crop 0,0,512,512` -- this is the first tile
`showinf -crop 21921,21970,512,512` - this is the last tile

With this change, both commands should result in the tile being displayed; it is expected for both tiles to be all black.  Reading the last tile will be noticeably slower than reading the first tile, which is also expected.

All builds should remain green.
