### PR TITLE
Fake: allow DeltaT to be set in INI file

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1204,7 +1204,23 @@ public class FakeReader extends FormatReader {
           }
         }
         catch (NumberFormatException e) {
-          LOGGER.trace("Could not parse ExposureTime for series #" + s + " plane #" + i, e);
+          LOGGER.trace("Could not parse ExposureTime for series #" + newSeries + " plane #" + i, e);
+        }
+      }
+
+      String deltaT = table.get("DeltaT_" + i);
+      String deltaTUnit = table.get("DeltaTUnit_" + i);
+
+      if (deltaT != null) {
+        try {
+          Double v = Double.valueOf(deltaT);
+          Time delta = FormatTools.getTime(v, deltaTUnit);
+          if (delta != null) {
+            store.setPlaneDeltaT(delta, newSeries, i);
+          }
+        }
+        catch (NumberFormatException e) {
+          LOGGER.trace("Could not parse DeltaT for series #" + newSeries + " plane #" + i, e);
         }
       }
 


### PR DESCRIPTION
See https://trello.com/c/ONAvIZoV/330-add-key-to-configure-deltat

```DeltaT``` can now be set for each plane in the .ini file, just like ```ExposureTime```.  With this PR:

```
$ cat test.fake.ini
[series_0]
DeltaT_0 = 1.5
DeltaTUnit_0 = ms
$ showinf -nopix -omexml test.fake
...
<?xml version="1.0" encoding="UTF-8"?>
<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
   <Image ID="Image:0" Name="test">
      <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" SignificantBits="8" SizeC="1" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint8">
         <Channel ID="Channel:0:0" SamplesPerPixel="1">
            <LightPath/>
         </Channel>
         <MetadataOnly/>
         <Plane DeltaT="1.5" DeltaTUnit="ms" TheC="0" TheT="0" TheZ="0"/>
      </Pixels>
   </Image>
</OME>
```