### PR TITLE
OIR: trim XML blocks

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -632,7 +632,7 @@ public class OIRReader extends FormatReader {
         break;
       }
       long fp = s.getFilePointer();
-      String xml = s.readString(length);
+      String xml = s.readString(length).trim();
       if (!xml.startsWith("<?xml")) {
         s.seek(fp - 2);
         continue;


### PR DESCRIPTION
Backported from a private PR.  Sometimes XML blocks end with CRLF, which prevented following pixel blocks from being detected - see line 646.

I don't have a relevant test file that can be shared, so the main thing to check is that tests pass and the code change isn't worrying.  In the original test case, metadata was parsed correctly (so plane counts etc. were fine), but none of the pixel blocks were detected so all planes were blank.  None of the other .oir missing pixel block issues describe quite the same behavior, but it's maybe possible that #3242 could be helped by this.  https://trello.com/c/DaXFseys/265-import-issue-with-oir-file-in-imagej-qa-21654 for sure is not fixed.