### PR TITLE
Add bash script for updating copyright headers

### DIFF
--- a/tools/update_copyright
+++ b/tools/update_copyright
@@ -1,6 +1,12 @@
 #! /bin/bash
 # Script for updating copyright headers across the code
 
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: update_copyright [year]"
+  exit 1
+fi
+
 COPYRIGHT="Copyright (C) "
 YEAR="[0-9]\{4\}"
 RANGE=" - "


### PR DESCRIPTION
This script is largely inspired from a Pull request from Curtis Rueden and should be called with a positional argument equal to the current year, e.g.

```
$ bash tools/update_copyright 2015
```
