### PR TITLE
OBF: Incorrect dimensions fix

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -450,10 +450,10 @@ public class OBFReader extends FormatReader {
           final String label = in.readString(length);
           labels.add(label);
 
-          if (label.endsWith("X") || (dimension == 1 && isFLIMLabel(labels.get(0)))) {
+          if ((label.endsWith("X") && meta_data.sizeX == 0) || (dimension == 1 && isFLIMLabel(labels.get(0)))) {
             meta_data.sizeX = sizes[dimension];
           }
-          else if (label.endsWith("Y") || (dimension == 2 && isFLIMLabel(labels.get(0)))) {
+          else if ((label.endsWith("Y") && meta_data.sizeY == 0) || (dimension == 2 && isFLIMLabel(labels.get(0)))) {
             meta_data.sizeY = sizes[dimension];
           }
           else if (isFLIMLabel(label)) {


### PR DESCRIPTION
This is a follow up to address the issues which have been reported in https://github.com/ome/bioformats/pull/3141

In this scenario the dimensions are only updated from the label if they have not already been set.
The provided sample file can be used for testing. Without this PR the second series should throw an exception. With this PR it should read and display without error. 

I will open a config PR with the new sample file.