### PR TITLE
Columbus: Add support for PlaneID

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -478,6 +479,7 @@ public class ColumbusReader extends FormatReader {
       Element image = (Element) images.item(i);
       Plane p = new Plane();
 
+      Location fileLoc = null;
       NodeList children = image.getChildNodes();
       for (int q=0; q<children.getLength(); q++) {
         Node child = children.item(q);
@@ -485,6 +487,7 @@ public class ColumbusReader extends FormatReader {
         String value = child.getTextContent();
         NamedNodeMap attrs = child.getAttributes();
         if (name.equals("URL")) {
+          fileLoc = new Location(parent, value);
           p.file = new Location(parent, value).getAbsolutePath();
 
           String buffer = attrs.getNamedItem("BufferNo").getNodeValue();
@@ -497,6 +500,9 @@ public class ColumbusReader extends FormatReader {
           p.col = Integer.parseInt(value) - 1;
         }
         else if (name.equals("FieldID")) {
+          p.field = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("PlaneID")) {
           p.field = Integer.parseInt(value) - 1;
         }
         else if (name.equals("TimepointID")) {
@@ -557,7 +563,9 @@ public class ColumbusReader extends FormatReader {
         }
       }
 
-      planes.add(p);
+      if (fileLoc.exists()) {
+        planes.add(p);
+      }
     }
 
   }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -28,7 +28,6 @@ package loci.formats.in;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -479,7 +478,6 @@ public class ColumbusReader extends FormatReader {
       Element image = (Element) images.item(i);
       Plane p = new Plane();
 
-      Location fileLoc = null;
       NodeList children = image.getChildNodes();
       for (int q=0; q<children.getLength(); q++) {
         Node child = children.item(q);
@@ -487,7 +485,6 @@ public class ColumbusReader extends FormatReader {
         String value = child.getTextContent();
         NamedNodeMap attrs = child.getAttributes();
         if (name.equals("URL")) {
-          fileLoc = new Location(parent, value);
           p.file = new Location(parent, value).getAbsolutePath();
 
           String buffer = attrs.getNamedItem("BufferNo").getNodeValue();
@@ -503,7 +500,10 @@ public class ColumbusReader extends FormatReader {
           p.field = Integer.parseInt(value) - 1;
         }
         else if (name.equals("PlaneID")) {
-          p.field = Integer.parseInt(value) - 1;
+          int planeID = Integer.parseInt(value) - 1;
+          if (planeID > p.field) {
+            p.field = planeID;
+          }
         }
         else if (name.equals("TimepointID")) {
           p.timepoint = Integer.parseInt(value) - 1;
@@ -563,9 +563,7 @@ public class ColumbusReader extends FormatReader {
         }
       }
 
-      if (fileLoc.exists()) {
-        planes.add(p);
-      }
+      planes.add(p);
     }
 
   }


### PR DESCRIPTION
See https://trello.com/c/1tAKDsuU/261-planeid-support-for-columbus

This PR adds support for the PlaneID field and is in relation to an issue originally raised in forum thread https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8550&p=19850&sid=65eaffd409d3f3b6e7506cf70614c778#p19850

A sample dataset is available in QA-21609. The partial fileset contains 9 planes, each with 3 channels. Currently only a single 3 channel image is opened.

All of the tiff files are picked up by the reader and the plane data is all correctly parsed. However the PlaneID attribute is not used. I have modified the reader to treat PlaneID the same as FieldID, this results in the correct number of series being used. A better longer term fix would be to include this as a separate attribute on plane rather than reusing field.

To read the dataset a MeasurementIndex.ColumbusIDX.xml must be added and the reader has also been modified to handle the partial dataset:

To test:
- Ensure builds and tests remain green
- Without the PR only the first plane is read
- With the PR all of the planes should be read correctly
