### PR TITLE
CZI: Use CreationDate as alternate AcquisitionDate 

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2086,6 +2086,9 @@ public class ZeissCZIReader extends FormatReader {
       }
 
       acquiredDate = getFirstNodeValue(image, "AcquisitionDateAndTime");
+      if (acquiredDate == null) {
+        acquiredDate = getFirstNodeValue(document, "CreationDate");
+      }
 
       Element objectiveSettings = getFirstNode(image, "ObjectiveSettings");
       correctionCollar =


### PR DESCRIPTION
This is a follow up to the thread: https://forum.image.sc/t/omero-does-not-import-acquisition-date-from-czi-file-metadata/28910/3
A sample file is available in QA-27807

When the usual `Information > Image > AcquisitionDateAndTime` metadata is not set then also check `Information > Document > CreationDate` and use it to populate Image Acquisition Date.