### PR TITLE
Deltavision: Add new objective info for new lensID

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2884,6 +2884,12 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 0.48;
         immersion = MetadataTools.getImmersion("Air");
         break;
+      case 20007: // Applied Precision 100X/1.4
+        lensNA = 1.4;
+        magnification = 100.0;
+        immersion = MetadataTools.getImmersion("Oil");
+        manufacturer = "Applied Precision";
+        break;
       case 1: // Zeiss 10X/.25
         lensNA = 0.25;
         magnification = 10.0;


### PR DESCRIPTION
The new objective metadata was provided in thread https://forum.image.sc/t/warning-when-opening-dv-files-in-fiji/27923/2 for a new lensID 20007

This is suitable for a patch release. Testing is simply to ensure that builds and tests are green with no regressions.