### PR TITLE
Zeiss CZI: fix position count when the starting index is > 0

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1694,6 +1694,9 @@ public class ZeissCZIReader extends FormatReader {
 
     ArrayList<Integer> uniqueT = new ArrayList<Integer>();
 
+    int minPositions = Integer.MAX_VALUE;
+    int maxPositions = Integer.MIN_VALUE;
+
     for (SubBlock plane : planes) {
       if (xyOnly && plane.coreIndex != coreIndex) {
         continue;
@@ -1764,8 +1767,11 @@ public class ZeissCZIReader extends FormatReader {
             }
             break;
           case 'S':
-            if (dimension.start >= positions) {
-              positions = dimension.start + 1;
+            if (dimension.start < minPositions) {
+              minPositions = dimension.start;
+            }
+            if (dimension.start > maxPositions) {
+              maxPositions = dimension.start;
             }
             break;
           case 'I':
@@ -1798,6 +1804,7 @@ public class ZeissCZIReader extends FormatReader {
         }
       }
     }
+    positions = maxPositions - minPositions + 1;
     setCoreIndex(previousCoreIndex);
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1804,7 +1804,9 @@ public class ZeissCZIReader extends FormatReader {
         }
       }
     }
-    positions = maxPositions - minPositions + 1;
+    if (maxPositions > Integer.MIN_VALUE && minPositions < Integer.MAX_VALUE) {
+      positions = maxPositions - minPositions + 1;
+    }
     setCoreIndex(previousCoreIndex);
   }
 


### PR DESCRIPTION
Backported from a private PR.

This is meant to fix a case where only one position is present, but the starting index is 10.  The file contains a pyramid, so an incorrect position count completely throws off pyramid building logic.

If this doesn't fail tests, additional commits could be added (here or in a separate PR) to calculate the illumination, phase, etc. dimensions similarly.  I'll find or put together a test file once it's clear that this doesn't break any existing files.