### PR TITLE
Zeiss CZI: check for uncompressed pixels incorrectly flagged as JPEG-XR

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3859,8 +3859,13 @@ public class ZeissCZIReader extends FormatReader {
             data = new JPEGXRCodec().decompress(data, options);
           }
           catch (FormatException e) {
-            LOGGER.warn("Could not decompress block; some pixels may be 0", e);
-            data = new byte[options.maxBytes];
+            if (data.length == options.maxBytes) {
+              LOGGER.debug("Invalid JPEG-XR compression flag");
+            }
+            else {
+              LOGGER.warn("Could not decompress block; some pixels may be 0", e);
+              data = new byte[options.maxBytes];
+            }
           }
           break;
         case 104: // camera-specific packed pixels


### PR DESCRIPTION
See https://github.com/ome/bioformats/issues/3401.

The JPEG-XR decompression warnings occurred because the pixel data blocks were actually uncompressed.  ```showinf -range 2 2 -series 8``` on the file from QA 27508 without this PR will show an image with all 0 pixel values.  With this PR, there should clearly be image data that aligns with the other channels.  Note that there are still blank areas in each corner, but that is correct.

I don't think this will affect tests (feel free to exclude if it does), and should be safe for a patch release.