### PR TITLE
Increment the Memoizer version

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -333,7 +333,7 @@ public class Memoizer extends ReaderWrapper {
    * cached items. This should happen when the order and type of objects stored
    * in the memo file changes.
    */
-  public static final Integer VERSION = 3;
+  public static final Integer VERSION = 4;
 
   /**
    * Default value for {@link #minimumElapsed} if none is provided in the

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.4</ome-common.version>
+    <ome-common.version>6.0.5</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.1.0</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>


### PR DESCRIPTION
Follow up of #3557, this PR bumps the internal version number of the `Memoizer` wrapper and the `ome-common` dependency to use the same `kryo` version across the board.

Tests should be unaffected and keep passing. A test for the version bump would be to test the memo file invalidation workflow:
- create a memo file using the last stable Bio-Formats release e.g. by running `showinf -nopix -cache -debug` 
- reopen the file with a version of Bio-Formats including  this PR  using `showinf -nopix -cache -debug`
- check the memo file has been invalidated and recreated as well as the error message in the log 