### PR TITLE
Add OBF file format version and stack version to the global metadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -165,7 +165,7 @@ public class OBFReader extends FormatReader {
     in = new RandomAccessInputStream(id);
 
     file_version = getFileVersion(in);
-    addGlobalMeta("Version", version);
+    addGlobalMeta("Version", file_version);
     long stackPosition = in.readLong();
     final int lengthOfDescription = in.readInt();
     final String description = in.readString(lengthOfDescription);

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -165,6 +165,7 @@ public class OBFReader extends FormatReader {
     in = new RandomAccessInputStream(id);
 
     file_version = getFileVersion(in);
+    addGlobalMeta("Version", version);
     long stackPosition = in.readLong();
     final int lengthOfDescription = in.readInt();
     final String description = in.readString(lengthOfDescription);
@@ -295,6 +296,7 @@ public class OBFReader extends FormatReader {
     final String magicString = in.readString(STACK_MAGIC_STRING.length());
     final short magicNumber = in.readShort();
     final int stackVersion = in.readInt();
+    addGlobalMeta("Stack version", stackVersion);
 
     if (magicString.equals(STACK_MAGIC_STRING) && magicNumber == MAGIC_NUMBER) {
       final int image = core.size();


### PR DESCRIPTION
Follow-up of https://github.com/ome/bioformats/pull/3528, this change adds the file version and stack version (see https://imspectordocs.readthedocs.io/en/latest/fileformat.html for more details) to the global metadata populated by the reader.

/cc @ngladitz 