### PR TITLE
Zeiss CZI: prevent index out of bounds when populating positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2136,7 +2136,7 @@ public class ZeissCZIReader extends FormatReader {
           }
           if (positions.getLength() == 0 && (mosaics <= 1 || (prestitched != null && prestitched))) {
             positions = scene.getElementsByTagName("CenterPosition");
-            if (positions.getLength() > 0) {
+            if (positions.getLength() > 0 && nextPosition < positionsX.length) {
               Element position = (Element) positions.item(0);
               String[] pos = position.getTextContent().split(",");
               positionsX[nextPosition] = new Length(DataTools.parseDouble(pos[0]), UNITS.MICROM);


### PR DESCRIPTION
The ```Scene``` node (which contains the ```CenterPosition``` coordinate) may be
duplicated, in which case only the first node should be parsed.

This should fix the issue with idr0011 (https://github.com/IDR/idr-metadata/blob/master/idr0011-ledesmafernandez-dad4/screens/Plate1-Blue-A_TS-Stinger.screen#L10), which was throwing:

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1
	at loci.formats.in.ZeissCZIReader.translateInformation(ZeissCZIReader.java:2142)
	at loci.formats.in.ZeissCZIReader.translateMetadata(ZeissCZIReader.java:1999)
	at loci.formats.in.ZeissCZIReader.initFile(ZeissCZIReader.java:1128)
	at loci.formats.FormatReader.setId(FormatReader.java:1389)
	at loci.formats.ImageReader.setId(ImageReader.java:843)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1035)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1121)
```

due to the following XML:

```
          <S>
            <Scenes>
              <Scene Index="0" Name="P3">
                <RegionId>635222908057000165</RegionId>
                <ScanMode>Comb</ScanMode>
                <CenterPosition>34447.748,21609</CenterPosition>
                <Shape Name="A1" Id="1-1">
                  <ColumnIndex>1</ColumnIndex>
                  <RowIndex>1</RowIndex>
                  <CenterPosition>35498.291,21621.564</CenterPosition>
                  <Size>6776.341,6776.341</Size>
                  <Contour Type="Ellipse" />
                </Shape>
              </Scene>
              <Scene Index="0" Name="P3">
                <RegionId>635222908057000165</RegionId>
                <ScanMode>Comb</ScanMode>
                <CenterPosition>34447.748,21609</CenterPosition>
                <Shape Name="A1" Id="1-1">
                  <ColumnIndex>1</ColumnIndex>
                  <RowIndex>1</RowIndex>
                  <CenterPosition>35498.291,21621.564</CenterPosition>
                  <Size>6776.341,6776.341</Size>
                  <Contour Type="Ellipse" />
                </Shape>
              </Scene>
            </Scenes>
          </S>
```

I wouldn't expect this to impact tests or memo files, so should be OK for a patch release.