### PR TITLE
BDV: Parse physical sizes from XML

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -100,7 +100,7 @@ public class BDVReader extends FormatReader {
   private HashMap<Integer, HashMap<String, String>> setupAttributeList = new HashMap<Integer, HashMap<String, String>>();
 
   // Store all custom attributes for each setup ID
-  private HashMap<Integer, List<Length>> setupVoxelSizes = new HashMap<Integer, List<Length>>();
+  private HashMap<Integer, ArrayList<Length>> setupVoxelSizes = new HashMap<Integer, ArrayList<Length>>();
 
   // Store the number of mipmap levels for each setup
   private HashMap<Integer, Integer> setupResolutionCounts = new HashMap<Integer, Integer>();
@@ -847,7 +847,8 @@ public class BDVReader extends FormatReader {
         Length sizeX = FormatTools.getPhysicalSize(DataTools.parseDouble(sizes[0]), voxelUnit);
         Length sizeY = FormatTools.getPhysicalSize(DataTools.parseDouble(sizes[1]), voxelUnit);
         Length sizeZ = FormatTools.getPhysicalSize(DataTools.parseDouble(sizes[2]), voxelUnit);
-        setupVoxelSizes.put(currentSetupIndex, Arrays.asList(sizeX, sizeY, sizeZ));
+ 
+        setupVoxelSizes.put(currentSetupIndex, new ArrayList<Length>(Arrays.asList(sizeX, sizeY, sizeZ)));
         parsingVoxelSizes = false;
         voxelSizes = "";
       }

--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -755,7 +755,7 @@ public class BDVReader extends FormatReader {
     private boolean parsingViewSetups;
     private boolean parsingId;
     private int currentSetupIndex;
-    private String voxelSizes;
+    private String voxelSizes = "";
     private String voxelUnit;
 
     public BDVXMLHandler() {
@@ -849,7 +849,7 @@ public class BDVReader extends FormatReader {
         Length sizeZ = FormatTools.getPhysicalSize(DataTools.parseDouble(sizes[2]), voxelUnit);
         setupVoxelSizes.put(currentSetupIndex, Arrays.asList(sizeX, sizeY, sizeZ));
         parsingVoxelSizes = false;
-        voxelSizes = null;
+        voxelSizes = "";
       }
       if (qName.toLowerCase().equals("id")) {
         parsingId = false;

--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -816,7 +816,7 @@ public class BDVReader extends FormatReader {
           voxelUnit = new String(ch, start, length);
         }
         if (parsingViewSetups && parsingVoxelSizes && currentQName.toLowerCase().equals("size")) {
-          voxelSizes = new String(ch, start, length);
+          voxelSizes += new String(ch, start, length);
         }
         if (parsingViewSetups && parsingAttributes && !currentQName.isEmpty() && !currentQName.toLowerCase().equals("attributes")) {
           String attributeValue = new String(ch, start, length);
@@ -849,6 +849,7 @@ public class BDVReader extends FormatReader {
         Length sizeZ = FormatTools.getPhysicalSize(DataTools.parseDouble(sizes[2]), voxelUnit);
         setupVoxelSizes.put(currentSetupIndex, Arrays.asList(sizeX, sizeY, sizeZ));
         parsingVoxelSizes = false;
+        voxelSizes = null;
       }
       if (qName.toLowerCase().equals("id")) {
         parsingId = false;


### PR DESCRIPTION
This is a follow up to the forum thread https://forum.image.sc/t/bio-formats-xml-hdf5-reader-voxel-dimensions/29645/2

The data is present in the XML under ViewSetup as below:
```
        <voxelSize>
          <unit>um</unit>
          <size>0.3518820106983185 0.3518820106983185 0.3518820106983185</size>
        </voxelSize>
```

An example dataset with this data present is 100-U-9-MV-f0

This will be memo breaking