### PR TITLE
BMP: fix offset calculation for files larger than 2 GB

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BMPReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BMPReader.java
@@ -119,7 +119,7 @@ public class BMPReader extends FormatReader {
       throw new UnsupportedCompressionException(compression + " not supported");
     }
 
-    int rowsToSkip = invertY ? y : getSizeY() - (h + y);
+    long rowsToSkip = invertY ? y : getSizeY() - (h + y);
     int rowLength = (getSizeX() * (isIndexed() ? 1 : getSizeC()) * bpp) / 8;
 
     in.seek(global + rowsToSkip * rowLength);


### PR DESCRIPTION
Noticed in passing while fixing something else.  Super low priority, just faster to write a PR than an issue.

Without this PR, on a BMP larger than 2 GB:

```
$ showinf -crop 2048,2048,512,512 test.bmp
...
Exception in thread "main" java.lang.IllegalArgumentException: Negative position
	at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:712)
	at loci.common.NIOByteBufferProvider.allocateDirect(NIOByteBufferProvider.java:127)
	at loci.common.NIOByteBufferProvider.allocate(NIOByteBufferProvider.java:112)
	at loci.common.NIOFileHandle.buffer(NIOFileHandle.java:647)
	at loci.common.NIOFileHandle.seek(NIOFileHandle.java:330)
	at loci.common.RandomAccessInputStream.seek(RandomAccessInputStream.java:203)
	at loci.formats.in.BMPReader.openBytes(BMPReader.java:125)
	at loci.formats.FormatReader.openBytes(FormatReader.java:897)
	at loci.formats.ImageReader.openBytes(ImageReader.java:449)
	at loci.formats.ReaderWrapper.openBytes(ReaderWrapper.java:334)
	at loci.formats.gui.BufferedImageReader.openImage(BufferedImageReader.java:86)
	at loci.formats.tools.ImageInfo.readPixels(ImageInfo.java:821)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1055)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1121)
```