### PR TITLE
Make AcquisitionDate check more strict

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OpenlabRawReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabRawReader.java
@@ -146,13 +146,12 @@ public class OpenlabRawReader extends FormatReader {
     in.skipBytes(1);
 
     long stampMs = in.readLong();
+    String stamp = null;
     if (stampMs > 0) {
       stampMs /= 1000000;
       stampMs -= (67 * 365.25 * 24 * 60 * 60);
+      stamp = DateTools.convertDate(stampMs, DateTools.UNIX);
     }
-    else stampMs = System.currentTimeMillis();
-
-    String stamp = DateTools.convertDate(stampMs, DateTools.UNIX);
 
     in.skipBytes(4);
     int len = in.read() & 0xff;

--- a/components/formats-gpl/src/loci/formats/in/PDSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PDSReader.java
@@ -199,7 +199,6 @@ public class PDSReader extends FormatReader {
     }
     Length xPos = null, yPos = null;
     Double deltaX = null, deltaY = null;
-    String date = null;
 
     CoreMetadata m = core.get(0);
 
@@ -253,12 +252,6 @@ public class PDSReader extends FormatReader {
           m.indexed = lutIndex >= 0;
         }
       }
-      else if (key.equals("SCAN TIME")) {
-        long modTime = new Location(currentId).getAbsoluteFile().lastModified();
-        String year = DateTools.convertDate(modTime, DateTools.UNIX, "yyyy");
-        date = value.replaceAll("'", "") + " " + year;
-        date = DateTools.formatDate(date, DATE_FORMAT);
-      }
       else if (key.equals("FILE REC LEN")) {
         recordWidth = Integer.parseInt(value) / 2;
       }
@@ -284,10 +277,6 @@ public class PDSReader extends FormatReader {
 
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, !minimumMetadata);
-
-    if (date != null) {
-      store.setImageAcquisitionDate(new Timestamp(date), 0);
-    }
 
     if (!minimumMetadata) {
       store.setPlanePositionX(xPos, 0, 0);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1160,7 +1160,12 @@ public class FormatReaderTest {
       if (retrieve.getImageAcquisitionDate(i) != null) {
         date = retrieve.getImageAcquisitionDate(i).getValue();
       }
-      if (expectedDate != null && date != null && !expectedDate.equals(date)) {
+      boolean bothNull = date == null && expectedDate == null;
+      boolean bothNotNull = date != null && expectedDate != null;
+
+      if ((!bothNull && !bothNotNull) ||
+        (bothNotNull && !expectedDate.equals(date)))
+      {
         result(testName, false, "series " + i +
           " (expected " + expectedDate + ", actual " + date + ")");
         return;


### PR DESCRIPTION
The DeltaT test is now much more likely to fail, since the configuration
must exactly match what is reported by MetadataStore.

The test should now fail on any of the following:
  - configuration date is null, but stored date is not null
  - configuration date is not null, but stored date is null
  - both configuration and stored dates are not null, but are not equal

The test should pass if:
  - both configuration and stored dates are null
  - both configuration and stored dates are not null and equal

As discussed in the formats meeting, this will probably cause a whole bunch of test failures.  I'm happy to have this run once, gather the list of failing folders, and then exclude until I can get a configuration PR opened.