### PR TITLE
MATLAB: Add function bfGetPlaneAtZCT.m and improve range checking for bfGetPlane

### DIFF
--- a/components/formats-gpl/matlab/bfGetPlane.m
+++ b/components/formats-gpl/matlab/bfGetPlane.m
@@ -49,24 +49,19 @@ ip.addRequired('r', isValidReader);
 ip.parse(r);
 
 % Plane check
-isValidPlane = @(x) isscalar(x) && ismember(x, 1 : r.getImageCount());
+isValidPlane = @(p) bfTestInRange(p,'iPlane',r.getImageCount());
 % Optional tile arguments check
-isValidX = @(x) isscalar(x) && ismember(x, 1 : r.getSizeX());
-isValidY = @(x) isscalar(x) && ismember(x, 1 : r.getSizeY());
+isValidX = @(x) bfTestInRange(x,'x',r.getSizeX());
+isValidY = @(y) bfTestInRange(y,'y',r.getSizeY());
+isValidWidth = @(w) bfTestInRange(w,'width',r.getSizeX()-varargin{2}+1);
+isValidHeight = @(h) bfTestInRange(h,'height',r.getSizeY()-varargin{3}+1);
+
 ip.addRequired('iPlane', isValidPlane);
 ip.addOptional('x', 1, isValidX);
 ip.addOptional('y', 1, isValidY);
-ip.addOptional('width', r.getSizeX(), isValidX);
-ip.addOptional('height', r.getSizeY(), isValidY);
+ip.addOptional('width', r.getSizeX(), isValidWidth);
+ip.addOptional('height', r.getSizeY(), isValidHeight);
 ip.parse(r, varargin{:});
-
-% Additional check for tile size
-assert(ip.Results.x - 1 + ip.Results.width <= r.getSizeX(),...
-     'MATLAB:InputParser:ArgumentFailedValidation',...
-     'Invalid tile size');
-assert(ip.Results.y - 1 + ip.Results.height <= r.getSizeY(),...
-     'MATLAB:InputParser:ArgumentFailedValidation',...
-     'Invalid tile size');
 
 % Get pixel type
 pixelType = r.getPixelType();

--- a/components/formats-gpl/matlab/bfGetPlaneAtZCT.m
+++ b/components/formats-gpl/matlab/bfGetPlaneAtZCT.m
@@ -38,9 +38,6 @@ function [I,idx] = bfGetPlaneAtZCT( r, z, c, t, varargin )
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-% Create a function to test whether a value is between 1 and the total
-inSequence = @(N) @(x) x >= 1 && x <= N;
-
 % Input check
 ip = inputParser;
 isValidReader = @(x) isa(x, 'loci.formats.IFormatReader') && ...

--- a/components/formats-gpl/matlab/bfGetPlaneAtZCT.m
+++ b/components/formats-gpl/matlab/bfGetPlaneAtZCT.m
@@ -1,0 +1,66 @@
+function [I,idx] = bfGetPlaneAtZCT( r, z, c, t, varargin )
+%bfGetPlaneAtCZT Obtains an image plane for the Z, C, T
+%
+%   I = bfGetPlaneAtZCT(r, z, c, t) returns a specified plane from the input
+%   format reader. The indices specifying the plane to retrieve should be
+%   contained between 1 and the number of planes for each dimesnion.
+%
+%   I = bfGetPlaneAtZCT(r, z, c, t, ...) does as above but passes extra
+%   arguments to bfGetPlane for tiling, etc.
+%
+% Examples
+%
+%    r = bfGetReader('example.tif');
+%    I = bfGetPlaneAtZCT(r, 1, 1, 1) % First plane of the series
+%    I = bfGetPlaneAtZCT(r,r.getSizeZ(),r.getSizeC(),r.getSizeT()) % Last plane of the series
+%    I = bfGetPlaneAtZCT(r, 1, 1, 1, 1, 1, 1, 20, 20) % 20x20 tile originated at (0, 0)
+%
+% See also: BFGETREADER, BFGETPLANE, loci.formats.IFormatReader.getIndex
+
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2017 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+% Create a function to test whether a value is between 1 and the total
+inSequence = @(N) @(x) x >= 1 && x <= N;
+
+% Input check
+ip = inputParser;
+isValidReader = @(x) isa(x, 'loci.formats.IFormatReader') && ...
+    ~isempty(x.getCurrentFile());
+ip.addRequired('r', isValidReader);
+ip.parse(r);
+
+ip = inputParser;
+% No validation because we already checked
+% Kept for positional errors
+ip.addRequired('r');
+
+% Check ZCT coordinates are within range
+ip.addOptional('z',1,@(x) bfTestInRange(x,'z',r.getSizeZ()));
+ip.addOptional('c',1,@(x) bfTestInRange(x,'c',r.getSizeC()));
+ip.addOptional('t',1,@(x) bfTestInRange(x,'t',r.getSizeT()));
+
+ip.parse(r, z, c, t);
+
+javaIndex = r.getIndex(z-1, c-1, t-1);
+I = bfGetPlane(r, javaIndex+1);
+
+end

--- a/components/formats-gpl/matlab/bfTestInRange.m
+++ b/components/formats-gpl/matlab/bfTestInRange.m
@@ -30,21 +30,21 @@ function test = bfTestInRange(x,name,maxValue)
     % Check to see if x is a single value
     test = isscalar(x);
     if(~test)
-        error('insequence:notScalar', ...
+        error('bfTestInRange:notScalar', ...
             [name ' value, [' num2str(x) '], is not scalar']);
     end
 
     % Check to see if x is a whole number
     test = mod(x,1) == 0;
     if(~test)
-        error('insequence:notAnInteger', ...
+        error('bfTestInRange:notAnInteger', ...
             [name ' value, ' num2str(x) ', is not an integer']);
     end
 
     % Check to see if x is between 1 and maxValue
     test = x >= 1 && x <= maxValue;
     if(~test)
-        error('insequence:notInSequence', ...
+        error('bfTestInRange:notInSequence', ...
             [name ' value, ' num2str(x) ', is not between 1 and ', ...
             num2str(maxValue)]);
     end

--- a/components/formats-gpl/matlab/bfTestInRange.m
+++ b/components/formats-gpl/matlab/bfTestInRange.m
@@ -1,0 +1,51 @@
+function test = bfTestInRange(x,name,maxValue)
+%bfTestInRange A validation function that tests if the argument
+% is scalar integer between 1 and maxValue
+%
+% This should be faster than ismember(x, 1:maxValue) while also producing
+% more readable errors.
+
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2012 - 2017 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+    % Check to see if x is a single value
+    test = isscalar(x);
+    if(~test)
+        error('insequence:notScalar', ...
+            [name ' value, [' num2str(x) '], is not scalar']);
+    end
+
+    % Check to see if x is a whole number
+    test = mod(x,1) == 0;
+    if(~test)
+        error('insequence:notAnInteger', ...
+            [name ' value, ' num2str(x) ', is not an integer']);
+    end
+
+    % Check to see if x is between 1 and maxValue
+    test = x >= 1 && x <= maxValue;
+    if(~test)
+        error('insequence:notInSequence', ...
+            [name ' value, ' num2str(x) ', is not between 1 and ', ...
+            num2str(maxValue)]);
+    end
+end


### PR DESCRIPTION
For MATLAB users, it is confusing on how to use bfGetPlane to get a particular plane at a ZCT coordinate. This pull request adds a function bfGetPlaneZCT that handles that exact scenario and all of the 0-indexing to 1-indexing issues per this thread:
https://forum.image.sc/t/ijm-getdataset-crashing-matlab/27210/9

Additionally this adds a function bfTestInRange.m which provides more efficient range checking than using ismember while producing more readable errors.

bfGetPlane range checking for width and height is done only once.