### PR TITLE
CellWorX/.htd: fix plane positions for series index > 0

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -481,9 +481,10 @@ public class CellWorxReader extends FormatReader {
           pnl = getReader(firstFile, true);
 
           IMetadata meta = (IMetadata) pnl.getMetadataStore();
-          Length posX = meta.getPlanePositionX(0, 0);
-          Length posY = meta.getPlanePositionY(0, 0);
-          Length posZ = meta.getPlanePositionZ(0, 0);
+          int pnlSeries = s % pnl.getSeriesCount();
+          Length posX = meta.getPlanePositionX(pnlSeries, 0);
+          Length posY = meta.getPlanePositionY(pnlSeries, 0);
+          Length posZ = meta.getPlanePositionZ(pnlSeries, 0);
 
           for (int p=0; p<getImageCount(); p++) {
             if (posX != null) {

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -465,45 +465,43 @@ public class CellWorxReader extends FormatReader {
 
     // check for stage positions in each file
 
-    for (int s=0; s<getSeriesCount(); s++) {
-      setSeries(s);
+    MetadataLevel metadataLevel = metadataOptions.getMetadataLevel();
+    if (metadataLevel != MetadataLevel.MINIMUM) {
+      for (int s=0; s<getSeriesCount(); s++) {
+        setSeries(s);
 
-      String firstFile = null;
-      int plane = 0;
-      while ((firstFile == null || !new Location(firstFile).exists()) &&
-        plane < getImageCount())
-      {
-        firstFile = getFile(s, plane);
-        plane++;
-      }
-      if (firstFile != null && new Location(firstFile).exists()) {
-        try {
-          pnl = getReader(firstFile, true);
+        String firstFile = null;
+        int plane = 0;
+        while ((firstFile == null || !new Location(firstFile).exists()) &&
+          plane < getImageCount())
+        {
+          firstFile = getFile(s, plane);
+          plane++;
+        }
+        if (firstFile != null && new Location(firstFile).exists()) {
+          try (IFormatReader helper = getReader(firstFile, true)) {
+            IMetadata meta = (IMetadata) helper.getMetadataStore();
+            int pnlSeries = s % helper.getSeriesCount();
+            Length posX = meta.getPlanePositionX(pnlSeries, 0);
+            Length posY = meta.getPlanePositionY(pnlSeries, 0);
+            Length posZ = meta.getPlanePositionZ(pnlSeries, 0);
 
-          IMetadata meta = (IMetadata) pnl.getMetadataStore();
-          int pnlSeries = s % pnl.getSeriesCount();
-          Length posX = meta.getPlanePositionX(pnlSeries, 0);
-          Length posY = meta.getPlanePositionY(pnlSeries, 0);
-          Length posZ = meta.getPlanePositionZ(pnlSeries, 0);
-
-          for (int p=0; p<getImageCount(); p++) {
-            if (posX != null) {
-              store.setPlanePositionX(posX, s, p);
-            }
-            if (posY != null) {
-              store.setPlanePositionY(posY, s, p);
-            }
-            if (posZ != null) {
-              store.setPlanePositionZ(posZ, s, p);
+            for (int p=0; p<getImageCount(); p++) {
+              if (posX != null) {
+                store.setPlanePositionX(posX, s, p);
+              }
+              if (posY != null) {
+                store.setPlanePositionY(posY, s, p);
+              }
+              if (posZ != null) {
+                store.setPlanePositionZ(posZ, s, p);
+              }
             }
           }
         }
-        finally {
-          pnl.close();
-        }
       }
+      setSeries(0);
     }
-    setSeries(0);
 
     // set up plate linkages
 

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -466,10 +466,10 @@ public class CellWorxReader extends FormatReader {
     // check for stage positions in each file
 
     MetadataLevel metadataLevel = metadataOptions.getMetadataLevel();
-    if (metadataLevel != MetadataLevel.MINIMUM) {
-      for (int s=0; s<getSeriesCount(); s++) {
-        setSeries(s);
+    for (int s=0; s<getSeriesCount(); s++) {
+      setSeries(s);
 
+      if (metadataLevel != MetadataLevel.MINIMUM) {
         String firstFile = null;
         int plane = 0;
         while ((firstFile == null || !new Location(firstFile).exists()) &&
@@ -500,8 +500,15 @@ public class CellWorxReader extends FormatReader {
           }
         }
       }
-      setSeries(0);
+      else {
+        for (int p=0; p<getImageCount(); p++) {
+          store.setPlanePositionX(null, s, p);
+          store.setPlanePositionY(null, s, p);
+          store.setPlanePositionZ(null, s, p);
+        }
+      }
     }
+    setSeries(0);
 
     // set up plate linkages
 


### PR DESCRIPTION
Backported from a private PR.

Without this change, plane positions were only parsed from the first valid file.  This meant that the positions were correct for however many series were covered by the first file (usually 1, but can be the field count for .pnl files).  All subsequent series reused the first series' positions though, which among other things can cause problems with stitching.

All plates under ```cellworx``` apart from ```cellworx/qa-4207``` are affected; I haven't added any new test data.  An updated configuration PR is forthcoming.

This will add a little time to the initial ```setId``` call, but in local tests the impact wasn't particularly noticeable.  Memo files shouldn't need to be regenerated, and with the configuration PR I would expect tests to pass.