### PR TITLE
Cellomics: set physical sizes for all series

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -437,10 +437,10 @@ public class CellomicsReader extends FormatReader {
       Length sizeY = FormatTools.getPhysicalSizeY(height);
       for (int i=0; i<getSeriesCount(); i++) {
         if (sizeX != null) {
-          store.setPixelsPhysicalSizeX(sizeX, 0);
+          store.setPixelsPhysicalSizeX(sizeX, i);
         }
         if (sizeY != null) {
-          store.setPixelsPhysicalSizeY(sizeY, 0);
+          store.setPixelsPhysicalSizeY(sizeY, i);
         }
       }
     }


### PR DESCRIPTION
Backported from a private PR.

Fixes typo that caused physical sizes to only be set for the first series.  Requires a configuration change, but tests should otherwise pass and this should be safe for a patch release.