### PR TITLE
Add support for VisiView STK files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -105,7 +105,7 @@ public class MetamorphReader extends BaseTiffReader {
   public static final String[] ND_SUFFIX = {"nd", "scan"};
   public static final String[] STK_SUFFIX = {"stk", "tif", "tiff"};
 
-  public static final String[] validSoftware = {"metamorph", "visiview"};
+  public static final String[] VALID_SOFTWARE = {"metamorph", "visiview"};
 
   public static final Pattern WELL_COORDS = Pattern.compile(
       "\\b([a-z])(\\d+)", Pattern.CASE_INSENSITIVE

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2305,7 +2305,7 @@ public class MetamorphReader extends BaseTiffReader {
   private static boolean isValidSoftware(String software) {
     if (software == null) return false;
     for (int i = 0; i < VALID_SOFTWARE.length; i++) {
-      if (software.trim().toLowerCase().startsWith(validSoftware[i])) return true;
+      if (software.trim().toLowerCase().startsWith(VALID_SOFTWARE[i])) return true;
     }
     return false;
   }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -105,6 +105,8 @@ public class MetamorphReader extends BaseTiffReader {
   public static final String[] ND_SUFFIX = {"nd", "scan"};
   public static final String[] STK_SUFFIX = {"stk", "tif", "tiff"};
 
+  public static final String[] validSoftware = {"metamorph", "visiview"};
+
   public static final Pattern WELL_COORDS = Pattern.compile(
       "\\b([a-z])(\\d+)", Pattern.CASE_INSENSITIVE
   );
@@ -234,10 +236,7 @@ public class MetamorphReader extends BaseTiffReader {
     IFD ifd = tp.getFirstIFD();
     if (ifd == null) return false;
     String software = ifd.getIFDTextValue(IFD.SOFTWARE);
-    boolean validSoftware = software != null &&
-      (software.trim().toLowerCase().startsWith("metamorph") || 
-          software.trim().toLowerCase().startsWith("visiview"));
-    return validSoftware || (ifd.containsKey(UIC1TAG) &&
+    return isValidSoftware(software) || (ifd.containsKey(UIC1TAG) &&
       ifd.containsKey(UIC3TAG) && ifd.containsKey(UIC4TAG));
   }
 
@@ -2301,6 +2300,14 @@ public class MetamorphReader extends BaseTiffReader {
       formatSuffix = "tif";
     }
     return formatSuffix;
+  }
+
+  private static boolean isValidSoftware(String software) {
+    if (software == null) return false;
+    for (int i = 0; i < validSoftware.length; i++) {
+      if (software.trim().toLowerCase().startsWith(validSoftware[i])) return true;
+    }
+    return false;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2304,7 +2304,7 @@ public class MetamorphReader extends BaseTiffReader {
 
   private static boolean isValidSoftware(String software) {
     if (software == null) return false;
-    for (int i = 0; i < validSoftware.length; i++) {
+    for (int i = 0; i < VALID_SOFTWARE.length; i++) {
       if (software.trim().toLowerCase().startsWith(validSoftware[i])) return true;
     }
     return false;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -235,7 +235,8 @@ public class MetamorphReader extends BaseTiffReader {
     if (ifd == null) return false;
     String software = ifd.getIFDTextValue(IFD.SOFTWARE);
     boolean validSoftware = software != null &&
-      software.trim().toLowerCase().startsWith("metamorph");
+      (software.trim().toLowerCase().startsWith("metamorph") || 
+          software.trim().toLowerCase().startsWith("visiview"));
     return validSoftware || (ifd.containsKey(UIC1TAG) &&
       ifd.containsKey(UIC3TAG) && ifd.containsKey(UIC4TAG));
   }


### PR DESCRIPTION
This PR is in response to forum thread https://forum.image.sc/t/issue-with-stk-timelapse-import-to-omero-or-fiji-with-bio-formats/54644

The VisiView software is generating STK files (no associated ND file) which can be handled by the existing MetaMorphReader, this PR simply allows VisiView as valid software for this readers `isThisType` method. Without this PR they will be read by the TiffDelegateReader and only a single plane of a time series will be displayed.

A follow up config PR will be opened once I have completed transfer of the sample file.