### PR TITLE
NDPI: Prevent Null Pointer Exception

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -219,7 +219,7 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
 
     if (restartInterval == 1 && restartMarkers.size() <= 1) {
       // interval and markers are not present or invalid
-      throw new IOException("Restart interval and markers invalid");
+      LOGGER.warn("Restart interval and markers are not present");
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -172,12 +172,12 @@ public class NDPIReader extends BaseTiffReader {
       try {
         service.close();
         long[] markers = ifd.getIFDLongArray(MARKER_TAG);
-        if (!use64Bit) {
-          for (int i=0; i<markers.length; i++) {
-            markers[i] = markers[i] & 0xffffffffL;
-          }
-        }
         if (markers != null) {
+          if (!use64Bit) {
+            for (int i=0; i<markers.length; i++) {
+              markers[i] = markers[i] & 0xffffffffL;
+            }
+          }
           service.setRestartMarkers(markers);
         }
         service.initialize(in, getSizeX(), getSizeY());

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -177,8 +177,8 @@ public class NDPIReader extends BaseTiffReader {
             for (int i=0; i<markers.length; i++) {
               markers[i] = markers[i] & 0xffffffffL;
             }
+            service.setRestartMarkers(markers);
           }
-          service.setRestartMarkers(markers);
         }
         service.initialize(in, getSizeX(), getSizeY());
       }


### PR DESCRIPTION
This issue was raised on the mailing list and a sample file has been provided: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2018-October/007233.html

The images failed to open due to a NullPointerException on line 176, with the `markers` variable being null.

To test:
- Ensure builds and tests remain green
- Using the sample file provided on the mailing list test that the file is able to be open and read correctly