### PR TITLE
Image converter: fix multi-series regression

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -578,10 +578,9 @@ public final class ImageConverter {
           writer.setMetadataRetrieve((MetadataRetrieve) meta);
         }
         else {
+          meta.setPixelsSizeX(new PositiveInteger(width), 0);
+          meta.setPixelsSizeY(new PositiveInteger(height), 0);
           for (int i=0; i<reader.getSeriesCount(); i++) {
-            meta.setPixelsSizeX(new PositiveInteger(width), i);
-            meta.setPixelsSizeY(new PositiveInteger(height), i);
-
             if (autoscale) {
               store.setPixelsType(PixelType.UINT8, i);
             }

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -66,6 +66,7 @@ public class ImageConverterTest {
   private Path tempDir;
   private File outFile;
   private int width = 512;
+  private int resolutionCount;
   private final SecurityManager oldSecurityManager = System.getSecurityManager();
   private final PrintStream oldOut = System.out;
   private final PrintStream oldErr = System.err;
@@ -98,6 +99,7 @@ public class ImageConverterTest {
     tempDir = Files.createTempDirectory(this.getClass().getName());
     tempDir.toFile().deleteOnExit();
     width = 512;
+    resolutionCount = 1;
   }
 
   @AfterMethod
@@ -125,8 +127,10 @@ public class ImageConverterTest {
 
   public void checkImage(String outFileToCheck, int expectedWidth) throws FormatException, IOException {
     IFormatReader r = new ImageReader();
+    r.setFlattenedResolutions(false);
     r.setId(outFileToCheck);
     assertEquals(r.getSizeX(), expectedWidth);
+    assertEquals(r.getResolutionCount(), resolutionCount);
     r.close();
   }
 
@@ -307,5 +311,24 @@ public class ImageConverterTest {
     String [] args = new String[argsList.size()];
     File outFileToCheck = outFile = tempDir.resolve("seperate-tiles_0_0_0.ome.tiff").toFile();
     assertConversion(argsList.toArray(args), outFileToCheck.getAbsolutePath(), 256);
+  }
+  
+  @Test
+  public void testConvertResolutionsFlattened() throws FormatException, IOException {
+    outFile = tempDir.resolve("resoutions_flat.ome.tiff").toFile();
+    String[] args = {
+      "test&resolutions=2.fake", outFile.getAbsolutePath()
+    };
+    assertConversion(args);
+  }
+
+  @Test
+  public void testConvertResolutions() throws FormatException, IOException {
+    outFile = tempDir.resolve("resolutions_noflat.ome.tiff").toFile();
+    String[] args = {
+      "-noflat", "test&resolutions=2.fake", outFile.getAbsolutePath()
+    };
+    resolutionCount = 2;
+    assertConversion(args);
   }
 }


### PR DESCRIPTION
Reported in https://forum.image.sc/t/bfconvert-throwing-an-error-for-an-vsi-file/37185, this fixes a regression introduced in #3518 for multi-series files with varying image sizes

`bfconvert "test&resolutions=2.fake" out.ome.tiff` should suffice to reproduce the issue reported in the forum thread. 205dae6  fixes the issue by only setting the pixel X and Y sizes to the first image. 5561dbb adds a simple test to `ImageConverterTest` which should fail without the fix and pass with it.