### PR TITLE
Update kryo to latest version

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -69,7 +69,7 @@
       <version>${jgoodies-forms.version}</version>
     </dependency>
     <dependency>
-     <groupId>com.esotericsoftware.kryo</groupId>
+     <groupId>com.esotericsoftware</groupId>
      <artifactId>kryo</artifactId>
      <version>${kryo.version}</version>
     </dependency>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -126,7 +126,7 @@
       <version>2.2</version>
     </dependency>
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
+      <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
       <version>${kryo.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <ome-metakit.version>5.3.2</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>1.7.6</slf4j.version>
-    <kryo.version>2.24.0</kryo.version>
+    <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.4</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>

--- a/pom.xml
+++ b/pom.xml
@@ -412,10 +412,6 @@
     </pluginManagement>
   </build>
 
-  <prerequisites>
-    <maven>3.0.5</maven>
-  </prerequisites>
-
   <organization>
     <name>Open Microscopy Environment</name>
     <url>http://www.openmicroscopy.org/</url>


### PR DESCRIPTION
From 2.24.0 to 3.0.0, the kryo project changed its groupId from `com.esotericsoftware.kryo` to `com.esotericsoftware`. Therefore, from Maven's perspective, both of these artifacts can be present on the classpath at the same time, creating duplicate class conflicts. Unfortunately, this scenario is happening when attempting to combine Bio-Formats (which wants kryo 2.24.0) with `graphics.scenery:scenery:0.7.0-beta-7` (which wants kryo 4.0.2).

One solution to this dilemma is to update the version of kryo here to 4.0.2, which is what this PR does. The code still compiles, and tests pass, although I am not certain how thorough (if at all) the kryo-related functionality is exercised.

See also ome/ome-common-java#50.