### PR TITLE
TiffParser: handle Deflate compressed tiles/strips with lsb2msb order

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -814,7 +814,9 @@ public class TiffParser implements Closeable {
     // reverse bits in each byte if FillOrder == 2
 
     if (ifd.getIFDIntValue(IFD.FILL_ORDER) == 2 &&
-      compression.getCode() <= TiffCompression.GROUP_4_FAX.getCode())
+      (compression.getCode() <= TiffCompression.GROUP_4_FAX.getCode() ||
+       compression.getCode() == TiffCompression.DEFLATE.getCode() ||
+       compression.getCode() == TiffCompression.PROPRIETARY_DEFLATE.getCode()))
     {
       for (int i=0; i<tile.length; i++) {
         tile[i] = (byte) (Integer.reverse(tile[i]) >> 24);


### PR DESCRIPTION
See https://forum.image.sc/t/tiff-file-fails-to-open/50416 for a TIFF file failing to open with Bio-Formats

As suggested by @cgohlke in https://forum.image.sc/t/tiff-file-fails-to-open/50416/3, the issue is that `FillOrder` is lsb2msb and the bytes need to be reordered before decompression.

e0c2e8e proposes to extend the scope of https://github.com/ome/bioformats/pull/3306 to handle TIFF files with Deflate compression (codes 8 and 32946).