### PR TITLE
Use __import__ for generateDS to handle FS case issues

### DIFF
--- a/components/xsd-fu/python/ome/modeltools/generateds.py
+++ b/components/xsd-fu/python/ome/modeltools/generateds.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 import sys
 import keyword
 import logging
 
 # The generateDS package and our generateds module
 # collide on case-insensitive file systems.
-generateDS = __import__("generateDS.generateDS")
+import generateDS.generateDS
 XschemaHandler = generateDS.generateDS.XschemaHandler
 set_type_constants = generateDS.generateDS.set_type_constants
 


### PR DESCRIPTION
While mounting the source tree from an OSX 10.10 host
over boot2docker to an Ubuntu container, Bio-Formats
builds failed with:

```
Traceback (most recent call last):
  File "./xsd-fu", line 45, in <module>
    from ome.modeltools import generateds
  File "/opt/tmp/components/bioformats/components/xsd-fu/python/ome/modeltools/generateds.py", line 6, in <module>
    from generateDS.generateDS import XschemaHandler, set_type_constants
  File "/opt/tmp/components/bioformats/components/xsd-fu/python/ome/modeltools/generateDS.py", line 6, in <module>
    from generateDS.generateDS import XschemaHandler, set_type_constants
ImportError: No module named generateDS
```

since there is a case-insensitive clash between our
ome.model.generateds (imported relatively) and
generateDS.generateDS (imported absolutely).

/cc @manics @chris-allan
