### PR TITLE
TIFF: only use ImageJ comment units if RESOLUTION_UNIT tag unclear

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -468,7 +468,8 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
       // only look for a unit in the comment if the unit is unclear
       // from the RESOLUTION_UNIT tag
       String unit = null;
-      if (firstIFD.getResolutionMultiplier() == 1) {
+      // "3" indicates cm
+      if (firstIFD.getIFDIntValue(IFD.RESOLUTION_UNIT) != 3) {
         unit = getResolutionUnitFromComment(firstIFD);
       }
 

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -465,11 +465,16 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
       double pixX = firstIFD.getXResolution();
       double pixY = firstIFD.getYResolution();
 
-      String unit = getResolutionUnitFromComment(firstIFD);
-      
+      // only look for a unit in the comment if the unit is unclear
+      // from the RESOLUTION_UNIT tag
+      String unit = null;
+      if (firstIFD.getResolutionMultiplier() == 1) {
+        unit = getResolutionUnitFromComment(firstIFD);
+      }
+
       Length sizeX = FormatTools.getPhysicalSizeX(pixX, unit);
       Length sizeY = FormatTools.getPhysicalSizeY(pixY, unit);
-      
+
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);
       }


### PR DESCRIPTION
Backported from a private PR.

This logic was originally added in #1716.  Original test data for that PR is now added to ```curated/tiff/qa-7589```, and an additional test for this PR is in ```curated/tiff/samples/melissa/imagej-units/1000cmx1000cm-test.tif```.

```showinf -nopix -omexml``` on the files from QA 7589 should show no change in physical pixel size and units with or without this PR.  ```showinf -nopix -omexml``` on ```1000cmx1000cm-test.tif``` without this PR should show physical pixel sizes of 20000cm; with this PR, they should be 20000um == 2cm.

As far as I can tell, this is specific to ImageJ TIFFs with unit set to ```cm``` in the ```Image Properties``` window.