### PR TITLE
bfoptions: Add ability to read options from file

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -32,6 +32,7 @@
 
 package loci.formats;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -47,7 +48,9 @@ import loci.common.RandomAccessInputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.FilterMetadata;
 import loci.formats.meta.IMetadata;
@@ -242,6 +245,14 @@ public abstract class FormatReader extends FormatHandler
     // reinitialize the MetadataStore
     // NB: critical for metadata conversion to work properly!
     getMetadataStore().createRoot();
+
+    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(id);
+    if (optionsFile != null) {
+      MetadataOptions options = getMetadataOptions();
+      if (options instanceof DynamicMetadataOptions) {
+        ((DynamicMetadataOptions) options).loadOptions(optionsFile);
+      }
+    }
   }
 
   /** Returns true if the given file name is in the used files list. */

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -255,7 +255,7 @@ public abstract class FormatReader extends FormatHandler
     }
   }
 
-  /** Returns true if the list of available metadata options. */
+  /** Returns the list of available metadata options. */
   protected ArrayList<String> getAvailableOptions() {
     ArrayList<String> optionsList = new ArrayList<String>();
     optionsList.add(DynamicMetadataOptions.METADATA_LEVEL_KEY);

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -250,11 +250,19 @@ public abstract class FormatReader extends FormatHandler
     if (optionsFile != null) {
       MetadataOptions options = getMetadataOptions();
       if (options instanceof DynamicMetadataOptions) {
-        ((DynamicMetadataOptions) options).loadOptions(optionsFile);
+        ((DynamicMetadataOptions) options).loadOptions(optionsFile, getAvailableOptions());
       }
     }
   }
 
+  /** Returns true if the list of available metadata options. */
+  protected ArrayList<String> getAvailableOptions() {
+    ArrayList<String> optionsList = new ArrayList<String>();
+    optionsList.add(DynamicMetadataOptions.METADATA_LEVEL_KEY);
+    optionsList.add(DynamicMetadataOptions.READER_VALIDATE_KEY);
+    return optionsList;
+  }
+  
   /** Returns true if the given file name is in the used files list. */
   protected boolean isUsedFile(String file) {
     String[] usedFiles = getUsedFiles();

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1018,25 +1018,34 @@ public abstract class FormatReader extends FormatHandler
   /* @see IFormatReader#getUsedFiles() */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
-    String[] seriesUsedFiles;
+    String[] seriesUsedFiles;    
+    Set<String> files = new LinkedHashSet<String>();
+    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
+    if (optionsFile != null) {
+      String optionsFilePath = optionsFile.getAbsolutePath();
+      files.add(optionsFilePath);
+    }
+
     int seriesCount = getSeriesCount();
     if (seriesCount == 1) {
       seriesUsedFiles = getSeriesUsedFiles(noPixels);
       if (null == seriesUsedFiles) {
         seriesUsedFiles = new String[] {};
       }
-      return seriesUsedFiles;
+      files.addAll(Arrays.asList(seriesUsedFiles));
     }
-    int oldSeries = getSeries();
-    Set<String> files = new LinkedHashSet<String>();
-    for (int i = 0; i < seriesCount; i++) {
-      setSeries(i);
-      seriesUsedFiles = getSeriesUsedFiles(noPixels);
-      if (seriesUsedFiles != null) {
-        files.addAll(Arrays.asList(seriesUsedFiles));
+    else {
+      int oldSeries = getSeries();
+  
+      for (int i = 0; i < seriesCount; i++) {
+        setSeries(i);
+        seriesUsedFiles = getSeriesUsedFiles(noPixels);
+        if (seriesUsedFiles != null) {
+          files.addAll(Arrays.asList(seriesUsedFiles));
+        }
       }
+      setSeries(oldSeries);
     }
-    setSeries(oldSeries);
     return files.toArray(new String[files.size()]);
   }
 

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1021,7 +1021,7 @@ public abstract class FormatReader extends FormatHandler
     String[] seriesUsedFiles;    
     Set<String> files = new LinkedHashSet<String>();
     File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
-    if (optionsFile != null) {
+    if (optionsFile != null && optionsFile.exists()) {
       String optionsFilePath = optionsFile.getAbsolutePath();
       files.add(optionsFilePath);
     }

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -520,7 +520,9 @@ public class DynamicMetadataOptions implements MetadataOptions {
     if (f != null && f.getParent() != null) {
       String p = f.getParent();
       String n = f.getName();
-      n = n.substring(0, n.indexOf("."));
+      if (n.indexOf(".") >= 0) {
+        n = n.substring(0, n.indexOf("."));
+      }
       return new File(p, n + ".bfoptions");
     }
     return null;

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -32,26 +32,19 @@
 
 package loci.formats.in;
 
+import java.util.ArrayList;
 import java.util.Properties;
-import java.util.StringTokenizer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import loci.common.Constants;
 import loci.common.IniList;
 import loci.common.IniParser;
 import loci.common.IniTable;
 import loci.formats.FormatException;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-
 
 /**
  * Configuration object for readers and writers.
@@ -495,7 +488,7 @@ public class DynamicMetadataOptions implements MetadataOptions {
     return new File(val);
   }
   
-  public void loadOptions(File optionsFile) throws IOException, FormatException {
+  public void loadOptions(File optionsFile, ArrayList<String> availableOptionKeys) throws IOException, FormatException {
     if (!optionsFile.exists()) {
       LOGGER.trace("Options file doesn't exist: {}", optionsFile);
       // TODO: potentially create option
@@ -510,6 +503,9 @@ public class DynamicMetadataOptions implements MetadataOptions {
     IniList list = parser.parseINI(optionsFile);
     for (IniTable attrs: list) {
       for (String key: attrs.keySet()) {
+        if (!availableOptionKeys.contains(key)) {
+          LOGGER.warn("Metadata Option Key is not supported in this reader " + key);
+        }
         set(key, attrs.get(key));
       }
     }

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -39,6 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import loci.common.Constants;
+import loci.common.IniList;
+import loci.common.IniParser;
+import loci.common.IniTable;
 import loci.formats.FormatException;
 
 import java.io.BufferedReader;
@@ -503,43 +506,18 @@ public class DynamicMetadataOptions implements MetadataOptions {
       return;
     }
 
-    // locate an input stream
-    InputStream stream = null;
-    try {
-      stream = new FileInputStream(optionsFile);
-    } catch (FileNotFoundException e) {
-      LOGGER.debug(e.getMessage());
-      return;
-    }
-
-    // Read options from file
-    BufferedReader in = null;
-    in = new BufferedReader(new InputStreamReader(stream, Constants.ENCODING));
-    while (true) {
-      String line = null;
-      line = in.readLine();
-      if (line == null) break;
-      // Ignore characters following # sign (comments)
-      int ndx = line.indexOf('#');
-      if (ndx >= 0) line = line.substring(0, ndx);
-      line = line.trim();
-      if (line.equals("")) break;
-
-      StringTokenizer st1 = new StringTokenizer(line, "=");
-      while (st1.hasMoreTokens()) {
-        String key = st1.nextToken();
-        if (st1.hasMoreTokens()) {
-          set(key, st1.nextToken());
-        }
+    IniParser parser = new IniParser();
+    IniList list = parser.parseINI(optionsFile);
+    for (IniTable attrs: list) {
+      for (String key: attrs.keySet()) {
+        set(key, attrs.get(key));
       }
     }
-    in.close();
   }
 
   public static File getMetadataOptionsFile(String id) {
     File f = new File(id);
     if (f != null && f.getParent() != null) {
-      f.getParentFile().mkdirs();
       String p = f.getParent();
       String n = f.getName();
       n = n.substring(0, n.indexOf("."));

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -578,6 +578,15 @@ public class ZeissCZIReader extends FormatReader {
   }
 
   // -- Internal FormatReader API methods --
+  
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected ArrayList<String> getAvailableOptions() {
+    ArrayList<String> optionsList = super.getAvailableOptions();
+    optionsList.add(ALLOW_AUTOSTITCHING_KEY);
+    optionsList.add(INCLUDE_ATTACHMENTS_KEY);
+    return optionsList;
+  }
 
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override


### PR DESCRIPTION
This is an initial prototype of the potential functionality for persisting options using a .bfoptions file as discussed at the formats meeting this week.

If a reader detects a file in the same folder as the currentId with the same name and extension `.bfoptions` then the options will be parsed from the file

An example of an options file might be:
```
zeissczi.attachments=true
zeissczi.autostitch=true
```

- This is very much an early prototype for discussion but might also be useful for IDR testing
- At the moment this is limited to reading options from file and does not create the file for you
- It is also limited to readers and not writers
- Further error and exception handling would also be needed