### PR TITLE
OME-TIFF reader: remove resolution annotation when resolutions are flattened

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -58,6 +58,7 @@ import loci.formats.MissingLibraryException;
 import loci.formats.Modulo;
 import loci.formats.SubResolutionFormatReader;
 import loci.formats.meta.MetadataStore;
+import loci.formats.ome.OMEPyramidStore;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
@@ -70,6 +71,7 @@ import loci.formats.tiff.TiffParser;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.Channel;
 import ome.xml.model.Image;
+import ome.xml.model.MapPair;
 import ome.xml.model.Pixels;
 import ome.xml.model.Plane;
 import ome.xml.model.primitives.NonNegativeInteger;
@@ -520,6 +522,16 @@ public class OMETiffReader extends SubResolutionFormatReader {
     for (int i=0; i<meta.getImageCount(); i++) {
       int sizeC = meta.getPixelsSizeC(i).getValue();
       service.removeChannels(meta, i, sizeC);
+    }
+
+    // if flattened resolutions are requested, remove resolution annotations
+    // otherwise, MetadataStore and reader metadata will be inconsistent
+    if (hasFlattenedResolutions()) {
+      for (int i=0; i<meta.getMapAnnotationCount(); i++) {
+        if (meta.getMapAnnotationNamespace(i).equals(OMEPyramidStore.NAMESPACE)) {
+          meta.setMapAnnotationValue(new ArrayList<MapPair>(), i);
+        }
+      }
     }
 
     Hashtable originalMetadata = service.getOriginalMetadata(meta);

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -527,10 +527,16 @@ public class OMETiffReader extends SubResolutionFormatReader {
     // if flattened resolutions are requested, remove resolution annotations
     // otherwise, MetadataStore and reader metadata will be inconsistent
     if (hasFlattenedResolutions()) {
-      for (int i=0; i<meta.getMapAnnotationCount(); i++) {
-        if (meta.getMapAnnotationNamespace(i).equals(OMEPyramidStore.NAMESPACE)) {
-          meta.setMapAnnotationValue(new ArrayList<MapPair>(), i);
+      try {
+        for (int i=0; i<meta.getMapAnnotationCount(); i++) {
+          if (meta.getMapAnnotationNamespace(i).equals(OMEPyramidStore.NAMESPACE)) {
+            meta.setMapAnnotationValue(new ArrayList<MapPair>(), i);
+          }
         }
+      }
+      catch (NullPointerException e) {
+        // not unexpected if there are no map annotations
+        LOGGER.trace("Could not remove resolution annotations", e);
       }
     }
 


### PR DESCRIPTION
Prevents inconsistent resolution counts between the reader and MetadataStore.

This demonstrates the problem:

```
$ bfconvert "test&sizeX=8000&sizeY=8000&resolutions=4.fake" test-pyramid.ome.tiff -noflat
$ bfconvert test-pyramid.ome.tiff -series 0 test-pyramid-series-0.ome.tiff
...
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1
	at loci.formats.out.PyramidOMETiffWriter.close(PyramidOMETiffWriter.java:128)
	at loci.formats.ImageWriter.close(ImageWriter.java:469)
	at loci.formats.tools.ImageConverter.testConvert(ImageConverter.java:749)
	at loci.formats.tools.ImageConverter.main(ImageConverter.java:1095)
```

With this PR, the re-running the second ```bfconvert``` command should result in a readable output file with no exception.
Comparing ```showinf -nopix -omexml test-pyramid.ome.tiff``` and ```showinf -nopix -omexml -noflat test-pyramid.ome.tiff``` with this PR should show an empty resolution map annotation.  This could instead change the namespace (leaving the value as-is) or completely remove the entire annotation; I don't have a strong preference for any of the three.

/cc @kkoz @chris-allan 