### PR TITLE
SCN: No color correction for SCN400

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -230,7 +230,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     // newer files from Versa systems do not
     if (handler != null) {
       Image i = handler.imageMap.get(0);
-      tiffParser.setYCbCrCorrection(!"versa".equalsIgnoreCase(i.devModel));
+      tiffParser.setYCbCrCorrection(!"versa".equalsIgnoreCase(i.devModel) && !"leica scn400".equalsIgnoreCase(i.devModel);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -230,7 +230,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     // newer files from Versa systems do not
     if (handler != null) {
       Image i = handler.imageMap.get(0);
-      tiffParser.setYCbCrCorrection(!"versa".equalsIgnoreCase(i.devModel) && !"leica scn400".equalsIgnoreCase(i.devModel);
+      tiffParser.setYCbCrCorrection(!("versa".equalsIgnoreCase(i.devModel) || "leica scn400".equalsIgnoreCase(i.devModel)));
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 
@@ -71,6 +72,8 @@ public class LeicaSCNReader extends BaseTiffReader {
     "http://www.leica-microsystems.com/scn/2010/03/10";
   private static final String SCHEMA_2010_10 =
     "http://www.leica-microsystems.com/scn/2010/10/01";
+
+  private static final String[] MODELS_WITHOUT_CORRECTION = {"versa", "leica scn400"};
 
   // -- Fields --
   LeicaSCNHandler handler;
@@ -230,7 +233,8 @@ public class LeicaSCNReader extends BaseTiffReader {
     // newer files from Versa systems do not
     if (handler != null) {
       Image i = handler.imageMap.get(0);
-      tiffParser.setYCbCrCorrection(!("versa".equalsIgnoreCase(i.devModel) || "leica scn400".equalsIgnoreCase(i.devModel)));
+      String model = i.devModel == null ? i.devModel : i.devModel.toLowerCase();
+      tiffParser.setYCbCrCorrection(!Arrays.asList(MODELS_WITHOUT_CORRECTION).contains(model));
     }
   }
 


### PR DESCRIPTION
This is a test PR for a potential fix to https://github.com/ome/bioformats/issues/3510

Currently color correction is applied for any non Versa systems, in this case an SCN400 system has been used that also does not require correction. Unfortunately I cant find anything else in the metadata that would indicate if correction is or isn't required. Opening this PR as a test to see its impact on other files in the data repo.