### PR TITLE
Options: test-suite improvements

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1020,11 +1020,6 @@ public abstract class FormatReader extends FormatHandler
   public String[] getUsedFiles(boolean noPixels) {
     String[] seriesUsedFiles;    
     Set<String> files = new LinkedHashSet<String>();
-    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
-    if (optionsFile != null && optionsFile.exists()) {
-      String optionsFilePath = optionsFile.getAbsolutePath();
-      files.add(optionsFilePath);
-    }
 
     int seriesCount = getSeriesCount();
     if (seriesCount == 1) {
@@ -1046,6 +1041,13 @@ public abstract class FormatReader extends FormatHandler
       }
       setSeries(oldSeries);
     }
+
+    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
+    if (optionsFile != null && optionsFile.exists()) {
+      String optionsFilePath = optionsFile.getAbsolutePath();
+      files.add(optionsFilePath);
+    }
+
     return files.toArray(new String[files.size()]);
   }
 

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -249,7 +249,7 @@ public abstract class FormatReader extends FormatHandler
     String optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(id);
     if (optionsFile != null) {
       MetadataOptions options = getMetadataOptions();
-      if (options instanceof DynamicMetadataOptions) {
+      if (options != null && options instanceof DynamicMetadataOptions) {
         ((DynamicMetadataOptions) options).loadOptions(optionsFile, getAvailableOptions());
       }
     }

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -246,7 +246,7 @@ public abstract class FormatReader extends FormatHandler
     // NB: critical for metadata conversion to work properly!
     getMetadataStore().createRoot();
 
-    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(id);
+    String optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(id);
     if (optionsFile != null) {
       MetadataOptions options = getMetadataOptions();
       if (options instanceof DynamicMetadataOptions) {
@@ -1042,10 +1042,9 @@ public abstract class FormatReader extends FormatHandler
       setSeries(oldSeries);
     }
 
-    File optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
-    if (optionsFile != null && optionsFile.exists()) {
-      String optionsFilePath = optionsFile.getAbsolutePath();
-      files.add(optionsFilePath);
+    String optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(currentId);
+    if (optionsFile != null && new Location(optionsFile).exists()) {
+      files.add(optionsFile);
     }
 
     return files.toArray(new String[files.size()]);

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -501,7 +501,7 @@ public class DynamicMetadataOptions implements MetadataOptions {
     }
 
     IniParser parser = new IniParser();
-    IniList list = parser.parseINI(optionsFile);
+    IniList list = parser.parseINI(new File(optionsFile));
     for (IniTable attrs: list) {
       for (String key: attrs.keySet()) {
         if (!availableOptionKeys.contains(key)) {

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import loci.common.IniList;
 import loci.common.IniParser;
 import loci.common.IniTable;
+import loci.common.Location;
 import loci.formats.FormatException;
 
 import java.io.File;
@@ -488,13 +489,13 @@ public class DynamicMetadataOptions implements MetadataOptions {
     return new File(val);
   }
   
-  public void loadOptions(File optionsFile, ArrayList<String> availableOptionKeys) throws IOException, FormatException {
-    if (!optionsFile.exists()) {
+  public void loadOptions(String optionsFile, ArrayList<String> availableOptionKeys) throws IOException, FormatException {
+    if (!new Location(optionsFile).exists()) {
       LOGGER.trace("Options file doesn't exist: {}", optionsFile);
       // TODO: potentially create option
       return;
     }
-    if(!optionsFile.canRead()) {
+    if(!new Location(optionsFile).canRead()) {
       LOGGER.trace("Can't read options file: {}", optionsFile);
       return;
     }
@@ -511,15 +512,15 @@ public class DynamicMetadataOptions implements MetadataOptions {
     }
   }
 
-  public static File getMetadataOptionsFile(String id) {
-    File f = new File(id);
+  public static String getMetadataOptionsFile(String id) {
+    Location f = new Location(id);
     if (f != null && f.getParent() != null) {
       String p = f.getParent();
       String n = f.getName();
       if (n.indexOf(".") >= 0) {
         n = n.substring(0, n.indexOf("."));
       }
-      return new File(p, n + ".bfoptions");
+      return new Location(p, n + ".bfoptions").getAbsolutePath();
     }
     return null;
   }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -42,6 +42,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.in.DefaultMetadataOptions;
 import loci.formats.ReaderWrapper;
 import loci.formats.meta.IMetadata;
 

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -42,7 +42,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.ReaderWrapper;
 import loci.formats.meta.IMetadata;
 
@@ -538,7 +538,7 @@ public class Configuration {
     if (seriesCount > 1) {
       unflattenedReader = new ImageReader();
       unflattenedReader.setFlattenedResolutions(false);
-      unflattenedReader.setMetadataOptions(new DefaultMetadataOptions());
+      unflattenedReader.setMetadataOptions(new DynamicMetadataOptions());
       try {
         unflattenedReader.setId(reader.getCurrentFile());
       }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -537,6 +537,7 @@ public class Configuration {
     if (seriesCount > 1) {
       unflattenedReader = new ImageReader();
       unflattenedReader.setFlattenedResolutions(false);
+      unflattenedReader.setMetadataOptions(new DefaultMetadataOptions());
       try {
         unflattenedReader.setId(reader.getCurrentFile());
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2454,6 +2454,12 @@ public class FormatReaderTest {
           for (int j=0; j<readers.length; j++) {
             boolean result = readers[j].isThisType(used[i]);
 
+            // Options files
+            if (!result && used[i].toLowerCase().endsWith(".bfoptions"))
+            {
+              continue;
+            }
+
             // Companion file grouping non-ome-tiff files:
             // setId must be called on the companion file
             if (!result && readers[j] instanceof OMETiffReader &&

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1840,6 +1840,12 @@ public class FormatReaderTest {
             }
           }
 
+          // Options files
+          if (base[i].toLowerCase().endsWith(".bfoptions"))
+          {
+            continue;
+          }
+
           // extra metadata files in Harmony/Operetta datasets
           // cannot be used for type detection
           if (reader.getFormat().equals("PerkinElmer Operetta")) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1767,6 +1767,7 @@ public class FormatReaderTest {
       LOGGER.debug("newFile = {}", newFile);
 
       IFormatReader check = new ImageReader();
+      check.setMetadataOptions(new DynamicMetadataOptions());
       try {
         check.setId(newFile);
         int nFiles = check.getUsedFiles().length;

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2968,7 +2968,7 @@ public class FormatReaderTest {
     if (flattened) {
       ir = new ImageReader();
       ir = new BufferedImageReader(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File("")));
-      ir.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.NO_OVERLAYS));
+      ir.setMetadataOptions(new DynamicMetadataOptions(MetadataLevel.NO_OVERLAYS));
     }
     else {
       ir = new BufferedImageReader(new ImageReader());


### PR DESCRIPTION
Folllowing the new API introduced in https://github.com/ome/bioformats/pull/3605, this PR makes a few modifications primarily in the `test-suite` component in order to run the non-regression tests against filesets containing `.bfoptions` files.

- the readers from `Configuration` and `FormatReaderTest` are systematically initialized with a `DynamicMetadataOptions` instance as the latter is required to load options file
- skip `.bfoptions` file in `FormatReaderTest.isThisType()`
- the options file is appended to the `FormatReader.getUsedFiles` API rather than being prepended. The rationale for doing so is that the `ImageReader.getRequiredDirectories()` determines the reader on the first file in this list. Without this change, `FormatReaderTest.testRequiredDirectories()` was failing with an `UnknownFormatException` against a fileset with an options file.
-  `DynamicMetadataOptions.getMetadataOptionsFile()` and `DynamicMetadataOptions.loadOptions()` are modified to return a `String` and take a `String` as an input (like `FormatReader.getCurrentId`). Internally, the function logic is updated to use `loci.common.Location` rather than `java.io.File`.