### PR TITLE
Artifactory deployment

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,18 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+      <server>
+        <id>ome.staging</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+      <server>
+        <id>ome.snapshots</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,6 @@ deploy:
   skip_cleanup: true
   on:
     jdk: openjdk11
-    all_branches: true
+    repo: ome/bioformats
+    branch: develop
     tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,19 @@ env:
 matrix:
   fast_finish: true
   exclude:
-  - jdk: oraclejdk11
-    env: BUILD=ant
   - jdk: openjdk11
-    env: BUILD=ant
-  - jdk: oraclejdk8
     env: BUILD=ant
   - jdk: openjdk8
     env: BUILD=maven
 
 script:
   - ./tools/test-build $BUILD
+
+deploy:
+  provider: script
+  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
+  skip_cleanup: true
+  on:
+    jdk: openjdk8
+    all_branches: true
+    tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,6 @@ deploy:
   script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
   skip_cleanup: true
   on:
-    jdk: openjdk8
+    jdk: openjdk11
     all_branches: true
     tags: false


### PR DESCRIPTION
This proposes to update the deployment mechanism of the Bio-Formats JARs (SNAPSHOT and release) to use Travis CI rather than relying on a secondary Jenkins job.

This logic is identical to what is in place for the downstream examples and documentation repositories and has been tested in the context of IDR - see https://github.com/IDR/bioformats/pull/16.

If accepted, the [Jenkins job](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-latest-maven/) achieving this task will become redundant and should be disabled and eventually archived when this PR is merged.