### PR TITLE
Zeiss CZI: detect plates

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -855,8 +855,9 @@ public class ZeissCZIReader extends FormatReader {
         angles = 1;
       }
       else {
-        int newX = planes.get(planes.size() - 1).x;
-        int newY = planes.get(planes.size() - 1).y;
+        SubBlock lastPlane = planes.get(planes.size() - 1);
+        int newX = lastPlane.x;
+        int newY = lastPlane.y;
         if (allowAutostitching() && (ms0.sizeX < newX || ms0.sizeY < newY)) {
           prestitched = true;
           mosaics = 1;
@@ -864,8 +865,14 @@ public class ZeissCZIReader extends FormatReader {
         else {
           prestitched = maxResolution > 0;
         }
-        ms0.sizeX = newX;
-        ms0.sizeY = newY;
+
+        // don't shrink the dimensions if prestitching is allowed
+        // implies that the image size is being set to a tile size
+        DimensionEntry mosaicDimension = lastPlane.directoryEntry.getDimensionEntry("M");
+        if (!prestitched || (mosaicDimension != null && mosaicDimension.start == 0)) {
+          ms0.sizeX = newX;
+          ms0.sizeY = newY;
+        }
       }
     }
     else if (!allowAutostitching() && calculatedSeries > seriesCount) {
@@ -4253,6 +4260,17 @@ public class ZeissCZIReader extends FormatReader {
           }
         }
       }
+    }
+
+    public DimensionEntry getDimensionEntry(String dimension) {
+      if (dimension != null) {
+        for (DimensionEntry entry : dimensionEntries) {
+          if (entry.dimension != null && entry.dimension.equals(dimension)) {
+            return entry;
+          }
+        }
+      }
+      return null;
     }
 
     @Override

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1233,7 +1233,7 @@ public class ZeissCZIReader extends FormatReader {
       }
     }
 
-    if (plateRows > 0 && plateColumns > 0) {
+    if (plateRows > 0 && plateColumns > 0 && platePositions.size() > 0) {
       store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
       store.setPlateRows(new PositiveInteger(plateRows), 0);
       store.setPlateColumns(new PositiveInteger(plateColumns), 0);
@@ -3243,7 +3243,9 @@ public class ZeissCZIReader extends FormatReader {
               for (int i=0; i<wells.getLength(); i++) {
                 Element well = (Element) wells.item(i);
                 String value = getFirstNodeValue(well, "TemplateShapeId");
-                platePositions.add(value);
+                if (value != null && !value.isEmpty()) {
+                  platePositions.add(value);
+                }
               }
             }
           }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1239,7 +1239,7 @@ public class ZeissCZIReader extends FormatReader {
       store.setPlateColumns(new PositiveInteger(plateColumns), 0);
 
       int nextWell = 0;
-      for (int i=0; i<getSeriesCount(); i++) {
+      for (int i=0, img=0; img<core.size(); i++, img+=core.get(img).resolutionCount) {
         if (i < platePositions.size() && platePositions.get(i) != null) {
           String[] index = platePositions.get(i).split("-");
           if (index.length != 2) {
@@ -1257,12 +1257,13 @@ public class ZeissCZIReader extends FormatReader {
           }
 
           if (row >= 0 && column >= 0) {
+            int imageIndex = coreIndexToSeries(img);
             store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
             store.setWellRow(new NonNegativeInteger(row), 0, nextWell);
             store.setWellColumn(new NonNegativeInteger(column), 0, nextWell);
             store.setWellSampleID(MetadataTools.createLSID("WellSample", 0, nextWell, 0), 0, nextWell, 0);
-            store.setWellSampleImageRef(MetadataTools.createLSID("Image", i), 0, nextWell, 0);
-            store.setWellSampleIndex(new NonNegativeInteger(i), 0, nextWell, 0);
+            store.setWellSampleImageRef(MetadataTools.createLSID("Image", imageIndex), 0, nextWell, 0);
+            store.setWellSampleIndex(new NonNegativeInteger(imageIndex), 0, nextWell, 0);
 
             nextWell++;
           }
@@ -3235,6 +3236,9 @@ public class ZeissCZIReader extends FormatReader {
             }
 
             NodeList wells = sampleHolder.getElementsByTagName("SingleTileRegionArray");
+            if (wells == null || wells.getLength() == 0) {
+              wells = sampleHolder.getElementsByTagName("TileRegion");
+            }
             if (wells != null) {
               for (int i=0; i<wells.getLength(); i++) {
                 Element well = (Element) wells.item(i);

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -421,7 +421,7 @@ public class Configuration {
   }
 
   public int getPlate() {
-    return getInt(PLATE, -1);
+    return getInt(PLATE, Integer.MIN_VALUE);
   }
 
   public int getPlateAcquisition() {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1461,7 +1461,7 @@ public class FormatReaderTest {
       if (plate >= retrieve.getPlateCount()) {
         result(testName, false, "Plate index" + failureSuffix);
       }
-      else if (plate < 0) {
+      else if (plate < -1) {
         if (retrieve.getPlateCount() > 0) {
           boolean allEmpty = true;
           for (int p=0; p<retrieve.getPlateCount(); p++) {
@@ -1486,82 +1486,87 @@ public class FormatReaderTest {
         continue;
       }
       boolean foundWell = false;
-      for (int w=0; w<retrieve.getWellCount(plate); w++) {
-        int row = config.getWellRow();
-        int col = config.getWellColumn();
-        if (row == retrieve.getWellRow(plate, w).getNumberValue().intValue() &&
-          col == retrieve.getWellColumn(plate, w).getNumberValue().intValue())
-        {
-          foundWell = true;
+      for (int p=0; p<retrieve.getPlateCount(); p++) {
+        if (plate >= 0 && plate != p) {
+          continue;
+        }
 
-          int wellSample = config.getWellSample();
-          String image = retrieve.getImageID(s);
-          if (wellSample >= retrieve.getWellSampleCount(plate, w) ||
-            wellSample < 0 ||
-            !image.equals(retrieve.getWellSampleImageRef(plate, w, wellSample)))
+        for (int w=0; w<retrieve.getWellCount(p); w++) {
+          int row = config.getWellRow();
+          int col = config.getWellColumn();
+          if (row == retrieve.getWellRow(p, w).getNumberValue().intValue() &&
+            col == retrieve.getWellColumn(p, w).getNumberValue().intValue())
           {
-            result(testName, false, "WellSample index" + failureSuffix);
-          }
+            foundWell = true;
 
-          Length positionX = retrieve.getWellSamplePositionX(plate, w, wellSample);
-          Length positionY = retrieve.getWellSamplePositionY(plate, w, wellSample);
-          Length configX = config.getWellSamplePositionX();
-          Length configY = config.getWellSamplePositionY();
-          if (positionX != null || configX != null) {
-            if (positionX == null || !positionX.equals(configX)) {
-              result(testName, false, "WellSample position X" + failureSuffix);
+            int wellSample = config.getWellSample();
+            String image = retrieve.getImageID(s);
+            if (wellSample >= retrieve.getWellSampleCount(p, w) ||
+              wellSample < 0 ||
+              !image.equals(retrieve.getWellSampleImageRef(p, w, wellSample)))
+            {
+              result(testName, false, "WellSample index" + failureSuffix);
             }
-          }
-          if (positionY != null || configY != null) {
-            if (positionY == null || !positionY.equals(configY)) {
-              result(testName, false, "WellSample position Y" + failureSuffix);
-            }
-          }
 
-          int plateAcq = config.getPlateAcquisition();
-          int plateAcqCount = retrieve.getPlateAcquisitionCount(plate);
-          if (plateAcq >= plateAcqCount) {
-            result(testName, false, "PlateAcquisition index" + failureSuffix);
-          }
-          else if (plateAcq < 0 && plateAcqCount > 0) {
-            // special case where this WellSample isn't
-            // linked to a PlateAcquisition,
-            // but multiple PlateAcquisitions exist
-            String wellSampleID =
-              retrieve.getWellSampleID(plate, w, wellSample);
-            for (int pa=0; pa<plateAcqCount; pa++) {
-              int wsCount = retrieve.getWellSampleRefCount(plate, pa);
-              for (int wsRef=0; wsRef<wsCount; wsRef++) {
-                String wellSampleRef =
-                  retrieve.getPlateAcquisitionWellSampleRef(plate, pa, wsRef);
-                if (wellSampleID.equals(wellSampleRef)) {
-                  result(testName, false,
-                    "PlateAcquisition-WellSample link" + failureSuffix);
+            Length positionX = retrieve.getWellSamplePositionX(p, w, wellSample);
+            Length positionY = retrieve.getWellSamplePositionY(p, w, wellSample);
+            Length configX = config.getWellSamplePositionX();
+            Length configY = config.getWellSamplePositionY();
+            if (positionX != null || configX != null) {
+              if (positionX == null || !positionX.equals(configX)) {
+                result(testName, false, "WellSample position X" + failureSuffix);
+              }
+            }
+            if (positionY != null || configY != null) {
+              if (positionY == null || !positionY.equals(configY)) {
+                result(testName, false, "WellSample position Y" + failureSuffix);
+              }
+            }
+
+            int plateAcq = config.getPlateAcquisition();
+            int plateAcqCount = retrieve.getPlateAcquisitionCount(p);
+            if (plateAcq >= plateAcqCount) {
+              result(testName, false, "PlateAcquisition index" + failureSuffix);
+            }
+            else if (plateAcq < 0 && plateAcqCount > 0) {
+              // special case where this WellSample isn't
+              // linked to a PlateAcquisition,
+              // but multiple PlateAcquisitions exist
+              String wellSampleID = retrieve.getWellSampleID(p, w, wellSample);
+              for (int pa=0; pa<plateAcqCount; pa++) {
+                int wsCount = retrieve.getWellSampleRefCount(p, pa);
+                for (int wsRef=0; wsRef<wsCount; wsRef++) {
+                  String wellSampleRef =
+                    retrieve.getPlateAcquisitionWellSampleRef(p, pa, wsRef);
+                  if (wellSampleID.equals(wellSampleRef)) {
+                    result(testName, false,
+                      "PlateAcquisition-WellSample link" + failureSuffix);
+                  }
                 }
               }
             }
-          }
-          else if (plateAcq >= 0 && plateAcqCount > 0) {
-            String wellSampleID = retrieve.getWellSampleID(plate, w, wellSample);
-            boolean foundWellSampleRef = false;
-            for (int wsRef=0; wsRef<retrieve.getWellSampleRefCount(plate, plateAcq); wsRef++) {
-              String wellSampleRef = retrieve.getPlateAcquisitionWellSampleRef(
-                plate, plateAcq, wsRef);
-              if (wellSampleID.equals(wellSampleRef)) {
-                foundWellSampleRef = true;
-                break;
+            else if (plateAcq >= 0 && plateAcqCount > 0) {
+              String wellSampleID = retrieve.getWellSampleID(p, w, wellSample);
+              boolean foundWellSampleRef = false;
+              for (int wsRef=0; wsRef<retrieve.getWellSampleRefCount(p, plateAcq); wsRef++) {
+                String wellSampleRef = retrieve.getPlateAcquisitionWellSampleRef(
+                  p, plateAcq, wsRef);
+                if (wellSampleID.equals(wellSampleRef)) {
+                  foundWellSampleRef = true;
+                  break;
+                }
+              }
+              if (!foundWellSampleRef) {
+                result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
               }
             }
-            if (!foundWellSampleRef) {
-              result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
-            }
+          }
+          if (foundWell) {
+            break;
           }
         }
-        if (foundWell) {
-          break;
-        }
       }
-      if (!foundWell) {
+      if (!foundWell && plate >= 0) {
         result(testName, false, "Well indexes" + failureSuffix);
       }
     }


### PR DESCRIPTION
Backported from a private PR.

To test, use any of the files with updated configurations from the forthcoming configuration PR.  Most have more than one resolution per field; it's also not uncommon to have an attachment image similar to a slide overview, although it doesn't look like any of the plates in the repo have this.

The test change allows for series to be marked as unlinked from a plate by design, by setting ```Plate = -1``` explicitly.  Omitting ```Plate``` from the configuration or setting ```Plate = 0``` should behave as before.