### PR TITLE
Add Zarr Reader and Writer

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -100,6 +100,7 @@ loci.formats.in.SPEReader             # spe
 loci.formats.in.OIRReader             # oir
 loci.formats.in.KLBReader             # klb
 loci.formats.in.MicroCTReader         # vff
+loci.formats.in.ZarrReader            # zarr
 
 # multi-extension messes
 loci.formats.in.JEOLReader            # dat, img, par

--- a/components/formats-api/src/loci/formats/writers.txt
+++ b/components/formats-api/src/loci/formats/writers.txt
@@ -19,3 +19,4 @@ loci.formats.out.V3DrawWriter	# v3draw
 # writers requiring third-party libraries
 loci.formats.out.WlzWriter	# wlz
 loci.formats.out.CellH5Writer 	# ch5
+loci.formats.out.ZarrWriter     # zarr

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -170,6 +170,13 @@
     	<artifactId>json</artifactId>
     	<version>20090211</version>
     </dependency>
+    
+    <dependency>
+      <groupId>com.bc.zarr</groupId>
+      <artifactId>jzarr</artifactId>
+      <version>0.2</version>
+    </dependency>
+
   </dependencies>
 
   <properties>
@@ -388,9 +395,15 @@
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
     <repository>
+      <id>bc-nexus-repo</id>
+      <name>Brockmann-Consult Public Maven Repository</name>
+      <url>http://nexus.senbox.net/nexus/content/groups/public/</url>
+   </repository>
+    <repository>
       <id>imagej.public</id>
       <name>ImageJ Maven repositrory</name>
       <url>https://maven.imagej.net/content/groups/public</url>
     </repository>
+
   </repositories>
 </project>

--- a/components/formats-gpl/src/loci/formats/in/ZarrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZarrReader.java
@@ -1,0 +1,242 @@
+package loci.formats.in;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import loci.common.DataTools;
+import loci.common.Location;
+import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.MissingLibraryException;
+import loci.formats.meta.MetadataStore;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.ZarrServiceImpl;
+import ome.xml.meta.MetadataConverter;
+import loci.formats.services.OMEXMLService;
+import loci.formats.services.ZarrService;
+
+
+public class ZarrReader extends FormatReader  {
+
+  private transient ZarrService zarrService;
+  
+  public ZarrReader() {
+    super("Zarr", "zarr");
+    suffixSufficient = true;
+    domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+  }
+  
+  /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
+  @Override
+  public boolean isThisType(String name, boolean open) {
+    Location zarrFolder = new Location(name).getParentFile();
+    if (zarrFolder != null && zarrFolder.exists() && zarrFolder.getAbsolutePath().indexOf(".zarr") > 0) {
+      return true;
+    }
+    return super.isThisType(name, open);
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    return zarrService.getChunkSize()[1];
+  }
+  
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    return zarrService.getChunkSize()[0];
+  }
+  
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
+    Location zarrFolder = new Location( id ).getParentFile();
+    String zarrPath = zarrFolder.getAbsolutePath();
+    String name = zarrPath.substring(zarrPath.lastIndexOf("/")+1, zarrPath.indexOf(".zarr"));
+    Location omeMetaFile = new Location( zarrFolder, name+".ome.xml" );
+    if ( !omeMetaFile.exists() ) { throw new IOException( "Could not find " + omeMetaFile + " in folder." ); }
+    
+    /*
+     * Open OME metadata file
+     */
+
+    RandomAccessInputStream measurement =
+      new RandomAccessInputStream(omeMetaFile.getAbsolutePath());
+    Document omeDocument = null;
+    try {
+      omeDocument = XMLTools.parseDOM(measurement);
+    }
+    catch (ParserConfigurationException e) {
+      throw new IOException(e);
+    }
+    catch (SAXException e) {
+      throw new IOException(e);
+    }
+    finally {
+      measurement.close();
+    }
+    omeDocument.getDocumentElement().normalize();
+    
+    OMEXMLService service = null;
+    String xml = null;
+    try
+    {
+      xml = XMLTools.getXML( omeDocument );
+    }
+    catch (TransformerException e2 )
+    {
+      LOGGER.debug( "", e2 );
+    }
+    OMEXMLMetadata omexmlMeta = null;
+    try
+    {
+      service = new ServiceFactory().getInstance( OMEXMLService.class );
+      omexmlMeta = service.createOMEXMLMetadata( xml );
+    }
+    catch (DependencyException | ServiceException | NullPointerException e1 )
+    {
+      LOGGER.debug( "", e1 );
+    }
+
+    int numDatasets = omexmlMeta.getImageCount();
+
+    int oldSeries = getSeries();
+    core.clear();
+    for (int i=0; i<numDatasets; i++) {
+      CoreMetadata ms = new CoreMetadata();
+      core.add(ms);
+
+      setSeries(i);
+
+      Integer w = omexmlMeta.getPixelsSizeX(i).getValue();
+      Integer h = omexmlMeta.getPixelsSizeY(i).getValue();
+      Integer t = omexmlMeta.getPixelsSizeT(i).getValue();
+      Integer z = omexmlMeta.getPixelsSizeZ(i).getValue();
+      Integer c = omexmlMeta.getPixelsSizeC(i).getValue();
+      if (w == null || h == null || t == null || z == null | c == null) {
+        throw new FormatException("Image dimensions not found");
+      }
+
+      Boolean endian = null;
+      String pixType = omexmlMeta.getPixelsType(i).toString();
+      ms.dimensionOrder = omexmlMeta.getPixelsDimensionOrder(i).toString();
+      ms.sizeX = w.intValue();
+      ms.sizeY = h.intValue();
+      ms.sizeT = t.intValue();
+      ms.sizeZ = z.intValue();
+      ms.sizeC = c.intValue();
+      ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
+      ms.littleEndian = endian == null ? false : !endian.booleanValue();
+      ms.rgb = false;
+      ms.interleaved = false;
+      ms.indexed = false;
+      ms.falseColor = true;
+      ms.pixelType = FormatTools.pixelTypeFromString(pixType);
+      ms.orderCertain = true;
+      if (omexmlMeta.getPixelsSignificantBits(i) != null) {
+        ms.bitsPerPixel = omexmlMeta.getPixelsSignificantBits(i).getValue();
+      }
+    }
+    setSeries(oldSeries);
+    final MetadataStore store = makeFilterMetadata();
+    MetadataConverter.convertMetadata( omexmlMeta, store );
+    MetadataTools.populatePixels( store, this, true );
+
+    initializeZarrService(zarrPath);
+  }
+
+  /* @see loci.formats.FormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    try {
+      initializeZarrService(currentId);
+    }
+    catch (FormatException e) {
+      throw new IOException(e);
+    }
+  }
+
+  // -- Helper methods --
+
+  private void initializeZarrService(String id) throws IOException, FormatException {
+    try {
+      ServiceFactory factory = new ServiceFactory();
+      zarrService = factory.getInstance(ZarrService.class);
+      zarrService.open(id);
+    } catch (DependencyException e) {
+      throw new MissingLibraryException(ZarrServiceImpl.NO_ZARR_MSG, e);
+    }
+  }
+  
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h) throws FormatException, IOException {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    int[] coordinates = getZCTCoords(no);
+    int [] shape = {w, h, 1, 1, 1};
+    int [] offsets = {x, y, coordinates[0], coordinates[1], coordinates[2]};
+    Object image = zarrService.readBytes(shape, offsets);
+
+    boolean little = zarrService.isLittleEndian();
+    int bpp = FormatTools.getBytesPerPixel(zarrService.getPixelType());
+    if (image instanceof byte[]) {
+      buf = (byte []) image;
+    }
+    else if (image instanceof short[]) {
+      short[] data = (short[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 2 * i, 2, little);
+        }
+      }
+    }
+    else if (image instanceof int[]) {
+      int[] data = (int[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 4 * i, 4, little);
+        }
+      }
+    }
+    else if (image instanceof float[]) {
+      float[] data = (float[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          int value = Float.floatToIntBits(data[(row * w) + i + x]);
+          DataTools.unpackBytes(value, buf, base + 4 * i, 4, little);
+        }
+      }
+    }
+    else if (image instanceof double[]) {
+      double[] data = (double[]) image;
+      for (int row = 0; row < h; row++) {
+        int base = row * w * bpp;
+        for (int i = 0; i < w; i++) {
+          long value = Double.doubleToLongBits(data[(row * w) + i + x]);
+          DataTools.unpackBytes(value, buf, base + 8 * i, 8, little);
+        }
+      }
+    }
+    return buf;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/ZarrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZarrReader.java
@@ -176,13 +176,14 @@ public class ZarrReader extends FormatReader  {
   // -- Helper methods --
 
   private void initializeZarrService(String id) throws IOException, FormatException {
-    try {
-      ServiceFactory factory = new ServiceFactory();
-      zarrService = factory.getInstance(ZarrService.class);
-      zarrService.open(id);
-    } catch (DependencyException e) {
-      throw new MissingLibraryException(ZarrServiceImpl.NO_ZARR_MSG, e);
-    }
+//    try {
+//      ServiceFactory factory = new ServiceFactory();
+//      zarrService = factory.getInstance(ZarrService.class);
+//      zarrService.open(id);
+//    } catch (DependencyException e) {
+//      throw new MissingLibraryException(ZarrServiceImpl.NO_ZARR_MSG, e);
+//    }
+    zarrService = new ZarrServiceImpl();
   }
   
   @Override

--- a/components/formats-gpl/src/loci/formats/out/ZarrWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/ZarrWriter.java
@@ -1,0 +1,208 @@
+package loci.formats.out;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+import java.util.UUID;
+
+import loci.common.Constants;
+import loci.common.Location;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.FormatWriter;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.ZarrServiceImpl;
+import ome.xml.meta.OMEXMLMetadataRoot;
+import loci.formats.services.OMEXMLService;
+import loci.formats.services.ZarrService;
+
+
+public class ZarrWriter extends FormatWriter {
+
+  // -- Fields --
+  private ZarrService zarrService = null;
+  private final int CHUNK_DEFAULT = 32;
+  private OMEXMLService service;
+  private OMEXMLMetadata omeMeta;
+  
+  
+  public ZarrWriter() {
+    this("Zarr", new String[] {"zarr"});
+  }
+ 
+  public ZarrWriter(String format, String[] exts) {
+    super(format, exts);
+  }
+  
+  
+  // -- IFormatWriter API methods --
+
+  /**
+   * @see loci.formats.IFormatWriter#saveBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public void saveBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    if(zarrService != null) {
+      checkParams(no, buf, x, y, w, h);
+      MetadataRetrieve meta = getMetadataRetrieve();
+      MetadataTools.verifyMinimumPopulated(meta, series);
+      
+      int zSize = meta.getPixelsSizeZ(series).getValue().intValue();
+      int cSize = meta.getPixelsSizeC(series).getValue().intValue();
+      int tSize = meta.getPixelsSizeT(series).getValue().intValue();
+      String order = meta.getPixelsDimensionOrder(series).toString();
+      int imageCount = getPlaneCount();
+      int[] coordinates = FormatTools.getZCTCoords(order, zSize, cSize, tSize, imageCount, no);
+      int [] shape = {w, h, 1, 1, 1};
+
+      int type = FormatTools.pixelTypeFromString(meta.getPixelsType(0).toString());
+      int bpp = FormatTools.getBytesPerPixel(type);
+      
+      int [] offsets = {x, y, coordinates[0], coordinates[1], coordinates[2]};
+      if (bpp==1) {
+        zarrService.saveBytes(buf, shape, offsets);
+      }
+      else if (bpp==2) {
+        ByteBuffer bb = ByteBuffer.wrap(buf);
+        ShortBuffer sb = bb.asShortBuffer();
+        short[] image = new short[w * h];
+        for (int x_i=0; x_i < w; x_i++) {
+            for (int y_i=0; y_i < h; y_i++) {
+                short value = sb.get(y_i*w + x_i);
+                image[y_i*w + x_i] = value;
+            }
+        }
+        zarrService.saveBytes(image, shape, offsets);
+      }
+      else if (bpp==4) {
+        ByteBuffer bb = ByteBuffer.wrap(buf);
+        IntBuffer sb = bb.asIntBuffer();
+        int[] image = new int[w * h];
+        for (int x_i=0; x_i < w; x_i++) {
+            for (int y_i=0; y_i < h; y_i++) {
+                int value = sb.get(y_i*w + x_i);
+                image[y_i*w + x_i] = value;
+            }
+        }
+        zarrService.saveBytes(image, shape, offsets);
+      }
+      else {
+        throw new FormatException("CellH5Writer: Pixel type not supported");
+      }
+    }
+  }
+  
+  /* @see loci.formats.IFormatWriter#canDoStacks() */
+  @Override
+  public boolean canDoStacks() {
+    return true;
+  }
+  
+  /* @see loci.formats.FormatWriter#setId(String) */
+  @Override
+  public void setId(String id) throws FormatException, IOException {
+    super.setId(id);
+    if(zarrService == null) {
+      try {
+        ServiceFactory factory = new ServiceFactory();
+        zarrService = factory.getInstance(ZarrService.class);
+      }
+      catch (DependencyException e) {
+        throw new FormatException(ZarrServiceImpl.NO_ZARR_MSG, e);
+      }
+    }
+    if(zarrService != null) {
+      if (!zarrService.isOpen() && zarrService.getID() != id) {
+        MetadataRetrieve meta = getMetadataRetrieve();
+        MetadataTools.verifyMinimumPopulated(meta, series);
+        int x = meta.getPixelsSizeX(series).getValue().intValue();
+        int y = meta.getPixelsSizeY(series).getValue().intValue();
+        int z = meta.getPixelsSizeZ(series).getValue().intValue();
+        int c = meta.getPixelsSizeC(series).getValue().intValue();
+        int t = meta.getPixelsSizeT(series).getValue().intValue();
+        int [] shape = {x, y, z, c, t};
+        int chunkX = getTileSizeX();
+        int chunkY = getTileSizeY();
+        boolean usingTiling = chunkX > 0 && chunkY > 0;
+        if (!usingTiling) {
+          chunkX = CHUNK_DEFAULT;
+          chunkY = CHUNK_DEFAULT;
+        }
+        int [] chunks = {chunkX, chunkY, 1, 1, 1};
+        int pixelType = FormatTools.pixelTypeFromString(
+            meta.getPixelsType(series).toString());
+   
+        zarrService.create(id, shape, chunks, pixelType, !meta.getPixelsBigEndian(series));
+      }
+    }
+  }
+  
+  /* @see loci.formats.IFormatHandler#close() */
+  @Override
+  public void close() throws IOException {
+    try {
+      if (currentId != null) {
+        setupServiceAndMetadata();
+        Location zarrFolder = new Location( currentId ).getAbsoluteFile();
+        String name = currentId.substring(currentId.lastIndexOf("/")+1, currentId.indexOf(".zarr"));
+        Location omeMetaFile = new Location( zarrFolder, name+".ome.xml" );
+        String companionXML = getOMEXML(omeMetaFile.getAbsolutePath());
+        PrintWriter out = new PrintWriter(omeMetaFile.getAbsolutePath(), Constants.ENCODING);
+        out.println(XMLTools.indentXML(companionXML, true));
+        out.close();
+      }
+    }
+    catch (DependencyException | ServiceException | FormatException | IllegalArgumentException ex) {
+      throw new RuntimeException(ex);
+    }
+    finally {
+      super.close();
+    }
+  }
+    
+  private String getOMEXML(String file) throws FormatException, IOException {
+    // generate UUID and add to OME element
+    String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
+    omeMeta.setUUID(uuid);
+
+    OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) omeMeta.getRoot();
+    root.setCreator(FormatTools.CREATOR);
+
+    String xml;
+    try {
+      xml = service.getOMEXML(omeMeta);
+    }
+    catch (ServiceException se) {
+      throw new FormatException(se);
+    }
+    return xml;
+  }
+    
+  private String getUUID(String filename) {
+    String uuid = UUID.randomUUID().toString();
+    return uuid;
+  }
+  
+  private void setupServiceAndMetadata() throws DependencyException, ServiceException {
+    // extract OME-XML string from metadata object
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+
+    ServiceFactory factory = new ServiceFactory();
+    service = factory.getInstance(OMEXMLService.class);
+    OMEXMLMetadata originalOMEMeta = service.getOMEMetadata(retrieve);
+    originalOMEMeta.resolveReferences();
+
+    String omexml = service.getOMEXML(originalOMEMeta);
+    omeMeta = service.createOMEXMLMetadata(omexml);
+  }
+}

--- a/components/formats-gpl/src/loci/formats/out/ZarrWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/ZarrWriter.java
@@ -113,13 +113,14 @@ public class ZarrWriter extends FormatWriter {
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);
     if(zarrService == null) {
-      try {
-        ServiceFactory factory = new ServiceFactory();
-        zarrService = factory.getInstance(ZarrService.class);
-      }
-      catch (DependencyException e) {
-        throw new FormatException(ZarrServiceImpl.NO_ZARR_MSG, e);
-      }
+//      try {
+//        ServiceFactory factory = new ServiceFactory();
+//        zarrService = factory.getInstance(ZarrService.class);
+//      }
+//      catch (DependencyException e) {
+//        throw new FormatException(ZarrServiceImpl.NO_ZARR_MSG, e);
+//      }
+      zarrService = new ZarrServiceImpl();
     }
     if(zarrService != null) {
       if (!zarrService.isOpen() && zarrService.getID() != id) {

--- a/components/formats-gpl/src/loci/formats/services/ZarrService.java
+++ b/components/formats-gpl/src/loci/formats/services/ZarrService.java
@@ -1,0 +1,83 @@
+package loci.formats.services;
+
+import java.io.IOException;
+
+import loci.common.services.Service;
+import loci.formats.FormatException;
+
+public interface ZarrService extends Service {
+  
+  enum Compression {
+    NONE,
+    ZLIB
+  }
+  
+  /**
+   * Initializes the service for the given file path.
+   * @param     file            File path with which to initialize the service.
+   * @throws    IOException
+   * @throws     FormatException
+   */
+  public void create(String file, int[] shape, int[] chunks, int pixelType, boolean isLittleEndian) throws IOException, FormatException;
+  
+  /**
+   * Initializes the service for the given file path.
+   * @param     file            File path with which to initialize the service.
+   * @throws    IOException
+   * @throws     FormatException
+   */
+  public void create(String file, int[] shape, int[] chunks, int pixelType, boolean isLittleEndian, Compression compression) throws IOException, FormatException;
+
+  /**
+   * Gets the text string for when Zarr implementation has not been found.
+   */
+  public String getNoZarrMsg();
+
+  /**
+   * Gets shape of Zarr as an array of dimensions.
+   * @return  shape.
+   */
+  public int [] getShape();
+
+  /**
+   * Gets the chunk size as an array of dimensions.
+   * @return  chunk size.
+   */
+  public int [] getChunkSize();
+
+  /**
+   * Gets the image pixel type.
+   * @return                    pixel type.
+   */
+  public int getPixelType();
+
+  /**
+   * Closes the file.
+   */
+  public void close() throws IOException;
+
+  /**
+  * Reads values from the Zarr Array
+  * @return     Buffer of bytes read.
+  * @param      shape           int array representing the shape of each dimension
+  * @param      offset          buffer for bytes.
+  */
+  public Object readBytes(int [] shape, int [] offset) throws FormatException, IOException;
+
+  /**
+  * Writes values to the Zarr Array
+  * @param      buf            values to be written in a one dimensional array
+  * @param      shape           int array representing the shape of each dimension
+  * @param      x               the offset for each dimension
+  */
+  void saveBytes(Object data, int[] shape, int[] offset) throws FormatException, IOException;
+
+  void open(String file) throws IOException, FormatException;
+
+  boolean isLittleEndian();
+
+  boolean isOpen() throws IOException;
+
+  String getID() throws IOException;
+
+}

--- a/components/formats-gpl/src/loci/formats/services/ZarrServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/ZarrServiceImpl.java
@@ -1,0 +1,193 @@
+package loci.formats.services;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+import com.bc.zarr.ArrayParams;
+import com.bc.zarr.Compressor;
+import com.bc.zarr.CompressorFactory;
+import com.bc.zarr.DataType;
+import com.bc.zarr.ZarrArray;
+
+import loci.common.services.AbstractService;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import ucar.ma2.InvalidRangeException;
+
+public class ZarrServiceImpl extends AbstractService
+implements ZarrService  {
+  // -- Constants --
+  public static final String NO_ZARR_MSG = "JZARR is required to read Zarr files.";
+
+  // -- Fields --
+  ZarrArray zarrArray;
+  String currentId;
+  Compressor zlibComp = CompressorFactory.create("zlib", 8);  // 8 = compression level .. valid values 0 .. 9
+  Compressor nullComp = CompressorFactory.create("null", 0);
+  
+  /**
+   * Default constructor.
+   */
+  public ZarrServiceImpl() {
+      checkClassDependency(com.bc.zarr.ZarrArray.class);
+  }
+  
+  @Override
+  public void open(String file) throws IOException, FormatException {
+    currentId = file;
+    zarrArray = ZarrArray.open(file);
+  }
+  
+  @Override
+  public void create(String file, int[] shape, int[] chunks, int pixelType, boolean isLittleEndian) throws IOException, FormatException {
+    create(file, shape, chunks, pixelType, isLittleEndian, Compression.NONE);
+  }
+  
+  @Override
+  public void create(String file, int[] shape, int[] chunks, int pixelType, boolean isLittleEndian, Compression compression) throws IOException, FormatException {
+    ArrayParams params = new ArrayParams();
+    DataType zarrPixelType = getZarrPixelType(pixelType);
+    params.shape(shape);
+    params.chunks(chunks);
+    params.dataType(zarrPixelType);
+    params.compressor(nullComp);
+    if (isLittleEndian) {
+      params.byteOrder(ByteOrder.LITTLE_ENDIAN);
+    }
+    zarrArray = ZarrArray.create(file, params);
+    currentId = file;
+  }
+  
+  private DataType getZarrPixelType(int pixType) {
+    DataType pixelType = null;
+      switch(pixType) {
+        case FormatTools.INT8:
+          pixelType = DataType.i1;
+          break;
+        case FormatTools.INT16:
+          pixelType = DataType.i2;
+          break;
+        case FormatTools.INT32:
+          pixelType = DataType.i4;
+          break;
+        case FormatTools.UINT8:
+          pixelType = DataType.u1;
+          break;
+        case FormatTools.UINT16:
+          pixelType = DataType.u2;
+          break;
+        case FormatTools.UINT32:
+          pixelType = DataType.u4;
+          break;
+        case FormatTools.FLOAT:
+          pixelType = DataType.f4;
+          break;
+        case FormatTools.DOUBLE:
+          pixelType = DataType.f8;
+          break;
+      }
+      return(pixelType);
+  }
+  
+  private int getOMEPixelType(DataType pixType) {
+    int pixelType = -1;
+      switch(pixType) {
+        case i1:
+          pixelType = FormatTools.INT8;
+          break;
+        case i2:
+          pixelType = FormatTools.INT16;
+          break;
+        case i4:
+          pixelType = FormatTools.INT32;
+          break;
+        case u1:
+          pixelType = FormatTools.UINT8;
+          break;
+        case u2:
+          pixelType = FormatTools.UINT16;
+          break;
+        case u4:
+          pixelType = FormatTools.UINT32;
+          break;
+        case f4:
+          pixelType = FormatTools.FLOAT;
+          break;
+        case f8:
+          pixelType = FormatTools.DOUBLE;
+          break;
+      default:
+        break;
+      }
+      return(pixelType);
+  }
+
+  @Override
+  public String getNoZarrMsg() {
+    return NO_ZARR_MSG;
+  }
+
+  @Override
+  public int[] getShape() {
+    if (zarrArray != null) return zarrArray.getShape();
+    return null;
+  }
+
+  @Override
+  public int[] getChunkSize() {
+    if (zarrArray != null) return zarrArray.getChunks();
+    return null;
+  }
+
+  @Override
+  public int getPixelType() {
+    if (zarrArray != null) return getOMEPixelType(zarrArray.getDataType());
+    return 0;
+  }
+  
+  @Override
+  public boolean isLittleEndian() {
+    if (zarrArray != null) return (zarrArray.getByteOrder() == ByteOrder.LITTLE_ENDIAN);
+    return false;
+  }
+
+  @Override
+  public void close() throws IOException {
+    zarrArray = null;
+    currentId = null;
+  }
+  
+  @Override
+  public boolean isOpen() throws IOException {
+    return (zarrArray != null && currentId != null);
+  }
+  
+  @Override
+  public String getID() throws IOException {
+    return currentId;
+  }
+
+  @Override
+  public Object readBytes(int[] shape, int[] offset) throws FormatException, IOException {
+    if (zarrArray != null) {
+      try {
+        return zarrArray.read(shape, offset);
+      } catch (InvalidRangeException e) {
+        throw new FormatException(e);
+      }
+    }
+    else throw new IOException("No Zarr file opened");
+  }
+
+  @Override
+  public void saveBytes(Object data, int[] shape, int[] offset) throws FormatException, IOException {
+    if (zarrArray != null) {
+      try {
+        zarrArray.write(data, shape, offset);
+      } catch (InvalidRangeException e) {
+        throw new FormatException(e);
+      }
+    }
+    else throw new IOException("No Zarr file opened");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.4</ome-common.version>
+    <ome-common.version>6.0.5-SNAPSHOT</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.0.1</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.5-SNAPSHOT</ome-common.version>
+    <ome-common.version>6.0.4</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.0.1</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>


### PR DESCRIPTION
Initial Zarr reader and writer for testing, this is an ongoing work in progress but can be used for testing purposes.

In its current form the writer expects a .zarr folder and will place the ome.xml within that location.
The reader will accept any file so long as its path has .zarr in it somewhere.

Notes:
- Trying to overwrite a file will not work due to a folder being used as the ID
- Dimension order of the Zarr is currently fixed to XYZTC
- Chunking is currently in X and Y dimensions only, when converting a file the readers tile size will be used for chunk size
- Javadoc needs added/finalised

Things to agreed:
- Location of XML
- File to select for SetID