### PR TITLE
InCell: invert Y coordinate in plane/field positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -1129,8 +1129,15 @@ public class InCellReader extends FormatReader {
           index = offsetPointCounter++;
         }
 
+        // Y value multiplied by -1 to correct for difference in assumptions
+        // - position is relative to center of well
+        // - acquisition software seems to assume smaller Y is below larger Y,
+        //   consistent with (0, 0) being the center
+        // - we typically assume smaller Y is above larger Y,
+        //   consistent with image origins being in the top left corner
+
         posX.put(index, new Length(Double.valueOf(x), UNITS.REFERENCEFRAME));
-        posY.put(index, new Length(Double.valueOf(y), UNITS.REFERENCEFRAME));
+        posY.put(index, new Length(-1 * Double.valueOf(y), UNITS.REFERENCEFRAME));
 
         addGlobalMetaList("X position for position", x);
         addGlobalMetaList("Y position for position", y);


### PR DESCRIPTION
Backported from a private PR.

This corrects for the difference in how Y coordinates are treated between the acquisition software and our model (see the code comment).  To test, open ```incell/michael/firstStack``` (1 well, 6 fields in a 3x2 grid) in ImageJ with ```Open all series``` and ```Stitch tiles``` checked.  Without this PR, there should be a very obvious horizontal line in the middle of the stitched image even when zoomed out.  With this PR, the stitched image should look much better.

Shouldn't affect memo files, but does require a substantial configuration update to change every Y position for every InCell plate. 