### PR TITLE
bfconvert: fix the writer's XY coordinate when the input image is cropped

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -868,15 +868,21 @@ public final class ImageConverter {
           m = System.currentTimeMillis();
         }
 
+        // calculate the XY coordinate in the output image
+        // don't use tileX and tileY, as they will be too large
+        // if any cropping was performed
+        int outputX = x * w;
+        int outputY = y * h;
+
         if (writer instanceof TiffWriter) {
           ((TiffWriter) writer).saveBytes(outputIndex, buf,
-            ifd, tileX, tileY, tileWidth, tileHeight);
+            ifd, outputX, outputY, tileWidth, tileHeight);
         }
         else if (writer instanceof ImageWriter) {
           IFormatWriter baseWriter = ((ImageWriter) writer).getWriter(out);
           if (baseWriter instanceof TiffWriter) {
             ((TiffWriter) baseWriter).saveBytes(outputIndex, buf, ifd,
-              tileX, tileY, tileWidth, tileHeight);
+              outputX, outputY, tileWidth, tileHeight);
           }
         }
       }

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -65,6 +65,7 @@ public class ImageConverterTest {
 
   private Path tempDir;
   private File outFile;
+  private int width = 512;
   private final SecurityManager oldSecurityManager = System.getSecurityManager();
   private final PrintStream oldOut = System.out;
   private final PrintStream oldErr = System.err;
@@ -96,6 +97,7 @@ public class ImageConverterTest {
 
     tempDir = Files.createTempDirectory(this.getClass().getName());
     tempDir.toFile().deleteOnExit();
+    width = 512;
   }
 
   @AfterMethod
@@ -123,7 +125,7 @@ public class ImageConverterTest {
   public void checkImage() throws FormatException, IOException {
     IFormatReader r = new ImageReader();
     r.setId(outFile.getAbsolutePath());
-    assertEquals(r.getSizeX(), 512);
+    assertEquals(r.getSizeX(), width);
     r.close();
   }
 
@@ -215,5 +217,21 @@ public class ImageConverterTest {
             "plate&plates=1&fields=2.fake", outFile.getAbsolutePath()
     };
     assertConversion(args);
+  }
+
+  @Test
+  public void testCrop() throws FormatException, IOException {
+    outFile = tempDir.resolve("test.ome.tiff").toFile();
+    String[] args = {
+      "-tilex", "128", "-tiley", "128",
+      "-crop", "256,256,256,256", "test.fake", outFile.getAbsolutePath()};
+    width = 256;
+    try {
+      ImageConverter.main(args);
+    } catch (ExitException e) {
+      outFile.deleteOnExit();
+      assertEquals(e.status, 0);
+      checkImage();
+    }
   }
 }

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -234,4 +234,22 @@ public class ImageConverterTest {
       checkImage();
     }
   }
+
+  @Test
+  public void testCropOddTileSize() throws FormatException, IOException {
+    outFile = tempDir.resolve("odd-test.ome.tiff").toFile();
+    String[] args = {
+      "-tilex", "128", "-tiley", "128",
+      "-crop", "123,127,129,131", "test.fake", outFile.getAbsolutePath()
+    };
+    width = 129;
+    try {
+      ImageConverter.main(args);
+    }
+    catch (ExitException e) {
+      outFile.deleteOnExit();
+      assertEquals(e.status, 0);
+      checkImage();
+    }
+  }
 }


### PR DESCRIPTION
Fixes #3461.  The previous behavior was to use the same XY coordinate when reading and writing a tile.  This is fine when there is no cropping, but otherwise results in a coordinate that fails the writer's bounds check.

Without this PR, ``` bfconvert -crop 32256,8704,5120,5120 "test&sizeX=49512&sizeY=38578.fake" test.tif``` should throw:

```
Exception in thread "main" loci.formats.FormatException: X:32256 must be < 5120
	at loci.formats.FormatWriter.checkParams(FormatWriter.java:453)
	at loci.formats.out.TiffWriter.saveBytes(TiffWriter.java:220)
	at loci.formats.tools.ImageConverter.convertTilePlane(ImageConverter.java:878)
	at loci.formats.tools.ImageConverter.convertPlane(ImageConverter.java:763)
	at loci.formats.tools.ImageConverter.testConvert(ImageConverter.java:691)
	at loci.formats.tools.ImageConverter.main(ImageConverter.java:1051)
```

With this PR, the same test should successfully write a 5120x5120 file without throwing an exception.  The resulting file should be read correctly as well.