### PR TITLE
Leica SCN: set core index correctly when populating original metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -370,6 +370,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     for (int s=0; s<core.size(); s++) {
       for (int r = 0; r < core.size(s); r++) {
         int coreIndex = core.flattenedIndex(s, r);
+        setCoreIndex(coreIndex);
         ImageCollection c = handler.collection;
         Image i = handler.imageMap.get(coreIndex);
 
@@ -484,6 +485,7 @@ public class LeicaSCNReader extends BaseTiffReader {
         ++pos;
       }
     }
+    setCoreIndex(0);
   }
 
   private int getParent(int coreIndex) {


### PR DESCRIPTION
Calls to ```addSeriesMeta``` depend upon the current core index, so a call to ```setCoreIndex``` is necessary.

To test, check the ```view.offset*``` keys for each series when running ```showinf -nopix -noflat -series n``` with and without this PR.  Without this PR, only the first series will have ```view.offset*``` keys.  With this PR, all series will have ```view.offset*``` keys and the values should correspond to the OME-XML ```PositionX``` and ```PositionY``` values reported by ```showinf -nopix -noflat -omexml```.

This shouldn't fail builds, and should be safe for a patch release.