### PR TITLE
Fake: allow .ini files in plates created by mkfake

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1294,7 +1294,7 @@ public class FakeReader extends FormatReader {
         rows = ResourceNamer.alphabeticIndexCount(elements[0]);
         cols = Integer.parseInt(elements[1]) + 1;
       } else if (pathToken.startsWith(ResourceNamer.FIELD)) {
-        String fieldName = pathToken.substring(0, pathToken.lastIndexOf("."));
+        String fieldName = pathToken.substring(0, pathToken.indexOf("."));
         fields = Integer.parseInt(fieldName.substring(fieldName.lastIndexOf(
             ResourceNamer.FIELD) + ResourceNamer.FIELD.length(),
             fieldName.length())) + 1;


### PR DESCRIPTION
See https://github.com/ome/bioformats/issues/3346

Without this PR, the following should throw a ```NumberFormatException``` as described in #3346 :

```
$ mkfake .
$ echo "sizeC=3" >>  screen.fake/Plate000/Run000/WellA000/Field000.fake.ini
$ showinf screen.fake
```

With this PR, the same test should successfully display one plane.  Note that ```SizeC``` will be 1 with the test case as written, since only the only .ini file parsed is the one matching what was passed to ```setId``` (```screen.fake.ini``` in this case).  To have ```SizeC``` set to 3, either run:

```
$ showinf screen.fake/Plate000/Run000/WellA000/Field000.fake
```

or:

```
$ echo "sizeC=3" >> screen.fake.ini
$ showinf screen.fake
```

I wouldn't expect this to have any test or memo impact, so should be fine for a patch release if necessary.