### PR TITLE
NDPIS: use channel names from "NDP Shading Data", if available

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -253,6 +253,9 @@ public class NDPISReader extends FormatReader {
                     bandUsed[c] == 2 ? 255 : 0, 255), 0, c);
                 }
               }
+              if (key.equals("Name") && value.length() > 0) {
+                store.setChannelName(value, 0, c);
+              }
             }
           }
         }


### PR DESCRIPTION
Backported from a private PR.  Sometimes the ```NDP Shading Data``` block has a channel name that isn't present in the channel name tag.