### PR TITLE
bfconvert: add -nobigtiff option

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -106,6 +106,7 @@ public final class ImageConverter {
   private String compression = null;
   private boolean stitch = false, separate = false, merge = false, fill = false;
   private boolean bigtiff = false, group = true;
+  private boolean nobigtiff = false;
   private boolean printVersion = false;
   private boolean lookup = true;
   private boolean autoscale = false;
@@ -156,6 +157,7 @@ public final class ImageConverter {
         else if (args[i].equals("-merge")) merge = true;
         else if (args[i].equals("-expand")) fill = true;
         else if (args[i].equals("-bigtiff")) bigtiff = true;
+        else if (args[i].equals("-nobigtiff")) nobigtiff = true;
         else if (args[i].equals("-map")) map = args[++i];
         else if (args[i].equals("-compression")) compression = args[++i];
         else if (args[i].equals("-nogroup")) group = false;
@@ -258,6 +260,11 @@ public final class ImageConverter {
         }
       }
     }
+
+    if (bigtiff && nobigtiff) {
+      LOGGER.error("Do not specify both -bigtiff and -nobigtiff");
+      return false;
+    }
     return true;
   }
 
@@ -304,7 +311,7 @@ public final class ImageConverter {
     String[] s = {
       "To convert a file between formats, run:",
       "  bfconvert [-debug] [-stitch] [-separate] [-merge] [-expand]",
-      "    [-bigtiff] [-compression codec] [-series series] [-noflat]",
+      "    [-bigtiff] [-nobigtiff] [-compression codec] [-series series] [-noflat]",
       "    [-cache] [-cache-dir dir] [-no-sas]",
       "    [-map id] [-range start end] [-crop x,y,w,h]",
       "    [-channel channel] [-z Z] [-timepoint timepoint] [-nogroup]",
@@ -321,6 +328,7 @@ public final class ImageConverter {
       "              -merge: combine separate channels into RGB image",
       "             -expand: expand indexed color to RGB",
       "            -bigtiff: force BigTIFF files to be written",
+      "          -nobigtiff: do not automatically switch to BigTIFF",
       "        -compression: specify the codec to use when saving images",
       "             -series: specify which image series to convert",
       "             -noflat: do not flatten subresolutions",
@@ -601,11 +609,13 @@ public final class ImageConverter {
 
     if (writer instanceof TiffWriter) {
       ((TiffWriter) writer).setBigTiff(bigtiff);
+      ((TiffWriter) writer).setCanDetectBigTiff(!nobigtiff);
     }
     else if (writer instanceof ImageWriter) {
       IFormatWriter w = ((ImageWriter) writer).getWriter(out);
       if (w instanceof TiffWriter) {
         ((TiffWriter) w).setBigTiff(bigtiff);
+        ((TiffWriter) w).setCanDetectBigTiff(!nobigtiff);
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -87,6 +87,9 @@ public class TiffWriter extends FormatWriter {
   /** Whether or not the output file is a BigTIFF file. */
   protected boolean isBigTiff;
 
+  /** Whether or not BigTIFF can be used automatically. */
+  protected boolean canDetectBigTiff = true;
+
   /** The TiffSaver that will do most of the writing. */
   protected TiffSaver tiffSaver;
 
@@ -183,8 +186,14 @@ public class TiffWriter extends FormatWriter {
         }
 
         if (totalBytes >= BIG_TIFF_CUTOFF) {
-          LOGGER.info("Switching to BigTIFF (by file size)");
-          isBigTiff = true;
+          if (canDetectBigTiff) {
+            LOGGER.info("Switching to BigTIFF (by file size)");
+            isBigTiff = true;
+          }
+          else {
+            LOGGER.info("Automatic BigTIFF disabled but pixel byte count = {}",
+              totalBytes);
+          }
         }
       }
     }
@@ -497,6 +506,16 @@ public class TiffWriter extends FormatWriter {
   public void setBigTiff(boolean bigTiff) {
     FormatTools.assertId(currentId, false, 1);
     isBigTiff = bigTiff;
+  }
+
+  /**
+   * Sets whether or not BigTIFF can be used automatically
+   * based upon the input data size (true by default).
+   * This flag is not reset when close() is called.
+   */
+  public void setCanDetectBigTiff(boolean detect) {
+    FormatTools.assertId(currentId, false, 1);
+    canDetectBigTiff = detect;
   }
 
   // -- Helper methods --


### PR DESCRIPTION
See https://github.com/ome/bioformats/issues/3404

Adds a ```setCanDetectBigTiff(boolean)``` method to ```TiffWriter``` and corresponding ```-nobigtiff``` option to ```bfconvert```.  If ```-nobigtiff``` is used (== ```setCanDetectBigTiff(false)```), then automatic switching to BigTIFF based upon the number of pixel bytes is turned off.  Extension-based switching is unchanged.

Using ```-bigtiff``` and ```-nobigtiff``` together should exit quickly with an error message, since the correct behavior is ambiguous.

Should not impact memo files or anything on the reading side of the stack, but does require a minor release due to new API.  I don't feel strongly that this needs to be in 6.4.0.