### PR TITLE
DeltavisionReader.java: synchronise objectives metadata with softWoRx 7.2.0

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -1836,7 +1836,7 @@ public class DeltavisionReader extends FormatReader {
       case 10211: // Olympus U-Plan S-Apo 20X/0.75
         lensNA = 0.75;
         magnification = 20.0;
-        workingDistance = 0.65;
+        workingDistance = 0.60;
         immersion = MetadataTools.getImmersion("Air");
         model = "1-U2B825";
         break;
@@ -1989,6 +1989,14 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 0.2;
         immersion = MetadataTools.getImmersion("Oil");
         model = "1-U2B530";
+        break;
+      case 10417: // Olympus 40X/1.25, UPLSAPO 40XS, Super Apochromat Silicone Oil
+        lensNA = 1.25;
+        magnification = 40.0;
+        workingDistance = 0.3;
+        immersion = MetadataTools.getImmersion("Other");
+        model = "";
+        correction = MetadataTools.getCorrection("Apo");
         break;
       case 10000: // Olympus 100X/1.30, DApo/340, IMT2
         lensNA = 1.30;
@@ -2279,6 +2287,25 @@ public class DeltavisionReader extends FormatReader {
         immersion = MetadataTools.getImmersion("Air");
         correction = MetadataTools.getCorrection("SuperFluor");
         break;
+      case 12209: // Nikon 20X/0.75, Plan Fluor, Multi-Immersion, CFI/60
+        lensNA = 0.75;
+        magnification = 20.;
+        workingDistance = 0.35;
+        immersion = MetadataTools.getImmersion("Water");
+        correction = MetadataTools.getCorrection("PlanFluor");
+        break;
+      case 12301: // Nikon 25X/1.10, Apo, LWD, Water, CFI
+        lensNA = 1.10;
+        magnification = 25.;
+        workingDistance = 2.0;
+        immersion = MetadataTools.getImmersion("Water");
+        break;
+      case 12302: // Nikon 20X/0.95, Apo, LWD, Water, CFI
+        lensNA = 0.95;
+        magnification = 20.;
+        workingDistance = 0.95;
+        immersion = MetadataTools.getImmersion("Water");
+        break;
       case 12401: // Nikon 40X/1.30, PlanFluar, 160mm tube length
         lensNA = 1.30;
         magnification = 40.0;
@@ -2369,6 +2396,19 @@ public class DeltavisionReader extends FormatReader {
         immersion = MetadataTools.getImmersion("Air");
         correction = MetadataTools.getCorrection("PlanFluor");
         break;
+      case 12414: // Nikon 40X/1.15, Apo S, LWD, Water, CFI/60 Lambda
+        lensNA = 1.15;
+        magnification = 40.0;
+        workingDistance = 0.61;
+        immersion = MetadataTools.getImmersion("Water");
+        model = "MRD77410";
+        break;
+      case 12415: // Nikon 40X/1.25, Apo S, Water, CFI/60 Lambda
+        lensNA = 1.25;
+        magnification = 40.0;
+        workingDistance = 0.2;
+        immersion = MetadataTools.getImmersion("Water");
+        break;
       case 12600: // Nikon 60X/1.40, CF N Plan Apochromat, 160mm tube length
         lensNA = 1.40;
         magnification = 60.0;
@@ -2425,6 +2465,37 @@ public class DeltavisionReader extends FormatReader {
         model = "MRH00602";
         correction = MetadataTools.getCorrection("PlanFluor");
         break;
+      case 12607: // Nikon 60X/1.40, Plan Apo, VC, CFI/60
+        lensNA = 1.40;
+        magnification = 60.;
+        workingDistance = 0.13;
+        immersion = MetadataTools.getImmersion("Oil");
+        model = "MRD01602";
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
+      case 12608: // Nikon 60X/1.20, Water, Plan Apo, VC, CFI/60
+        lensNA = 1.20;
+        magnification = 60.;
+        workingDistance = 0.28;
+        immersion = MetadataTools.getImmersion("Water");
+        model = "MRD07602";
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
+      case 12609: // Nikon 60X/1.40, Plan Apochromat, Lambda, CFI/60
+        lensNA = 1.40;
+        magnification = 60.;
+        workingDistance = 0.13;
+        immersion = MetadataTools.getImmersion("Oil");
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
+      case 12610: // Nikon 60X/1.27, Plan Apochromat IR, Water, Lambda, CFI/60
+        lensNA = 1.27;
+        magnification = 60.;
+        workingDistance = 0.17;
+        immersion = MetadataTools.getImmersion("Water");
+        model = "MRD07620";
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
       case 12000: // Nikon 100X/1.40, CF N Plan Apochromat, 160mm tube length
         lensNA = 1.40;
         magnification = 100.0;
@@ -2470,6 +2541,21 @@ public class DeltavisionReader extends FormatReader {
         immersion = MetadataTools.getImmersion("Air");
         model = "MRH00900";
         correction = MetadataTools.getCorrection("PlanFluor");
+        break;
+      case 12006: // Nikon 100X/0.85, CR L EPI Plan, Corr Collar 0.0-0.70, CFI 60
+        lensNA = 0.85;
+        magnification = 100.;
+        workingDistance = 0.85;
+        immersion = MetadataTools.getImmersion("Air");
+        model = "MUE35900";
+        break;
+      case 12007: // Nikon 100X/1.40, Plan Apo, VC, CFI/60
+        lensNA = 1.40;
+        magnification = 100.;
+        workingDistance = 0.13;
+        immersion = MetadataTools.getImmersion("Oil");
+        model = "MRD01901";
+        correction = MetadataTools.getCorrection("PlanApo");
         break;
       case 12101: // Nikon 2X/0.10, Plan Apo, 160mm tube length
         lensNA = 0.10;
@@ -2801,6 +2887,24 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 24.00;
         immersion = MetadataTools.getImmersion("Air");
         break;
+      case 18107: // API 10X, BH
+        lensNA = 0.15;
+        magnification = 10.0;
+        workingDistance = 15.00;
+        immersion = MetadataTools.getImmersion("Air");
+        break;
+      case 18108: // GE 10X/0.45, 1mm substrate, GRC
+        lensNA = 0.45;
+        magnification = 10.0;
+        workingDistance = 3.00;
+        immersion = MetadataTools.getImmersion("Air");
+        break;
+      case 18109: // GE 10X/0.45, 0.17mm coverslip, GRC
+        lensNA = 0.45;
+        magnification = 10.0;
+        workingDistance = 3.00;
+        immersion = MetadataTools.getImmersion("Air");
+        break;
       case 18201: // API 20X, HiRes A, CW
         lensNA = 0.55;
         magnification = 20.;
@@ -2850,12 +2954,6 @@ public class DeltavisionReader extends FormatReader {
         magnification = 40.0;
         workingDistance = 0.48;
         immersion = MetadataTools.getImmersion("Air");
-        break;
-      case 20007: // Applied Precision 100X/1.4
-        lensNA = 1.4;
-        magnification = 100.0;
-        immersion = MetadataTools.getImmersion("Oil");
-        manufacturer = "Applied Precision";
         break;
       case 1: // Zeiss 10X/.25
         lensNA = 0.25;

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2801,38 +2801,6 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 24.00;
         immersion = MetadataTools.getImmersion("Air");
         break;
-      case 18107: // API 10X, BH
-        lensNA = 0.15;
-        magnification = 10.0;
-        workingDistance = 15.00;
-        immersion = MetadataTools.getImmersion("Air");
-        correction = MetadataTools.getCorrection("PlanFluor");
-        manufacturer = "Nikon";
-        break;
-      case 18108:
-        magnification = 20.0;
-        lensNA = 0.75;
-        correction = MetadataTools.getCorrection("PlanApo");
-        manufacturer = "Nikon";
-        break;
-      case 18109:
-        magnification = 40.0;
-        lensNA = 0.95;
-        correction = MetadataTools.getCorrection("PlanApo");
-        manufacturer = "Nikon";
-        break;
-      case 18110:
-        magnification = 40.0;
-        lensNA = 0.60;
-        correction = MetadataTools.getCorrection("PlanFluor");
-        manufacturer = "Nikon";
-        break;
-      case 18111:
-        magnification = 4.0;
-        lensNA = 0.20;
-        correction = MetadataTools.getCorrection("PlanApo");
-        manufacturer = "Nikon";
-        break;
       case 18201: // API 20X, HiRes A, CW
         lensNA = 0.55;
         magnification = 20.;

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2892,6 +2892,8 @@ public class DeltavisionReader extends FormatReader {
         magnification = 10.0;
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");
+        correction = MetadataTools.getCorrection("PlanFluor");  
+        manufacturer = "Nikon"; 
         break;
       case 18108: // GE 10X/0.45, 1mm substrate, GRC
         lensNA = 0.45;
@@ -2954,6 +2956,12 @@ public class DeltavisionReader extends FormatReader {
         magnification = 40.0;
         workingDistance = 0.48;
         immersion = MetadataTools.getImmersion("Air");
+        break;
+      case 20007: // Applied Precision 100X/1.4 
+        lensNA = 1.4; 
+        magnification = 100.0;  
+        immersion = MetadataTools.getImmersion("Oil");  
+        manufacturer = "Applied Precision"; 
         break;
       case 1: // Zeiss 10X/.25
         lensNA = 0.25;

--- a/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
@@ -28,7 +28,10 @@ package loci.formats.in;
 import java.io.IOException;
 
 import loci.formats.FormatException;
+import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
 
 public class RCPNLReader extends DeltavisionReader {
 
@@ -57,8 +60,45 @@ public class RCPNLReader extends DeltavisionReader {
   {
     super.populateObjective(store, lensID);
 
-    if (lensID == 18107) {
-      store.setObjectiveLensNA(0.30, 0, 0);
+    switch (lensID) {
+      case 18107:
+        store.setObjectiveNominalMagnification(10.0, 0, 0);
+        store.setObjectiveLensNA(0.30, 0, 0);
+        store.setObjectiveWorkingDistance(
+          new Length(15.0, UNITS.MILLIMETER), 0, 0);
+        store.setObjectiveImmersion(MetadataTools.getImmersion("Air"), 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanFluor"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
+      case 18108:
+        store.setObjectiveNominalMagnification(20.0, 0, 0);
+        store.setObjectiveLensNA(0.75, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanApo"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
+      case 18109:
+        store.setObjectiveNominalMagnification(40.0, 0, 0);
+        store.setObjectiveLensNA(0.95, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanApo"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
+      case 18110:
+        store.setObjectiveNominalMagnification(40.0, 0, 0);
+        store.setObjectiveLensNA(0.60, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanFluor"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
+      case 18111:
+        store.setObjectiveNominalMagnification(4.0, 0, 0);
+        store.setObjectiveLensNA(0.20, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanApo"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
     }
   }
 


### PR DESCRIPTION
This is pretty much the same as #3204 . I used a [script](https://github.com/MicronOxford/scripts/blob/master/auto/dvlenses2readercases.pl) to parse the `dvlenses.tab` from the last release of softWoRx and convert to the java code required for the deltavision reader.

This does adds more objectives but also removes a few which I found odd since I don't know from where those were coming (mainly 33a19733b32b and a644a10df03e). At least the change made by ace7daf99e43 are odd because they mark them as Nikon objectives but they are not in the 12000-13999 range.