### PR TITLE
LIfReader - Fix for NPE

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1077,7 +1077,7 @@ public class LIFReader extends FormatReader {
   }
 
   private Length checkFlip(boolean flip, Length pos) {
-    if (flip) {
+    if (flip && pos != null) {
       pos = new Length(-pos.value().doubleValue(), pos.unit());
     }
     return pos;


### PR DESCRIPTION
This is a fix for the issue discovered in https://forum.image.sc/t/lif-cannot-open-with-bioformats-6-3-0/30856 and a follow up to https://github.com/ome/bioformats/pull/3423

I will configure the provided sample file and add it to the repo before ready to review