### PR TITLE
Converter: Default max tile size to either width or optimalTileSize

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -788,8 +788,8 @@ public final class ImageConverter {
     String currentFile)
     throws FormatException, IOException
   {
-    int w = reader.getOptimalTileWidth();
-    int h = reader.getOptimalTileHeight();
+    int w = Math.min(reader.getOptimalTileWidth(), width);
+    int h = Math.min(reader.getOptimalTileHeight(), height);
     if (saveTileWidth > 0 && saveTileWidth <= width) {
       w = saveTileWidth;
     }


### PR DESCRIPTION
Opened in response to https://forum.image.sc/t/bftools-issue-with-the-tip-of-the-pyramid/28879

In the above scenario the smallest resolution has a width less than the selected tile size, as such the tile size reverts to optimalTileSize which is the full resolution width and height of the image.

This fix will change the default to use the min of optimalTileSize and width.