### PR TITLE
MinimalTiffReader: be defensive and use DataTools.safeMultiply64

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -422,7 +422,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
       // Some TIFF files only store a single tile, even if the image is
       // very, very large.  In those cases, we don't want to open the whole
       // tile if we can avoid it.
-      if (DataTools.safeMultiply32(height, getOptimalTileWidth()) >
+      if (DataTools.safeMultiply64(height, getOptimalTileWidth()) >
         10 * 1024 * 1024)
       {
         return super.getOptimalTileHeight();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1332,7 +1332,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
           c.tileHeight = c.sizeY;
         }
         // Duplicate MinimalTiffReader getOptimalTileHeight logic
-        if (DataTools.safeMultiply32(c.tileHeight, c.tileWidth) >
+        if (DataTools.safeMultiply64(c.tileHeight, c.tileWidth) >
           10 * 1024 * 1024) {
           int bpp = FormatTools.getBytesPerPixel(c.pixelType);
           int effC = c.sizeC / (c.imageCount / (c.sizeZ * c.sizeT));


### PR DESCRIPTION
See https://forum.image.sc/t/standard-workflow-and-format-to-handle-huge-slidescanner-images/28159/12

If the the TIFF is stored using very large tile/strips dimensions, `DataTools.safeMultiply32` might throw an IllegalArgumentException before the size comparison can happen.

To test, use the sample file available under `/uod/idr/repos/curated/tiff/tobias`. Without this PR, `showinf` or `bfconvert` should throw an `IllegalArgumentException` while retrieving the optimal tile size and importing into OMERO server should result in an exception during the pyramid generation. With the PR included, it should be possible to read and convert the TIFF file.