### PR TITLE
Optionsfiles fixes

### DIFF
--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -504,7 +504,8 @@ public class DynamicMetadataOptions implements MetadataOptions {
     IniList list = parser.parseINI(new File(optionsFile));
     for (IniTable attrs: list) {
       for (String key: attrs.keySet()) {
-        if (!availableOptionKeys.contains(key)) {
+        if (!key.equals(IniTable.HEADER_KEY) &&
+            !availableOptionKeys.contains(key)) {
           LOGGER.warn("Metadata Option Key is not supported in this reader " + key);
         }
         set(key, attrs.get(key));

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -517,9 +517,6 @@ public class DynamicMetadataOptions implements MetadataOptions {
     if (f != null && f.getParent() != null) {
       String p = f.getParent();
       String n = f.getName();
-      if (n.indexOf(".") >= 0) {
-        n = n.substring(0, n.indexOf("."));
-      }
       return new Location(p, n + ".bfoptions").getAbsolutePath();
     }
     return null;

--- a/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
+++ b/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
@@ -100,6 +100,13 @@ public class DynamicMetadataOptionsTest {
                            {"-3.14", new Double(-3.14)}};
   }
 
+  @DataProvider(name = "optionFiles")
+  public Object[][] mkOptionFiles() {
+    return new Object[][] {{"t1.tiff", null},
+                           {"/t1.tiff", "/t1.tiff.bfoptions"},
+                           {"/foo/t1.tiff", "/foo/t1.tiff.bfoptions"}};
+  }
+
   @BeforeMethod
   public void setUp() {
     opt = new DynamicMetadataOptions();
@@ -361,6 +368,11 @@ public class DynamicMetadataOptionsTest {
     assertTrue(opt.isValidate());
     opt.setValidate(false);
     assertFalse(opt.isValidate());
+  }
+
+  @Test(dataProvider = "optionFiles")
+  public void testGetMetadataOptionsFile(String source, String target) {
+    assertEquals(DynamicMetadataOptions.getMetadataOptionsFile(source), target);
   }
 
 }


### PR DESCRIPTION
Discussed during the weekly Formats meeting,

- 6f1716c and be2b2bd address the concern initially raised in https://github.com/ome/bioformats/pull/3605#discussion_r501092971 by making option filenames unique
- b51a2f6 is a minor fix for a warning discovered during testing and should avoid unnecessary warnings related to the `IniList` way of storing headers
