### PR TITLE
ND2 metadata parsing fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1924,9 +1924,8 @@ public class NativeND2Reader extends SubResolutionFormatReader {
               in.seek(stop);
               continue;
             }
-            byte[] data = new byte[(int) length];
-            in.read(data);
-            value = new String(data, Constants.ENCODING);
+            value = "ByteArray";
+            iterateIn(in, stop);
             break;
           case (10): // deprecated
             // Its like LEVEL but offset is pointing absolutely not relatively
@@ -2003,7 +2002,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
           positionCount++;
         }
 
-        if (type != 11 && type != 10) {    // if not level add global meta
+        if (type != 11 && type != 10 && type != 9) {    // if not level add global meta
           addGlobalMeta(name, value);
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -755,6 +755,10 @@ public class NativeND2Reader extends SubResolutionFormatReader {
 
           iterateIn(in, startFP + dataLength - 1);
           validDimensions.add(blockCount > 2);
+
+          // make sure the file pointer is at the end of the block
+          in.seek(startFP + dataLength - 1);
+          skip = 0;
         }
         else if (blockType.startsWith("Image") ||
           blockType.startsWith("CustomDataVa"))

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -747,13 +747,14 @@ public class NativeND2Reader extends SubResolutionFormatReader {
           long startFP = in.getFilePointer();
           in.seek(startFP - 1);
 
-          String textString = DataTools.stripString(in.readString((int) dataLength));
-          textStrings.add(textString);
-          validDimensions.add(blockCount > 2);
+          int typeByte = in.read();
+          int charCount = in.read();
+          textStrings.add(DataTools.stripString(in.readString(charCount * 2)));
+          int numTextInfos = in.readInt();
+          long remainingBytes = in.readLong();
 
-          if (!textString.startsWith("<")) {
-            skip = 0;
-          }
+          iterateIn(in, startFP + dataLength - 1);
+          validDimensions.add(blockCount > 2);
         }
         else if (blockType.startsWith("Image") ||
           blockType.startsWith("CustomDataVa"))

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1978,7 +1978,12 @@ public class NativeND2Reader extends SubResolutionFormatReader {
               continue;
             }
             value = "ByteArray";
-            iterateIn(in, stop);
+            if (length > 2) {
+              iterateIn(in, stop);
+            }
+            else {
+              in.skipBytes(length);
+            }
             break;
           case (10): // deprecated
             // Its like LEVEL but offset is pointing absolutely not relatively


### PR DESCRIPTION
Backported from a private PR.

For a private test file, the original metadata table contained some bad data e.g. ```Data: ��D�������;����;?��D����```.  The changes here fixed it so that the original metadata table no longer contains invalid characters, and expected key/value pairs are present.

I wouldn't expect any test failures or configuration changes, but there is a possibility that both commits here are specific to newer versions of ND2 and/or NIS Elements and will need to be adjusted to handle older files.