### PR TITLE
OME-TIFF: reduce memory usage and memo file size

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1192,6 +1192,18 @@ public class OMETiffReader extends SubResolutionFormatReader {
       }
     }
 
+    // remove any values we no longer need from the
+    // helper readers' IFDs
+    for (OMETiffPlane[] s : info) {
+      for (OMETiffPlane p : s) {
+        if (p.reader != null && p.reader instanceof MinimalTiffReader) {
+          for (IFD ifd : ((MinimalTiffReader) p.reader).ifds) {
+            ifd.remove(IFD.IMAGE_DESCRIPTION);
+          }
+        }
+      }
+    }
+
     MetadataTools.populatePixels(metadataStore, this, false, false);
     for (int i=0; i<meta.getImageCount(); i++) {
       // make sure that TheZ, TheC, and TheT are all set on any


### PR DESCRIPTION
Backported from a private PR.

This explicitly removes the ```IFD.IMAGE_DESCRIPTION``` key from every IFD in the helper readers for ```OMETiffReader```.  This should be safe, since the OME-XML isn't used again after initial parsing.

The use case being targeted is a dataset with 144,000 planes across ~200 files, with each file containing a 60 MB OME-XML string.  Without this change, ```setId``` required ```BF_MAX_MEM``` to be set to > 6 GB, and the generated memo file size was > 400 MB.  I'll try to put together something representative next week.

Memo files will be affected, so this will require a minor release.  Feel free to exclude if too disruptive for right now.  I would expect tests to continue to pass, but am not sure how time performance will be affected.  It's probably worth keeping an eye on the run time for the ```ome-tiff``` folder test for a couple of days.