### PR TITLE
CZI: Pad scene number and switch to 1 indexed

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1265,7 +1265,8 @@ public class ZeissCZIReader extends FormatReader {
           store.setImageName("", i);
         }
         else {
-          store.setImageName("Scene #" + i, i);
+          int paddingLength = (""+getSeriesCount()).length();
+          store.setImageName("Scene #" + String.format("%0"+paddingLength+"d", (i + 1)), i);
         }
       }
       else if (extraIndex == 0) {


### PR DESCRIPTION
This request was raised in forum thread https://forum.image.sc/t/scene-numbering-in-omero-from-multi-scene-czi-files/41794
The PR switches the image name which is Scene #0, Scene #&#x2060;1 etc to be 1 indexed. It also adds zero padding when necessary.

As far as I can find we only have 2 datasets in the repo which use this scene number and unfortunately both only have a single digit number of scenes.

To test you can use either of the below:
```
zeiss-czi/zeiss/zen-2012/Multiscene/Mouse-kidney-3-scene_VivaTome_1chZS.czi
zeiss-czi/qa-27169/226-0903_wt_DAPI_0_DsRED_tdT_0_CB-Scene-1-ScanRegion0.czi
```

The updated value can be seen when viewing the Image Name in the OME-XML using (note noflat must be set) :
`showinf -noflat -nopix -omexml path/to/file.czi`


