### PR TITLE
Add a null check to LIFReader.checkFlip

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1077,7 +1077,7 @@ public class LIFReader extends FormatReader {
   }
 
   private Length checkFlip(boolean flip, Length pos) {
-    if (flip) {
+    if (flip && pos != null) {
       pos = new Length(-pos.value().doubleValue(), pos.unit());
     }
     return pos;


### PR DESCRIPTION
This should prevent `NullPointerException` using some variants of the LIF
file format as reported in https://forum.image.sc/t/lif-cannot-open-with-bioformats-6-3-0/30856/

/cc @NicoKiaru