### PR TITLE
Restrict readers used during image conversion tests

### DIFF
--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -42,11 +42,15 @@ import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import loci.formats.ClassList;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.ImageWriter;
 import loci.formats.FormatException;
 import loci.formats.tools.ImageConverter;
+import loci.formats.in.ICSReader;
+import loci.formats.in.OMETiffReader;
+import loci.formats.in.TiffDelegateReader;
 import loci.formats.out.OMETiffWriter;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -126,7 +130,12 @@ public class ImageConverterTest {
   }
 
   public void checkImage(String outFileToCheck, int expectedWidth) throws FormatException, IOException {
-    IFormatReader r = new ImageReader();
+    ClassList<IFormatReader> readerClasses = new ClassList<IFormatReader>(IFormatReader.class);
+    readerClasses.addClass(OMETiffReader.class);
+    readerClasses.addClass(ICSReader.class);
+    readerClasses.addClass(TiffDelegateReader.class);
+
+    IFormatReader r = new ImageReader(readerClasses);
     r.setFlattenedResolutions(false);
     r.setId(outFileToCheck);
     assertEquals(r.getSizeX(), expectedWidth);


### PR DESCRIPTION
Backported from a private PR.

```testConvertResolutionsFlattened``` as introduced in #3553 was failing in the private repo because a reader other than ```OMETiffReader``` was (correctly) picking up the output file and detecting multiple resolutions.

This changes the ```ClassList``` that ```ImageReader``` uses when checking output file dimensions, so that only the 3 expected output formats are present.