### PR TITLE
MetaMorph: Fix for finding first valid file

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2000,7 +2000,7 @@ public class MetamorphReader extends BaseTiffReader {
    */
   private String locateFirstValidFile() {
     for (int q = 0; q < stks.length; q++) {
-      for (int f = 0; f < stks.length; f++) {
+      for (int f = 0; f < stks[q].length; f++) {
         if (stks[q][f] != null) {
           return stks[q][f];
         }


### PR DESCRIPTION
This fix came about from a series of QA files (QA-27845 - QA-27863)

The nd file provided does have valid Tiff associated with it, it is expecting 3 channels (561, 488, 405), but only 2 are present for that nd file. The first channel is missing and resulted in being unable to locate any valid files due to a bug in the nested loop params.

With this fix the nd file should open and 2 of the channels will be correctly populated, the first channel will remain blank.