### PR TITLE
Gatan: Strip null chars from value string

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -638,6 +638,7 @@ public class GatanReader extends FormatReader {
 
       NumberFormat f = NumberFormat.getInstance(Locale.ENGLISH);
       if (value != null) {
+        value = value.replaceAll("\0", "");
         addGlobalMeta(labelString, value);
 
         if (parent != null &&


### PR DESCRIPTION
This issue was raised on forum thread: https://forum.image.sc/t/gatan-dm4-files-wont-open/55627/3

The issue was related to the parsing of metadata values. In this case some of the position where as below:

- -199.355 (This String contains extra null 0 bytes in between each char)
- -199.355 (The same String with the null bytes removed parses without exception)

A sample file was provided which I will include in the data repo and a config PR is to follow before review