### PR TITLE
Deltavision: fix IndexOutOfBoundsException

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
@@ -487,18 +488,18 @@ public class DeltavisionReader extends FormatReader {
       extHdrFields[i] = hdr;
 
       if (!uniqueTileX.contains(hdr.stageXCoord) &&
-              hdr.stageXCoord.value().floatValue() != 0) {
+          Math.abs(hdr.stageXCoord.value().floatValue()) > Constants.EPSILON) {
         uniqueTileX.add(hdr.stageXCoord);
       }
-      else if (hdr.stageXCoord.value().floatValue() == 0) {
+      else if (Math.abs(hdr.stageXCoord.value().floatValue()) <= Constants.EPSILON) {
         hasZeroX = true;
       }
 
       if (!uniqueTileY.contains(hdr.stageYCoord) &&
-              hdr.stageYCoord.value().floatValue() != 0) {
+          Math.abs(hdr.stageYCoord.value().floatValue()) > Constants.EPSILON) {
         uniqueTileY.add(hdr.stageYCoord);
       }
-      else if (hdr.stageYCoord.value().floatValue() == 0) {
+      else if (Math.abs(hdr.stageYCoord.value().floatValue()) <= Constants.EPSILON) {
         hasZeroY = true;
       }
     }
@@ -507,13 +508,14 @@ public class DeltavisionReader extends FormatReader {
     yTiles = uniqueTileY.size();
 
     if (xTiles > 1 || yTiles > 1) {
-      if (hasZeroX && xTiles == 0) {
+      if (hasZeroX) {
         xTiles++;
       }
-      if (hasZeroY && yTiles == 0) {
+      if (hasZeroY) {
         yTiles++;
       }
     }
+
     if (xTiles > 1) {
       final Number x0 = uniqueTileX.get(0).value(UNITS.REFERENCEFRAME);
       final Number x1 = uniqueTileX.get(1).value(UNITS.REFERENCEFRAME);

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -507,14 +507,13 @@ public class DeltavisionReader extends FormatReader {
     yTiles = uniqueTileY.size();
 
     if (xTiles > 1 || yTiles > 1) {
-      if (hasZeroX) {
+      if (hasZeroX && xTiles == 0) {
         xTiles++;
       }
-      if (hasZeroY) {
+      if (hasZeroY && yTiles == 0) {
         yTiles++;
       }
     }
-
     if (xTiles > 1) {
       final Number x0 = uniqueTileX.get(0).value(UNITS.REFERENCEFRAME);
       final Number x1 = uniqueTileX.get(1).value(UNITS.REFERENCEFRAME);


### PR DESCRIPTION
This PR tries to address a regression in the Deltavision reader introduced in Bio-Formats 6.2.0.
Initial support for multi-stage positions was introduced in https://github.com/ome/bioformats/commit/1e6686286760bbac249a64c05e42b5af6ec5a8a2. https://github.com/ome/bioformats/pull/1324 introduced some special handling of cases where some coordinates are equal to 0 and https://github.com/ome/bioformats/pull/3398 added support for detecting backward stages in X.

A representative sample files was uploaded as part of an IDR submission where `uniqueTileX.size()` is 1, `uniqueTileY.size()` is 3 and `hasZeroX` is true. As per the following block

https://github.com/ome/bioformats/blob/b68a64959b9f17ceb6b9cb57c15d7b46b56f23ed/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java#L506-L516

`xTiles` is incremented by one and causes the following block to fail when accessing the second element:

https://github.com/ome/bioformats/blob/b68a64959b9f17ceb6b9cb57c15d7b46b56f23ed/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java#L518-L520

The PR updates the coordinates detection to use `Constants.EPSILON` and round small values to zero.
