### PR TITLE
Changed ND2 metadata string handling to work properly with empty strings

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1621,13 +1621,12 @@ public class NativeND2Reader extends FormatReader {
             value = in.readLong();
             break;
           case (8): // String
-            //in.read(); // size of string
-            long start = in.getFilePointer();
-            value = DataTools.stripString(in.findString("\0\0\0"));
-            long end = in.getFilePointer();
-            if ((end - start) % 2 != 0) {
-              in.skipBytes(1);
+            char currentChar = 0;
+            StringBuilder resultString = new StringBuilder();
+            while((currentChar = in.readChar()) != 0) {
+                resultString.append(currentChar);
             }
+            value = resultString.toString();
             break;
           case (9): // ByteArray
             long length = in.readLong();


### PR DESCRIPTION
Hello,

on demand by @ctrueden in reference to mailing list problem 'Bioformats opening ND2 error' by Peter Saxon, here's a patch fixing the file opening problem, which seems due to the reader fetching too many bytes on empty string fields (in metadata), then reading garbage and getting stuck in an infinite loop.

As a positive side effect, this seems to clear away a lot of nonsensical metadata normally present in ND2 files opened with bioformats. I diff'd the results of Fiji's 'Show Info' for a file opened with a DEVELOP version and a patched version, and some nonsensical fields got removed, and some fields got filled with more meaningful values.

I guess there would be a way to get the findString function to work properly, but this 'easy' solution was just too tempting ;)

I only tested it with two files; please check it with your collection of different ND2 files ...

Best regards,
Christian Sachs
