### PR TITLE
CellWorX: add support for single site HCS variant

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -217,7 +217,7 @@ public class CellWorxReader extends FormatReader {
     }
 
     int planeIndex = no;
-    if (lastReader.getSeriesCount() == fieldCount) {
+    if (lastReader.getSeriesCount() == fieldCount && fieldCount > 1) {
       lastReader.setSeries(fieldIndex);
     }
     else if (lastReader.getImageCount() == getSizeZ()) {

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -362,6 +362,12 @@ public class CellWorxReader extends FormatReader {
       }
     }
 
+    // If the acquisition only contains one site, the SiteSelection1 key
+    // might be asent. In that case, assume the field was selected.
+    if (xFields == 1 && yFields == 1) {
+      fieldMap[0][0] = true;
+    }
+
     for (int row=0; row<fieldMap.length; row++) {
       for (int col=0; col<fieldMap[row].length; col++) {
         if (fieldMap[row][col]) fieldCount++;

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -335,7 +335,18 @@ public class CellWorxReader extends FormatReader {
       }
       else if (key.equals("YSites")) {
         yFields = Integer.parseInt(value);
-        fieldMap = new boolean[yFields][xFields];
+        // if no site acquisition ("Sites" == "FALSE"),
+        // don't overwrite the single-site field map
+        if (fieldMap == null) {
+          fieldMap = new boolean[yFields][xFields];
+        }
+      }
+      else if (key.equals("Sites")) {
+        // field acquisition may be turned off with
+        // XSites and YSites both greater than 1
+        if (value.equalsIgnoreCase("false")) {
+          fieldMap = new boolean[][] {{true}};
+        }
       }
       else if (key.equals("TimePoints")) {
         nTimepoints = Integer.parseInt(value);


### PR DESCRIPTION
The number of well samples/fields of view per well is computed from the total number of acquisition sites and the number of selected sites, determined by XSites, YSites and the SiteSelection<index> entries in the HTD file.

For single site acquisitions (XSites=1, YSites=1), the SiteSelection1 key might be absent from the HTD files. This commit updates the reader to assume the single site is selected.