### PR TITLE
Review and update the instances of image index in the API documentation

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -632,7 +632,7 @@ public final class FormatTools {
 
     // check image count
     if (num <= 0) {
-      throw new IllegalArgumentException("Invalid image count: " + num);
+      throw new IllegalArgumentException("Invalid plane count: " + num);
     }
     if (num != zSize * cSize * tSize) {
       // if this happens, there is probably a bug in metadata population --
@@ -643,7 +643,7 @@ public final class FormatTools {
         ", total=" + num + ")");
     }
     if (index < 0 || index >= num) {
-      throw new IllegalArgumentException("Invalid image index: " +
+      throw new IllegalArgumentException("Invalid plane index: " +
         index + "/" + num);
     }
 

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -256,7 +256,7 @@ public interface IFormatReader extends IFormatHandler, IPyramidHandler {
    * pre-allocated byte array of
    * (sizeX * sizeY * bytesPerPixel * RGB channel count).
    *
-   * @param no the image index within the file.
+   * @param no the plane index within the current series.
    * @param buf a pre-allocated buffer.
    * @return the pre-allocated buffer <code>buf</code> for convenience.
    * @throws FormatException if there was a problem parsing the metadata of the
@@ -270,7 +270,7 @@ public interface IFormatReader extends IFormatHandler, IPyramidHandler {
    * Obtains a sub-image of the specified image plane
    * into a pre-allocated byte array.
    *
-   * @param no the image index within the file.
+   * @param no the plane index within the current series.
    * @param buf a pre-allocated buffer.
    * @param x X coordinate of the upper-left corner of the sub-image
    * @param y Y coordinate of the upper-left corner of the sub-image

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -48,7 +48,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param buf the byte array that represents the image.
    * @throws FormatException if one of the parameters is invalid.
    * @throws IOException if there was a problem writing to the file.
@@ -58,7 +58,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image tile to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param buf the byte array that represents the image tile.
    * @param x the X coordinate of the upper-left corner of the image tile.
    * @param y the Y coordinate of the upper-left corner of the image tile.
@@ -73,7 +73,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image tile to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param buf the byte array that represents the image tile.
    * @param tile the Region representing the image tile to be read.
    * @throws FormatException if one of the parameters is invalid.
@@ -85,7 +85,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image plane to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param plane the image plane.
    * @throws FormatException if one of the parameters is invalid.
    * @throws IOException if there was a problem writing to the file.
@@ -95,7 +95,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image plane to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param plane the image plane.
    * @param x the X coordinate of the upper-left corner of the image tile.
    * @param y the Y coordinate of the upper-left corner of the image tile.
@@ -110,7 +110,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
   /**
    * Saves the given image plane to the current series in the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param plane the image plane.
    * @param tile the Region representing the image tile to be read.
    * @throws FormatException if one of the parameters is invalid.

--- a/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
+++ b/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
@@ -297,7 +297,7 @@ public class MinMaxCalculator extends ReaderWrapper {
 
   /**
    * Updates min/max values based on the given byte array.
-   * @param no the image index within the file.
+   * @param no the plane index within the series.
    * @param buf a pre-allocated buffer.
    * @param len as <code>buf</code> may be larger than the actual pixel count
    * having been written to it, the length (in bytes) of the those pixels.

--- a/components/formats-bsd/src/loci/formats/gui/BufferedImageWriter.java
+++ b/components/formats-bsd/src/loci/formats/gui/BufferedImageWriter.java
@@ -69,7 +69,7 @@ public class BufferedImageWriter extends WriterWrapper {
   /**
    * Saves the given BufferedImage to the current file.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param image the BufferedImage to save.
    */
   public void saveImage(int no, BufferedImage image)
@@ -82,7 +82,7 @@ public class BufferedImageWriter extends WriterWrapper {
    * Saves the given BufferedImage to the current file.  The BufferedImage
    * may represent a subsection of the full image to be saved.
    *
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param image the BufferedImage to save.
    * @param x the X coordinate of the upper-left corner of the image.
    * @param y the Y coordinate of the upper-left corner of the image.

--- a/components/formats-bsd/src/loci/formats/out/JPEG2000Writer.java
+++ b/components/formats-bsd/src/loci/formats/out/JPEG2000Writer.java
@@ -86,7 +86,7 @@ public class JPEG2000Writer extends FormatWriter {
   /**
    * Compresses the buffer.
    * 
-   * @param no the image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param buf the byte array that represents the image tile.
    * @param x the X coordinate of the upper-left corner of the image tile.
    * @param y the Y coordinate of the upper-left corner of the image tile.

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -260,7 +260,7 @@ public class TiffSaver implements Closeable {
    *
    * @param buf The block that is to be written.
    * @param ifd The Image File Directories. Mustn't be <code>null</code>.
-   * @param no  The image index within the current file, starting from 0.
+   * @param no the plane index within the current series.
    * @param pixelType The type of pixels.
    * @param x   The X-coordinate of the top-left corner.
    * @param y   The Y-coordinate of the top-left corner.
@@ -441,7 +441,7 @@ public class TiffSaver implements Closeable {
    * Performs the actual work of dealing with IFD data and writing it to the
    * TIFF for a given image or sub-image.
    * @param ifd The Image File Directories. Mustn't be <code>null</code>.
-   * @param no The image index within the current file, starting from 0.
+   * @param no the plane index within the series.
    * @param strips The strips to write to the file.
    * @param last Pass <code>true</code> if it is the last image,
    * <code>false</code> otherwise.


### PR DESCRIPTION
Reported in https://forum.image.sc/t/loci-formats-in-ometiffreader-loads-different-slices-than-loci-formats-in-tiffreader/42536/9, the Javadoc of various APIs still refers to the `the image index within the file.` which erroneously lead to thinking the reader is iterating over the IFDs in order within a TIFF file for instance.

This PR updates all relevant locations to use `the plane index within the current series` as was done in `ome-files-cpp`. 