### PR TITLE
Use skipBytes(long) in places where integer overflow is possible

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -524,23 +524,23 @@ public abstract class FormatReader extends FormatHandler
     }
     else if (x == 0 && w == getSizeX() && scanlinePad == 0) {
       if (isInterleaved()) {
-        s.skipBytes(y * w * bpp * c);
+        s.skipBytes((long) y * w * bpp * c);
         s.read(buf, 0, h * w * bpp * c);
       }
       else {
         int rowLen = w * bpp;
         for (int channel=0; channel<c; channel++) {
-          s.skipBytes(y * rowLen);
+          s.skipBytes((long) y * rowLen);
           s.read(buf, channel * h * rowLen, h * rowLen);
           if (channel < c - 1) {
             // no need to skip bytes after reading final channel
-            s.skipBytes((getSizeY() - y - h) * rowLen);
+            s.skipBytes((long) (getSizeY() - y - h) * rowLen);
           }
         }
       }
     }
     else {
-      int scanlineWidth = getSizeX() + scanlinePad;
+      long scanlineWidth = getSizeX() + scanlinePad;
       if (isInterleaved()) {
         s.skipBytes(y * scanlineWidth * bpp * c);
         for (int row=0; row<h; row++) {

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -237,7 +237,8 @@ public class AVIReader extends FormatReader {
       pad = bytes;
     }
 
-    in.skipBytes((getSizeX() + pad) * (bmpBitsPerPixel / 8) * (getSizeY() - h - y));
+    long skipRows = getSizeY() - h - y;
+    in.skipBytes((getSizeX() + pad) * (bmpBitsPerPixel / 8) * skipRows);
 
     if (getSizeX() == w && pad == 0) {
       for (int row=0; row<h; row++) {

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1100,7 +1100,7 @@ public class DicomReader extends FormatReader {
     if (skip) {
       long skipCount = (long) elementLength;
       if (in.getFilePointer() + skipCount <= in.length()) {
-        in.skipBytes((int) skipCount);
+        in.skipBytes(skipCount);
       }
       location += elementLength;
       value = "";

--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -125,7 +125,7 @@ public class EPSReader extends FormatReader {
       }
 
       byte[] b = new byte[w * h];
-      int bpp = (int) (byteCounts[0] / (getSizeX() * getSizeY()));
+      long bpp = byteCounts[0] / (getSizeX() * getSizeY());
       in.skipBytes(bpp * y * getSizeX());
       for (int row=0; row<h; row++) {
         in.skipBytes(x * bpp);

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -363,8 +363,8 @@ public class TiffParser implements Closeable {
     while (offset > 0 && offset < in.length()) {
       in.seek(offset);
       offsets.add(offset);
-      int nEntries = bigTiff ? (int) in.readLong() : in.readUnsignedShort();
-      int entryBytes = nEntries * bytesPerEntry;
+      long nEntries = bigTiff ? in.readLong() : in.readUnsignedShort();
+      long entryBytes = nEntries * bytesPerEntry;
       if (in.getFilePointer() + entryBytes + (bigTiff ? 8 : 4) > in.length()) {
         // this can easily happen when writing multiple planes to a file
         break;

--- a/components/formats-gpl/src/loci/formats/in/AliconaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AliconaReader.java
@@ -99,7 +99,7 @@ public class AliconaReader extends FormatReader {
     // so instead of LMLMLM... storage, we have LLLLL...MMMMM...
     for (int i=0; i<numBytes; i++) {
       in.seek(textureOffset + (no * planeSize * (i + 1)));
-      in.skipBytes(y * (getSizeX() + pad));
+      in.skipBytes((long) y * (getSizeX() + pad));
       if (getSizeX() == w) {
         in.read(buf, i * w * h, w * h);
       }

--- a/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
@@ -116,7 +116,7 @@ public class BioRadGelReader extends FormatReader {
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int pixel = bpp * getSizeC();
 
-    in.skipBytes(pixel * getSizeX() * (getSizeY() - h - y));
+    in.skipBytes((long) pixel * getSizeX() * (getSizeY() - h - y));
 
     for (int row=h-1; row>=0; row--) {
       in.skipBytes(x * pixel);

--- a/components/formats-gpl/src/loci/formats/in/BioRadReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadReader.java
@@ -373,7 +373,7 @@ public class BioRadReader extends FormatReader {
     // skip image data
     int imageLen = getSizeX() * getSizeY();
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
-    in.skipBytes(bpp * getImageCount() * imageLen + 6);
+    in.skipBytes((long) bpp * getImageCount() * imageLen + 6);
 
     m.sizeZ = getImageCount();
     m.sizeC = 1;
@@ -538,7 +538,7 @@ public class BioRadReader extends FormatReader {
     throws IOException
   {
     s.seek(70);
-    int imageLen = getSizeX() * getSizeY();
+    long imageLen = getSizeX() * getSizeY();
     if (picFiles == null) imageLen *= getImageCount();
     else {
       imageLen *= (getImageCount() / picFiles.length);

--- a/components/formats-gpl/src/loci/formats/in/HISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HISReader.java
@@ -140,8 +140,8 @@ public class HISReader extends FormatReader {
         if (getBitsPerPixel() == 12) {
           core.get(i - 1).bitsPerPixel = 16;
 
-          int prevSkip = (getSizeX() * getSizeY() * getSizeC() * 12) / 8;
-          int totalBytes = FormatTools.getPlaneSize(this);
+          long prevSkip = ((long) getSizeX() * getSizeY() * getSizeC() * 12) / 8;
+          long totalBytes = FormatTools.getPlaneSize(this);
           in.skipBytes(totalBytes - prevSkip);
           adjustedBitDepth = true;
         }

--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -390,7 +390,7 @@ public class IMODReader extends FormatReader {
         int surface = in.readShort();
 
         // TODO
-        in.skipBytes(12 * vsize + 4 * lsize);
+        in.skipBytes((long) 12 * vsize + (long) 4 * lsize);
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/IPLabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPLabReader.java
@@ -310,7 +310,7 @@ public class IPLabReader extends FormatReader {
         store.setROIID(roiID, 0);
         store.setImageROIRef(roiID, 0, 0);
 
-        in.skipBytes(8 * numRoiPts);
+        in.skipBytes((long) 8 * numRoiPts);
       }
       else if (tag.equals("mask")) {
         // read in Segmentation Mask

--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -208,7 +208,7 @@ public class ImspectorReader extends FormatReader {
     }
     m.pixelType = FormatTools.UINT16;
     int bpp = FormatTools.getBytesPerPixel(m.pixelType);
-    in.skipBytes(m.sizeX * m.sizeY * planesPerBlock.get(0) * bpp + 2);
+    in.skipBytes((long) m.sizeX * m.sizeY * planesPerBlock.get(0) * bpp + 2);
 
     int tileX = 1;
     int tileY = 1;
@@ -655,7 +655,7 @@ public class ImspectorReader extends FormatReader {
       planesPerBlock.get(planesPerBlock.size() - 1) * 2;
     if (planeSize > 0 && in.getFilePointer() + planeSize < in.length()) {
       pixelsOffsets.add(in.getFilePointer());
-      in.skipBytes((int) planeSize + 2);
+      in.skipBytes(planeSize + 2);
     }
     else {
       planesPerBlock.remove(planesPerBlock.size() - 1);

--- a/components/formats-gpl/src/loci/formats/in/IvisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IvisionReader.java
@@ -109,7 +109,7 @@ public class IvisionReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int planeSize = getSizeX() * getSizeY() * getSizeC();
+    long planeSize = (long) getSizeX() * getSizeY() * getSizeC();
     if (color16) planeSize = 2 * (planeSize / 3);
     else if (squareRoot) planeSize *= 2;
     else if (hasPaddingByte) {
@@ -129,15 +129,15 @@ public class IvisionReader extends FormatReader {
     }
     else if (hasPaddingByte) {
       int next = 0;
-      in.skipBytes(y * getSizeX() * getSizeC());
+      in.skipBytes((long) y * getSizeX() * getSizeC());
       for (int row=0; row<h; row++) {
-        in.skipBytes(x * getSizeC());
+        in.skipBytes((long) x * getSizeC());
         for (int col=0; col<w; col++) {
           in.skipBytes(1);
           in.read(buf, next, getSizeC());
           next += getSizeC();
         }
-        in.skipBytes(getSizeC() * (getSizeX() - w - x));
+        in.skipBytes((long) getSizeC() * (getSizeX() - w - x));
       }
     }
     else readPlane(in, x, y, w, h, buf);

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -328,7 +328,7 @@ public class LIFReader extends FormatReader {
     long planeSize = (long) getSizeX() * getSizeY() * bpp;
     long nextOffset = index + 1 < offsets.size() ?
       offsets.get(index + 1).longValue() : endPointer;
-    int bytesToSkip = (int) (nextOffset - offset - planeSize * getImageCount());
+    long bytesToSkip = nextOffset - offset - planeSize * getImageCount();
     bytesToSkip /= getSizeY();
     if ((getSizeX() % 4) == 0) bytesToSkip = 0;
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -1079,7 +1079,7 @@ public class LeicaReader extends FormatReader {
     addSeriesMeta("Maximum voxel intensity", getString(true));
     addSeriesMeta("Minimum voxel intensity", getString(true));
     int len = in.readInt();
-    in.skipBytes(len * 2 + 4);
+    in.skipBytes((long) len * 2 + 4);
 
     len = in.readInt();
     for (int j=0; j<len; j++) {

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -231,7 +231,7 @@ public class LiFlimReader extends FormatReader {
       int thisSeries = getSeries();
       for (int i=0; i<thisSeries; i++) {
         setSeries(i);
-        in.skipBytes(getImageCount() * FormatTools.getPlaneSize(this));
+        in.skipBytes((long) getImageCount() * FormatTools.getPlaneSize(this));
       }
       setSeries(thisSeries);
       readPlane(in, x, y, w, h, buf);

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1680,7 +1680,7 @@ public class MetamorphReader extends BaseTiffReader {
           hasAbsoluteZValid = true;
           break;
         case 46:
-          in.skipBytes(mmPlanes * 8); // TODO
+          in.skipBytes((long) mmPlanes * 8); // TODO
           break;
         default:
           in.skipBytes(4);

--- a/components/formats-gpl/src/loci/formats/in/NAFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NAFReader.java
@@ -145,7 +145,7 @@ public class NAFReader extends FormatReader {
       String name = in.readCString();
 
       if (i == 0) {
-        in.skipBytes((int) (92 - in.getFilePointer() + pointer));
+        in.skipBytes(92 - in.getFilePointer() + pointer);
         while (true) {
           int check = in.readInt();
           if (check > in.getFilePointer()) {

--- a/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
@@ -395,7 +395,7 @@ public class OpenlabReader extends FormatReader {
         in.skipBytes(16);
         long pointer = in.getFilePointer();
         planes[imagesFound].planeName = readCString().trim();
-        in.skipBytes((int) (256 - in.getFilePointer() + pointer));
+        in.skipBytes(256 - in.getFilePointer() + pointer);
 
         planes[imagesFound].planeOffset = in.getFilePointer();
 

--- a/components/formats-gpl/src/loci/formats/in/PSDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PSDReader.java
@@ -274,7 +274,7 @@ public class PSDReader extends FormatReader {
         int[] lens = new int[h[i]];
         for (int cc=0; cc<c[i]; cc++) {
           boolean compressed = in.readShort() == 1;
-          if (!compressed) in.skipBytes(w[i] * h[i]);
+          if (!compressed) in.skipBytes((long) w[i] * h[i]);
           else {
             for (int y=0; y<h[i]; y++) {
               lens[y] = in.readShort();

--- a/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
@@ -248,7 +248,7 @@ public class PhotoshopTiffReader extends BaseTiffReader {
             addGlobalMetaList("Layer name", layerNames[layer]);
             core.add(layerCore);
           }
-          tag.skipBytes((int) (fp + len - tag.getFilePointer()));
+          tag.skipBytes(fp + len - tag.getFilePointer());
         }
 
         nLayers = core.size() - 1;
@@ -282,7 +282,7 @@ public class PhotoshopTiffReader extends BaseTiffReader {
           }
         }
       }
-      else tag.skipBytes(length + skip);
+      else tag.skipBytes((long) length + skip);
     }
 
     MetadataStore store = makeFilterMetadata();

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -178,7 +178,7 @@ public class SDTReader extends FormatReader {
     if (info.mcstaPoints == getSizeT()) {
       times = getSizeT();
     }
-    int planeSize = paddedWidth * sizeY * times * bpp;
+    long planeSize = (long) paddedWidth * sizeY * times * bpp;
 
     // remove width padding if we can be reasonably certain
     // that the unpadded width is correct
@@ -316,11 +316,12 @@ public class SDTReader extends FormatReader {
         codec.skip(channel * planeSize + y * paddedWidth * bpp * times);
       }
       else {
-        in.skipBytes(channel * planeSize + y * paddedWidth * bpp * times);
+        in.skipBytes(
+          channel * planeSize + (long) y * paddedWidth * bpp * times);
       }
 
       for (int row = 0; row < h; row++) {
-        readPixels(rowBuf, in, codec, x * bpp * times);
+        readPixels(rowBuf, in, codec, (long) x * bpp * times);
         if (intensity) {
           System.arraycopy(rowBuf, 0, b, row * bpp * times * w, b.length);
         }
@@ -334,7 +335,7 @@ public class SDTReader extends FormatReader {
           }
         }
         if (codec == null) {
-          in.skipBytes(bpp * times * (paddedWidth - x - w));
+          in.skipBytes((long) bpp * times * (paddedWidth - x - w));
         }
         else {
           codec.skip(bpp * times * (paddedWidth - x - w));
@@ -469,7 +470,7 @@ public class SDTReader extends FormatReader {
     MetadataTools.populatePixels(store, this);
   }
 
-  private void readPixels(byte[] rowBuf, RandomAccessInputStream in, ZipInputStream codec, int skip)
+  private void readPixels(byte[] rowBuf, RandomAccessInputStream in, ZipInputStream codec, long skip)
     throws IOException
   {
     if (codec == null) {

--- a/components/formats-gpl/src/loci/formats/in/SlidebookReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlidebookReader.java
@@ -668,7 +668,7 @@ public class SlidebookReader extends FormatReader {
           in.seek(in.getFilePointer() - 1);
           long nSkipped = in.getFilePointer() - fp;
           if (nSkipped < 8) {
-            in.skipBytes((int) (8 - nSkipped));
+            in.skipBytes(8 - nSkipped);
           }
           String objective = readCString().trim();
           in.seek(fp + 144);

--- a/components/formats-gpl/src/loci/formats/in/TargaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TargaReader.java
@@ -95,8 +95,8 @@ public class TargaReader extends FormatReader {
     while (bpp % 8 != 0) bpp++;
     bpp /= 8;
 
-    int rowSkip = orientation < 2 ? (getSizeY() - h - y) : y;
-    int colSkip = (orientation % 2) == 1 ? (getSizeX() - w - x) : x;
+    long rowSkip = orientation < 2 ? (getSizeY() - h - y) : y;
+    long colSkip = (orientation % 2) == 1 ? (getSizeX() - w - x) : x;
 
     try {
       s.skipBytes(rowSkip * getSizeX() * bpp);

--- a/components/formats-gpl/src/loci/formats/in/VisitechReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VisitechReader.java
@@ -129,8 +129,8 @@ public class VisitechReader extends FormatReader {
       s.order(isLittleEndian());
       s.seek(pixelOffsets[fileIndex]);
 
-      int paddingBytes =
-          (int) (s.length() - s.getFilePointer() - div * plane) / (div - 1);
+      long paddingBytes =
+        (s.length() - s.getFilePointer() - div * plane) / (div - 1);
       if (planeIndex > 0) {
         s.skipBytes((plane + paddingBytes) * planeIndex);
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
@@ -89,7 +89,7 @@ public class ZeissLMSReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     in.seek(offsets.get(getSeriesCount() - getSeries() - 1));
-    in.skipBytes(no * FormatTools.getPlaneSize(this));
+    in.skipBytes((long) no * FormatTools.getPlaneSize(this));
     readPlane(in, x, y, w, h, buf);
 
     return buf;
@@ -144,7 +144,7 @@ public class ZeissLMSReader extends FormatReader {
     seekToNextMarker();
     in.skipBytes(50);
     offsets.add(in.getFilePointer());
-    in.skipBytes(thumb.sizeX * thumb.sizeY * thumb.sizeC);
+    in.skipBytes((long) thumb.sizeX * thumb.sizeY * thumb.sizeC);
 
     seekToNextMarker();
     in.skipBytes(50);

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -598,7 +598,7 @@ public class ZeissZVIReader extends BaseZeissReader {
       int length = s.readInt();
 
       Shape nshape = new Shape();
-      s.skipBytes(length + 6);
+      s.skipBytes((long) length + 6);
 
       long shapeAttrOffset = s.getFilePointer();
       int shapeAttrLength = s.readInt();


### PR DESCRIPTION
Inspired by https://github.com/ome/bioformats/pull/3519, https://github.com/ome/bioformats/pull/3303, and https://github.com/ome/bioformats/pull/3157.  This uses ```skipBytes(long)``` in more places where integer overflow seems plausible.

I would expect this to be safe for a patch release and have no impact on tests.  I don't anticipate this will fix any outstanding issues, it's just an attempt at being more defensive.