### PR TITLE
Pattern reader: populate channel names from pattern tokens

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import loci.common.DataTools;
 import loci.common.Location;
+import loci.formats.AxisGuesser;
 import loci.formats.ClassList;
 import loci.formats.CoreMetadata;
 import loci.formats.FileStitcher;
@@ -229,6 +230,22 @@ public class FilePatternReader extends WrappedReader {
     helper.setCanChangePattern(false);
     helper.setId(pattern);
     core = helper.getCoreMetadataList();
+
+    if (getEffectiveSizeC() > 1) {
+      MetadataStore store = makeFilterMetadata();
+      String[][] elements = helper.getFilePattern().getElements();
+      int[] axisTypes = helper.getAxisTypes();
+      int nextChannel = 0;
+      for (int i=0; i<axisTypes.length; i++) {
+        if (axisTypes[i] == AxisGuesser.C_AXIS) {
+          for (int c=0; c<elements[i].length; c++) {
+            if (nextChannel < getEffectiveSizeC()) {
+              store.setChannelName(elements[i][c], 0, nextChannel++);
+            }
+          }
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
To test, use something like:

```
$ cat test.pattern
c<DAPI,FITC>.fake
$ showinf -nopix -omexml test.pattern
```

and verify that channel names are set to ```DAPI``` and ```FITC```.  This will only work when using a pattern file, not with ```showinf -stitch c<DAPI,FITC>.fake```.  I'm not completely opposed to adding this feature to ```FileStitcher``` instead, it just seems simpler and less breaking in ```FilePatternReader```.