### PR TITLE
DICOM: do not check other directories for matching files

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1291,18 +1291,7 @@ public class DicomReader extends FormatReader {
       Location currentFile = new Location(currentId).getAbsoluteFile();
       Location directory = currentFile.getParentFile();
 
-      // move up a directory and look for other directories that
-      // could contain matching files
-
-      directory = directory.getParentFile();
-      String[] subdirs = directory.list(true);
-      if (subdirs != null) {
-        for (String subdir : subdirs) {
-          Location f = new Location(directory, subdir).getAbsoluteFile();
-          if (!f.isDirectory()) continue;
-          scanDirectory(f, true);
-        }
-      }
+      scanDirectory(directory, true);
 
       for (final List<String> files : fileList.values()) {
         final Iterator<String> fileIterator = files.iterator();


### PR DESCRIPTION
Files spread across multiple directories are now handled by a ```DICOMDIR``` file that groups everything together.  See previous work in #2785 and #3222.

Main thing to check is that this has no impact on existing tests.  I would expect this to speed up initialization of multi-file datasets, especially in a directory structure similar to:

```
/path/to/dicom/set/1/
/path/to/dicom/set/2/
```

with each fileset containing hundreds or thousands of files.

Not urgent for 6.5.0; assuming tests pass, should be safe for a later patch release.