### PR TITLE
Bump jxrlib version to 0.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.3.0</ome-codecs.version>
-    <jxrlib.version>0.2.2</jxrlib.version>
+    <jxrlib.version>0.2.3</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 
     <!-- Maven plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.3.0</ome-codecs.version>
-    <jxrlib.version>0.2.3</jxrlib.version>
+    <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 
     <!-- Maven plugin versions -->


### PR DESCRIPTION
Should be functionally identical but resolves duplicate class leakages
outlined here:

  https://forum.image.sc/t/how-to-resolve-duplicate-classes-in-unshaded-ome-jxrlib-all-artifact/37290