### PR TITLE
Metamorph: expand wavelength parsing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.Vector;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
@@ -997,6 +998,14 @@ public class MetamorphReader extends BaseTiffReader {
         }
         store.setDetectorSettingsID(detectorID, i, c);
 
+        if (wave == null && handler.getWavelengths() != null) {
+          Vector<Integer> xmlWavelengths = handler.getWavelengths();
+          wave = new double[xmlWavelengths.size()];
+          for (int w=0; w<wave.length; w++) {
+            wave[w] = xmlWavelengths.get(w);
+          }
+        }
+
         if (wave != null && waveIndex < wave.length) {
           Length wavelength =
             FormatTools.getWavelength(wave[waveIndex]);
@@ -1013,6 +1022,7 @@ public class MetamorphReader extends BaseTiffReader {
 
             if (wavelength != null) {
               store.setChannelLightSourceSettingsWavelength(wavelength, i, c);
+              store.setChannelEmissionWavelength(wavelength, i, c);
             }
           }
         }
@@ -1436,7 +1446,10 @@ public class MetamorphReader extends BaseTiffReader {
           }
           else if (key.equalsIgnoreCase("wavelength")) {
             try {
-              wavelength = Integer.parseInt(value);
+              if (wave == null || wave.length == 0) {
+                wave = new double[1];
+              }
+              wave[0] = DataTools.parseDouble(value);
             }
             catch (NumberFormatException e) {
             }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1434,6 +1434,13 @@ public class MetamorphReader extends BaseTiffReader {
               catch (NumberFormatException e) { }
             }
           }
+          else if (key.equalsIgnoreCase("wavelength")) {
+            try {
+              wavelength = Integer.parseInt(value);
+            }
+            catch (NumberFormatException e) {
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Backported from a private PR.

This will attempt to use wavelengths from Metamorph XML or original metadata to populate ```Channel.EmissionWavelength``` and ```Channel.LightSourceSettings.Wavelength``` if no other wavelengths are defined.

I think this would be safe for a patch release.  The only potential test impact I would expect is that some files might need to have an emission wavelength added to the configuration.  If that turns out to be the case, I will open a config PR tomorrow.