### PR TITLE
ChannelFiller: reset bits per pixel if a lookup table is applied

### DIFF
--- a/components/formats-bsd/src/loci/formats/ChannelFiller.java
+++ b/components/formats-bsd/src/loci/formats/ChannelFiller.java
@@ -110,6 +110,17 @@ public class ChannelFiller extends ReaderWrapper {
     return false;
   }
 
+  /* @see IFormatReader#getBitsPerPixel() */
+  @Override
+  public int getBitsPerPixel() {
+    if (isFilled()) {
+      // reader may have set a lower number of bits
+      // but that will apply to the indexes, not the filled values
+      return FormatTools.getBytesPerPixel(reader.getPixelType()) * 8;
+    }
+    return reader.getBitsPerPixel();
+  }
+
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {


### PR DESCRIPTION
Fairly certain this will resolve https://trac.openmicroscopy.org/ome/ticket/13258

An underlying format reader's ```getBitsPerPixel()``` applies only to what it returns in ```openBytes```.
The lookup table may contain a larger range of values, so ```getBitsPerPixel()``` now returns
the full pixel type width any time a lookup table is applied.

I would not expect this to have any impact on tests or memo files.  Comparing the output of ```showinf -expand -minmax``` on https://trac.openmicroscopy.org/ome/raw-attachment/ticket/13258/tartan.png with and without this PR should confirm that:

- without this PR, bits per pixel is 4
- with this PR, bits per pixel is 8
- the max pixel values with lookup table applied are greater than 15