### PR TITLE
CellWorx: add support for multiple Z sections

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -937,9 +937,8 @@ public class CellWorxReader extends FormatReader {
           }
         }
         if (nextFile != files.length) {
-          throw new FormatException(
-            "Well " + well + " expected " + files.length +
-            " files; found " + nextFile);
+          LOGGER.warn("Well {} expected {} files; found {}",
+            well, files.length, nextFile);
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -819,8 +819,10 @@ public class CellWorxReader extends FormatReader {
 
   private String[] getTiffFiles(String plateName, char rowLetter, int col,
     int channels, int nTimepoints, int zSteps)
+    throws FormatException
   {
-    String base = plateName + rowLetter + String.format("%02d", col + 1);
+    String well = rowLetter + String.format("%02d", col + 1);
+    String base = plateName + well;
 
     String[] files = new String[fieldCount * channels * nTimepoints * zSteps];
 
@@ -893,12 +895,20 @@ public class CellWorxReader extends FormatReader {
                 for (String f : zList) {
                   String path = new Location(file, f).getAbsolutePath();
                   if (f.startsWith(base) && path.indexOf("_thumb") < 0) {
-                    files[nextFile++] = path;
+                    if (nextFile < files.length) {
+                      files[nextFile] = path;
+                    }
+                    nextFile++;
                   }
                 }
               }
             }
           }
+        }
+        if (nextFile != files.length) {
+          throw new FormatException(
+            "Well " + well + " expected " + files.length +
+            " files; found " + nextFile);
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -901,6 +901,7 @@ public class CellWorxReader extends FormatReader {
         //    * ZStep_<z>
         //      * file_<...>.tif
         base = base.substring(base.lastIndexOf(File.separator) + 1);
+        LOGGER.debug("expected file prefix = {}", base);
         nextFile = 0;
         for (int i=0; i<nTimepoints; i++) {
           Location dir = new Location(parent, "TimePoint_" + (i + 1));
@@ -917,10 +918,12 @@ public class CellWorxReader extends FormatReader {
                 file = dir;
                 zList = file.list(true);
               }
+              LOGGER.debug("parent directory = {}", file);
 
               if (zList != null) {
                 Arrays.sort(zList);
                 for (String f : zList) {
+                  LOGGER.debug("  checking relative path = {}", f);
                   String path = new Location(file, f).getAbsolutePath();
                   if (f.startsWith(base) && path.indexOf("_thumb") < 0) {
                     if (nextFile < files.length) {

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -907,8 +907,18 @@ public class CellWorxReader extends FormatReader {
           if (dir.exists() && dir.isDirectory()) {
             for (int z=0; z<zSteps; z++) {
               Location file = new Location(dir, "ZStep_" + (z + 1));
+              String[] zList = null;
               if (file.exists() && file.isDirectory()) {
-                String[] zList = file.list(true);
+                zList = file.list(true);
+              }
+              else if (zSteps == 1) {
+                // if SizeZ == 1, the TIFF files may be in the
+                // TimePoint_<t> directory
+                file = dir;
+                zList = file.list(true);
+              }
+
+              if (zList != null) {
                 Arrays.sort(zList);
                 for (String f : zList) {
                   String path = new Location(file, f).getAbsolutePath();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2692,6 +2692,13 @@ public class FormatReaderTest {
               continue;
             }
 
+            // CellWorx datasets can only be reliably detected with the .HTD file
+            if (!used[i].toLowerCase().endsWith(".htd") &&
+              r instanceof CellWorxReader)
+            {
+              continue;
+            }
+
             boolean expected = r == readers[j];
             if (result != expected) {
               success = false;


### PR DESCRIPTION
Backported from a private PR.

If multiple Z sections are present, each one is expected to be in a separate directory as described on line 898.  A test dataset is being uploaded to ```curated/cellworx/samples/multi-z/``` (generated from idr0005).  Without this PR, ```showinf -nopix 2011-04-19-plate-1.HTD``` should throw an exception.  With this PR, ```SizeZ``` should be 2 for every series.  ```showinf -trace 2011-04-19-plate-1.HTD -series n``` for any series should show that the 2 planes are coming from different files.  The planes won't be visually different, so it's worth checking the file names. 

Existing tests should continue to pass.  This will impact memo files, so requires a minor version.