### PR TITLE
CZI: IlluminationType not overridden by DisplaySettings

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2654,7 +2654,7 @@ public class ZeissCZIReader extends FormatReader {
 
           String illumination = getFirstNodeValue(channel, "IlluminationType");
 
-          if (illumination != null) {
+          if (illumination != null && (channels.get(i).illumination == null || channels.get(i).illumination == IlluminationType.OTHER)) {
             channels.get(i).illumination = MetadataTools.getIlluminationType(illumination);
           }
         }


### PR DESCRIPTION
This is a fix for the reported issue in https://forum.image.sc/t/czi-reader-illuminationtype-mapping-and-exposuretime-units/37557/3 with regards the IlluminationType.

A sample file has been provided in QA-29273 which can be used for testing.

From debugging it appears that the Channel information is correct and contains Epifluorescence:
```
Information|Image|Channel|IlluminationType #1: Epifluorescence
Information|Image|Channel|IlluminationType #2: Epifluorescence
```

However this was then being overridden by the DisplaySettings metadata which contains:
```
DisplaySetting|Channel|IlluminationType: Fluorescence
```

To test:
- Ensure builds and tests remain green
- Use the provided sample file (QA-29273), without this PR the `IlluminationType` pf the 2 channels should appear as `Other` in the OME-XML
- Retest the sample file with the PR included and the `IlluminationType` should now appear as `Epifluorescence`