### PR TITLE
Split .rcpnl checks into separate reader

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -25,6 +25,7 @@ loci.formats.in.GIFReader             # gif
 loci.formats.in.BMPReader             # bmp
 loci.formats.in.IPLabReader           # ipl
 loci.formats.in.IvisionReader         # ipm
+loci.formats.in.RCPNLReader           # rcpnl
 loci.formats.in.DeltavisionReader     # dv, r3d
 loci.formats.in.MRCReader             # mrc, st, ali
 loci.formats.in.GatanReader           # dm3

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -134,6 +134,9 @@ public class DeltavisionReader extends FormatReader {
   private String imageSequence;
   private boolean newFileType = false;
 
+  // toggle whether to treat timepoints as positions
+  protected boolean positionInT = false;
+
   // -- Constructor --
 
   /** Constructs a new Deltavision reader. */
@@ -520,10 +523,7 @@ public class DeltavisionReader extends FormatReader {
 
     int nStagePositions = xTiles * yTiles;
 
-    // if an *.rcpnl file is encountered, assume all timepoints are positions
-    // the stage position values may not represent a uniform grid,
-    // but should still be separate positions
-    if (checkSuffix(currentId, "rcpnl")) {
+    if (positionInT) {
       nStagePositions = getSizeT();
       if (xTiles * yTiles != nStagePositions) {
         // if positions are not uniform, we can't reliably determine
@@ -1585,7 +1585,7 @@ public class DeltavisionReader extends FormatReader {
    * Populate an Objective based upon the lens ID.
    * This is based upon information received from Applied Precision.
    */
-  private void populateObjective(MetadataStore store, int lensID)
+  protected void populateObjective(MetadataStore store, int lensID)
     throws FormatException
   {
     Double lensNA = null;
@@ -2799,11 +2799,6 @@ public class DeltavisionReader extends FormatReader {
         break;
       case 18107: // API 10X, BH
         lensNA = 0.15;
-
-        if (checkSuffix(currentId, "rcpnl")) {
-          lensNA = 0.30;
-        }
-
         magnification = 10.0;
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");

--- a/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2019 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+
+import loci.formats.FormatException;
+import loci.formats.meta.MetadataStore;
+
+public class RCPNLReader extends DeltavisionReader {
+
+  public RCPNLReader() {
+    super();
+    format = "RCPNL";
+    suffixes = new String[] {"rcpnl"};
+    suffixNecessary = true;
+    hasCompanionFiles = false;
+
+    // if an *.rcpnl file is encountered, assume all timepoints are positions
+    // the stage position values may not represent a uniform grid,
+    // but should still be separate positions
+
+    positionInT = true;
+  }
+
+  @Override
+  public boolean isThisType(String name, boolean open) {
+    return checkSuffix(name, "rcpnl") && super.isThisType(name, open);
+  }
+
+  @Override
+  protected void populateObjective(MetadataStore store, int lensID)
+    throws FormatException
+  {
+    super.populateObjective(store, lensID);
+
+    if (lensID == 18107) {
+      store.setObjectiveLensNA(0.30, 0, 0);
+    }
+  }
+
+}

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2655,6 +2655,13 @@ public class FormatReaderTest {
               continue;
             }
 
+            // Deltavision reader can pick up .rcpnl files
+            if (result && (r instanceof RCPNLReader) &&
+              (readers[j] instanceof DeltavisionReader))
+            {
+              continue;
+            }
+
             boolean expected = r == readers[j];
             if (result != expected) {
               success = false;


### PR DESCRIPTION
This creates a separate ```RCPNLReader``` that handles .rcpnl files, as discussed in various formats meetings.  The only functional difference should be that .rcpnl files are read with ```RCPNLReader``` instead of ```DeltavisionReader```.

I opted not to completely split out the "treat all timepoints as positions" logic since that would require a pretty significant refactoring of ```DeltavisionReader```.  Instead, timepoints-as-positions can now be turned on in ```DeltavisionReader``` (it's off by default).  Adding a proper option would be a possible next step.

Memo files will be impacted since this introduces a new reader, so this will require a minor release.  A configuration PR is forthcoming to update the reader name for existing .rcpnl datasets.