### PR TITLE
CellSens vsi: fix offset check to prevent seeking beyond EOF

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1884,7 +1884,7 @@ public class CellSensReader extends FormatReader {
         }
 
         if (nextField == 0 || tag == -494804095) {
-          if (fp + dataSize < vsi.length() && fp + dataSize >= 0) {
+          if (fp + dataSize + 32 < vsi.length() && fp + dataSize >= 0) {
             vsi.seek(fp + dataSize + 32);
           }
           return;


### PR DESCRIPTION
Fixes #3438

To test, use ```showinf -nopix -debug``` on .vsi files in ```inbox/gh-3438```.  Without this PR, an exception should be logged as noted in #3438.  With this PR, there should be no exception.

I would not expect any test or memo file impact; this should be safe for a patch release.