### PR TITLE
Review setId() Javadocs for readers/writers

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1372,7 +1372,16 @@ public abstract class FormatReader extends FormatHandler
     return isThisType(name, true);
   }
 
-  /* @see IFormatHandler#setId(String) */
+  /**
+   * Initializes a reader from the input file name.
+   *
+   * Calls {@link #initFile(String id)} to initializes the input file, reads
+   * all of the metadata and sets the reader up for reading planes.
+   * The performance of this method depends on the format and can be up to
+   * several minutes for large file sets.
+   *
+   *  @param id a {@link String} specifying the path to the file
+   */
   @Override
   public void setId(String id) throws FormatException, IOException {
     LOGGER.debug("{} initializing {}", this.getClass().getSimpleName(), id);

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -295,7 +295,15 @@ public abstract class FormatWriter extends FormatHandler
 
   // -- IFormatHandler API methods --
 
-  /* @see IFormatHandler#setId(String) */
+  /**
+   * Initializes a writer from the input file name.
+   *
+   * Initializes a {@link RandomAccessOutputStream} for the output
+   * file and initializes the metadata for all the series using
+   * {@link #setSeries(int)}.
+   *
+   *  @param id a {@link String} specifying the path to the file
+   */
   @Override
   public void setId(String id) throws FormatException, IOException {
     if (id.equals(currentId)) return;

--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -69,9 +69,9 @@ public class JPEGReader extends DelegateReader {
     suffixNecessary = false;
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatReader API methods --
 
-  /* @see IFormatHandler#setId(String) */
+  /* @see FormatReader#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     try {

--- a/components/formats-bsd/src/loci/formats/out/APNGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/APNGWriter.java
@@ -112,9 +112,9 @@ public class APNGWriter extends FormatWriter {
       FormatTools.UINT16};
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);
@@ -171,7 +171,7 @@ public class APNGWriter extends FormatWriter {
     }
   }
 
-  /* @see loci.formats.IFormatHandler#close() */
+  /* @see loci.formats.FormatWriter#close() */
   @Override
   public void close() throws IOException {
     super.close();

--- a/components/formats-bsd/src/loci/formats/out/AVIWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/AVIWriter.java
@@ -218,9 +218,9 @@ public class AVIWriter extends FormatWriter {
     return new int[] {FormatTools.UINT8};
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#close() */
+  /* @see loci.formats.FormatWriter#close() */
   @Override
   public void close() throws IOException {
     super.close();
@@ -234,7 +234,7 @@ public class AVIWriter extends FormatWriter {
     saveidx1Length = 0;
   }
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);

--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -176,7 +176,7 @@ public class ICSWriter extends FormatWriter {
 
   // -- IFormatHandler API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);

--- a/components/formats-bsd/src/loci/formats/out/JavaWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/JavaWriter.java
@@ -126,7 +126,7 @@ public class JavaWriter extends FormatWriter {
 
   // -- IFormatHandler API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -207,9 +207,9 @@ public class OMETiffWriter extends TiffWriter {
     imageLocations[series][index] = currentId;
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see IFormatHandler#setId(String) */
+  /* @see FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     if (id.equals(currentId)) return;

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -81,9 +81,9 @@ public class OMEXMLWriter extends FormatWriter {
     compression = compressionTypes[0];
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     if (id.equals(currentId)) {

--- a/components/formats-bsd/src/loci/formats/out/QTWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/QTWriter.java
@@ -272,9 +272,9 @@ public class QTWriter extends FormatWriter {
     return new int[] {FormatTools.UINT8};
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);
@@ -319,7 +319,7 @@ public class QTWriter extends FormatWriter {
     }
   }
 
-  /* @see loci.formats.IFormatHandler#close() */
+  /* @see loci.formats.FormatWriter#close() */
   @Override
   public void close() throws IOException {
     if (out != null) writeFooter();

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -132,9 +132,9 @@ public class TiffWriter extends FormatWriter {
     isBigTiff = false;
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);

--- a/components/formats-bsd/src/loci/formats/out/V3DrawWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/V3DrawWriter.java
@@ -190,15 +190,15 @@ public class V3DrawWriter extends FormatWriter {
             FormatTools.FLOAT};
     }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-    /* @see loci.formats.IFormatHandler#setId(String) */
+    /* @see loci.formats.FormatWriter#setId(String) */
     @Override
     public void setId(String id) throws FormatException, IOException {
         super.setId(id);
     }
 
-    /* @see loci.formats.IFormatHandler#close() */
+    /* @see loci.formats.FormatWriter#close() */
     @Override
     public void close() throws IOException {
         super.close();

--- a/components/formats-gpl/src/loci/formats/out/WlzWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/WlzWriter.java
@@ -151,9 +151,9 @@ public class WlzWriter extends FormatWriter {
     return(spt);
   }
 
-  // -- IFormatHandler API methods --
+  // -- FormatWriter API methods --
 
-  /* @see loci.formats.IFormatHandler#setId(String) */
+  /* @see loci.formats.FormatWriter#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);
@@ -209,7 +209,7 @@ public class WlzWriter extends FormatWriter {
     }
   }
 
-  /* @see loci.formats.IFormatHandler#close() */
+  /* @see loci.formats.FormatWriter#close() */
   @Override
   public void close() throws IOException {
     super.close();


### PR DESCRIPTION
- expand description of setId() for the FormatReader/FormatWriter interfaces
- properly link to the interface setId Javadoc for classes overriding setId()

--no-rebase
