### PR TITLE
Zeiss CZI: fix some tile stitching and position size issues

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2821,6 +2821,37 @@ public class ZeissCZIReader extends FormatReader {
           shape = populateRectangles(text, roiCount, shape);
         }
 
+        NodeList events = getGrandchildren(layer, "Elements", "Events");
+        if (events != null) {
+          for (int s=0; s<events.getLength(); s++) {
+            Element event = (Element) events.item(s);
+
+            Element geometry = getFirstNode(event, "Geometry");
+            Element textElements = getFirstNode(event, "TextElements");
+            Element attributes = getFirstNode(event, "Attributes");
+            Element features = getFirstNode(event, "Features");
+
+            String points = getFirstNodeValue(geometry, "Points");
+            if (points != null) {
+              String[] coords = points.split(" ");
+
+              for (String point : coords) {
+                String[] xy = point.split(",");
+                if (xy.length == 2) {
+                  String pointID =
+                    MetadataTools.createLSID("Shape", roiCount, shape);
+                  store.setPointID(pointID, roiCount, shape);
+                  store.setPointX(
+                    DataTools.parseDouble(xy[0]), roiCount, shape);
+                  store.setPointY(
+                    DataTools.parseDouble(xy[1]), roiCount, shape);
+                  shape++;
+                }
+              }
+            }
+          }
+        }
+
         if (shape > 0) {
           String roiID = MetadataTools.createLSID("ROI", roiCount);
           store.setROIID(roiID, roiCount);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -852,7 +852,8 @@ public class ZeissCZIReader extends FormatReader {
       prestitched = true;
     }
     else if (allowAutostitching() && prestitched == null && mosaics > 1) {
-      prestitched = mosaics == seriesCount && mosaics == calculatedSeries;
+      prestitched = (mosaics == seriesCount && mosaics == calculatedSeries) ||
+        (mosaics == (seriesCount / positions));
     }
 
     if (ms0.imageCount * seriesCount > planes.size() * scanDim &&
@@ -914,9 +915,9 @@ public class ZeissCZIReader extends FormatReader {
     // usually this indicates a big image for which a pyramid is
     // expected but not present
     if ((prestitched != null && prestitched) &&
-      seriesCount == mosaics && maxResolution == 0)
+      seriesCount == (mosaics * positions) && maxResolution == 0)
     {
-      seriesCount = 1;
+      seriesCount = positions;
     }
 
     if (seriesCount > 1 || maxResolution > 0) {
@@ -935,7 +936,7 @@ public class ZeissCZIReader extends FormatReader {
 
     assignPlaneIndices();
 
-    if (maxResolution > 0 || (mosaics > 1 && seriesCount == 1) ||
+    if (maxResolution > 0 || (mosaics > 1 && seriesCount == positions) ||
       (mosaics == 1 && seriesCount > 1))
     {
       tileWidth = new int[core.size()];

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -935,7 +935,9 @@ public class ZeissCZIReader extends FormatReader {
 
     assignPlaneIndices();
 
-    if (maxResolution > 0 || (mosaics > 1 && seriesCount == 1)) {
+    if (maxResolution > 0 || (mosaics > 1 && seriesCount == 1) ||
+      (mosaics == 1 && seriesCount > 1))
+    {
       tileWidth = new int[core.size()];
       tileHeight = new int[core.size()];
       for (int s=0; s<core.size();) {


### PR DESCRIPTION
Backported from a private PR.  See also https://trello.com/c/7MRDBwSn/178-czi-file-not-automatically-stitching

3add3da fixes a problem with the XY sizes when there are multiple positions ("Scenes" in ZEN).  Without this PR, ```qa-17179/WT_calc_after24h_stitch_2.czi``` had the same XY size for all 3 series.  With this PR, the sizes vary slightly between the 3 series.

604a1a0 fixes a problem where some datasets with multiple positions ("Scenes") and multiple mosaics (tiles) were not automatically stitched.  Without this PR, each position and mosaic in ```michael/multipos-z-time-*-tile.czi``` is split into a separate series.  With this PR, the mosaics are correctly stitched.

50da2d0 adds basic parsing for the ```Events``` annotation type, which was required in the original private PR but could be split into a separate PR if that helps with review.

The three files mentioned above need configuration changes; I'll put screenshots from ZEN on the corresponding PR.