### PR TITLE
ND2: Always fall back to check channel names

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2035,7 +2035,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
       if (channelNames.size() < getEffectiveSizeC() && backupHandler != null) {
         channelNames = backupHandler.getChannelNames();
       }
-      else if (channelNames.size() < getEffectiveSizeC()) {
+      if (channelNames.size() < getEffectiveSizeC()) {
         channelNames = textChannelNames;
       }
       for (int c=0; c<getEffectiveSizeC(); c++) {


### PR DESCRIPTION
Issue was raised on imagesc thread https://forum.image.sc/t/incorrect-default-color-for-channels-when-opening-nd2-images/50734/8

A sample image was provided via Zenodo, when opened with Bio-Formats 6.6.1 the channel names and colours are missing from the OME-XML metadata and the fourth channel displays as Red rather than Magenta.

With this fix the metadata should be present and the colour correct.

To test:
- Using the provided sample check that without this PR the OME-XML Channels are missing the properties Name and Color
- With this PR included the Name and Color values are populated and correct
- Without this PR the 4th channel should display as Red, with the PR included it should be Magenta 