### PR TITLE
Have ijview suggest HTTPS URL for fetching ImageJ upgrades.

### DIFF
--- a/tools/ijview
+++ b/tools/ijview
@@ -24,7 +24,7 @@ then
     echo "Required JAR libraries not found. Please download:"
     echo "  ij.jar"
     echo "from:"
-    echo "  http://imagej.nih.gov/ij/upgrade/"
+    echo "  https://imagej.nih.gov/ij/upgrade/"
     echo "and place in the same directory as the command line tools."
     echo ""
     exit 3

--- a/tools/ijview.bat
+++ b/tools/ijview.bat
@@ -20,7 +20,7 @@ if "%BF_DEVEL%" == "" (
     echo Required JAR libraries not found. Please download:
     echo   ij.jar
     echo from:
-    echo   http://imagej.nih.gov/ij/upgrade/
+    echo   https://imagej.nih.gov/ij/upgrade/
     echo and place in the same directory as the command line tools.
     goto end
   )


### PR DESCRIPTION
When running CLI `ijview` without an ImageJ have the help message suggest a secure URL for downloading code.