### PR TITLE
Bump ome-codecs component to version 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.2.5</ome-codecs.version>
+    <ome-codecs.version>0.3.0</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 


### PR DESCRIPTION
See https://github.com/ome/ome-codecs/milestone/8?closed=1

These changes should have been tested daily in the CI builds for the last month. This bump is primarily to include the new component  in the upcoming release 