### PR TITLE
Cellomics: parse channel data from companion .mdb file

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -149,6 +149,7 @@ public class CellomicsReader extends FormatReader {
     if (!fileOnly) {
       files.clear();
       cellomicsPattern = null;
+      metadataFiles.clear();
     }
   }
 
@@ -162,13 +163,13 @@ public class CellomicsReader extends FormatReader {
     }
 
     ArrayList<String> seriesFiles = new ArrayList<String>();
-    seriesFiles.addAll(metadataFiles);
     for (int c=0; c<getSizeC(); c++) {
       ChannelFile f = lookupFile(getSeries(), c);
       if (f != null && f.filename != null) {
         seriesFiles.add(f.filename);
       }
     }
+    seriesFiles.addAll(metadataFiles);
     return seriesFiles.toArray(new String[seriesFiles.size()]);
   }
 
@@ -181,10 +182,10 @@ public class CellomicsReader extends FormatReader {
     }
 
     ArrayList<String> allFiles = new ArrayList<String>();
-    allFiles.addAll(metadataFiles);
     for (ChannelFile f : files) {
       allFiles.add(f.filename);
     }
+    allFiles.addAll(metadataFiles);
     return allFiles.toArray(new String[allFiles.size()]);
   }
 
@@ -551,7 +552,14 @@ public class CellomicsReader extends FormatReader {
     if (m.matches()) {
       return m.group(1);
     }
-    return filename.substring(0, filename.lastIndexOf("."));
+    if (checkSuffix(filename, suffixes)) {
+      return null;
+    }
+    int lastDot = filename.lastIndexOf(".");
+    if (lastDot < 0) {
+      lastDot = filename.length();
+    }
+    return filename.substring(0, lastDot);
   }
 
   private String getWellName(String filename) {

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -362,33 +362,30 @@ public class CellomicsReader extends FormatReader {
         mdb = factory.getInstance(MDBService.class);
 
         mdb.initialize(mdbFile);
-        Vector<Vector<String[]>> tables = mdb.parseDatabase();
-        for (Vector<String[]> table : tables) {
+        Vector<String[]> table = mdb.parseTable("asnProtocolChannel");
+        if (table != null) {
           String[] header = table.get(0);
-          if (header[0].equals("asnProtocolChannel")) {
-            int nameColumn = DataTools.indexOf(header, "Name") - 1;
-            int exposureTimeColumn = DataTools.indexOf(header, "ExposureTime") - 1;
-            int colorColumn = DataTools.indexOf(header, "CompositeColor") - 1;
-            for (int r=1; r<table.size(); r++) {
-              String[] row = table.get(r);
-              if (nameColumn >= 0) {
-                channelNames[r - 1] = row[nameColumn];
-              }
-              if (colorColumn >= 0) {
-                int color = Integer.parseInt(row[colorColumn]);
-                int alpha = (color >> 24) & 0xff;
-                int blue = (color >> 16) & 0xff;
-                int green = (color >> 8) & 0xff;
-                int red = color & 0xff;
-
-                channelColors[r - 1] = new Color(red, green, blue, alpha);
-              }
-              if (exposureTimeColumn >= 0) {
-                double exposure = DataTools.parseDouble(row[exposureTimeColumn]);
-                exposureTimes[r - 1] = FormatTools.getTime(exposure, null);
-              }
+          int nameColumn = DataTools.indexOf(header, "Name") - 1;
+          int exposureTimeColumn = DataTools.indexOf(header, "ExposureTime") - 1;
+          int colorColumn = DataTools.indexOf(header, "CompositeColor") - 1;
+          for (int r=1; r<table.size(); r++) {
+            String[] row = table.get(r);
+            if (nameColumn >= 0) {
+              channelNames[r - 1] = row[nameColumn];
             }
-            break;
+            if (colorColumn >= 0) {
+              int color = Integer.parseInt(row[colorColumn]);
+              int alpha = (color >> 24) & 0xff;
+              int blue = (color >> 16) & 0xff;
+              int green = (color >> 8) & 0xff;
+              int red = color & 0xff;
+
+              channelColors[r - 1] = new Color(red, green, blue, alpha);
+            }
+            if (exposureTimeColumn >= 0) {
+              double exposure = DataTools.parseDouble(row[exposureTimeColumn]);
+              exposureTimes[r - 1] = FormatTools.getTime(exposure, null);
+            }
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -467,7 +467,7 @@ public class CellomicsReader extends FormatReader {
     if (m.matches()) {
       return m.group(1);
     }
-    return null;
+    return filename.substring(0, filename.lastIndexOf("."));
   }
 
   private String getWellName(String filename) {

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -365,26 +365,36 @@ public class CellomicsReader extends FormatReader {
         Vector<String[]> table = mdb.parseTable("asnProtocolChannel");
         if (table != null) {
           String[] header = table.get(0);
-          int nameColumn = DataTools.indexOf(header, "Name") - 1;
-          int exposureTimeColumn = DataTools.indexOf(header, "ExposureTime") - 1;
-          int colorColumn = DataTools.indexOf(header, "CompositeColor") - 1;
+          int nameColumn = DataTools.indexOf(header, "Name");
+          int exposureTimeColumn = DataTools.indexOf(header, "ExposureTime");
+          int colorColumn = DataTools.indexOf(header, "CompositeColor");
           for (int r=1; r<table.size(); r++) {
             String[] row = table.get(r);
             if (nameColumn >= 0) {
               channelNames[r - 1] = row[nameColumn];
             }
             if (colorColumn >= 0) {
-              int color = Integer.parseInt(row[colorColumn]);
-              int alpha = (color >> 24) & 0xff;
-              int blue = (color >> 16) & 0xff;
-              int green = (color >> 8) & 0xff;
-              int red = color & 0xff;
+              try {
+                int color = Integer.parseInt(row[colorColumn]);
+                int alpha = (color >> 24) & 0xff;
+                int blue = (color >> 16) & 0xff;
+                int green = (color >> 8) & 0xff;
+                int red = color & 0xff;
 
-              channelColors[r - 1] = new Color(red, green, blue, alpha);
+                channelColors[r - 1] = new Color(red, green, blue, alpha);
+              }
+              catch (NumberFormatException e) {
+                LOGGER.debug("Could not parse channel color " + row[colorColumn], e);
+              }
             }
             if (exposureTimeColumn >= 0) {
-              double exposure = DataTools.parseDouble(row[exposureTimeColumn]);
-              exposureTimes[r - 1] = FormatTools.getTime(exposure, null);
+              try {
+                double exposure = DataTools.parseDouble(row[exposureTimeColumn]);
+                exposureTimes[r - 1] = FormatTools.getTime(exposure, null);
+              }
+              catch (NumberFormatException e) {
+                LOGGER.debug("Could not parse exposure time " + row[exposureTimeColumn], e);
+              }
             }
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -29,11 +29,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceFactory;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
@@ -42,9 +46,12 @@ import loci.formats.MetadataTools;
 import loci.formats.UnsupportedCompressionException;
 import loci.formats.codec.ZlibCodec;
 import loci.formats.meta.MetadataStore;
+import loci.formats.services.MDBService;
 import ome.xml.model.enums.NamingConvention;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.units.quantity.Length;
+import ome.units.quantity.Time;
 
 /**
  * Reader for Cellomics C01 files.
@@ -200,6 +207,7 @@ public class CellomicsReader extends FormatReader {
     ArrayList<String> pixelFiles = new ArrayList<String>();
 
     String plateName = getPlateName(baseFile.getName());
+    String mdbFile = null;
 
     if (plateName != null && isGroupFiles()) {
       String[] list = parent.list();
@@ -213,6 +221,10 @@ public class CellomicsReader extends FormatReader {
         }
         else if (hasPlateName) {
           metadataFiles.add(loc.getAbsolutePath());
+
+          if (checkSuffix(f, "mdb")) {
+            mdbFile = loc.getAbsolutePath();
+          }
         }
       }
     }
@@ -340,6 +352,56 @@ public class CellomicsReader extends FormatReader {
       addGlobalMeta("Color important", colorImportant);
     }
 
+    Color[] channelColors = new Color[uniqueChannels.size()];
+    String[] channelNames = new String[uniqueChannels.size()];
+    Time[] exposureTimes = new Time[uniqueChannels.size()];
+    if (mdbFile != null) {
+      MDBService mdb = null;
+      try {
+        ServiceFactory factory = new ServiceFactory();
+        mdb = factory.getInstance(MDBService.class);
+
+        mdb.initialize(mdbFile);
+        Vector<Vector<String[]>> tables = mdb.parseDatabase();
+        for (Vector<String[]> table : tables) {
+          String[] header = table.get(0);
+          if (header[0].equals("asnProtocolChannel")) {
+            int nameColumn = DataTools.indexOf(header, "Name") - 1;
+            int exposureTimeColumn = DataTools.indexOf(header, "ExposureTime") - 1;
+            int colorColumn = DataTools.indexOf(header, "CompositeColor") - 1;
+            for (int r=1; r<table.size(); r++) {
+              String[] row = table.get(r);
+              if (nameColumn >= 0) {
+                channelNames[r - 1] = row[nameColumn];
+              }
+              if (colorColumn >= 0) {
+                int color = Integer.parseInt(row[colorColumn]);
+                int alpha = (color >> 24) & 0xff;
+                int blue = (color >> 16) & 0xff;
+                int green = (color >> 8) & 0xff;
+                int red = color & 0xff;
+
+                channelColors[r - 1] = new Color(red, green, blue, alpha);
+              }
+              if (exposureTimeColumn >= 0) {
+                double exposure = DataTools.parseDouble(row[exposureTimeColumn]);
+                exposureTimes[r - 1] = FormatTools.getTime(exposure, null);
+              }
+            }
+            break;
+          }
+        }
+      }
+      catch (DependencyException e) {
+        LOGGER.warn("Could not parse MDB file", e);
+      }
+      finally {
+        if (mdb != null) {
+          mdb.close();
+        }
+      }
+    }
+
     LOGGER.info("Populating core metadata");
 
     for (int i=0; i<getSeriesCount(); i++) {
@@ -359,7 +421,7 @@ public class CellomicsReader extends FormatReader {
     LOGGER.info("Populating metadata store");
 
     MetadataStore store = makeFilterMetadata();
-    MetadataTools.populatePixels(store, this);
+    MetadataTools.populatePixels(store, this, true);
 
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateName(plateName, 0);
@@ -441,6 +503,21 @@ public class CellomicsReader extends FormatReader {
         }
         if (sizeY != null) {
           store.setPixelsPhysicalSizeY(sizeY, i);
+        }
+
+        for (int c=0; c<getEffectiveSizeC(); c++) {
+          if (channelNames[c] != null) {
+            store.setChannelName(channelNames[c], i, c);
+          }
+          if (channelColors[c] != null) {
+            store.setChannelColor(channelColors[c], i, c);
+          }
+        }
+        for (int p=0; p<getImageCount(); p++) {
+          int[] zct = getZCTCoords(p);
+          if (exposureTimes[zct[1]] != null) {
+            store.setPlaneExposureTime(exposureTimes[zct[1]], i, p);
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -378,12 +378,11 @@ public class CellomicsReader extends FormatReader {
             if (colorColumn >= 0) {
               try {
                 int color = Integer.parseInt(row[colorColumn]);
-                int alpha = (color >> 24) & 0xff;
                 int blue = (color >> 16) & 0xff;
                 int green = (color >> 8) & 0xff;
                 int red = color & 0xff;
 
-                channelColors[r - 1] = new Color(red, green, blue, alpha);
+                channelColors[r - 1] = new Color(red, green, blue, 255);
               }
               catch (NumberFormatException e) {
                 LOGGER.debug("Could not parse channel color " + row[colorColumn], e);

--- a/components/formats-gpl/src/loci/formats/services/MDBService.java
+++ b/components/formats-gpl/src/loci/formats/services/MDBService.java
@@ -58,6 +58,21 @@ public interface MDBService extends Service {
    */
   public Vector<Vector<String[]>> parseDatabase() throws IOException;
 
+  /**
+   * Read named table from a pre-initialized .mdb files.
+   * Each String[] in a table represents a row, and each element of the String[]
+   * represents the value of a particular column within the row.
+   *
+   * The first row in the table contains the names for each column.
+   *
+   * {@link #initialize(String)} must be called before calling parseTable.
+   *
+   * @param name table name
+   * @return table data or null if the named table does not exist
+   * @throws IOException if there is a problem reading the table data
+   */
+  public Vector<String[]> parseTable(String name) throws IOException;
+
   /** Close the currently initialized file. */
   public void close();
 

--- a/components/formats-gpl/src/loci/formats/services/MDBService.java
+++ b/components/formats-gpl/src/loci/formats/services/MDBService.java
@@ -71,7 +71,9 @@ public interface MDBService extends Service {
    * @return table data or null if the named table does not exist
    * @throws IOException if there is a problem reading the table data
    */
-  public Vector<String[]> parseTable(String name) throws IOException;
+  public default Vector<String[]> parseTable(String name) throws IOException {
+    return null;
+  }
 
   /** Close the currently initialized file. */
   public void close();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1963,6 +1963,13 @@ public class FormatReaderTest {
             }
           }
 
+          // Cellomics datasets cannot be reliably detected with the .mdb file
+          if (reader.getFormat().equals("Cellomics C01") &&
+            base[i].toLowerCase().endsWith(".mdb"))
+          {
+            continue;
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();
@@ -2695,6 +2702,13 @@ public class FormatReaderTest {
             // CellWorx datasets can only be reliably detected with the .HTD file
             if (!used[i].toLowerCase().endsWith(".htd") &&
               r instanceof CellWorxReader)
+            {
+              continue;
+            }
+
+            // Cellomics datasets cannot be reliably detected with .mdb file
+            if (used[i].toLowerCase().endsWith(".mdb") &&
+              r instanceof CellomicsReader)
             {
               continue;
             }


### PR DESCRIPTION
Backported from a couple of private PRs.  See also https://trac.openmicroscopy.org/ome/ticket/7092

This updates the ```MDBService``` API to allow retrieval of one table at a time.  ```CellomicsReader``` uses the new API to retrieve just the channel table from the optional companion .mdb file, so that channel names, colors, and plane exposure times are now populated.

This will require a minor release, and may require a configuration PR to add channel/plane metadata.  If there are any other test failures, feel free to exclude for now.