### PR TITLE
Zeiss LSM: reset plane cache variables on setCoreIndex

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -364,11 +364,24 @@ public class ZeissLSMReader extends FormatReader {
     return s;
   }
 
+  /* @see loci.formats.IFormatReader#setCoreIndex(int) */
+  @Override
+  public void setCoreIndex(int coreIndex) {
+    if (coreIndex != getCoreIndex()) {
+      prevBuf = null;
+      prevPlane = -1;
+      prevRegion = null;
+    }
+    super.setCoreIndex(coreIndex);
+  }
+
   /* @see loci.formats.IFormatReader#setSeries(int) */
   @Override
   public void setSeries(int series) {
     if (series != getSeries()) {
       prevBuf = null;
+      prevPlane = -1;
+      prevRegion = null;
     }
     super.setSeries(series);
   }


### PR DESCRIPTION
Matches the behavior of setSeries.  See https://github.com/ome/bioformats/pull/3595#issuecomment-664795854

Without this change, ```ant ... test-config && ant ... test-automated``` on ```zeiss-lsm/jcb``` should result in test failures as described in #3595.  With this change, the same test should result in passing tests with correct configuration.