### PR TITLE
IM3: fix memoization and whitespace

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/IM3Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/IM3Reader.java
@@ -871,9 +871,15 @@ public class IM3Reader extends FormatReader {
     super.close(fileOnly);
     if (!fileOnly) {
       data = null;
-      records.clear();
-      spectra.clear();
-      dataSets.clear();
+      if (records != null) {
+        records.clear();
+      }
+      if (spectra != null) {
+        spectra.clear();
+      }
+      if (dataSets != null) {
+        dataSets.clear();
+      }
     }
   }
 


### PR DESCRIPTION
Most of the diff is concerned with removing tabs and trailing whitespace.  The two things to check are code changes in caf5937, and to verify that builds (particularly 5.1-merge-full-repository) remain green.  Automated testing for .im3 files is now turned on, so memo file tests should pass.
