### PR TITLE
TiffSaver: make tile writing faster

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -335,7 +335,10 @@ public class TiffSaver {
 
       // write pixel strips to output buffers
       // Check for the sane cases
-      if (ifd.getImageWidth() == w && ifd.getTileWidth() == w && channelsAllSameSize) {
+      if (channelsAllSameSize &&
+        (ifd.getImageWidth() == w && ifd.getTileWidth() == w) ||
+        (tileHeight * tileWidth * nChannels * bytesPerPixel == buf.length))
+      {
         // If the input, output, and tile widths are all the same,
         // and the input bytesPerPixel (which is actually bytes per sample)
         // matches the bits per channel for all channels,


### PR DESCRIPTION
Mentioned in formats meeting 2019-10-30.  See also discussion in https://github.com/glencoesoftware/raw2ometiff/pull/1.

This should prevent unnecessary array copying when writing a tile buffer whose size matches the expected tile dimensions.  The overall conversion time for large tiled images should be noticeably faster with this PR.  ```bfconvert``` from an NDPI/SVS/etc. to pyramid OME-TIFF would be a good test.