### PR TITLE
Improve stringency of ChannelName and ImageName check

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -613,7 +613,7 @@ public class Configuration {
 
         if (canOpenImages(reader)) {
           try {
-            byte[] plane = reader.openBytes(0);
+            byte[] plane = unflattenedReader.openBytes(0);
             seriesTable.put(MD5, TestTools.md5(plane));
           } catch (FormatException e) {
             // TODO
@@ -626,7 +626,7 @@ public class Configuration {
           int w = (int) Math.min(TILE_SIZE, reader.getSizeX());
           int h = (int) Math.min(TILE_SIZE, reader.getSizeY());
 
-          byte[] tile = reader.openBytes(0, 0, 0, w, h);
+          byte[] tile = unflattenedReader.openBytes(0, 0, 0, w, h);
           seriesTable.put(TILE_MD5, TestTools.md5(tile));
         } catch (FormatException e) {
           // TODO

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -613,7 +613,7 @@ public class Configuration {
 
         if (canOpenImages(reader)) {
           try {
-            byte[] plane = unflattenedReader.openBytes(0);
+            byte[] plane = reader.openBytes(0);
             seriesTable.put(MD5, TestTools.md5(plane));
           } catch (FormatException e) {
             // TODO
@@ -626,7 +626,7 @@ public class Configuration {
           int w = (int) Math.min(TILE_SIZE, reader.getSizeX());
           int h = (int) Math.min(TILE_SIZE, reader.getSizeY());
 
-          byte[] tile = unflattenedReader.openBytes(0, 0, 0, w, h);
+          byte[] tile = reader.openBytes(0, 0, 0, w, h);
           seriesTable.put(TILE_MD5, TestTools.md5(tile));
         } catch (FormatException e) {
           // TODO

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -963,7 +963,7 @@ public class FormatReaderTest {
     } else if (expected == null) {
       return false;
     } else {
-      return expected.equals(real);
+      return expected.trim().equals(real.trim());
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -954,6 +954,17 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
+  private boolean isEqual(String s1, String s2) {
+
+    if (s1 == null && s2 == null) {
+      return true;
+    } else if (s1 == null || s2 == null) {
+      return false;
+    } else {
+      return s1.equals(s2);
+    }
+  }
+
   private boolean isAlmostEqual(Quantity q1, Quantity q2) {
 
     if (q1 == null && q2 == null) {
@@ -1094,9 +1105,7 @@ public class FormatReaderTest {
         String realName = retrieve.getChannelName(i, c);
         String expectedName = config.getChannelName(c);
 
-        if (!expectedName.equals(realName) &&
-          (realName == null && !expectedName.equals("null")))
-        {
+        if (!isEqual(expectedName, realName)) {
           result(testName, false, "Series " + i + " channel " + c +
             " (got '" + realName + "', expected '" + expectedName + "')");
         }
@@ -1398,9 +1407,7 @@ public class FormatReaderTest {
       String realName = retrieve.getImageName(i);
       String expectedName = config.getImageName();
 
-      if (!expectedName.equals(realName) &&
-        !(realName == null && expectedName.equals("null")))
-      {
+      if (!isEqual(expectedName, realName)) {
         result(testName, false, "Series " + i + " (got '" + realName +
           "', expected '" + expectedName + "')");
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -954,14 +954,16 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
-  private boolean isEqual(String s1, String s2) {
+  private boolean isEqual(String expected, String real) {
 
-    if (s1 == null && s2 == null) {
+    if (expected == null && real == null) {
       return true;
-    } else if (s1 == null || s2 == null) {
+    } else if (expected.equals("null")  && real == null) {
+      return true;
+    } else if (expected == null) {
       return false;
     } else {
-      return s1.equals(s2);
+      return expected.equals(real);
     }
   }
 


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/3588#issuecomment-663512854

The previous tests for channel and image names check were not failing as expected. This PR fixes the check to handle various scenarios of comparison between strings (note that the `null` value is handled specially).

f2e82c6 also fixes an issue discovered when regenerating configuration files (`zeiss-lsm`) with the pixel hashes of series > 0 being incorrect (and identical).

A companion private PR accompanies this change, updating all configuration files to use the correct metadata.