### PR TITLE
MetaXpress/CellWorX: ignore case when checking for thumbnail paths

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetaxpressTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetaxpressTiffReader.java
@@ -253,7 +253,7 @@ public class MetaxpressTiffReader extends CellWorxReader {
                 for (String f : zList) {
                   LOGGER.debug("  checking relative path = {}", f);
                   String path = new Location(file, f).getAbsolutePath();
-                  if (f.startsWith(base) && path.indexOf("_thumb") < 0) {
+                  if (f.startsWith(base) && path.toLowerCase().indexOf("_thumb") < 0) {
                     if (nextFile < files.length) {
                       files[nextFile] = path;
                     }


### PR DESCRIPTION
Backported from a private PR.  Handles the case when thumbnail files are named ```*_Thumb.TIF```.

Tests should continue to pass, and should be safe for a patch release.