### PR TITLE
ICS: Update y start value when invertY

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -608,6 +608,11 @@ public class ICSReader extends FormatReader {
     int len = FormatTools.getPlaneSize(this);
     int rowLen = FormatTools.getPlaneSize(this, w, 1);
 
+    // Update y value when invertY and reading tiles
+    if (invertY) { 
+      y = getSizeY() - y - h;
+    }
+
     int[] coordinates = getZCTCoords(no);
     int[] prevCoordinates = getZCTCoords(prevImage);
 


### PR DESCRIPTION
This is a follow up to the thread https://forum.image.sc/t/trouble-with-converter-testconvert-from-bio-formats-tools/29189/5

When using an ICS file from SVI-Huygens then using tiled reading produces inverted bands as in the thread. This fix aims to resolve that issue similar to other readers such as https://github.com/ome/bioformats/blob/develop/components/formats-bsd/src/loci/formats/in/BMPReader.java#L122