### PR TITLE
ND2: reset series count to limit offsets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1442,8 +1442,8 @@ public class NativeND2Reader extends SubResolutionFormatReader {
       // reset the series count if we're confident that the image count
       // covers all of the offsets; this prevents too much memory being used
       // when the offsets array is allocated
-      if (getImageCount() == imageOffsets.size() && numSeries > 1 &&
-        getSizeC() == 1)
+      if (numSeries > 1 && ((getImageCount() == imageOffsets.size()  &&
+          getSizeC() == 1) || (getImageCount() == imageOffsets.size() * getSizeC()))) 
       {
         CoreMetadata first = core.get(0, 0);
         core.clear();


### PR DESCRIPTION
This PR is attempting to fix an issue raised in https://forum.image.sc/t/bioformats-high-memory-use-for-nd2-files/47187/1
There is a large sample file available which I will make available for testing.

The change is really a follow up to https://github.com/ome/bioformats/pull/1351 and expanding on that logic. I have initially opted for adding an additional condition which complicates the logic but should be the least likely to cause any regressions. If tests continue to pass with this initial commit then I will probably try to loosen and simplify the conditions.