### PR TITLE
ScanR: Merge IDR changes and add new option

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -70,7 +70,9 @@ public class ScanrReader extends FormatReader {
   private static final String EXPERIMENT_FILE = "experiment_descriptor.dat";
   private static final String ACQUISITION_FILE = "AcquisitionLog.dat";
   private static final String[] METADATA_SUFFIXES = new String[] {"dat", "xml"};
-
+  public static final String SKIP_MISSING_WELLS = "scanr.skip_missing_wells";
+  public static final boolean INCLUDE_ATTACHMENTS_DEFAULT = true;
+  
   // -- Fields --
 
   private final List<String> metadataFiles = new ArrayList<String>();
@@ -518,7 +520,12 @@ public class ScanrReader extends FormatReader {
       if (next == originalIndex &&
         missingWellFiles == nSlices * nTimepoints * nChannels * nPos)
       {
-        wellNumbers.remove(well);
+        if (skipMissingWells()) {
+          wellNumbers.remove(well);
+        }
+        else {
+          next += nSlices * nTimepoints * nChannels * nPos;
+        }
       }
     }
     nWells = wellNumbers.size();
@@ -710,6 +717,15 @@ public class ScanrReader extends FormatReader {
       store.setPlateColumnNamingConvention(MetadataTools.getNamingConvention(col), 0);
       store.setPlateName(plateName, 0);
     }
+  }
+  
+  public boolean skipMissingWells() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+          SKIP_MISSING_WELLS, SKIP_MISSING_WELLS_DEFAULT);
+    }
+    return SKIP_MISSING_WELLS_DEFAULT;
   }
 
   // -- Helper class --

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -544,7 +544,12 @@ public class ScanrReader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
-    reader.setId(tiffs[0]);
+    for (String tiff : tiffs) {
+      if (tiff != null) {
+        reader.setId(tiff);
+        break;
+      }
+    }
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();
     int pixelType = reader.getPixelType();

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -71,7 +71,7 @@ public class ScanrReader extends FormatReader {
   private static final String ACQUISITION_FILE = "AcquisitionLog.dat";
   private static final String[] METADATA_SUFFIXES = new String[] {"dat", "xml"};
   public static final String SKIP_MISSING_WELLS = "scanr.skip_missing_wells";
-  public static final boolean INCLUDE_ATTACHMENTS_DEFAULT = true;
+  public static final boolean SKIP_MISSING_WELLS_DEFAULT = true;
   
   // -- Fields --
 


### PR DESCRIPTION
This PR merges the IDR specific changes https://github.com/IDR/bioformats/commit/d74f7f75ea14e7da22604faacef45ead7ff8e10a and https://github.com/IDR/bioformats/commit/563299273fd14e3e5bf0914a36330ee17f093155

A new metadata option `scanr.skip_missing_wells` has been added to retain the original functionality or allow the IDR behaviour to be toggled. This should mean no breakages in behaviour for existing OMERO users.

To test:
- Ensure builds and tests remain green
- Default behaviour should see missing wells skipped when imported
- Ensure IDR behaviour is not impacted when `scanr.skip_missing_wells` is set to `false`