### PR TITLE
Memoizer: Persist caching to sub readers

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -53,6 +53,8 @@ import loci.formats.FilePattern;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.UnsupportedCompressionException;
 import loci.formats.codec.Codec;
@@ -153,7 +155,7 @@ public class DicomReader extends FormatReader {
   private int originalSeries;
   private int originalX, originalY;
 
-  private DicomReader helper;
+  private IFormatReader helper;
 
   private List<String> companionFiles = new ArrayList<String>();
 
@@ -494,6 +496,7 @@ public class DicomReader extends FormatReader {
     attachCompanionFiles();
 
     helper = new DicomReader();
+    helper = Memoizer.wrap(getMetadataOptions(), helper);
     helper.setGroupFiles(false);
 
     m.littleEndian = true;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -50,6 +50,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -99,7 +101,7 @@ public class MicromanagerReader extends FormatReader {
   // -- Fields --
 
   /** Helper reader for TIFF files. */
-  private MinimalTiffReader tiffReader;
+  private IFormatReader tiffReader;
 
   private Vector<Position> positions;
   private int start = 0;
@@ -260,6 +262,7 @@ public class MicromanagerReader extends FormatReader {
   public void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
     tiffReader = new MinimalTiffReader();
+    tiffReader = Memoizer.wrap(getMetadataOptions(), tiffReader);
     positions = new Vector<Position>();
 
     LOGGER.info("Reading metadata file");

--- a/components/formats-bsd/src/loci/formats/in/NRRDReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NRRDReader.java
@@ -48,6 +48,7 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.UnknownFormatException;
 import loci.formats.UnsupportedCompressionException;
@@ -67,7 +68,7 @@ public class NRRDReader extends FormatReader {
   // -- Fields --
 
   /** Helper reader. */
-  private ImageReader helper;
+  private IFormatReader helper;
 
   /** Name of data file, if the current extension is 'nhdr'. */
   private String dataFile;
@@ -259,6 +260,7 @@ public class NRRDReader extends FormatReader {
       }
     }
     helper = new ImageReader(newClasses);
+    helper = Memoizer.wrap(getMetadataOptions(), helper);
     helper.setMetadataOptions(
       new DefaultMetadataOptions(MetadataLevel.MINIMUM));
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -53,6 +53,7 @@ import loci.formats.CoreMetadataList;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.MissingLibraryException;
 import loci.formats.Modulo;
@@ -548,6 +549,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
     if (!isGroupFiles() && !isSingleFile(currentId)) {
       IFormatReader reader = new MinimalTiffReader();
+      reader = Memoizer.wrap(getMetadataOptions(), reader);
       initializeReader(reader, currentId);
       core.set(0, 0, new OMETiffCoreMetadata(reader.getCoreMetadataList().get(0)));
       int ifdCount = reader.getImageCount();
@@ -1021,6 +1023,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
         }
         if (info[s][0].reader == null) {
           info[s][0].reader = new MinimalTiffReader();
+          info[s][0].reader = Memoizer.wrap(getMetadataOptions(), info[s][0].reader);
         }
         String firstFile = info[s][0].id;
         if (firstFile == null ||

--- a/components/formats-bsd/src/loci/formats/in/ZipReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ZipReader.java
@@ -45,7 +45,9 @@ import loci.common.ZipHandle;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
+import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.Memoizer;
 
 /**
  * Reader for Zip files.
@@ -54,7 +56,7 @@ public class ZipReader extends FormatReader {
 
   // -- Fields --
 
-  private transient ImageReader reader;
+  private transient IFormatReader reader;
   private String entryName;
 
   private ArrayList<String> mappedFiles = new ArrayList<String>();
@@ -125,6 +127,7 @@ public class ZipReader extends FormatReader {
     }
     else {
       reader = new ImageReader();
+      reader = Memoizer.wrap(getMetadataOptions(), reader);
     }
     findZipEntries();
   }
@@ -139,6 +142,7 @@ public class ZipReader extends FormatReader {
       reader.close();
     }
     reader = new ImageReader();
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
 
     reader.setMetadataOptions(getMetadataOptions());
     reader.setMetadataFiltered(isMetadataFiltered());

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -48,6 +48,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -81,7 +83,7 @@ public class BDReader extends FormatReader {
   private List<String> wellLabels = new ArrayList<String>();
   private String plateName, plateDescription;
   private String[][] tiffs;
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
 
   private String roiFile;
   private double[] emWave, exWave;
@@ -344,6 +346,7 @@ public class BDReader extends FormatReader {
     tiffs = getTiffs();
 
     reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
     reader.setId(tiffs[0][0]);
 
     int sizeX = reader.getSizeX();

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -42,6 +42,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -79,7 +81,7 @@ public class CV7000Reader extends FormatReader {
 
   private String[] allFiles;
   private Location parent;
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
   private String wppPath;
   private String detailPath;
   private String measurementPath;
@@ -334,6 +336,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
     reader.setId(firstFile);
     core.clear();
     core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -42,6 +42,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.codec.Codec;
 import loci.formats.codec.CodecOptions;
@@ -1076,12 +1077,13 @@ public class CellSensReader extends FormatReader {
         case PNG:
           file = "tile.png";
           reader = new APNGReader();
+          reader = Memoizer.wrap(getMetadataOptions(), reader);
         case BMP:
           if (reader == null) {
             file = "tile.bmp";
             reader = new BMPReader();
+            reader = Memoizer.wrap(getMetadataOptions(), reader);
           }
-
           byte[] b = new byte[(int) (end - offset)];
           ets.read(b);
           Location.mapFile(file, new ByteArrayHandle(b));

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -44,6 +44,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
@@ -146,7 +148,7 @@ public class CellVoyagerReader extends FormatReader
     final int areaIndex = indices[ 1 ];
     final WellInfo well = wells.get( wellIndex );
     final AreaInfo area = well.areas.get( areaIndex );
-    final MinimalTiffReader tiffReader = new MinimalTiffReader();
+    final IFormatReader tiffReader = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
 
     imageFolder = new Location(currentId).getAbsoluteFile().getParentFile();
     imageFolder = new Location(imageFolder, "Image");

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -43,6 +43,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataStore;
@@ -835,6 +836,7 @@ public class CellWorxReader extends FormatReader {
     if (checkSuffix(file, "tif")) {
       pnl = new MetamorphReader();
     }
+    pnl = Memoizer.wrap(getMetadataOptions(), pnl);
 
     if (omexml) {
       IMetadata metadata;

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -43,6 +43,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 
@@ -80,7 +82,7 @@ public class ColumbusReader extends FormatReader {
 
   private ArrayList<String> metadataFiles = new ArrayList<String>();
   private ArrayList<Plane> planes = new ArrayList<Plane>();
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
 
   private int nFields = 0;
   private String acquisitionDate;
@@ -296,6 +298,7 @@ public class ColumbusReader extends FormatReader {
     planes.clear();
 
     reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
     reader.setId(tmpPlanes[0].file);
     core = reader.getCoreMetadataList();
 

--- a/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
@@ -43,6 +43,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.codec.JPEGTileDecoder;
 import loci.formats.meta.MetadataStore;
@@ -148,7 +150,8 @@ public class HamamatsuVMSReader extends FormatReader {
     }
 
     if (getSizeX() <= MAX_SIZE || getSizeY() <= MAX_SIZE) {
-      JPEGReader reader = new JPEGReader();
+      IFormatReader reader = new JPEGReader();
+      reader = Memoizer.wrap(getMetadataOptions(), reader);
       reader.setId(file);
       reader.openBytes(0, buf, x, y, w, h);
       reader.close();

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -41,6 +41,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.IMinMaxStore;
 import loci.formats.meta.MetadataStore;
@@ -80,7 +82,7 @@ public class InCellReader extends FormatReader {
   private boolean[][] plateMap;
 
   private Image[][][][] imageFiles;
-  private MinimalTiffReader tiffReader;
+  private IFormatReader tiffReader;
   private List<Double> emWaves, exWaves;
   private List<String> channelNames;
   private int totalImages;
@@ -508,6 +510,7 @@ public class InCellReader extends FormatReader {
 
     if (isTiff && filename != null) {
       tiffReader = new MinimalTiffReader();
+      tiffReader = Memoizer.wrap(getMetadataOptions(), tiffReader);
       tiffReader.setId(filename);
       for (int i=0; i<seriesCount; i++) {
         CoreMetadata ms = core.get(i);

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -38,6 +38,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import ome.units.quantity.Length;
@@ -61,7 +63,7 @@ public class L2DReader extends FormatReader {
   /** List of all metadata files in the dataset. */
   private List<String>[] metadataFiles;
 
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
   private int[] tileWidth, tileHeight;
 
   // -- Constructor --
@@ -219,6 +221,7 @@ public class L2DReader extends FormatReader {
       }
       r.close();
       reader = new MinimalTiffReader();
+      reader = Memoizer.wrap(getMetadataOptions(), reader);
       return;
     }
 
@@ -301,6 +304,7 @@ public class L2DReader extends FormatReader {
     setSeries(0);
 
     reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
 
     MetadataStore store = makeFilterMetadata();
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -44,6 +44,8 @@ import loci.formats.FilePattern;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -114,7 +116,7 @@ public class LeicaReader extends FormatReader {
   protected IFDList headerIFDs;
 
   /** Helper readers. */
-  protected MinimalTiffReader tiff;
+  protected IFormatReader tiff;
 
   /** Array of image file names. */
   protected List<String>[] files;
@@ -385,6 +387,7 @@ public class LeicaReader extends FormatReader {
         files = new List[] {new ArrayList<String>()};
         files[0].add(id);
         tiff = new MinimalTiffReader();
+        tiff = Memoizer.wrap(getMetadataOptions(), tiff);
 
         return;
       }
@@ -539,6 +542,7 @@ public class LeicaReader extends FormatReader {
     }
 
     tiff = new MinimalTiffReader();
+    tiff = Memoizer.wrap(getMetadataOptions(), tiff);
 
     LOGGER.info("Populating metadata");
 

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -45,7 +45,9 @@ import loci.formats.FilePattern;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
 import loci.formats.ImageTools;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.codec.BitWriter;
 import loci.formats.meta.MetadataStore;
@@ -74,7 +76,7 @@ public class MIASReader extends FormatReader {
   private String[][] tiffs;
 
   /** Delegate readers. */
-  private MinimalTiffReader[][] readers;
+  private IFormatReader[][] readers;
 
   /** Path to file containing analysis results for all plates. */
   private String resultFile = null;
@@ -320,8 +322,8 @@ public class MIASReader extends FormatReader {
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
     if (readers != null) {
-      for (MinimalTiffReader[] images : readers) {
-        for (MinimalTiffReader r : images) {
+      for (IFormatReader[] images : readers) {
+        for (IFormatReader r : images) {
           if (r != null) r.close(fileOnly);
         }
       }
@@ -424,7 +426,7 @@ public class MIASReader extends FormatReader {
     if (!isGroupFiles()) {
       tiffs = new String[][] {{id}};
       readers = new MinimalTiffReader[1][1];
-      readers[0][0] = new MinimalTiffReader();
+      readers[0][0] = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
 
       TiffReader r = new TiffReader();
       r.setMetadataStore(getMetadataStore());
@@ -675,7 +677,7 @@ public class MIASReader extends FormatReader {
       LOGGER.debug("Well {} has {} files.", j, tiffFiles.length);
       readers[j] = new MinimalTiffReader[tiffFiles.length];
       for (int k=0; k<tiffFiles.length; k++) {
-        readers[j][k] = new MinimalTiffReader();
+        readers[j][k] = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -58,6 +58,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.CoreMetadataList;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -143,7 +145,7 @@ public class MetamorphReader extends BaseTiffReader {
 
   private int mmPlanes; //number of metamorph planes
 
-  private MetamorphReader[][] stkReaders;
+  private IFormatReader[][] stkReaders;
 
   /** List of STK files in the dataset. */
   private String[][] stks;
@@ -332,9 +334,9 @@ public class MetamorphReader extends BaseTiffReader {
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
     if (stkReaders != null) {
-      for (MetamorphReader[] s : stkReaders) {
+      for (IFormatReader[] s : stkReaders) {
         if (s != null) {
-          for (MetamorphReader reader : s) {
+          for (IFormatReader reader : s) {
             if (reader != null) reader.close(fileOnly);
           }
         }
@@ -746,17 +748,19 @@ public class MetamorphReader extends BaseTiffReader {
     }
 
     if (stks == null) {
-      stkReaders = new MetamorphReader[1][1];
+      stkReaders = new IFormatReader[1][1];
       stkReaders[0][0] = new MetamorphReader();
-      stkReaders[0][0].setCanLookForND(false);
+      ((MetamorphReader)stkReaders[0][0]).setCanLookForND(false);
+      stkReaders[0][0] = Memoizer.wrap(getMetadataOptions(), stkReaders[0][0]);
     }
     else {
-      stkReaders = new MetamorphReader[stks.length][];
+      stkReaders = new IFormatReader[stks.length][];
       for (int i=0; i<stks.length; i++) {
-        stkReaders[i] = new MetamorphReader[stks[i].length];
+        stkReaders[i] = new IFormatReader[stks[i].length];
         for (int j=0; j<stkReaders[i].length; j++) {
           stkReaders[i][j] = new MetamorphReader();
-          stkReaders[i][j].setCanLookForND(false);
+          ((MetamorphReader)stkReaders[i][j]).setCanLookForND(false);
+          stkReaders[i][j] = Memoizer.wrap(getMetadataOptions(), stkReaders[i][j]);
           if (j > 0) {
             stkReaders[i][j].setMetadataOptions(
               new DefaultMetadataOptions(MetadataLevel.MINIMUM));

--- a/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
@@ -38,6 +38,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.codec.CodecOptions;
 import loci.formats.codec.LZOCodec;
@@ -87,7 +88,7 @@ public class OpenlabReader extends FormatReader {
   // -- Static fields --
 
   /** Helper reader to read PICT data. */
-  private PictReader pict = new PictReader();
+  private IFormatReader pict = Memoizer.wrap(getMetadataOptions(), new PictReader());
 
   // -- Fields --
 

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -38,6 +38,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -72,7 +74,7 @@ public class OperettaReader extends FormatReader {
   // -- Fields --
 
   private Plane[][] planes;
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
   private ArrayList<String> metadataFiles = new ArrayList<String>();
 
   // -- Constructor --
@@ -225,7 +227,7 @@ public class OperettaReader extends FormatReader {
 
       if (p != null && p.filename != null && new Location(p.filename).exists()) {
         if (reader == null) {
-          reader = new MinimalTiffReader();
+          reader = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
         }
         reader.setId(p.filename);
         if (reader.getSizeX() >= getSizeX() && reader.getSizeY() >= getSizeY()) {
@@ -396,7 +398,7 @@ public class OperettaReader extends FormatReader {
       }
     }
 
-    reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
 
     for (int i=0; i<seriesCount; i++) {
       CoreMetadata ms = new CoreMetadata();

--- a/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
@@ -39,6 +39,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 
@@ -74,7 +76,7 @@ public class PerkinElmerReader extends FormatReader {
   // -- Fields --
 
   /** Helper reader. */
-  protected MinimalTiffReader tiff;
+  protected IFormatReader tiff;
 
   /** List of files to open. */
   protected PixelsFile[] files;
@@ -441,7 +443,7 @@ public class PerkinElmerReader extends FormatReader {
       }
     }
 
-    tiff = new MinimalTiffReader();
+    tiff = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
 
     // we always parse the .tim and .htm files if they exist, along with
     // either the .csv file or the .zpo file

--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -40,6 +40,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.in.PrairieMetadata.Frame;
 import loci.formats.in.PrairieMetadata.PFile;
@@ -88,7 +90,7 @@ public class PrairieReader extends FormatReader {
   // -- Fields --
 
   /** Helper reader for opening images. */
-  private TiffReader tiff;
+  private IFormatReader tiff;
 
   /** The associated XML files. */
   private Location xmlFile, cfgFile, envFile;
@@ -316,7 +318,7 @@ public class PrairieReader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
-    tiff = new TiffReader();
+    tiff = Memoizer.wrap(getMetadataOptions(), new TiffReader());
 
     if (checkSuffix(id, XML_SUFFIX)) {
       xmlFile = new Location(id);

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -45,6 +45,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -89,7 +91,7 @@ public class ScanrReader extends FormatReader {
   private int tileHeight = 0;
 
   private String[] tiffs;
-  private MinimalTiffReader reader;
+  private IFormatReader reader;
 
   private boolean foundPositions = false;
   private Length[] fieldPositionX;
@@ -332,7 +334,7 @@ public class ScanrReader extends FormatReader {
 
       r.close();
       tiffs = new String[] {id};
-      reader = new MinimalTiffReader();
+      reader = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
 
       return;
     }
@@ -543,7 +545,7 @@ public class ScanrReader extends FormatReader {
       nPos = realPosCount;
     }
 
-    reader = new MinimalTiffReader();
+    reader = Memoizer.wrap(getMetadataOptions(), new MinimalTiffReader());
     reader.setId(tiffs[0]);
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -42,6 +42,8 @@ import loci.formats.FilePattern;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -73,7 +75,7 @@ public class TCSReader extends FormatReader {
   private List<String> tiffs;
 
   /** Helper readers. */
-  private TiffReader[] tiffReaders;
+  private IFormatReader[] tiffReaders;
 
   private TiffParser tiffParser;
 
@@ -224,7 +226,7 @@ public class TCSReader extends FormatReader {
     if (!fileOnly) {
       tiffs = null;
       if (tiffReaders != null) {
-        for (TiffReader r : tiffReaders) {
+        for (IFormatReader r : tiffReaders) {
           if (r != null) r.close();
         }
       }
@@ -282,7 +284,7 @@ public class TCSReader extends FormatReader {
     tiffReaders = new TiffReader[tiffs.size()];
 
     for (int i=0; i<tiffReaders.length; i++) {
-      tiffReaders[i] = new TiffReader();
+      tiffReaders[i] = Memoizer.wrap(getMetadataOptions(), new TiffReader());
     }
     tiffReaders[0].setId(tiffs.get(0));
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -118,6 +118,8 @@ import loci.common.Location;
 import loci.common.xml.XMLTools;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.Memoizer;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.IFDList;
@@ -143,7 +145,7 @@ public class ZeissTIFFReader extends BaseZeissReader {
   ArrayList<Plane> planes;
 
   /** Helper reader for TIFF files. */
-  private MinimalTiffReader tiffReader;
+  private IFormatReader tiffReader;
 
   private transient HashMap<String, String[]> directoryCache =
     new HashMap<String, String[]>();
@@ -451,7 +453,7 @@ public class ZeissTIFFReader extends BaseZeissReader {
       planes.add(np);
       if (bpp == 0) {
         tiffReader.setId(np.filename);
-        IFDList ifds = tiffReader.getIFDs();
+        IFDList ifds = ((MinimalTiffReader)tiffReader).getIFDs();
         tiffReader.close();
         IFD firstIFD = ifds.get(0);
         int bits = firstIFD.getBitsPerSample()[0];
@@ -499,6 +501,8 @@ public class ZeissTIFFReader extends BaseZeissReader {
     int total = tileIndices.size() * channelIndices.size() * zIndices.size() * timepointIndices.size();
     if(total != planes.size())
       LOGGER.warn("Number of image planes not detected correctly: total={} planes.size={}", total, planes.size());
+    
+    tiffReader = Memoizer.wrap(getMetadataOptions(), tiffReader);
 
   }
 


### PR DESCRIPTION
Initial PR for testing and discussion of a possible option for passing Memoization to sub readers. In this case each reader must wrap its sub readers, which leaves a significant amount of testing required to cover the large number of readers involved.

- MetadataOptions used to store Memoizer otpions
- A wrap method in Memoizer to handle the wrapping
- Each reader then wraps its sub readers

Likely to be further commits to bring this more inline with the IDR branch
New MetaxpressTiffReader also needs to be updated