### PR TITLE
BDV: Fix for tiled reading

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -282,7 +282,7 @@ public class BDVReader extends FormatReader {
     lastChannel = getZCTCoords(no)[1];
 
     // pixel data is stored in XYZ blocks
-    Object image = getImageData(no, y, h);
+    Object image = getImageData(no, x, y, w, h);
 
     boolean little = isLittleEndian();
 
@@ -370,13 +370,12 @@ public class BDVReader extends FormatReader {
     }
   }
 
-  private Object getImageData(int no, int y, int height) throws FormatException
+  private Object getImageData(int no, int x, int y, int width, int height) throws FormatException
   {
     int[] zct = getZCTCoords(no);
     int zslice = zct[0];
     int channel = zct[1];
     int time = zct[2];
-    int width = getSizeX();
     
     int seriesIndex = series;
     int requiredResolution = getResolution();
@@ -427,7 +426,7 @@ public class BDVReader extends FormatReader {
 
     int elementSize = jhdf.getElementSize(imagePath.pathToImageData);
 
-    int[] arrayOrigin = new int[] {zslice, y, 0};
+    int[] arrayOrigin = new int[] {zslice, y, x};
     int[] arrayDimension = new int[] {1, height, width};
 
     MDIntArray subBlock = jhdf.readIntBlockArray(imagePath.pathToImageData, arrayOrigin, arrayDimension);

--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -299,26 +299,26 @@ public class BDVReader extends FormatReader {
         short[][] data = (short[][]) image;
         short[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(rowData[i + x], buf, base + 2 * i, 2, little);
+          DataTools.unpackBytes(rowData[i], buf, base + 2 * i, 2, little);
         }
       } else if (image instanceof int[][]) {
         int[][] data = (int[][]) image;
         int[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(rowData[i + x], buf, base + i * 4, 4, little);
+          DataTools.unpackBytes(rowData[i], buf, base + i * 4, 4, little);
         }
       } else if (image instanceof float[][]) {
         float[][] data = (float[][]) image;
         float[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          int v = Float.floatToIntBits(rowData[i + x]);
+          int v = Float.floatToIntBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i * 4, 4, little);
         }
       } else if (image instanceof double[][]) {
         double[][] data = (double[][]) image;
         double[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          long v = Double.doubleToLongBits(rowData[i + x]);
+          long v = Double.doubleToLongBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i * 8, 8, little);
         }
       }


### PR DESCRIPTION
This fix should greatly improve the performance when reading BDV data in a tiled manner, specifically this should help improve performance in IDR.

This fixes a bug where previously the entire row was being read and then the tile read from it, this fix now takes the x offset and tile width into account when retrieving the pixel data.

To test:
- Open any of the existing BDV samples and verify that the pixel data remains accurate
- Ensure builds and tests remain green