### PR TITLE
OBF: Fix outOfBounds exception with DummyMetadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -181,7 +181,7 @@ public class OBFReader extends FormatReader {
 
               OMEXMLMetadata reference
                   = service.getOMEMetadata(service.asRetrieve(metadataStore));
-              for (int image = 0; image != ome_meta_data.getImageCount(); ++ image) {
+              for (int image = 0; image != reference.getImageCount(); ++ image) {
                 service.addMetadataOnly(reference, image);
               }
             }


### PR DESCRIPTION
When metadataStore is an instance of DummyMetadata it will not
contain any Images. Use the metadataStore's own image count rather than
the file stored image count when indexing the metadataStore's Images.