### PR TITLE
Deltavision: sanity check the panel count and fall back to old style header

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -351,12 +351,23 @@ public class DeltavisionReader extends FormatReader {
     if (fileType == NEW_TYPE) {
       in.seek(852);
       int secondaryT = in.readInt();
-      if (secondaryT > 0 && (rawSizeT <= 0 || rawSizeT == 65535)) {
-        rawSizeT = secondaryT;
-      }
       in.seek(880);
       numPanels = in.readInt();
       in.seek(182);
+
+      // if unreasonable data found, assume that an old header
+      // version is used in spite of the newer file type ID
+      // maybe happens when files are processed in other software?
+      if (numPanels < 0 || numPanels > (in.length() / (sizeX * sizeY))) {
+        fileType = 0;
+        numPanels = 0;
+      }
+      else {
+        // if the panel data looks reasonable, then the T value can be trusted
+        if (secondaryT > 0 && (rawSizeT <= 0 || rawSizeT == 65535)) {
+          rawSizeT = secondaryT;
+        }
+      }
     }
     int sizeT = rawSizeT == 0 ? 1 : rawSizeT;
 


### PR DESCRIPTION
Backported from a private PR.

Some files have the file type value set to indicate a "new" header format,
but actually have an "old" header format.  This causes the panel/series count
to be wildly inaccurate, which in extreme cases can trigger an ```OutOfMemoryError```.
A basic check on the number of detected panels allows the reader to fall
back to parsing an "old" header instead.

An artificial test file created from one of the public samples is in ```inbox/dv-bad-header``` (see the readme in that directory).  Without this PR, ```showinf``` on the test file should eventually throw an ```OutOfMemoryError```.  With this PR, images should be displayed without error and the output should match the original file from which the test was created.