### PR TITLE
OME-TIFF: improve testing coverage for companion filesets

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -32,6 +32,7 @@
 
 package loci.formats;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -2029,5 +2030,49 @@ public final class FormatTools {
         return null;
       }
       return createLength(value, l);
+  }
+
+  /**
+   * Returns the maximum number of directories below the common parent of a
+   * list of file pahts
+   *
+   * @param files            a string array containing a list of file paths
+   *
+   * @return                 the maximum number of directories under the common
+   *                         parent 
+   */
+  public static int getRequiredDirectories(String[] files)
+  {
+    final StringBuilder commonParent = new StringBuilder();
+
+    int dirCount = 0;
+
+    String[] dirs = files[0].split(File.separatorChar == '/' ? "/" : "\\\\");
+    for (String dir : dirs) {
+      boolean canAppend = true;
+      for (String f : files) {
+        if (!f.startsWith(commonParent.toString() + dir)) {
+          canAppend = false;
+          break;
+        }
+      }
+
+      if (canAppend) {
+        commonParent.append(dir);
+        commonParent.append(File.separator);
+        dirCount++;
+      }
+    }
+
+    int maxDirCount = 0;
+    for (String f : files) {
+      int parentDirCount =
+              f.split(File.separatorChar == '/' ? "/" : "\\\\").length - 1;
+      if (parentDirCount > maxDirCount) {
+        maxDirCount = parentDirCount;
+      }
+    }
+
+    return (int) Math.max(maxDirCount - dirCount, 0);
   }
 }

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -2034,7 +2034,7 @@ public final class FormatTools {
 
   /**
    * Returns the maximum number of directories below the common parent of a
-   * list of file pahts
+   * list of file paths
    *
    * @param files            a string array containing a list of file paths
    *
@@ -2043,6 +2043,7 @@ public final class FormatTools {
    */
   public static int getRequiredDirectories(String[] files)
   {
+    if (files == null || files.length == 0) return 0;
     final StringBuilder commonParent = new StringBuilder();
 
     int dirCount = 0;

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -217,6 +217,20 @@ public class FormatToolsTest {
     };
   }
 
+
+  @DataProvider(name = "fileLists")
+  public Object[][] createFileLists() {
+    return new Object[][] {
+      {new String[]{"/dir1/dir2/test.tif"}, 0},
+      {new String[]{"test.tif"}, 0},
+      {new String[]{"/dir1/dir2/test.tif", "/dir1/dir2/test2.tif"}, 0},
+      {new String[]{"/dir1/test.tif", "/dir1/dir2/test2.tif"}, 1},
+      {new String[]{"test.tif", "dir2/test2.tif"}, 1},
+      {new String[]{"/test.tif", "/dir1/dir2/test2.tif"}, 2},
+      {new String[]{"/dir1/dir2/test.tif", "/dir3/dir4/dir5/test2.tif"}, 3},
+    };
+  }
+
   @Test(dataProvider = "stagePositionStringUnit")
   public void testGetStagePositionStringUnit(Double value, String unit, Length length) {
     assertEquals(length, FormatTools.getStagePosition(value, unit));
@@ -242,5 +256,10 @@ public class FormatToolsTest {
     assertEquals(length, FormatTools.parseLength(value + " " + unit));
     assertEquals(length, FormatTools.parseLength(" " + value + unit));
     assertEquals(length, FormatTools.parseLength(value + unit + " "));
+  }
+  
+  @Test(dataProvider = "fileLists")
+  public void testGetRequiredDirectories(String[] files, int number) {
+    assertEquals(number, FormatTools.getRequiredDirectories(files));
   }
 }

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -221,6 +221,8 @@ public class FormatToolsTest {
   @DataProvider(name = "fileLists")
   public Object[][] createFileLists() {
     return new Object[][] {
+      {null, 0},
+      {new String[]{}, 0},
       {new String[]{"/dir1/dir2/test.tif"}, 0},
       {new String[]{"test.tif"}, 0},
       {new String[]{"/dir1/dir2/test.tif", "/dir1/dir2/test2.tif"}, 0},

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -435,6 +435,14 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
   // -- Internal FormatReader API methods --
 
+  /* @see loci.formats.SubResolutionFormatReader#getRequiredDirectories(String[]) */
+  @Override
+  public int getRequiredDirectories(String[] files)
+          throws FormatException, IOException
+  {
+    return FormatTools.getRequiredDirectories(files);
+  }
+
   /* @see loci.formats.SubResolutionFormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1278,7 +1278,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
   // -- Helper methods --
 
   private String normalizeFilename(String dir, String name) {
-     File file = new File(dir, name);
+     Location file = new Location(dir, name);
      if (file.exists()) return file.getAbsolutePath();
      return name;
   }

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -83,6 +83,9 @@ import ome.xml.model.primitives.Timestamp;
  */
 public class OMETiffReader extends SubResolutionFormatReader {
 
+  public static final String[] OME_TIFF_SUFFIXES =
+    {"ome.tiff", "ome.tif", "ome.tf2", "ome.tf8", "ome.btf", "companion.ome"};
+
   // -- Fields --
 
   /** Mapping from series and plane numbers to files and IFD entries. */
@@ -104,8 +107,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
   /** Constructs a new OME-TIFF reader. */
   public OMETiffReader() {
-    super("OME-TIFF", new String[] {"ome.tiff", "ome.tif", "ome.tf2",
-                                    "ome.tf8", "ome.btf", "companion.ome"});
+    super("OME-TIFF", OME_TIFF_SUFFIXES);
     suffixNecessary = false;
     suffixSufficient = false;
     domains = FormatTools.NON_GRAPHICS_DOMAINS;

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1943,6 +1943,17 @@ public class FormatReaderTest {
             continue;
           }
 
+          // Companion file grouping non-ome-tiff files:
+          // setId must be called on the companion file
+          if (reader.getFormat().equals("OME-TIFF")) {
+            if (file.toLowerCase().endsWith(".companion.ome") &&
+                !OMETiffReader.checkSuffix(base[i],
+                                           OMETiffReader.OME_TIFF_SUFFIXES))
+            {
+              continue;
+            }
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();
@@ -2420,6 +2431,16 @@ public class FormatReaderTest {
           // and only one reader, identifies the dataset as its own
           for (int j=0; j<readers.length; j++) {
             boolean result = readers[j].isThisType(used[i]);
+
+            // Companion file grouping non-ome-tiff files:
+            // setId must be called on the companion file
+            if (!result && readers[j] instanceof OMETiffReader &&
+                r.getCurrentFile().toLowerCase().endsWith(".companion.ome") &&
+                !OMETiffReader.checkSuffix(used[i],
+                                           OMETiffReader.OME_TIFF_SUFFIXES))
+            {
+              continue;
+            }
 
             // TIFF reader is allowed to redundantly green-light files
             if (result && readers[j] instanceof TiffDelegateReader) continue;


### PR DESCRIPTION
This PR contains a set of improvements necessary to add test coverage for multi-file OME-TIFF filesets such as the one created for the [idr0052 study](https://idr.openmicroscopy.org/search/?query=Name:idr0052-walther-condensinmap/experimentA)

- c4aa35f was cherry-picked from the original work of @simleo https://github.com/ome/bioformats/pull/2867 and allows to handle multi-file OME-TIFF with no backlink from the TIFF to the companion OME-XML
- 7b7cc1a and 007f9fa implement `OMETIFFReader.getRequiredDirectories()` (previously always set to 0) by creating a helper `FormatTools` API allowing to compute the maximum number of folders under the common parent
- 3b38dac allow to fix the case of OME-TIFF filesets where files have been mapped using `Location.mapFile()` as it is used in the `testRequiredDirectories`
