### PR TITLE
Operetta: fix metadata files logic to skip plate folders

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -288,16 +288,25 @@ public class OperettaReader extends FormatReader {
     for (String f : list) {
       Location path = new Location(parent, f);
       if (path.isDirectory()) {
+        // the current file's parent directory will usually be "Images",
+        // but may have been renamed especially if there are no
+        // analysis results
+        if (f.equals(currentFile.getParentFile().getName())) {
+          LOGGER.trace("Skipping current directory {}", f);
+          continue;
+        }
+        // Skipping other directories containing Operetta metadata files
+        for (String XML_FILE : XML_FILES) {
+          if (new Location(path, XML_FILE).exists()) {
+            LOGGER.trace("Skipping {} containing {}", f, XML_FILE);
+            continue;
+          }
+        }
         String[] companionFolders = path.list(true);
         Arrays.sort(companionFolders);
         for (String folder : companionFolders) {
           LOGGER.trace("Found folder {}", folder);
-          // the current file's parent directory will usually be "Images",
-          // but may have been renamed especially if there are no
-          // analysis results
-          if ((!f.equals("Images") &&
-            !f.equals(currentFile.getParentFile().getName())) ||
-            !checkSuffix(folder, "tiff"))
+          if (!checkSuffix(folder, "tiff"))
           {
             String metadataFile = new Location(path, folder).getAbsolutePath();
             if (!metadataFile.equals(currentFile.getAbsolutePath())) {


### PR DESCRIPTION
This commit deals with the scenario of an IDR submission where plate folders containing the TIFF data + the metadata XML files directly (without the usual Images subdirectory) were found under the same current level. The assumptions of the reader currently causes all other plates to be added to the fileset as ancillary metadata files, increasing the size of the original 7K fileset to 55K and slowing down import down the line.

The new logic adds early directory checks when adding metadata files to skip either the directory containing the master XML file or other directories containing XML files.

From the mainline Bio-Formats, the main impact is that there should be no regression at the level of the automated tests. There should be a slight performance improvement to `setId` as the current directory should be skipped early during the discovery of associated metadata files.