### PR TITLE
ND2 - Support multipoint global metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -123,6 +123,7 @@ public class NativeND2Reader extends FormatReader {
 
   private boolean textData = false;
   private Double refractiveIndex = null;
+  private boolean hasMultipointNames = false;
 
   // -- Constructor --
 
@@ -1980,8 +1981,16 @@ public class NativeND2Reader extends FormatReader {
         else if (name.equals("dZLow")) {
           zLow = DataTools.parseDouble(value.toString());
         }
-        else if (name.equals("dPosX")) {
+        else if (name.equals("dPosName")) {
+          hasMultipointNames = true;
           positionCount++;
+        }
+        else if (name.equals("dPosX") && !hasMultipointNames) {
+          positionCount++;
+        }
+        
+        if (name.toLowerCase().startsWith("dpos")) {
+          name += " " + positionCount;
         }
 
         if (type != 11 && type != 10) {    // if not level add global meta


### PR DESCRIPTION
This PR is in relation to https://trello.com/c/obHnFk58/12-nd2-multipoint-point-name-missing

Previously the values for the multiple positions were correctly being read but as each set used the same names, when added to the global metadata the key values were duplicate and as a result only the last set of values was stored. This PR resolves this by storing each set by adding an index to the key.

Bio-Formats already identified when multiple positions were present and keeps a count. I am reusing this value as the index. The slight change is that dPosX was being used to keep this count. In instances were an associated name is not present this is still the same behaviour, however if a name is present (dPosName) this will appear before the X value and as such will be used for the index instead.

To Test:
- Using the sample file from QA-17936, read the file and view the global metadata. 
- Without this PR there should be a single set of entries with the key dPos (dPosName, dPosX, dPosY, dPosZ etc)
- With this PR included there should be multiple entries of these position sets with an index beside them. The values should match up with those in the screenshot of forum thread https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8368&p=18538&sid=247d39d589db9edc0815d8868720803a#p18538
