### PR TITLE
ND2Handler: Catch NPE when parsing key value pairs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -919,7 +919,7 @@ public class ND2Handler extends BaseHandler {
         }
       }
     }
-    catch (NumberFormatException exc) {
+    catch (NumberFormatException | NullPointerException exc) {
       LOGGER.warn("Could not parse {} value: {}", key, value);
     }
   }


### PR DESCRIPTION
Issue was raised in forum thread https://forum.image.sc/t/command-line-bfconvert-to-convert-nd2-to-tif-java-error/43728/3

A sample file is available in QA-29634 which reproduces the reported bug in BF 6.5.1

To test:
Using the file in QA-29634 attempt to open the image using BF 6.5.1, this should throw a NullPointerException
With the PR included repeat the above and the file should open and display without exception. A warning message will be logged: `[WARN] Could not parse Power value: -nan(ind)`