### PR TITLE
Bump ome-model version to 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.4</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.0.1</ome-model.version>
+    <ome-model.version>6.1.0</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>


### PR DESCRIPTION
See https://github.com/ome/ome-model/blob/v6.1.0/NEWS.md for the list of changes

The latest version of ome-model has been pulled in the daily merge CI builds so I expect tests will keep passing.

Bumping the  component version in the pom.xml is necessary to consume the new `OME Creator` API - see #3541.