### PR TITLE
Zeiss CZI: add support for zstd compression

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -130,6 +130,11 @@
       <artifactId>kryo</artifactId>
       <version>${kryo.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>0.18</version>
+    </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2111,11 +2111,16 @@ public class ZeissCZIReader extends FormatReader {
       }
 
       plane.planeIndex = getIndex(z, c, t);
-      int seriesIndex = FormatTools.positionToRaster(extraLengths, extra);
-      plane.resolutionIndex = plane.coreIndex;
-      plane.coreIndex += seriesIndex * (maxResolution + 1);
-      LOGGER.trace("    assigned plane index = {}; series index = {}; coreIndex = {}",
-        plane.planeIndex, seriesIndex, plane.coreIndex);
+      if (plane.pixelTypeIndex > 0) {
+        plane.coreIndex = plane.pixelTypeIndex;
+      }
+      else {
+        int seriesIndex = FormatTools.positionToRaster(extraLengths, extra);
+        plane.resolutionIndex = plane.coreIndex;
+        plane.coreIndex += seriesIndex * (maxResolution + 1);
+        LOGGER.trace("    assigned plane index = {}; series index = {}; coreIndex = {}",
+          plane.planeIndex, seriesIndex, plane.coreIndex);
+      }
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -25,6 +25,8 @@
 
 package loci.formats.in;
 
+import io.airlift.compress.zstd.ZstdDecompressor;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -107,6 +109,7 @@ public class ZeissCZIReader extends FormatReader {
   private static final int JPEG = 1;
   private static final int LZW = 2;
   private static final int JPEGXR = 4;
+  private static final int ZSTD_0 = 5;
 
   /** Pixel type constants. */
   private static final int GRAY8 = 0;
@@ -4042,6 +4045,12 @@ public class ZeissCZIReader extends FormatReader {
               data = new byte[options.maxBytes];
             }
           }
+          break;
+        case ZSTD_0:
+          ZstdDecompressor decompressor = new ZstdDecompressor();
+          byte[] output = new byte[(int) decompressor.getDecompressedSize(data, 0, data.length)];
+          decompressor.decompress(data, 0, data.length, output, 0, output.length);
+          data = output;
           break;
         case 104: // camera-specific packed pixels
           data = decode12BitCamera(data, options.maxBytes);


### PR DESCRIPTION
Ported from a private PR.  Adds support for both zstd variants in Zeiss CZI, using https://github.com/airlift/aircompressor to do the actual decompression.

Test data for ZSTD0, ZSTD1, and corresponding uncompressed data is being uploaded to ```inbox/zeiss-czi-zstd```.  Compressed data should mostly match the corresponding uncompressed data (comparing MD5s/pixel values).  The ```/LLS*``` datasets are an exception due to how they were exported, but should match visually despite the pixel value differences.

I'd expect this to require a minor release since there is a new dependency.