### PR TITLE
SVS/AFI: fix NPE when exposure time is not defined

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -370,7 +370,9 @@ public class AFIReader extends FormatReader {
             store.setChannelColor(displayColor[c], i, c);
           }
 
-          store.setPlaneExposureTime(FormatTools.createTime(exposure[c], UNITS.SECOND), i, c);
+          if (exposure[c] != null) {
+            store.setPlaneExposureTime(FormatTools.createTime(exposure[c], UNITS.SECOND), i, c);
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -579,6 +579,11 @@ public class SVSReader extends BaseTiffReader {
   }
 
   protected Double getExposureTime() {
+    if (exposureTime == null || exposureScale == null) {
+      LOGGER.debug("Ignoring exposure time = {}, scale = {}",
+        exposureTime, exposureScale);
+      return null;
+    }
     return exposureTime * exposureScale * 1000;
   }
 


### PR DESCRIPTION
Backported from a private PR.

Defends against a potential NPE if either the exposure time or units are missing from an SVS file.  Tests should remain green, and this should be safe for a patch release.