### PR TITLE
Metamorph: don't allow underlying TIFF reader to treat each IFD as a series

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -171,6 +171,7 @@ public class MetamorphReader extends BaseTiffReader {
     suffixSufficient = false;
     datasetDescription = "One or more .stk or .tif/.tiff files plus an " +
       "optional .nd or .scan file";
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --


### PR DESCRIPTION
Instead, trust dimension from tag metadata and/or .nd file.  Backported from a private PR.

I wouldn't expect this to have any impact on tests.  I will put together a test file in the next day or two once it's clear that this does not break anything.