### PR TITLE
Add script to bump version numbers

### DIFF
--- a/tools/bump_maven_version.py
+++ b/tools/bump_maven_version.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python
-# Script for updating copyright headers across the code
+# Script for increasing versions numbers across the code
 
 import glob
 import re


### PR DESCRIPTION
This Python script should simplify the creation of PRs bumping the version numbers before and after release. To test it, follow a typical release workflow

```
$ python tools/bump_maven_version.py 5.1.0-rc1
$ git diff
$ python tools/bump_maven_version.py 5.1.0
$ git diff
$ $ python tools/bump_maven_version.py 5.1.1-SNAPSHOT
$ git diff
```

First 2 commands should update the versions in all `pom.xml` files as well as `STABLE_VERSION` in `UpgradeChecker.java` while the last one (with SNAPSHOT) should update the versions in all `pom.xml` only.
