### PR TITLE
Leica .lif: parse attachments to determine if XY positions should be flipped or swapped

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1902,6 +1902,9 @@ public class LIFReader extends FormatReader {
   {
     NodeList scannerSettings = getNodes(imageNode, "ScannerSettingRecord");
     NodeList attachmentNodes = getNodes(imageNode, "Attachment");
+    if (attachmentNodes == null) {
+      return;
+    }
     NodeList confocalSettings = null;
     for (int i=0; i<attachmentNodes.getLength(); i++) {
       Element attachment = (Element) attachmentNodes.item(i);

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -121,6 +121,8 @@ public class LIFReader extends FormatReader {
     return h.build();
   }
 
+  private static final long METER_MULTIPLY = 1000000;
+
   // -- Fields --
 
   /** Offsets to memory blocks, paired with their corresponding description. */
@@ -1938,7 +1940,7 @@ public class LIFReader extends FormatReader {
         }
         else if (id.equals("dblPinhole")) {
           if (value != null && !value.trim().isEmpty()) {
-            pinholes[image] = DataTools.parseDouble(value.trim()) * 1000000;
+            pinholes[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
           }
         }
         else if (id.equals("dblZoom")) {
@@ -1948,7 +1950,7 @@ public class LIFReader extends FormatReader {
         }
         else if (id.equals("dblStepSize")) {
           if (value != null && !value.trim().isEmpty()) {
-            zSteps[image] = DataTools.parseDouble(value.trim()) * 1000000;
+            zSteps[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
           }
         }
         else if (id.equals("nDelayTime_s")) {
@@ -2014,7 +2016,7 @@ public class LIFReader extends FormatReader {
         String value = confocalSetting.getAttribute("Pinhole");
 
         if (value != null && !value.trim().isEmpty()) {
-          pinholes[image] = DataTools.parseDouble(value.trim()) * 1000000;
+          pinholes[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
         }
 
         value = confocalSetting.getAttribute("Zoom");
@@ -2224,8 +2226,8 @@ public class LIFReader extends FormatReader {
         offByOnePhysicalLen /= 1000;
       }
       else if (unit.equals("m")) {
-        physicalLen *= 1000000;
-        offByOnePhysicalLen *= 1000000;
+        physicalLen *= METER_MULTIPLY;
+        offByOnePhysicalLen *= METER_MULTIPLY;
       }
 
       boolean oldPhysicalSize = useOldPhysicalSizeCalculation();
@@ -2532,19 +2534,19 @@ public class LIFReader extends FormatReader {
 
       // coordinates are in meters
 
-      transX *= 1000000;
-      transY *= 1000000;
+      transX *= METER_MULTIPLY;
+      transY *= METER_MULTIPLY;
       transX *= 1;
       transY *= 1;
 
       for (int i=0; i<x.size(); i++) {
-        double coordinate = x.get(i).doubleValue() * 1000000;
+        double coordinate = x.get(i).doubleValue() * METER_MULTIPLY;
         coordinate *= 1;
         x.set(i, coordinate);
       }
 
       for (int i=0; i<y.size(); i++) {
-        double coordinate = y.get(i).doubleValue() * 1000000;
+        double coordinate = y.get(i).doubleValue() * METER_MULTIPLY;
         coordinate *= 1;
         y.set(i, coordinate);
       }

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2126,18 +2126,14 @@ public class LIFReader extends FormatReader {
 
           String value = confocalSetting.getAttribute("StagePosX");
 
-          if (value != null) {
-            if (value != null && !value.trim().isEmpty()) {
-              fieldPosX.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
-            }
+          if (value != null && !value.trim().isEmpty()) {
+            fieldPosX.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
           }
 
           value = confocalSetting.getAttribute("StagePosY");
 
-          if (value != null) {
-            if (value != null && !value.trim().isEmpty()) {
-              fieldPosY.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
-            }
+          if (value != null && !value.trim().isEmpty()) {
+            fieldPosY.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -137,6 +137,7 @@ public class LIFReader extends FormatReader {
 
   private String[] descriptions, microscopeModels, serialNumber;
   private Double[] pinholes, zooms, zSteps, tSteps, lensNA;
+  private boolean[] flipX, flipY, swapXY;
   private Double[][] expTimes, gains, detectorOffsets;
   private String[][] channelNames;
   private List[] detectorModels;
@@ -441,6 +442,7 @@ public class LIFReader extends FormatReader {
       physicalSizeYs.clear();
       descriptions = microscopeModels = serialNumber = null;
       pinholes = zooms = lensNA = null;
+      flipX = flipY = swapXY = null;
       zSteps = tSteps = null;
       expTimes = gains = null;
       detectorOffsets = null;
@@ -1023,6 +1025,16 @@ public class LIFReader extends FormatReader {
         if (i < fieldPosY.size() && fieldPosY.get(i) != null) {
           yPos = fieldPosY.get(i);
         }
+
+        if (swapXY[index]) {
+          Length temp = xPos;
+          xPos = yPos;
+          yPos = temp;
+        }
+
+        xPos = checkFlip(flipX[index], xPos);
+        yPos = checkFlip(flipY[index], yPos);
+
         if (xPos != null) {
           store.setPlanePositionX(xPos, i, image);
         }
@@ -1061,6 +1073,14 @@ public class LIFReader extends FormatReader {
       }
     }
   }
+
+  private Length checkFlip(boolean flip, Length pos) {
+    if (flip) {
+      pos = new Length(-pos.value().doubleValue(), pos.unit());
+    }
+    return pos;
+  }
+
 
   private Element getMetadataRoot(String xml)
     throws FormatException, IOException
@@ -1164,7 +1184,9 @@ public class LIFReader extends FormatReader {
     tSteps = new Double[imageNodes.size()];
     pinholes = new Double[imageNodes.size()];
     zooms = new Double[imageNodes.size()];
-
+    flipX = new boolean[imageNodes.size()];
+    flipY = new boolean[imageNodes.size()];
+    swapXY = new boolean[imageNodes.size()];
     expTimes = new Double[imageNodes.size()][];
     gains = new Double[imageNodes.size()][];
     detectorOffsets = new Double[imageNodes.size()][];
@@ -1879,7 +1901,19 @@ public class LIFReader extends FormatReader {
     throws FormatException
   {
     NodeList scannerSettings = getNodes(imageNode, "ScannerSettingRecord");
-    if (scannerSettings == null) return;
+    NodeList attachmentNodes = getNodes(imageNode, "Attachment");
+    NodeList confocalSettings = null;
+    for (int i=0; i<attachmentNodes.getLength(); i++) {
+      Element attachment = (Element) attachmentNodes.item(i);
+
+      String attachmentName = attachment.getAttribute("Name");
+
+      if ("HardwareSetting".equals(attachmentName)) {
+        confocalSettings = getNodes(attachment, "ATLConfocalSettingDefinition");
+      }
+    }
+
+    if (scannerSettings == null && confocalSettings == null) return;
 
     expTimes[image] = new Double[getEffectiveSizeC()];
     gains[image] = new Double[getEffectiveSizeC()];
@@ -1888,82 +1922,129 @@ public class LIFReader extends FormatReader {
     exWaves[image] = new Double[getEffectiveSizeC()];
     detectorModels[image] = new ArrayList<String>();
 
-    for (int i=0; i<scannerSettings.getLength(); i++) {
-      Element scannerSetting = (Element) scannerSettings.item(i);
-      String id = scannerSetting.getAttribute("Identifier");
-      if (id == null) id = "";
-      String suffix = scannerSetting.getAttribute("Identifier");
-      String value = scannerSetting.getAttribute("Variant");
+    if (scannerSettings != null) {
+      for (int i=0; i<scannerSettings.getLength(); i++) {
+        Element scannerSetting = (Element) scannerSettings.item(i);
+        String id = scannerSetting.getAttribute("Identifier");
+        if (id == null) id = "";
+        String suffix = scannerSetting.getAttribute("Identifier");
+        String value = scannerSetting.getAttribute("Variant");
 
-      if (id.equals("SystemType")) {
-        microscopeModels[image] = value;
-      }
-      else if (id.equals("dblPinhole")) {
-        if (value != null && !value.trim().isEmpty()) {
-          pinholes[image] = DataTools.parseDouble(value.trim()) * 1000000;
+        if (id.equals("SystemType")) {
+          microscopeModels[image] = value;
         }
-      }
-      else if (id.equals("dblZoom")) {
-        if (value != null && !value.trim().isEmpty()) {
-          zooms[image] = DataTools.parseDouble(value.trim());
-        }
-      }
-      else if (id.equals("dblStepSize")) {
-        if (value != null && !value.trim().isEmpty()) {
-          zSteps[image] = DataTools.parseDouble(value.trim()) * 1000000;
-        }
-      }
-      else if (id.equals("nDelayTime_s")) {
-        if (value != null && !value.trim().isEmpty()) {
-          tSteps[image] = DataTools.parseDouble(value.trim());
-        }
-      }
-      else if (id.equals("CameraName")) {
-        detectorModels[image].add(value);
-      }
-      else if (id.equals("eDirectional")) {
-        addSeriesMeta("Reverse X orientation", "1".equals(value.trim()));
-      }
-      else if (id.equals("eDirectionalY")) {
-        addSeriesMeta("Reverse Y orientation", "1".equals(value.trim()));
-      }
-      else if (id.indexOf("WFC") == 1) {
-        int c = 0;
-        try {
-          c = Integer.parseInt(id.replaceAll("\\D", ""));
-        }
-        catch (NumberFormatException e) { }
-        if (c < 0 || c >= getEffectiveSizeC()) {
-          continue;
-        }
-
-        if (id.endsWith("ExposureTime")) {
+        else if (id.equals("dblPinhole")) {
           if (value != null && !value.trim().isEmpty()) {
-            expTimes[image][c] = DataTools.parseDouble(value.trim());
+            pinholes[image] = DataTools.parseDouble(value.trim()) * 1000000;
           }
         }
-        else if (id.endsWith("Gain")) {
+        else if (id.equals("dblZoom")) {
           if (value != null && !value.trim().isEmpty()) {
-            gains[image][c] = DataTools.parseDouble(value.trim());
+            zooms[image] = DataTools.parseDouble(value.trim());
           }
         }
-        else if (id.endsWith("WaveLength")) {
+        else if (id.equals("dblStepSize")) {
           if (value != null && !value.trim().isEmpty()) {
-            Double exWave = DataTools.parseDouble(value.trim());
-            if (exWave != null && exWave > 0) {
-              exWaves[image][c] = exWave;
+            zSteps[image] = DataTools.parseDouble(value.trim()) * 1000000;
+          }
+        }
+        else if (id.equals("nDelayTime_s")) {
+          if (value != null && !value.trim().isEmpty()) {
+            tSteps[image] = DataTools.parseDouble(value.trim());
+          }
+        }
+        else if (id.equals("CameraName")) {
+          detectorModels[image].add(value);
+        }
+        else if (id.equals("eDirectional")) {
+          addSeriesMeta("Reverse X orientation", "1".equals(value.trim()));
+        }
+        else if (id.equals("eDirectionalY")) {
+          addSeriesMeta("Reverse Y orientation", "1".equals(value.trim()));
+        }
+        else if (id.indexOf("WFC") == 1) {
+          int c = 0;
+          try {
+            c = Integer.parseInt(id.replaceAll("\\D", ""));
+          }
+          catch (NumberFormatException e) { }
+          if (c < 0 || c >= getEffectiveSizeC()) {
+            continue;
+          }
+
+          if (id.endsWith("ExposureTime")) {
+            if (value != null && !value.trim().isEmpty()) {
+              expTimes[image][c] = DataTools.parseDouble(value.trim());
+            }
+          }
+          else if (id.endsWith("Gain")) {
+            if (value != null && !value.trim().isEmpty()) {
+              gains[image][c] = DataTools.parseDouble(value.trim());
+            }
+          }
+          else if (id.endsWith("WaveLength")) {
+            if (value != null && !value.trim().isEmpty()) {
+              Double exWave = DataTools.parseDouble(value.trim());
+              if (exWave != null && exWave > 0) {
+                exWaves[image][c] = exWave;
+              }
+            }
+          }
+          // NB: "UesrDefName" is not a typo.
+          else if ((id.endsWith("UesrDefName") || id.endsWith("UserDefName")) &&
+            !value.equals("None"))
+          {
+            if (channelNames[image][c] == null ||
+              channelNames[image][c].trim().isEmpty())
+            {
+              channelNames[image][c] = value;
             }
           }
         }
-        // NB: "UesrDefName" is not a typo.
-        else if ((id.endsWith("UesrDefName") || id.endsWith("UserDefName")) &&
-          !value.equals("None"))
-        {
-          if (channelNames[image][c] == null ||
-            channelNames[image][c].trim().isEmpty())
-          {
-            channelNames[image][c] = value;
-          }
+      }
+    }
+
+    if (confocalSettings != null) {
+      for (int i=0; i<confocalSettings.getLength(); i++) {
+        Element confocalSetting = (Element) confocalSettings.item(i);
+
+        String value = confocalSetting.getAttribute("Pinhole");
+
+        if (value != null && !value.trim().isEmpty()) {
+          pinholes[image] = DataTools.parseDouble(value.trim()) * 1000000;
+        }
+
+        value = confocalSetting.getAttribute("Zoom");
+
+        if (value != null && !value.trim().isEmpty()) {
+          zooms[image] = DataTools.parseDouble(value.trim());
+        }
+
+        value = confocalSetting.getAttribute("ObjectiveName");
+
+        if (value != null && !value.trim().isEmpty()) {
+          objectiveModels[image] = value.trim();
+        }
+
+        value = confocalSetting.getAttribute("FlipX");
+
+        if (value != null && !value.trim().isEmpty()) {
+          flipX[image] = "1".equals(value.trim());
+          addSeriesMeta("Reverse X orientation", flipX[image]);
+        }
+
+        value = confocalSetting.getAttribute("FlipY");
+
+        if (value != null && !value.trim().isEmpty()) {
+          flipY[image] = "1".equals(value.trim());
+          addSeriesMeta("Reverse Y orientation", flipY[image]);
+        }
+
+        value = confocalSetting.getAttribute("SwapXY");
+
+        if (value != null && !value.trim().isEmpty()) {
+          swapXY[image] = "1".equals(value.trim());
+          addSeriesMeta("Swap XY orientation", swapXY[image]);
         }
       }
     }
@@ -1972,6 +2053,7 @@ public class LIFReader extends FormatReader {
   private void translateAttachmentNodes(Element imageNode, int image)
     throws FormatException
   {
+    boolean tilesAttachmentFound = false;
     NodeList attachmentNodes = getNodes(imageNode, "Attachment");
     if (attachmentNodes == null) return;
     for (int i=0; i<attachmentNodes.getLength(); i++) {
@@ -2018,6 +2100,47 @@ public class LIFReader extends FormatReader {
             }
           }
         }
+        tilesAttachmentFound = true;
+      }
+    }
+
+    if (!tilesAttachmentFound) {
+      NodeList confocalSettings = null;
+      for (int i=0; i<attachmentNodes.getLength(); i++) {
+        Element attachment = (Element) attachmentNodes.item(i);
+
+        String attachmentName = attachment.getAttribute("Name");
+
+        if ("HardwareSetting".equals(attachmentName)) {
+          confocalSettings = getNodes(attachment, "ATLConfocalSettingDefinition");
+          break;
+        }
+      }
+
+      if (confocalSettings != null) {
+        for (int i=0; i<confocalSettings.getLength(); i++) {
+          Element confocalSetting = (Element) confocalSettings.item(i);
+
+          String value = confocalSetting.getAttribute("StagePosX");
+
+          if (value != null) {
+            if (value != null && !value.trim().isEmpty()) {
+              fieldPosX.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
+            }
+          }
+
+          value = confocalSetting.getAttribute("StagePosY");
+
+          if (value != null) {
+            if (value != null && !value.trim().isEmpty()) {
+              fieldPosY.add(new Length(DataTools.parseDouble(value.trim()), UNITS.METER));
+            }
+          }
+        }
+      }
+      else {
+        fieldPosX.add(null);
+        fieldPosY.add(null);
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1935,28 +1935,24 @@ public class LIFReader extends FormatReader {
         String suffix = scannerSetting.getAttribute("Identifier");
         String value = scannerSetting.getAttribute("Variant");
 
+        if (value == null || value.trim().isEmpty()) {
+          continue;
+        }
+
         if (id.equals("SystemType")) {
           microscopeModels[image] = value;
         }
         else if (id.equals("dblPinhole")) {
-          if (value != null && !value.trim().isEmpty()) {
-            pinholes[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
-          }
+          pinholes[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
         }
         else if (id.equals("dblZoom")) {
-          if (value != null && !value.trim().isEmpty()) {
-            zooms[image] = DataTools.parseDouble(value.trim());
-          }
+          zooms[image] = DataTools.parseDouble(value.trim());
         }
         else if (id.equals("dblStepSize")) {
-          if (value != null && !value.trim().isEmpty()) {
-            zSteps[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
-          }
+          zSteps[image] = DataTools.parseDouble(value.trim()) * METER_MULTIPLY;
         }
         else if (id.equals("nDelayTime_s")) {
-          if (value != null && !value.trim().isEmpty()) {
-            tSteps[image] = DataTools.parseDouble(value.trim());
-          }
+          tSteps[image] = DataTools.parseDouble(value.trim());
         }
         else if (id.equals("CameraName")) {
           detectorModels[image].add(value);
@@ -1978,21 +1974,15 @@ public class LIFReader extends FormatReader {
           }
 
           if (id.endsWith("ExposureTime")) {
-            if (value != null && !value.trim().isEmpty()) {
-              expTimes[image][c] = DataTools.parseDouble(value.trim());
-            }
+            expTimes[image][c] = DataTools.parseDouble(value.trim());
           }
           else if (id.endsWith("Gain")) {
-            if (value != null && !value.trim().isEmpty()) {
-              gains[image][c] = DataTools.parseDouble(value.trim());
-            }
+            gains[image][c] = DataTools.parseDouble(value.trim());
           }
           else if (id.endsWith("WaveLength")) {
-            if (value != null && !value.trim().isEmpty()) {
-              Double exWave = DataTools.parseDouble(value.trim());
-              if (exWave != null && exWave > 0) {
-                exWaves[image][c] = exWave;
-              }
+            Double exWave = DataTools.parseDouble(value.trim());
+            if (exWave != null && exWave > 0) {
+              exWaves[image][c] = exWave;
             }
           }
           // NB: "UesrDefName" is not a typo.


### PR DESCRIPTION
Backported from a private PR.  Should fix https://trello.com/c/3eJGDfHh/374-lif-tilescan-flip-and-swap-values-not-being-parsed; the test files are in ```curated/leica-lif/romain```.

To test, compare the results of ```showinf -nopix -omexml curated/leica-lif/romain/tile 002.lif``` with and without this PR.  With this PR, the resulting ```PositionX``` and ```PositionY``` values should match the expectations in https://forum.image.sc/t/tilling-issue-with-lif-file/26843 (i.e. X and Y swapped, and both values multiplied by -1).

Tests should continue to pass, and memo files should be unaffected, so this should be safe for a patch release.