### PR TITLE
Fake: allow channel names in series tables

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1191,6 +1191,11 @@ public class FakeReader extends FormatReader {
     int s = getSeries();
     setSeries(newSeries);
 
+    for (int c=0; c<getEffectiveSizeC(); c++) {
+      String channelName = table.get("ChannelName_" + c);
+      store.setChannelName(channelName, newSeries, c);
+    }
+
     for (int i=0; i<getImageCount(); i++) {
       String exposureTime = table.get("ExposureTime_" + i);
       String exposureTimeUnit = table.get("ExposureTimeUnit_" + i);


### PR DESCRIPTION
```ChannelName_c```, with 0 <= c < channel count.  Test dataset (also in ```curated/fake/samples/channel-name```):

```
$ ls -hl
total 4.0K
-rw-rw-r-- 1 melissa melissa  0 Mar 15 13:21 test&sizeC=3.fake
-rw-rw-r-- 1 melissa melissa 73 Mar 15 13:23 test&sizeC=3.fake.ini
$ cat test\&sizeC\=3.fake.ini 
[series_0]
ChannelName_0 = DAPI
ChannelName_1 = Cy5
ChannelName_2 = FITC
```

```showinf -nopix -omexml test&sizeC=3.fake``` should show OME-XML channel names matching the channel names in the INI.