### PR TITLE
Remove FileStitcher from FormatReaderTest and FormatReaderTestFactory

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -38,7 +38,6 @@ import loci.common.IniParser;
 import loci.common.IniTable;
 import loci.common.IniWriter;
 import loci.common.Location;
-import loci.formats.FileStitcher;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
@@ -536,7 +535,7 @@ public class Configuration {
     int seriesCount = reader.getSeriesCount();
     IFormatReader unflattenedReader = reader;
     if (seriesCount > 1) {
-      unflattenedReader = new FileStitcher();
+      unflattenedReader = new ImageReader();
       unflattenedReader.setFlattenedResolutions(false);
       try {
         unflattenedReader.setId(reader.getCurrentFile());

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -48,7 +48,6 @@ import loci.common.RandomAccessInputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
-import loci.formats.FileStitcher;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
@@ -591,7 +590,6 @@ public class FormatReaderTest {
 
         // NB: OME-TIFF files do not have a BinData element under Pixels
         IFormatReader r = reader.unwrap();
-        if (r instanceof FileStitcher) r = ((FileStitcher) r).getReader();
         if (r instanceof ReaderWrapper) r = ((ReaderWrapper) r).unwrap();
         if (!(r instanceof OMETiffReader)) {
           boolean littleEndian = false;
@@ -1768,7 +1766,7 @@ public class FormatReaderTest {
 
       LOGGER.debug("newFile = {}", newFile);
 
-      IFormatReader check = new FileStitcher();
+      IFormatReader check = new ImageReader();
       try {
         check.setId(newFile);
         int nFiles = check.getUsedFiles().length;
@@ -1819,7 +1817,7 @@ public class FormatReaderTest {
       else if (success) {
         Arrays.sort(base);
         IFormatReader r =
-          /*config.noStitching() ? new ImageReader() :*/ new FileStitcher();
+          /*config.noStitching() ? new ImageReader() :*/ new ImageReader();
 
         int maxFiles = (int) Math.min(base.length, 100);
 
@@ -2443,9 +2441,6 @@ public class FormatReaderTest {
         if (r instanceof ReaderWrapper) {
           r = ((ReaderWrapper) r).getReader();
         }
-        else if (r instanceof FileStitcher) {
-          r = ((FileStitcher) r).getReader();
-        }
         else break;
       }
       if (r instanceof ImageReader) {
@@ -2972,11 +2967,11 @@ public class FormatReaderTest {
     IFormatReader ir = null;
     if (flattened) {
       ir = new ImageReader();
-      ir = new BufferedImageReader(new FileStitcher(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File(""))));
+      ir = new BufferedImageReader(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File("")));
       ir.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.NO_OVERLAYS));
     }
     else {
-      ir = new BufferedImageReader(new FileStitcher());
+      ir = new BufferedImageReader(new ImageReader());
       ir.setFlattenedResolutions(false);
     }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import loci.common.DataTools;
-import loci.formats.FileStitcher;
+import loci.formats.ImageReader;
 import loci.formats.UnknownFormatException;
 
 import org.slf4j.Logger;
@@ -239,7 +239,7 @@ public class FormatReaderTestFactory {
       originalPath.put(canonicalPath, s);
     }
     Set<String> minimalFiles = new LinkedHashSet<String>();
-    FileStitcher reader = new FileStitcher();
+    ImageReader reader = new ImageReader();
     Set<String> failingIds = new LinkedHashSet<String>();
     while (!fileSet.isEmpty()) {
       String file = fileSet.iterator().next();


### PR DESCRIPTION
The `FileStitcher` has been included in the automated tests since the inception of the `test-suite` component. This means that file stitching based on name pattern is automatically executed fo every fileset for every format in the curated QA repository - see [here](https://downloads.openmicroscopy.org/images/DV/U2OS/), [here](https://downloads.openmicroscopy.org/images/DICOM/nema/WG04/IMAGES/J2KR/) or. [here](https://downloads.openmicroscopy.org/images/PNG/user-4/dataset-user-4/) for public filesets where several files are grouped by stitching. For some filesets, the non-stitched filesets have mismatching dimensions and the stitching logic fails. In these cases, the only way to configuration the files for testing is to artificially split them into separate folders - see [here](https://downloads.openmicroscopy.org/images/Leica-SCN/openslide/).

This PR proposes to remove the `FileStitcher` from the `FormatReaderTest` and other relevant locations. A separate private PR updates all configuration files for all filesets that were previously grouped by the stitcher, testing each non-stitched fileset instead. The performance of the daily CI job should be largely unaffected.

The stitching functionality will remain tested by the non-regression tests specifically in the case of the `.pattern` filesets since the associated `FilePatternReader` largely delegates its logic to `FileStitcher`.