### PR TITLE
Improve failure message and description of dist target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -248,7 +248,7 @@ Apache XML-RPC
   <import file="ant/toplevel.xml"/>
 
   <!-- OME-compatibility layer -->
-  <target name="dist" description="OME hook: build and publish Bio-Formats dist">
+  <target name="dist" description="OME hook: build and publish Bio-Formats submodule dist">
     <ant target="tools"/>
     <ant target="tools-ome"/>
     <ant target="jar-formats-bsd-tests"/>

--- a/ome.xml
+++ b/ome.xml
@@ -4,6 +4,13 @@
   </description>
 
   <property name="import.dir" value="${basedir}/../antlib/resources"/>
+  <fail message="No file ${import.dir}/global.xml found. Make sure this target is called from Bio-Formats as a submodule of openmicroscopy.git.">
+	<condition>
+      <not>
+        <available file="${import.dir}/global.xml" />
+      </not>
+    </condition>
+  </fail>
   <import file="${import.dir}/gitversion.xml" optional="true"/>
   <import file="${import.dir}/global.xml"/>
   <import file="${import.dir}/version.xml"/>


### PR DESCRIPTION
This commit should clarify the fact that the ant dist target is expected to be run from Bio-Formats as a submodule of openmicroscopy.git

/cc @emilroz @dominikl 

--no-rebase
