### PR TITLE
Fix case where JPEGTurboService is used to read single-tile images

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -219,10 +219,15 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
 
     if (restartInterval == 1 && restartMarkers.size() <= 1) {
       // interval and markers are not present or invalid
-      LOGGER.warn("Restart interval and markers invalid, attempting to read as single tile");
-      xTiles = 1;
-      yTiles = 1;
-      tileDim = (int) Math.max(imageWidth, imageHeight);
+      if (imageWidth < 8192 || imageHeight < 8192) {
+        LOGGER.warn("Restart interval and markers invalid, attempting to read as single tile");
+        xTiles = 1;
+        yTiles = 1;
+        tileDim = (int) Math.max(imageWidth, imageHeight);
+      }
+      else {
+        throw new IOException("Restart interval and markers invalid");
+      }
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -219,7 +219,10 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
 
     if (restartInterval == 1 && restartMarkers.size() <= 1) {
       // interval and markers are not present or invalid
-      throw new IOException("Restart interval and markers invalid");
+      LOGGER.warn("Restart interval and markers invalid, attempting to read as single tile");
+      xTiles = 1;
+      yTiles = 1;
+      tileDim = (int) Math.max(imageWidth, imageHeight);
     }
   }
 


### PR DESCRIPTION
Backported from a private PR.  Had hoped this might fix https://trello.com/c/pVIlQ3Xe/327-jpeg-ioexception, but it only changes the error message.

Very low priority and should be fine for a patch release.