### PR TITLE
Fix mock object to match changes from int to double for channel

### DIFF
--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -662,7 +662,7 @@ public class XMLMockObjects
     settings.setGain(1.0);
     settings.setOffset(1.0);
     settings.setReadOutRate(new Frequency(1.0, UNITS.HZ));
-    settings.setVoltage(new ElectricPotential(0, UNITS.V));
+    settings.setVoltage(new ElectricPotential(1.0, UNITS.V));
     return settings;
   }
 


### PR DESCRIPTION
To test the PR
Check that https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration/integration.ImporterTest/testImportImageWithAcquisitionData/? is green
