### PR TITLE
CZI: Parse TimeSpan Default Units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -69,6 +69,7 @@ import ome.units.quantity.Power;
 import ome.units.quantity.Pressure;
 import ome.units.quantity.Temperature;
 import ome.units.quantity.Time;
+import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 import org.xml.sax.SAXException;
@@ -1491,8 +1492,8 @@ public class ZeissCZIReader extends FormatReader {
           if (channel < channels.size() &&
             channels.get(channel).exposure != null)
           {
-            store.setPlaneExposureTime(
-              new Time(channels.get(channel).exposure, UNITS.SECOND), i, plane);
+            Time expTime = FormatTools.getTime(channels.get(channel).exposure, channels.get(channel).timeUnit);
+            store.setPlaneExposureTime(expTime, i, plane);
           }
         }
       }
@@ -1750,16 +1751,16 @@ public class ZeissCZIReader extends FormatReader {
               ms0.sizeZ = dimension.size;
             }
             break;
-          case 'T':        	  
-    		    int startIndex = dimension.start;
-    		    int endIndex = startIndex + dimension.size;
-    	  
-    		    for (int i=startIndex; i<endIndex; i++) {
-    			    if (!uniqueT.contains(i)) {
+          case 'T': 
+            int startIndex = dimension.start;
+            int endIndex = startIndex + dimension.size;
+        
+            for (int i=startIndex; i<endIndex; i++) {
+              if (!uniqueT.contains(i)) {
                 uniqueT.add(i);
                 ms0.sizeT = uniqueT.size();
               }
-    		    }
+            }
             break;
           case 'R':
             if (dimension.start >= rotations) {
@@ -3266,6 +3267,14 @@ public class ZeissCZIReader extends FormatReader {
         while (channels.size() <= i) {
           channels.add(new Channel());
         }
+        
+        Element timeSpan = getFirstNode(acquisition, "TimeSpan");
+        if (timeSpan != null) {
+          String units = getFirstNodeValue(timeSpan, "DefaultUnitFormat");
+          if (units != null) {
+            channels.get(i).timeUnit = units;
+          }
+        }
 
         try {
           if (exposure != null) {
@@ -4237,6 +4246,7 @@ public class ZeissCZIReader extends FormatReader {
   }
 
   static class Channel {
+    public String timeUnit;
     public String name;
     public String color;
     public IlluminationType illumination;


### PR DESCRIPTION
Fixes https://github.com/ome/bioformats/issues/3560

This issue was raised in https://forum.image.sc/t/czi-reader-illuminationtype-mapping-and-exposuretime-units/37557/4 and a sample file showing the issue is available in QA-29273

This now parses the metadata value `Experiment|AcquisitionBlock|TimeSeriesSetup|Interval|TimeSpan|DefaultUnitFormat` and makes use of the units which had previously been hardcoded to seconds (note, seconds remains the default if the tag is not available).

This may have a knock on effect on sample files in the data repo, in which they will need to be reviewed to ensure the new values are correct.

To test:
- Ensure builds and tests remain green
- Using the file QA-29273, without the PR the exposure time will be in seconds
- With this PR included the exposure time should correctly be ms