### PR TITLE
Add standard GPL-2 license to MikroscanTiffReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MikroscanTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MikroscanTiffReader.java
@@ -1,8 +1,28 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/*-
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2019 - 2020 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
  */
+
 package loci.formats.in;
 
 import java.io.IOException;


### PR DESCRIPTION
The reader was added in #3333 but the correct license was not included back then. This updates the file header using the standard assumptions in terms of license and copyright owner holders.