### PR TITLE
Cellomics: use maximum row/column index to calculate plate size

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -367,8 +367,8 @@ public class CellomicsReader extends FormatReader {
     store.setPlateRowNamingConvention(NamingConvention.LETTER, 0);
     store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
 
-    int realRows = wellRows;
-    int realCols = wellColumns;
+    int realRows = wellRows + 1;
+    int realCols = wellColumns + 1;
 
     if (getSeriesCount() == 1) {
       realRows = 1;

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -276,11 +276,12 @@ public class CellomicsReader extends FormatReader {
       if (!uniqueChannels.contains(channel)) uniqueChannels.add(channel);
 
       files.add(new ChannelFile(f, wellRow, wellCol, field, channel));
+
+      wellRows = (int) Math.max(wellRows, wellRow);
+      wellColumns = (int) Math.max(wellColumns, wellCol);
     }
 
     fields = uniqueFields.size();
-    wellRows = uniqueRows.size();
-    wellColumns = uniqueCols.size();
 
     for (int file=0; file<files.size(); file++) {
       ChannelFile f = files.get(file);


### PR DESCRIPTION
Backported from a private PR.

Test plate is in ```inbox/cellomics-plate-size```.  Compare ```showinf -nopix -omexml``` with and without this PR.  Without this PR, only the first well is linked to the plate.  With this PR, both wells are linked to the plate, and the plate has 384 instead of 96 wells.

This should be safe for a minor release; memo files and tests should be unaffected.