### PR TITLE
MikroscanTiffReader: set suffixSufficient to false

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MikroscanTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MikroscanTiffReader.java
@@ -58,6 +58,7 @@ public class MikroscanTiffReader extends SVSReader {
     super("Mikroscan TIFF", new String[] {"tif", "tiff"});
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN, FormatTools.LM_DOMAIN};
     suffixNecessary = false;
+    suffixSufficient = false;
   }
 
   // -- IFormatReader API methods --


### PR DESCRIPTION
See #3571 for more context

This change should allow `MikroscanTiffReader.isThisType(name, open)` to fail in case `open` is set to false i.e. file access is disallowed

I expect this change should have no impact on the standar Bio-Formats detection logic in `ImageReader`. Non-regression CI builds should keep passing against all sample datasets including the Mikroscan TIFF ones.

When the `MikroscanTiffReader.isThisType(name, open)` API is used with `open` set to false like in the case `python-bioformats`, this should prevent all TIFF files to be erroneously flagged as Mikroscan TIFF. The code snippet from https://github.com/ome/bioformats/issues/3571#issuecomment-643281905 could be used for testing this PR after replacing the JAR with a version of Bio-Formats including this PR.