### PR TITLE
PCI: Don't modify the width when binning is used

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -387,8 +387,8 @@ public class PCIReader extends FormatReader {
     String file = imageFiles.get(0);
     RandomAccessInputStream s = poi.getDocumentStream(file);
     TiffParser tp = new TiffParser(s);
-    // don't correct the image width if it's stored as a TIFF
-    if (!tp.isValidHeader() && s.length() > expectedPlaneSize) {
+    // don't correct the image width if it's stored as a TIFF or if binning
+    if (!tp.isValidHeader() && binning == 0 && s.length() > expectedPlaneSize) {
       m.sizeX += (s.length() - expectedPlaneSize) / (m.sizeY * bpp * m.sizeC);
     }
     s.close();


### PR DESCRIPTION
This issue has been raised a few times, see Trello card https://trello.com/c/MQYsukMf/132-pci-reader-incorrect-width

In a previous PR it was necessary to adjust the width if extra bytes were available https://github.com/openmicroscopy/bioformats/pull/1944, however in instances were binning is used there appears to extra bytes available but no need to adjust the size.

This is not an ideal solution, it would much better if we had an understanding of what exactly the extra bytes are being used for. However if it provides a solution for users then it may be worth including.

Sample QA files can be found in QA-17696 and QA-19182