### PR TITLE
OME-TIFF: use blank planes when UUID cannot be resolved to a filename

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -722,7 +722,11 @@ public class OMETiffReader extends SubResolutionFormatReader {
         }
         else {
           filename = meta.getUUIDFileName(i, td);
-          if (!new Location(dir, filename).exists()) filename = null;
+          if (!new Location(dir, filename).exists()) {
+            LOGGER.error("Missing file {} for UUID {} (planes will be black)",
+              filename, uuid);
+            filename = null;
+          }
           if (filename == null) {
             if (uuid.equals(currentUUID) || currentUUID == null) {
               // UUID references this file
@@ -754,7 +758,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
           // TODO search...
           // should scan only other .ome.tif files
           // to make this work with OME server may be a little tricky?
-          throw new FormatException("Unmatched UUID: " + uuid);
+          LOGGER.error("Unmatched UUID: {} " +
+            "(all corresponding planes will be black)", uuid);
         }
       }
     }


### PR DESCRIPTION
A UUID with no matching file name no longer throws an exception, but missing files and unmatched UUIDs are logged at ```ERROR```.  While datasets that expose this case are arguably invalid, logging instead of throwing an exception at least allows any readable image data to be extracted.

To test, use ```inbox/ome-tiff-uuid-mismatch/test_Z0.ome.tiff```, which was generated from a .fake file as described in the readme.  Without this change, ```showinf -debug test_Z0.ome.tiff``` should throw:

```
loci.formats.FormatException: Unmatched UUID: urn:uuid:1a4f0c67-38f8-4b0a-ac78-a0bf8d506f22
	at loci.formats.in.OMETiffReader.initFile(OMETiffReader.java:757) ~[bioformats_package.jar:6.0.0-SNAPSHOT]
	at loci.formats.SubResolutionFormatReader.setId(SubResolutionFormatReader.java:1378) ~[bioformats_package.jar:6.0.0-SNAPSHOT]
	at loci.formats.ImageReader.setId(ImageReader.java:842) ~[bioformats_package.jar:6.0.0-SNAPSHOT]
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650) ~[bioformats_package.jar:6.0.0-SNAPSHOT]
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1035) [bioformats_package.jar:6.0.0-SNAPSHOT]
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1121) [bioformats_package.jar:6.0.0-SNAPSHOT]
```

With this change, the same test should result in two planes being read.  The first should have the typical gradient, and the second should be all black.  There should be ```ERROR```-level logging to indicate that a file is missing and that black planes should be expected.

Memo files and tests should be unaffected, so this should be fine for a patch release.