### PR TITLE
Use javaObject to construct Boolean object in GNU Octave

### DIFF
--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -53,12 +53,7 @@ metadata = OMEXMLService.createOMEXMLMetadata();
 metadata.createRoot();
 metadata.setImageID('Image:0', 0);
 metadata.setPixelsID('Pixels:0', 0);
-if is_octave()
-    java_true = javaObject('java.lang.Boolean', 'TRUE');
-else
-    java_true = java.lang.Boolean.TRUE;
-end
-metadata.setPixelsBigEndian(java_true, 0);
+metadata.setPixelsBigEndian(javaObject('java.lang.Boolean', 'TRUE'), 0);
 
 % Set dimension order
 dimensionOrderEnumHandler = javaObject('ome.xml.model.enums.handlers.DimensionOrderEnumHandler');

--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -54,7 +54,7 @@ metadata.createRoot();
 metadata.setImageID('Image:0', 0);
 metadata.setPixelsID('Pixels:0', 0);
 if is_octave()
-    java_true = java_get('java.lang.Boolean', 'TRUE');
+    java_true = javaObject('java.lang.Boolean', 'TRUE');
 else
     java_true = java.lang.Boolean.TRUE;
 end


### PR DESCRIPTION
See https://forum.image.sc/t/bio-formats-octave-error-on-bfsave/27504/4. This
should fix the execution of bfsave in the GNU Octave environment

The impact of this PR should be tested both in GNU Octave (4.2.0 e.g. available from Ubuntu 18.04) and MATLAB R2017b or later. In both environments, a call to the writer API e.g. using `bfsave(zeros(512,512,10,3,1), 'out.ome.tiff')` should successfully create an output file. Without this PR the command should fail on GNU Octave