### PR TITLE
NDPIReader: fix nominal magnification population

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -69,8 +69,7 @@ public class NDPIReader extends BaseTiffReader {
 
   private JPEGTurboService service = new JPEGTurboServiceImpl();
 
-  private Double nominalMagnification;
-  private Double calibratedMagnification;
+  private Double magnification;
   private String serialNumber;
   private String instrumentModel;
 
@@ -238,8 +237,7 @@ public class NDPIReader extends BaseTiffReader {
       initializedPlane = -1;
       sizeZ = 1;
       pyramidHeight = 1;
-      calibratedMagnification = null;
-      nominalMagnification = null;
+      magnification = null;
       serialNumber = null;
       instrumentModel = null;
       if (tiffParser != null) {
@@ -440,7 +438,7 @@ public class NDPIReader extends BaseTiffReader {
     Object source_lens_value = ifds.get(0).getIFDValue(SOURCE_LENS);
     if (source_lens_value != null)
     {
-      nominalMagnification = Double.valueOf((float) source_lens_value);
+      magnification = Double.valueOf((float) source_lens_value);
     }
     String metadataTag = ifds.get(0).getIFDStringValue(METADATA_TAG);
     if (metadataTag != null) {
@@ -455,10 +453,7 @@ public class NDPIReader extends BaseTiffReader {
 
         addGlobalMeta(key, value);
 
-        if (key.equals("Objective.Lens.Magnificant")) { // not a typo
-          calibratedMagnification = new Double(value);
-        }
-        else if (key.equals("NDP.S/N")) {
+        if (key.equals("NDP.S/N")) {
           serialNumber = value;
         }
         else if (key.equals("Product")) {
@@ -485,12 +480,8 @@ public class NDPIReader extends BaseTiffReader {
       store.setMicroscopeModel(instrumentModel, 0);
     }
 
-    if (nominalMagnification != null) {
-      store.setObjectiveNominalMagnification(nominalMagnification, 0, 0);
-    }
-
-    if (calibratedMagnification != null) {
-      store.setObjectiveCalibratedMagnification(calibratedMagnification, 0, 0);
+    if (magnification != null) {
+      store.setObjectiveNominalMagnification(magnification, 0, 0);
     }
 
     for (int i=0; i<getSeriesCount(); i++) {


### PR DESCRIPTION
Fixes #3439 

Support for the magnification in the Hamamatsu NDPI reader was introduced in Bio-Formats 5.1.0 (#1553). The original implementation makes use of the `Objective.Lens.Magnificant` key in the metadata TIFF tag (65449). Across our samples, the value is found to be always constant and equal to 35.16 for the largest resolution of the pyramid.

This PR adjusts the reader to populate the nominal magnification from the SourceLens TIFF tag (65449) for the pyramidal images. This is in agreement with what NDP.view displays when opening NDPI samples files