### PR TITLE
Bump ome-codecs component to version 0.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.2.3</ome-codecs.version>
+    <ome-codecs.version>0.2.4</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 


### PR DESCRIPTION
This patch release includes the two following external contributions

- https://github.com/ome/ome-codecs/pull/16
- https://github.com/ome/ome-codecs/pull/17