### PR TITLE
Leica LIF: fix units and indexing for tile-based plane positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1990,10 +1990,17 @@ public class LIFReader extends FormatReader {
           String posX = tileNode.getAttribute("PosX");
           String posY = tileNode.getAttribute("PosY");
 
+          while (fieldPosX.size() < image) {
+            fieldPosX.add(null);
+          }
+          while (fieldPosY.size() < image) {
+            fieldPosY.add(null);
+          }
+
           if (posX != null) {
             try {
               final Double number = DataTools.parseDouble(posX);
-              fieldPosX.add(new Length(number, UNITS.REFERENCEFRAME));
+              fieldPosX.add(new Length(number, UNITS.METER));
             }
             catch (NumberFormatException e) {
               LOGGER.debug("", e);
@@ -2003,7 +2010,7 @@ public class LIFReader extends FormatReader {
           if (posY != null) {
             try {
               final Double number = DataTools.parseDouble(posY);
-              fieldPosY.add(new Length(number, UNITS.REFERENCEFRAME));
+              fieldPosY.add(new Length(number, UNITS.METER));
             }
             catch (NumberFormatException e) {
               LOGGER.debug("", e);


### PR DESCRIPTION
Backported from a private PR.

This updates the units for tile positions to meters, and fixes how tile positions are indexed when there is a mixed tile/non-tile dataset.  Specifically, if a non-tile series is present before a set of tiles, then the first tile's position is applied to the non-tile series (and all remaining positions are off by one).  I don't think we have an example of this that can be added to the repo, but I'll try to make one shortly.

I would expect 3 existing files to be affected, as described in the forthcoming config PR.  The only change is the units of ```PositionX``` and ```PositionY```, which change from ```reference frame``` to ```m```.  This seems to yield positions that are consistent with the physical pixel sizes, and should help anyone trying to stitch tiles.

With the config PR, all tests should continue to pass.  I wouldn't expect memo files to be affected, so this should be OK for a patch release.