### PR TITLE
Amira: Support for Amira 3.0 keys

### DIFF
--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -245,7 +245,7 @@ public class AmiraParameters {
 
   protected String readKey() throws IOException {
     StringBuilder result = new StringBuilder();
-    while (c >= '0' || c == '-') {
+    while (c >= '0' || c == '-' || c == '&') {
       result.append(c);
       readByte();
     }


### PR DESCRIPTION
This issue was raised on forum thread https://forum.image.sc/t/bio-formats-cant-open-newer-am-files-version-3-0/50585
Newer Amira files have metadata keys which begin with the “&” character, for example “&Pixels_per_meter__X_”.
When Bio-Formats tries to read these values it throws an Invalid Key Exception as below:
`loci.formats.FormatException: Syntax Error:19:10: Invalid key`

Sample files have been provided which reproduce the issue. 

To test:
- With Bio-Formats 6.6.1, attempting to read the BF_CheckAmira.am file will result in the Invalid Key exception
- With this PR included the file will be read without exception
- With this PR the metadata for both BF_CheckAmira.am and BF_CheckMIB.am should be the same

A follow up config PR will add the new samples to the repo tests