### PR TITLE
MetaMorph: Correct laser index for multi series datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -59,6 +59,7 @@ import loci.formats.CoreMetadataList;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
+import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.IFDList;
@@ -1012,7 +1013,7 @@ public class MetamorphReader extends BaseTiffReader {
 
           if ((int) wave[waveIndex] >= 1) {
             // link LightSource to Image
-            int laserIndex = i * getEffectiveSizeC() + c;
+            int laserIndex = ((IMetadata)getMetadataStore()).getLightSourceCount(0);
             String lightSourceID =
               MetadataTools.createLSID("LightSource", 0, laserIndex);
             store.setLaserID(lightSourceID, 0, laserIndex);


### PR DESCRIPTION
This issue was raised in forum thread https://forum.image.sc/t/error-during-opening-an-nd-file/7131

A sample file was provided via ftp and is located at `repos/curated/metamorph/imagesc-wafle-2020-08-18`. This new dataset will be configured and added to the data repo tests as a follow up.

The bug was caused because the dataset contains multiple series, which had varying dimensions, particularly the effective size C for each differed. This meant that the calculation for the laser index was incorrect. As I believe the value should always be incrementing then basing the index on the existing size should correct for this.

To test:
- All other repo tests should remain green and unaffected
- Without this PR trying to import the file will result in an IndexOutOfBoundsException
- With this PR included the file should import and images displayed and looking sensible