### PR TITLE
Deltavision: allow .dv date to override .log date

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -852,10 +852,6 @@ public class DeltavisionReader extends FormatReader {
       }
 
       store.setImageDescription(imageDesc, series);
-
-      if (timestamp != null) {
-        store.setImageAcquisitionDate(new Timestamp(timestamp), series);
-      }
     }
 
     populateObjective(store, lensID);
@@ -869,6 +865,14 @@ public class DeltavisionReader extends FormatReader {
               parseDeconvolutionLog(s, store);
             }
         }
+    }
+
+    // timestamp stored in the .dv file takes precedence
+    // over the timestamp in the log file
+    if (timestamp != null) {
+      for (int series=0; series<getSeriesCount(); series++) {
+        store.setImageAcquisitionDate(new Timestamp(timestamp), series);
+      }
     }
 
     if (xTiles * yTiles > getSeriesCount()) {


### PR DESCRIPTION
This improves the behavior when the .log date is incorrectly formatted or cannot be parsed using the current locale.

See https://github.com/openmicroscopy/data_repo_config/pull/411#issuecomment-511465566.  The issue is that when the ```user.language``` is set to something other than ```en```, log file date parsing is likely to fail since the dates are of the format ```Wed Jun 13 13:45:04 2012```.  Since the .log file date took precedence, this meant that the resulting ```AcquisitionDate``` in the ```MetadataStore``` was locale dependent.  This PR changes the date precedence so that the .log file's date will only be kept if it is present and valid and the .dv date does not exist.

With this code change only, all locales should now consistently fail as they have been for ```fr_FR```.  A forthcoming config PR updates the 8 affected datasets to use the .dv date, so that all tests should pass for all locales that we use.