### PR TITLE
Bump ome-common to version 6.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
   exclude:
   - jdk: openjdk11
     env: BUILD=ant
-  - jdk: openjdk8
-    env: BUILD=maven
 
 script:
   - ./tools/test-build $BUILD

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.5</ome-common.version>
+    <ome-common.version>6.0.6</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.1.0</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>


### PR DESCRIPTION
See https://forum.image.sc/t/fiji-wont-open-czi-files-after-update-there-was-a-problem-with-the-class-java/40932
for the rationale and the issue with ome-common 6.0.5