### PR TITLE
ND2 Reader Incorrect dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -111,6 +111,7 @@ public class ND2Handler extends BaseHandler {
 
   private boolean canAdjustDimensions = true;
   private boolean firstTimeLoop = true;
+  public boolean imageMetadataLVExists = false;
 
   // -- Constructor --
 
@@ -704,7 +705,7 @@ public class ND2Handler extends BaseHandler {
       }
       else if (key.endsWith("uiCount")) {
         if (runtype != null) {
-          if (runtype.endsWith("ZStackLoop")) {
+          if (runtype.endsWith("ZStackLoop") && !imageMetadataLVExists) {
             if (ms0.sizeZ == 0) {
               ms0.sizeZ = Integer.parseInt(value);
               if (ms0.dimensionOrder.indexOf('Z') == -1) {
@@ -712,7 +713,7 @@ public class ND2Handler extends BaseHandler {
               }
             }
           }
-          else if (runtype.endsWith("TimeLoop")) {
+          else if (runtype.endsWith("TimeLoop") && !imageMetadataLVExists) {
             if (ms0.sizeT == 0) {
               ms0.sizeT = Integer.parseInt(value);
               if (ms0.dimensionOrder.indexOf('T') == -1) {
@@ -770,7 +771,7 @@ public class ND2Handler extends BaseHandler {
           }
         }
       }
-      else if (isDimensions(key)) {
+      else if (isDimensions(key) && !imageMetadataLVExists) {
         String[] dims = value.split(" x ");
 
         if (ms0.sizeZ == 0) ms0.sizeZ = 1;

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -998,8 +998,8 @@ public class NativeND2Reader extends SubResolutionFormatReader {
               if(currentCountSetted)
                 setDimensions(timeCount, zCount, XYCount);
 
-              if (in.getFilePointer() > endFP) {
-                in.seek(endFP);
+              if (in.getFilePointer() > startFilePointer) {
+                in.seek(startFilePointer);
               }
             }
 


### PR DESCRIPTION
This PR fixes https://github.com/ome/bioformats/issues/3502 issue. 

The solution was tested on the .nd2 documents that I had in my possession. In particular, those that were shared in the issue on the GitHub. The pull request will need to be tested with files from QA-29035 if its possible(I don't have an access to this).

For new documents that do not use xml as metadata, the parser has been changed, as a result of which the order of the demensions is read directly from the metadata (Previously, they were read from the information in the document description).