### PR TITLE
Fix a handful of deprecation warnings

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -353,7 +353,8 @@ public class GatanReader extends FormatReader {
               i, 0);
 
         if (mode != null) {
-          store.setChannelAcquisitionMode(getAcquisitionMode(mode), i, 0);
+          store.setChannelAcquisitionMode(
+            MetadataTools.getAcquisitionMode(mode), i, 0);
         }
 
         if (foundMontage && i < stageX.size()) {

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -571,7 +571,8 @@ public class OperettaReader extends FormatReader {
           }
           if (planes[i][c] != null) {
             if (planes[i][c].acqType != null) {
-              store.setChannelAcquisitionMode(getAcquisitionMode(planes[i][c].acqType), i, c);
+              store.setChannelAcquisitionMode(
+                MetadataTools.getAcquisitionMode(planes[i][c].acqType), i, c);
             }
             if (planes[i][c].channelType != null) {
               store.setChannelContrastMethod(

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2142,8 +2142,8 @@ public class ZeissCZIReader extends FormatReader {
             if (positions.getLength() > 0 && nextPosition < positionsX.length) {
               Element position = (Element) positions.item(0);
               String[] pos = position.getTextContent().split(",");
-              positionsX[nextPosition] = new Length(DataTools.parseDouble(pos[0]), UNITS.MICROM);
-              positionsY[nextPosition] = new Length(DataTools.parseDouble(pos[1]), UNITS.MICROM);
+              positionsX[nextPosition] = new Length(DataTools.parseDouble(pos[0]), UNITS.MICROMETER);
+              positionsY[nextPosition] = new Length(DataTools.parseDouble(pos[1]), UNITS.MICROMETER);
             }
             nextPosition++;
           }
@@ -3939,15 +3939,15 @@ public class ZeissCZIReader extends FormatReader {
               if (text != null) {
                 if (tagNode.getNodeName().equals("StageXPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageX = new Length(number, UNITS.MICROM);
+                  stageX = new Length(number, UNITS.MICROMETER);
                 }
                 else if (tagNode.getNodeName().equals("StageYPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageY = new Length(number, UNITS.MICROM);
+                  stageY = new Length(number, UNITS.MICROMETER);
                 }
                 else if (tagNode.getNodeName().equals("FocusPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageZ = new Length(number, UNITS.MICROM);
+                  stageZ = new Length(number, UNITS.MICROMETER);
                 }
                 else if (tagNode.getNodeName().equals("AcquisitionTime")) {
                   Timestamp t = Timestamp.valueOf(text);


### PR DESCRIPTION
Cleans up a few places where readers were using a deprecated method or variable.  There should be no behavior changes or failing tests; the only difference is that the build log should be a bit cleaner.  Should be safe for a patch release, but definitely not urgent.