### PR TITLE
NativeND2 - Use floating point for 32 bit values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -835,7 +835,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
               }
               else if (attributeName.equals("uiBpcInMemory")) {
                 core.get(0, 0).pixelType = FormatTools.pixelTypeFromBytes(
-                  valueOrLength / 8, false, false);
+                  valueOrLength / 8, false, true);
               }
               else if (attributeName.equals("uiBpcSignificant")) {
                 core.get(0, 0).bitsPerPixel = valueOrLength;


### PR DESCRIPTION
Opening as a follow up to https://trello.com/c/4PvmeIIP/378-nd2-32-bit-float-being-treated-as-int to test impact on data repo