### PR TITLE
APNGReader: fix hanging openBytes call

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -358,6 +358,14 @@ public class APNGReader extends FormatReader {
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int rowLen = width * getRGBChannelCount() * bpp;
 
+    if (width > getSizeX()) {
+      throw new FormatException(
+        "Width (" + width + ") exceeds image width (" +  getSizeX() + ")");
+    }
+    if (height > getSizeY()) {
+      throw new FormatException(
+        "Height (" + height + ") exceeds image height (" +  getSizeY() + ")");
+    }
     if (getBitsPerPixel() < bpp * 8) {
       int div = (bpp * 8) / getBitsPerPixel();
       if (div < rowLen) {

--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -149,7 +149,7 @@ public class APNGReader extends FormatReader {
       try (PNGInputStream stream = new PNGInputStream("IDAT")) {
         int decodeHeight = y + h;
         if (decodeHeight < getSizeY() && decodeHeight % 8 != 0) {
-          decodeHeight += 8 - (decodeHeight % 8);
+          decodeHeight += Math.min(8 - (decodeHeight % 8), getSizeY() - decodeHeight);
         }
         lastImage = decode(stream, getSizeX(), decodeHeight);
       }


### PR DESCRIPTION
Following an investigation on a hanging import of a PNG, this bug addresses an issue when opening the pixel data of a PNG in tiles and the requested tile height is not a multiple of 8. Under some conditions, this could lead to a height larger than the image height passed to the `APNGReader.decode` and the reader hanging.

This PR should fix the behavior by capping the height passed to `APNGReader.decode` to the image height. It also adds some  preliminary checks to the `APNGReader.decode(PNGInputStream, int, int)` to throw an exception if the dimensions are too large.

Without this PR, some PNG files would fail an OMERO import, hanging during the tile-based min/max calculation step and freezing a server thread indefinitely. With this PR included, the same file should import successfully. 

/cc @pwalczysko @joshmoore 