### PR TITLE
MetamorphReader: allow loading of single stk files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -249,7 +249,7 @@ public class MetamorphReader extends BaseTiffReader {
       if (checkSuffix(file, ND_SUFFIX) &&
        l.getName().startsWith(file.substring(0, file.lastIndexOf("."))))
       {
-        return FormatTools.MUST_GROUP;
+        return FormatTools.CAN_GROUP;
       }
     }
 


### PR DESCRIPTION
In case the id is pointing to an *stk* file (and not to the main *nd* file), returning `CAN_GROUP` instead of `MUST_GROUP` here should provide the flexibility of choosing between loading a single stk file or the entire dataset.

This leads to people using more or less ugly workarounds, e.g.:

https://github.com/TissueMAPS/TissueMAPS/blob/59f44ce1c76fe3c3abb0a932a8badc834b122e98/tmlibrary/tmlib/workflow/metaconfig/visiview.py#L168-L176

or entire macros for custom metadata handling, using ImageJ's `open` instead of bio-formats to open the single stk files:

https://github.com/bvernay/ImageJ-Macros/blob/558415ef8ea619e45f0d5010fdcf791bc3e46aab/Metamorph%20Utilities/MetamorphFilesFolderToHyperstacks.ijm
