### PR TITLE
JPEG2000 reader: add full support for sub-resolutions

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -234,8 +234,8 @@ public class JPEG2000Reader extends FormatReader {
       for (int i = 1; i < seriesCount; i++) {
         CoreMetadata ms = new CoreMetadata(this, 0);
         core.add(ms);
-        ms.sizeX = core.get(i - 1).sizeX / 2;
-        ms.sizeY = core.get(i - 1).sizeY / 2;
+        ms.sizeX = Math.max(core.get(i - 1).sizeX / 2, 1);
+        ms.sizeY = Math.max(core.get(i - 1).sizeY / 2, 1);
         ms.thumbnail = true;
       }
     }

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -213,6 +213,7 @@ public class JPEG2000Reader extends FormatReader {
       ms0.pixelType = metadataParser.getHeaderPixelType();
     }
     lut = metadataParser.getLookupTable();
+    resolutionLevels = metadataParser.getResolutionLevels();
 
     pixelsOffset = metadataParser.getCodestreamOffset();
 

--- a/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
@@ -138,6 +138,7 @@ public class ConversionTest {
     writer.close();
 
     ImageReader reader = new ImageReader();
+    reader.setFlattenedResolutions(false);
     reader.setId(tmp.getAbsolutePath());
 
     assertEquals(reader.getSeriesCount(), seriesCount);
@@ -289,10 +290,10 @@ public class ConversionTest {
 
     for (String type : pixelTypes) {
       String compression = CompressionType.J2K.getCompression();
-      testCompressDecompress(ext, compression, false, 6, type);
+      testCompressDecompress(ext, compression, false, 1, type);
 
       compression = CompressionType.J2K_LOSSY.getCompression();
-      testCompressDecompress(ext, compression, true, 6, type);
+      testCompressDecompress(ext, compression, true, 1, type);
     }
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
@@ -289,10 +289,10 @@ public class ConversionTest {
 
     for (String type : pixelTypes) {
       String compression = CompressionType.J2K.getCompression();
-      testCompressDecompress(ext, compression, false, 1, type);
+      testCompressDecompress(ext, compression, false, 6, type);
 
       compression = CompressionType.J2K_LOSSY.getCompression();
-      testCompressDecompress(ext, compression, true, 1, type);
+      testCompressDecompress(ext, compression, true, 6, type);
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -156,6 +156,10 @@ public class FormatReaderTest {
     return id;
   }
 
+  public String toString() {
+    return getID();
+  }
+
   // -- Setup/teardown methods --
 
   @BeforeClass


### PR DESCRIPTION
The JPEG2000 codec logic has full support for sub-resolution and is used in a couple of places in this code as well as consumers. I realized recently that this is not exposed at the level of the [JPEG2000 file format](https://docs.openmicroscopy.org/bio-formats/6.2.1/formats/jpeg-2000.html) reader so all `.jp2` images are read as single-resolution at the moment.

5e5606c updates the reader to pass the `resolutionLevels` detected by the metadata parser. This will impact the configuration files for all JPEG200 which will need to be regenerated. 
4a50653 is not strictly necessary but addresses the long-standing problem of the file ordering when regenerating configuration files /cc @melissalinkert 

Without this PR,  running `showinf` on JPEG2000 files should show no additional series/sub-resolutions depending on `-noflat`. Importing large JPEG2000 images into OMERO should generate pyramids.

With this PR, `showinf` should display series/sub-resolutions and OMERO should read sub-resolutions natively from the image i.e. no pyramid generation step in the UI/logs.

- `jpeg200/david/cy5-tph.jp2`
- `jpeg2000/big-images/8kx8k.jpf`