### PR TITLE
Update directory for OME-TIFF filesets with BinaryOnly across multiple folders

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -507,6 +507,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
           meta = service.createOMEXMLMetadata(xml);
           // Compute all paths relative to the directory of the metadata file
           dir = path.getParentFile().getCanonicalPath();
+          // Set the current ID to the metadata file
+          currentId = metadataFile;
         }
         catch (ServiceException se) {
           throw new FormatException(se);

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -504,6 +504,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
         try {
           meta = service.createOMEXMLMetadata(xml);
+          // Compute all paths relative to the directory of the metadata file
+          dir = path.getParentFile().getCanonicalPath();
         }
         catch (ServiceException se) {
           throw new FormatException(se);

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -499,7 +499,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
       // overwrite XML with what is in the companion OME-XML file
       Location path = new Location(dir, metadataPath);
       if (path.exists()) {
-        metadataFile = path.getAbsolutePath();
+        // Since metatadataPath can be relative, use getCanonicalPath()
+        metadataFile = path.getCanonicalPath();
         xml = readMetadataFile();
 
         try {
@@ -1373,6 +1374,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
   /** Extracts the OME-XML from the current {@link #metadataFile}. */
   private String readMetadataFile() throws IOException {
+    LOGGER.debug("Reading metadata from {}", metadataFile);
     if (checkSuffix(metadataFile, "ome.tiff") ||
         checkSuffix(metadataFile, "ome.tif") ||
         checkSuffix(metadataFile, "ome.tf2") ||


### PR DESCRIPTION
See https://forum.image.sc/t/opening-images-from-a-yokogawa-cq1-with-bio-formats/52615/

This PR deals with the case of a multi-file OME-TIFF fileset distributed over multiple folders, where the master file containing the metadata is up one directory from the individual files referring to it using the `BinaryOnly.MetadataFile` element.

53621b2 adjust the current directory to use the directory of the metadata file. This allows to compute all the  paths of the TiffData elements relative to this directory.

bd13a7c  also uses `getCanonicalPath()` to resolve the relative paths stored in `BinaryOnly.MetadataFile`

7c28bcc sets the `currentId` to the master metadata file. This is not a rquirement for the fix and can be reviewed/discussed separately if problematic. 

A sample fileset can be downloaded from the [Zenodo record](https://zenodo.org/record/4751185) and is also available under `/uod/idr/scratch/inbox/imagesc-52615`. Without this PR, `showinf` should work when pointing to the master OME-TIFF file (`MeasurementResultMIP.ome.tif`) but fail when pointing at one of the TIFF under the `Projection` folder with a `Mismatch UUID` error. With this PR, the fileset should be detected independently of the TIFF chosen. Additionally the list the used files should always start with the master metadata file and be canonical paths (no `../`).