### PR TITLE
Make TiffParser and TiffSaver implement Closeable

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -32,6 +32,7 @@
 
 package loci.formats.tiff;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * @author Melissa Linkert melissa at glencoesoftware.com
  * @author Chris Allan callan at blackcat.ca
  */
-public class TiffParser {
+public class TiffParser implements Closeable {
 
   // -- Constants --
 
@@ -95,11 +96,14 @@ public class TiffParser {
   /** Codec options to be used when decoding compressed pixel data. */
   private CodecOptions codecOptions = CodecOptions.getDefaultOptions();
 
+  private boolean canClose = false;
+
   // -- Constructors --
 
   /** Constructs a new TIFF parser from the given file name. */
   public TiffParser(String filename) throws IOException {
     this(new RandomAccessInputStream(filename));
+    canClose = true;
   }
 
   /** Constructs a new TIFF parser from the given input source. */
@@ -112,6 +116,20 @@ public class TiffParser {
       in.seek(fp);
     }
     catch (IOException e) { }
+  }
+
+  // -- Closeable methods --
+
+  /**
+   * Close the underlying stream, if this TiffParser was constructed
+   * with a file path.  Closing a stream that was pre-initialized
+   * is potentially dangerous.
+   */
+  @Override
+  public void close() throws IOException {
+    if (canClose && in != null) {
+      in.close();
+    }
   }
 
   // -- TiffParser methods --

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -33,6 +33,7 @@
 package loci.formats.tiff;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -60,7 +61,7 @@ import org.slf4j.LoggerFactory;
  * @author Melissa Linkert melissa at glencoesoftware.com
  * @author Chris Allan callan at blackcat.ca
  */
-public class TiffSaver {
+public class TiffSaver implements Closeable {
 
   // -- Constructor --
 


### PR DESCRIPTION
See https://trello.com/c/JHikBmdv/368-make-tiffparser-and-tiffsaver-closeable and https://github.com/openmicroscopy/bioformats/pull/3331#pullrequestreview-223532670

```TiffSaver``` already implemented ```close()```, so the only change there is to explicitly implement ```Closeable``` which should be pretty safe.

```TiffParser``` needed a new ```close()``` method though, and I'm not 100% sure of the best approach.  Always closing the underlying ```RandomAccessInputStream``` would make sure that the file handle is always closed, but would be problematic for existing code of this form:

```
RandomAccessInputStream s = new RandomAccessInputStream("file.tiff");
TiffParser p = new TiffParser(s);
...
p.close();
s.seek(0);
```

The current approach is to only close the ```RandomAccessInputStream``` if it was opened by ```TiffParser```, i.e. if the ```TiffParser(String)``` constructor was used, which seems safer.  Happy to hear other thoughts.

Shouldn't impact tests, but I'd assume requires a minor release.