### PR TITLE
QPTIFF: metadata fixes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -230,15 +230,8 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     putInt("MinSampleValue", firstIFD, IFD.MIN_SAMPLE_VALUE);
     putInt("MaxSampleValue", firstIFD, IFD.MAX_SAMPLE_VALUE);
 
-    TiffRational xResolution = firstIFD.getIFDRationalValue(IFD.X_RESOLUTION);
-    TiffRational yResolution = firstIFD.getIFDRationalValue(IFD.Y_RESOLUTION);
-
-    if (xResolution != null) {
-      put("XResolution", xResolution.doubleValue());
-    }
-    if (yResolution != null) {
-      put("YResolution", yResolution.doubleValue());
-    }
+    putDouble("XResolution", firstIFD, IFD.X_RESOLUTION);
+    putDouble("YResolution", firstIFD, IFD.Y_RESOLUTION);
 
     int planar = firstIFD.getIFDIntValue(IFD.PLANAR_CONFIGURATION);
     String planarConfig = null;
@@ -252,8 +245,8 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     }
     put("PlanarConfiguration", planarConfig);
 
-    putInt("XPosition", firstIFD, IFD.X_POSITION);
-    putInt("YPosition", firstIFD, IFD.Y_POSITION);
+    putDouble("XPosition", firstIFD, IFD.X_POSITION);
+    putDouble("YPosition", firstIFD, IFD.Y_POSITION);
     putInt("FreeOffsets", firstIFD, IFD.FREE_OFFSETS);
     putInt("FreeByteCounts", firstIFD, IFD.FREE_BYTE_COUNTS);
     putInt("GrayResponseUnit", firstIFD, IFD.GRAY_RESPONSE_UNIT);
@@ -573,6 +566,15 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     } catch (FormatException e) {
     }
     put(key, value);
+  }
+
+  protected void putDouble(String key, IFD ifd, int tag) {
+    if (ifd.getIFDValue(tag) instanceof Number) {
+      Number number = (Number) ifd.getIFDValue(tag);
+      if (number != null) {
+        put(key, number.doubleValue());
+      }
+    }
   }
 
   // -- Internal FormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -26,12 +26,16 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import loci.common.DataTools;
+import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
@@ -69,10 +73,17 @@ public class VectraReader extends BaseTiffReader {
   /** TIFF image description prefix for PerkinElmer Vectra/QPTIFF files. */
   private static final String SOFTWARE_CHECK = "PerkinElmer-QPI";
 
+  private static final String ANNOTATION_SUFFIX = "_annotations.xml";
+  private static final List<String> EXTRA_FILES = Arrays.asList(
+    "CoverslipMask.tif", "FocusMap.tif", "Label.tif",
+    "OverviewBF.tif", "OverviewFL.tif", "SampleMask.tif"
+  );
+
   // -- Fields --
 
   private int pyramidDepth = 1;
   private String profileXML;
+  private List<String> allFiles = new ArrayList<String>();
 
   // -- Constructor --
 
@@ -83,6 +94,7 @@ public class VectraReader extends BaseTiffReader {
     noSubresolutions = true;
     suffixSufficient = false;
     canSeparateSeries = false;
+    hasCompanionFiles = true;
   }
 
   // -- IFormatReader API methods --
@@ -113,6 +125,19 @@ public class VectraReader extends BaseTiffReader {
       LOGGER.debug("I/O exception during isThisType() evaluation.", e);
       return false;
     }
+  }
+
+  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    if (allFiles.size() == 1) {
+      return super.getSeriesUsedFiles(noPixels);
+    }
+    if (noPixels) {
+      return allFiles.subList(
+        1, allFiles.size()).toArray(new String[allFiles.size() - 1]);
+    }
+    return allFiles.toArray(new String[allFiles.size()]);
   }
 
   /**
@@ -151,6 +176,7 @@ public class VectraReader extends BaseTiffReader {
     if (!fileOnly) {
       pyramidDepth = 1;
       profileXML = null;
+      allFiles.clear();
     }
   }
 
@@ -188,6 +214,21 @@ public class VectraReader extends BaseTiffReader {
   @Override
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
+
+    // look for companion files
+
+    Location currentFile = new Location(currentId).getAbsoluteFile();
+    allFiles.add(currentFile.getAbsolutePath());
+    Location parent = currentFile.getParentFile();
+    String[] list = parent.list(true);
+    Arrays.sort(list);
+    for (String f : list) {
+      if (f.endsWith(ANNOTATION_SUFFIX) || EXTRA_FILES.contains(f)) {
+        allFiles.add(new Location(parent, f).getAbsolutePath());
+      }
+    }
+
+    // set up IFDs
 
     ifds = tiffParser.getMainIFDs();
     thumbnailIFDs = null;

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -354,7 +354,7 @@ public class VectraReader extends BaseTiffReader {
 
     // each high-resolution IFD has an XML description that needs to be parsed
 
-    for (int c=0; c<getSizeC(); c++) {
+    for (int c=0; c<getEffectiveSizeC(); c++) {
       String xml = getIFDComment(c);
       try {
         Element root = XMLTools.parseDOM(xml).getDocumentElement();

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -176,7 +176,9 @@ public class VectraReader extends BaseTiffReader {
     if (!fileOnly) {
       pyramidDepth = 1;
       profileXML = null;
-      allFiles.clear();
+      if (allFiles != null) {
+        allFiles.clear();
+      }
     }
   }
 


### PR DESCRIPTION
Backported from a private PR.

9e15251 fixes how the ```X_POSITION``` and ```Y_POSITION``` TIFF tags are recorded in the original metadata table for all TIFFs.  Without this change, the ```XPosition``` and ```YPosition``` values were treated as integers, and now they are treated as doubles.  ```showinf -nopix``` on any of the *.qptiff files in ```data_repo/curated/vectra-qptiff/``` should show the difference, and ```tiffinfo /path/to/file | grep Position``` can confirm that this PR is correct.

e9fc01a uses the ```X_POSITION``` and ```Y_POSITION``` TIFF tags to set ```Plane.PositionX``` and ```Plane.PositionY``` in the OME-XML for QPTIFF files.  ```showinf -nopix -omexml``` on any of the *.qptiff files in ```data_repo/curated/vectra-qptiff/``` should show that both values are populated with this PR.

a65cfe7 adds support for known companion files to QPTIFF.  As far as I know, this is a new addition since the instruments/software that produce QPTIFFs were acquired by Akoya Biosciences.  This commit will affect memo files, so the PR will require a minor release as-is.  I can split it into a separate PR if necessary.

All tests should continue to pass without configuration changes.