### PR TITLE
Ventana: try harder to find physical sizes for prestitched TIFFs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -456,7 +456,7 @@ public class VentanaReader extends BaseTiffReader {
       }
       String xml = ifds.get(index).getIFDTextValue(XML_TAG);
       LOGGER.debug("XMP tag for series #{} = {}", i, xml);
-      if (xml != null && resolutionCount == 1) {
+      if (xml != null && resolutionCount <= 1) {
         parseXML(xml);
       }
     }
@@ -819,15 +819,21 @@ public class VentanaReader extends BaseTiffReader {
     }
 
     Element iScan = (Element) root.getElementsByTagName("iScan").item(0);
-    String physicalSize = iScan.getAttribute("ScanRes");
-    if (physicalSize != null) {
-      physicalPixelSize = DataTools.parseDouble(physicalSize);
+    if (iScan != null) {
+      String physicalSize = iScan.getAttribute("ScanRes");
+      if (physicalSize != null) {
+        physicalPixelSize = DataTools.parseDouble(physicalSize);
+      }
     }
 
     Element slideStitchInfo =
       (Element) root.getElementsByTagName("SlideStitchInfo").item(0);
     Element aoiOrigins =
       (Element) root.getElementsByTagName("AoiOrigin").item(0);
+
+    if (slideStitchInfo == null || aoiOrigins == null) {
+      return;
+    }
 
     NodeList imageInfos = slideStitchInfo.getElementsByTagName("ImageInfo");
     for (int i=0; i<imageInfos.getLength(); i++) {


### PR DESCRIPTION
See #3416.

Without this PR, ```showinf -nopix -noflat -omexml``` on the file from QA 27763 should show that ```PhysicalSizeX``` and ```PhysicalSizeY``` are not included in the OME-XML.  With this PR, the same command should show both ```PhysicalSizeX``` and ```PhysicalSizeY``` set to ```0.25```.

Ventana TIFFs (which is what QA 27763 is) are typically converted from .bif files and don't have as much metadata stored in the IFDs for each pyramid level.  Most of the XML on the pyramid IFDs in a .bif file is related to stitching tiles; when the .bif file is converted to a Ventana TIFF, all of that XML is presumably stripped out since it's no longer relevant.

I wouldn't expect any test failures, and memo files should not be impacted.  