### PR TITLE
MetamorphReader: improve the detection of companion binary files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -401,12 +401,16 @@ public class MetamorphReader extends BaseTiffReader {
       Arrays.sort(dirList);
       String suffix = getNDVersionSuffix(ndfile);
       for (String f : dirList) {
-        int underscore = f.indexOf('_');
-        if (underscore < 0) underscore = f.indexOf('.');
-        if (underscore < 0) underscore = f.length();
-        String prefix = f.substring(0, underscore);
-        if ((f.equals(stkFile) || stkFile.startsWith(prefix)) &&
-           checkSuffix(f, suffix))
+        if (!checkSuffix(f, suffix)) {
+          continue;
+        }
+        if (!f.startsWith(stkFile)) {
+          continue;
+        }
+        LOGGER.debug(f);
+        String s = f.substring(stkFile.length(), f.lastIndexOf("."));
+        LOGGER.debug(s);
+        if (s.isEmpty() || s.startsWith("_w") || s.startsWith("_s") || s.startsWith("_t")  )
         {
           stkFile = new Location(parent.getAbsolutePath(), f).getAbsolutePath();
           break;
@@ -414,7 +418,7 @@ public class MetamorphReader extends BaseTiffReader {
       }
 
       if (!checkSuffix(stkFile, STK_SUFFIX)) {
-        throw new FormatException("STK file not found in " +
+        throw new FormatException(suffix + " file not found in " +
           parent.getAbsolutePath() + ".");
       }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -407,9 +407,7 @@ public class MetamorphReader extends BaseTiffReader {
         if (!f.startsWith(stkFile)) {
           continue;
         }
-        LOGGER.debug(f);
         String s = f.substring(stkFile.length(), f.lastIndexOf("."));
-        LOGGER.debug(s);
         if (s.isEmpty() || s.startsWith("_w") || s.startsWith("_s") || s.startsWith("_t")  )
         {
           stkFile = new Location(parent.getAbsolutePath(), f).getAbsolutePath();


### PR DESCRIPTION
This commit tries to address the remaining issues discussed at https://github.com/ome/bioformats/pull/3032#issuecomment-802096824.

This commit tries to address a scenario where the ND filename contain underscores and unrelated TIF/STK files starting with part of the ND prefix are present in the directory. For instance with the following layout,

```
benchmark_v1_2018_x64y64z1c1s1t1.tif 
benchmark_v1_2018_x64y64z1c2s1t11.nd
benchmark_v1_2018_x64y64z1c2s1t11_w1Laser4054BD4BP.tif
benchmark_v1_2018_x64y64z1c2s1t11_w2Laser4914BD4BP.tif 
```

the current `initFile()` logic would detect the unrelated `benchmark_v1_2018_x64y64z1c1s1t1.tif` as the binary file to initialize.

The proposed fix reviews the code path selecting the STK/TIFF file associated with a ND file and enforces the following rules:
- the binary file should end with either stk or tif as determined by the private method introduced in https://github.com/ome/bioformats/pull/3032
- the binary file should start with the same prefix as the nd file
- the binary file should either have exactly the same prefix as the nd file, or be followed by one of the three separators: `_w`, `_s` or `_t` 

With this change, the sample Metamorph filesets in https://github.com/fmi-basel/faim-imagej-bio-formats-tests/tree/master/src/test/resources/ch/fmi should no longer detect the unrelated TIFF files in the same directory.