### PR TITLE
Review all instances of whitelist/blacklist

### DIFF
--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -324,8 +324,18 @@ public class ClassList<T> {
     return options;
   }
 
-  /** Returns whether a given key is a whitelisted option.*/
+  /**
+   * Returns whether a given key is an allowed option.
+   *
+   * @deprecated Use {@link #isAllowedKey(String)} instead.
+   */
+  @Deprecated
   public boolean isWhitelistedKey(String s) {
+    return isAllowedKey(s);
+  }
+
+  /** Returns whether a given key is an allowed option.*/
+  public boolean isAllowedKey(String s) {
     String key = s.substring(s.lastIndexOf(".") + 1);
     for (String k: KEYS) {
       if (key.equals(k)) return true;
@@ -335,8 +345,8 @@ public class ClassList<T> {
 
   /** Add a key/value pair to the list of options.*/
   public void addOption(String key, String value) {
-    if (!isWhitelistedKey(key)) {
-      LOGGER.debug("{} is not a whitelisted key", key);
+    if (!isAllowedKey(key)) {
+      LOGGER.debug("{} is not an allowed key", key);
     }
     options.put(key, value);
   }

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -173,7 +173,7 @@ public class ImageReader implements IFormatReader {
    boolean fake = id != null && id.toLowerCase().endsWith(".fake");
    boolean omero = isOmero(id);
 
-   // blacklist temporary files that are being copied e.g. by WinSCP
+   // block temporary files that are being copied e.g. by WinSCP
    boolean invalid = id != null && id.toLowerCase().endsWith(".filepart");
 
    // NB: Check that we can generate a valid handle for the ID;

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -274,14 +274,14 @@ public class ClassListTest {
   }
 
   @Test
-  public void testWhitelistedKeys() throws IOException
+  public void testAllowedKeys() throws IOException
   {
     c = new ClassList<Iterable>(null, Iterable.class);
-    assertTrue(c.isWhitelistedKey("type"));
-    assertTrue(c.isWhitelistedKey("package.name.type"));
-    assertTrue(c.isWhitelistedKey("type"));
-    assertFalse(c.isWhitelistedKey("type.subtype"));
-    assertFalse(c.isWhitelistedKey(""));
-    assertFalse(c.isWhitelistedKey("."));
+    assertTrue(c.isAllowedKey("type"));
+    assertTrue(c.isAllowedKey("package.name.type"));
+    assertTrue(c.isAllowedKey("type"));
+    assertFalse(c.isAllowedKey("type.subtype"));
+    assertFalse(c.isAllowedKey(""));
+    assertFalse(c.isAllowedKey("."));
   }
 }


### PR DESCRIPTION
Fixes #3580 

This PR reviews the output `git grep -i whitelist` and `git grep -i blacklist`. Proposed changes are quite small and contained but will require a minor version increment due to the API addition.

- add new `ClassList.isAllowedKey(String)` API
- deprecate `ClassList.isWhitelistedKey(String)` and forward it to the new API
- update `ClassListTest.isAllowedKeys()` unit test
- remove blacklist inline comment
