### PR TITLE
Populate plate row and column dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -514,6 +514,8 @@ public class BDReader extends FormatReader {
       }
 
       store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+      store.setPlateRows(new PositiveInteger(wellRows), 0);
+      store.setPlateColumns(new PositiveInteger(wellCols), 0);
       store.setPlateRowNamingConvention(MetadataTools.getNamingConvention("Letter"), 0);
       store.setPlateColumnNamingConvention(MetadataTools.getNamingConvention("Number"), 0);
       store.setPlateName(plateName, 0);

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -50,6 +50,7 @@ import loci.formats.services.MDBService;
 import ome.xml.model.enums.NamingConvention;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
 
@@ -460,6 +461,9 @@ public class CellomicsReader extends FormatReader {
       realRows = 16;
       realCols = 24;
     }
+
+    store.setPlateRows(new PositiveInteger(realRows), 0);
+    store.setPlateColumns(new PositiveInteger(realCols), 0);
 
     for (int row=0; row<realRows; row++) {
       for (int col=0; col<realCols; col++) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -557,6 +557,9 @@ public class FlexReader extends FormatReader {
         new Timestamp(plateAcqStartTime), 0, 0);
     }
 
+    store.setPlateRows(new PositiveInteger(wellRows), 0);
+    store.setPlateColumns(new PositiveInteger(wellColumns), 0);
+
     for (int row=0; row<wellRows; row++) {
       for (int col=0; col<wellColumns; col++) {
         int well = row * wellColumns + col;

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -557,8 +557,12 @@ public class FlexReader extends FormatReader {
         new Timestamp(plateAcqStartTime), 0, 0);
     }
 
-    store.setPlateRows(new PositiveInteger(wellRows), 0);
-    store.setPlateColumns(new PositiveInteger(wellColumns), 0);
+    if (wellRows > 0) {
+      store.setPlateRows(new PositiveInteger(wellRows), 0);
+    }
+    if (wellColumns > 0) {
+      store.setPlateColumns(new PositiveInteger(wellColumns), 0);
+    }
 
     for (int row=0; row<wellRows; row++) {
       for (int col=0; col<wellColumns; col++) {

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -816,7 +816,12 @@ public class MIASReader extends FormatReader {
     String plateAcqId = MetadataTools.createLSID("PlateAcquisition", 0, 0);
     store.setPlateAcquisitionID(plateAcqId, 0, 0);
     store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(1), 0, 0);
-    store.setPlateRows(new PositiveInteger(nWells / wellColumns), 0);
+    if (nWells >= wellColumns) {
+      store.setPlateRows(new PositiveInteger(nWells / wellColumns), 0);
+    }
+    else {
+      store.setPlateRows(new PositiveInteger(1), 0);
+    }
     store.setPlateColumns(new PositiveInteger(wellColumns), 0);
 
     for (int well=0; well<nWells; well++) {

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -816,6 +816,8 @@ public class MIASReader extends FormatReader {
     String plateAcqId = MetadataTools.createLSID("PlateAcquisition", 0, 0);
     store.setPlateAcquisitionID(plateAcqId, 0, 0);
     store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(1), 0, 0);
+    store.setPlateRows(new PositiveInteger(nWells / wellColumns), 0);
+    store.setPlateColumns(new PositiveInteger(wellColumns), 0);
 
     for (int well=0; well<nWells; well++) {
       int wellIndex = wellNumber[well];


### PR DESCRIPTION
Noticed while working on https://github.com/glencoesoftware/bioformats2raw/pull/69.

Older HCS readers didn't set ```Plate.Rows``` and ```Plate.Columns```, since those values are optional and were introduced in the 2010-04 schema.  The only remaining reader that sets ```Plate.ID``` but not ```Plate.Rows``` and ```Plate.Columns``` is ```CellH5Reader```, but I suspect all of the plate population needs to be rewritten there so will save it for a later date.

Tests should continue to pass, and this should be safe for a patch release.