### PR TITLE
Leica SCN: change position units from reference frame to nm

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -390,8 +390,8 @@ public class LeicaSCNReader extends BaseTiffReader {
         // Leica units are nanometres; convert to µm
         double sizeX = i.vSizeX / 1000.0;
         double sizeY = i.vSizeY / 1000.0;
-        final Length offsetX = new Length(i.vOffsetX, UNITS.REFERENCEFRAME);
-        final Length offsetY = new Length(i.vOffsetY, UNITS.REFERENCEFRAME);
+        final Length offsetX = new Length(i.vOffsetX, UNITS.NM);
+        final Length offsetY = new Length(i.vOffsetY, UNITS.NM);
         double sizeZ = i.vSpacingZ / 1000.0;
 
         store.setPixelsPhysicalSizeX(


### PR DESCRIPTION
Existing comment on line 390 indicates that the image position and size values stored in XML are in nm.  This can be verified by comparing the ```view.sizeX``` and ```view.sizeY``` values with the image width, height, and physical pixel size stored in the corresponding IFD. 

A configuration PR is forthcoming, but otherwise tests should continue to pass and this should be safe for a patch release.

