### PR TITLE
OMEXMLService: Use XML catalog in specifications.jar

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -174,6 +174,9 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
             /* from specification.jar */
             return getClass().getResourceAsStream("/released-schema/" +
                  matcher.group(1) + "/" + matcher.group(2) + ".xsd");
+          } else if(url.equals("http://www.w3.org/2001/xml.xsd")) {
+            return getClass().getResourceAsStream(
+              "/released-schema/external/xml.xsd");
           } else {
             return null;
           }


### PR DESCRIPTION
Before this change OME schema references for
"http://www.w3.org/2001/xml.xsd" lead to throttled downloads.

After this change an embedded copy from specifications.jar
should be used instead.

This seems to be a more generic solution than what I proposed for #3699 earlier and it does seem to work as well (maybe a tiny bit slower due to the additional catalog processing but still much faster than the initial throttled download).

Again I only half know what I am doing here so I'd appreciate a thorough review of the changes.