### PR TITLE
200809-Transforms: Add tests for custom attributes

### DIFF
--- a/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
+++ b/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
@@ -51,7 +51,13 @@
 		<ExperimenterRef ID = "urn:lsid:foo.bar.com:Experimenter:123456"/>
 		<GroupRef ID = "urn:lsid:foo.bar.com:Group:123456"/>
 		<ProjectRef ID = "urn:lsid:foo.bar.com:Project:123456"/>
-		<CA:CustomAttributes/>
+    <CustomAttributes>
+      <OriginalMetadata ID="OriginalMetadata:0" Name="Custom Metadata 0" Value="0"/>
+      <OriginalMetadata ID="OriginalMetadata:1" Name="Custom Metadata 1" Value="1"/>
+      <OriginalMetadata ID="OriginalMetadata:2" Name="Custom Metadata 2" Value="2"/>
+      <OriginalMetadata ID="OriginalMetadata:3" Name="Custom Metadata 3" Value="3"/>
+      <OriginalMetadata ID="OriginalMetadata:4" Name="Custom Metadata 4" Value="4"/>
+    </CustomAttributes>
 	</Dataset>
 	<Experiment Type = "TimeLapse" ID = "urn:lsid:foo.bar.com:Experiment:123456">
 		<Description>This was an experiment.</Description>
@@ -149,7 +155,21 @@
 		<Pixels DimensionOrder = "XYZCT" PixelType = "int16" BigEndian = "true"
 			ID = "urn:lsid:foo.bar.com:Pixels:123456" SizeX = "20" SizeY = "20" SizeZ = "5" SizeC = "1" SizeT = "6" PhysicalSizeX="0.2" PhysicalSizeY="0.2" PhysicalSizeZ="0.2">
 		</Pixels>
+    <CustomAttributes>
+      <OriginalMetadata ID="OriginalMetadata:5" Name="Custom Metadata 5" Value="5"/>
+      <OriginalMetadata ID="OriginalMetadata:6" Name="Custom Metadata 6" Value="6"/>
+    </CustomAttributes>
+    <Feature>
+      <CustomAttributes>
+        <OriginalMetadata ID="OriginalMetadata:7" Name="Custom Metadata 7" Value="7"/>
+      </CustomAttributes>
+    </Feature>
 	</Image>
+	<CustomAttributes>
+    <OriginalMetadata ID="OriginalMetadata:8" Name="Custom Metadata 8" Value="8"/>
+    <OriginalMetadata ID="OriginalMetadata:9" Name="Custom Metadata 9" Value="9"/>
+    <OriginalMetadata ID="OriginalMetadata:10" Name="Custom Metadata 10" Value="10"/>
+  </CustomAttributes>
 	<!--
 	<STD:SemanticTypeDefinitions>
 		< - - INSERT STD's here - - >

--- a/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
+++ b/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
@@ -51,13 +51,13 @@
 		<ExperimenterRef ID = "urn:lsid:foo.bar.com:Experimenter:123456"/>
 		<GroupRef ID = "urn:lsid:foo.bar.com:Group:123456"/>
 		<ProjectRef ID = "urn:lsid:foo.bar.com:Project:123456"/>
-    <CA:CustomAttributes>
-      <OriginalMetadata ID="OriginalMetadata:0" Name="Custom Metadata 0" Value="0"/>
-      <OriginalMetadata ID="OriginalMetadata:1" Name="Custom Metadata 1" Value="1"/>
-      <OriginalMetadata ID="OriginalMetadata:2" Name="Custom Metadata 2" Value="2"/>
-      <OriginalMetadata ID="OriginalMetadata:3" Name="Custom Metadata 3" Value="3"/>
-      <OriginalMetadata ID="OriginalMetadata:4" Name="Custom Metadata 4" Value="4"/>
-    </CA:CustomAttributes>
+		<CA:CustomAttributes>
+			<OriginalMetadata ID="OriginalMetadata:0" Name="Custom Metadata 0" Value="0"/>
+			<OriginalMetadata ID="OriginalMetadata:1" Name="Custom Metadata 1" Value="1"/>
+			<OriginalMetadata ID="OriginalMetadata:2" Name="Custom Metadata 2" Value="2"/>
+			<OriginalMetadata ID="OriginalMetadata:3" Name="Custom Metadata 3" Value="3"/>
+			<OriginalMetadata ID="OriginalMetadata:4" Name="Custom Metadata 4" Value="4"/>
+		</CA:CustomAttributes>
 	</Dataset>
 	<Experiment Type = "TimeLapse" ID = "urn:lsid:foo.bar.com:Experiment:123456">
 		<Description>This was an experiment.</Description>
@@ -155,21 +155,21 @@
 		<Pixels DimensionOrder = "XYZCT" PixelType = "int16" BigEndian = "true"
 			ID = "urn:lsid:foo.bar.com:Pixels:123456" SizeX = "20" SizeY = "20" SizeZ = "5" SizeC = "1" SizeT = "6" PhysicalSizeX="0.2" PhysicalSizeY="0.2" PhysicalSizeZ="0.2">
 		</Pixels>
-    <CA:CustomAttributes>
-      <OriginalMetadata ID="OriginalMetadata:5" Name="Custom Metadata 5" Value="5"/>
-      <OriginalMetadata ID="OriginalMetadata:6" Name="Custom Metadata 6" Value="6"/>
-    </CA:CustomAttributes>
-    <Feature>
-      <CA:CustomAttributes>
-        <OriginalMetadata ID="OriginalMetadata:7" Name="Custom Metadata 7" Value="7"/>
-      </CA:CustomAttributes>
-    </Feature>
+		<CA:CustomAttributes>
+			<OriginalMetadata ID="OriginalMetadata:5" Name="Custom Metadata 5" Value="5"/>
+			<OriginalMetadata ID="OriginalMetadata:6" Name="Custom Metadata 6" Value="6"/>
+		</CA:CustomAttributes>
+		<Feature>
+			<CA:CustomAttributes>
+				<OriginalMetadata ID="OriginalMetadata:7" Name="Custom Metadata 7" Value="7"/>
+			</CA:CustomAttributes>
+		</Feature>
 	</Image>
 	<CA:CustomAttributes>
-    <OriginalMetadata ID="OriginalMetadata:8" Name="Custom Metadata 8" Value="8"/>
-    <OriginalMetadata ID="OriginalMetadata:9" Name="Custom Metadata 9" Value="9"/>
-    <OriginalMetadata ID="OriginalMetadata:10" Name="Custom Metadata 10" Value="10"/>
-  </CA:CustomAttributes>
+		<OriginalMetadata ID="OriginalMetadata:8" Name="Custom Metadata 8" Value="8"/>
+		<OriginalMetadata ID="OriginalMetadata:9" Name="Custom Metadata 9" Value="9"/>
+		<OriginalMetadata ID="OriginalMetadata:10" Name="Custom Metadata 10" Value="10"/>
+	</CA:CustomAttributes>
 	<!--
 	<STD:SemanticTypeDefinitions>
 		< - - INSERT STD's here - - >

--- a/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
+++ b/components/formats-gpl/test/loci/formats/utests/xml/2008-09.ome
@@ -51,13 +51,13 @@
 		<ExperimenterRef ID = "urn:lsid:foo.bar.com:Experimenter:123456"/>
 		<GroupRef ID = "urn:lsid:foo.bar.com:Group:123456"/>
 		<ProjectRef ID = "urn:lsid:foo.bar.com:Project:123456"/>
-    <CustomAttributes>
+    <CA:CustomAttributes>
       <OriginalMetadata ID="OriginalMetadata:0" Name="Custom Metadata 0" Value="0"/>
       <OriginalMetadata ID="OriginalMetadata:1" Name="Custom Metadata 1" Value="1"/>
       <OriginalMetadata ID="OriginalMetadata:2" Name="Custom Metadata 2" Value="2"/>
       <OriginalMetadata ID="OriginalMetadata:3" Name="Custom Metadata 3" Value="3"/>
       <OriginalMetadata ID="OriginalMetadata:4" Name="Custom Metadata 4" Value="4"/>
-    </CustomAttributes>
+    </CA:CustomAttributes>
 	</Dataset>
 	<Experiment Type = "TimeLapse" ID = "urn:lsid:foo.bar.com:Experiment:123456">
 		<Description>This was an experiment.</Description>
@@ -155,21 +155,21 @@
 		<Pixels DimensionOrder = "XYZCT" PixelType = "int16" BigEndian = "true"
 			ID = "urn:lsid:foo.bar.com:Pixels:123456" SizeX = "20" SizeY = "20" SizeZ = "5" SizeC = "1" SizeT = "6" PhysicalSizeX="0.2" PhysicalSizeY="0.2" PhysicalSizeZ="0.2">
 		</Pixels>
-    <CustomAttributes>
+    <CA:CustomAttributes>
       <OriginalMetadata ID="OriginalMetadata:5" Name="Custom Metadata 5" Value="5"/>
       <OriginalMetadata ID="OriginalMetadata:6" Name="Custom Metadata 6" Value="6"/>
-    </CustomAttributes>
+    </CA:CustomAttributes>
     <Feature>
-      <CustomAttributes>
+      <CA:CustomAttributes>
         <OriginalMetadata ID="OriginalMetadata:7" Name="Custom Metadata 7" Value="7"/>
-      </CustomAttributes>
+      </CA:CustomAttributes>
     </Feature>
 	</Image>
-	<CustomAttributes>
+	<CA:CustomAttributes>
     <OriginalMetadata ID="OriginalMetadata:8" Name="Custom Metadata 8" Value="8"/>
     <OriginalMetadata ID="OriginalMetadata:9" Name="Custom Metadata 9" Value="9"/>
     <OriginalMetadata ID="OriginalMetadata:10" Name="Custom Metadata 10" Value="10"/>
-  </CustomAttributes>
+  </CA:CustomAttributes>
 	<!--
 	<STD:SemanticTypeDefinitions>
 		< - - INSERT STD's here - - >

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
@@ -88,5 +88,14 @@ public class Upgrade200809Test {
     // OME:Channel, Color now use new colour representation and is required
     assertEquals(-1, metadata.getChannelColor(0, 0).getValue().intValue());
   }
+  
+  @Test
+  public void testCustomAttributes() throws ServiceException {
+    assertNotNull(ome.getStructuredAnnotations());
+    assertEquals(4, metadata.getXMLAnnotationCount());
+    String expectedAnnotation = "<OriginalMetadata ID=\"OriginalMetadata:7\" "
+        + "Name=\"Custom Metadata 7\" Value=\"7\"/>";
+    assertEquals(expectedAnnotation, metadata.getXMLAnnotationValue(2));
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,22 +42,22 @@
     <imagej1.version>1.51r</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <log4j.version>1.2.17</log4j.version>
-    <logback.version>1.1.1</logback.version>
+    <logback.version>1.2.0</logback.version>
     <ome-stubs.version>5.3.2</ome-stubs.version>
     <lwf-stubs.version>${ome-stubs.version}</lwf-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.2</ome-metakit.version>
+    <ome-metakit.version>5.3.3</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.6</ome-common.version>
+    <ome-common.version>6.0.7</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.2.3</ome-model.version>
-    <ome-poi.version>5.3.3</ome-poi.version>
+    <ome-poi.version>5.3.4</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.3.0</ome-codecs.version>
+    <ome-codecs.version>0.3.1</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.6</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.2.2</ome-model.version>
+    <ome-model.version>6.2.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>


### PR DESCRIPTION
This is a follow up to https://github.com/ome/ome-model/issues/142

From the 2003-FC spec the CustomAttributes can be positioned in 4 different places. The CustomAttributes which are not at the top level must be copied there before transforming to XMLAnnotations. 

These tests should fail until a transform fix has been included with OME-Model.