### PR TITLE
AVIWriter: Set fps from Pixels Time Increment

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/AVIWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/AVIWriter.java
@@ -44,7 +44,6 @@ import loci.formats.FormatWriter;
 import loci.formats.meta.MetadataRetrieve;
 import ome.units.UNITS;
 import ome.units.quantity.Time;
-import ome.units.unit.Unit;
 
 /**
  * AVIWriter is the file format writer for AVI files.

--- a/components/formats-bsd/src/loci/formats/out/AVIWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/AVIWriter.java
@@ -42,6 +42,9 @@ import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.FormatWriter;
 import loci.formats.meta.MetadataRetrieve;
+import ome.units.UNITS;
+import ome.units.quantity.Time;
+import ome.units.unit.Unit;
 
 /**
  * AVIWriter is the file format writer for AVI files.
@@ -280,6 +283,13 @@ public class AVIWriter extends FormatWriter {
     int pixelType = FormatTools.pixelTypeFromString(type);
     bytesPerPixel = FormatTools.getBytesPerPixel(pixelType);
     bytesPerPixel *= getSamplesPerPixel();
+    Time timeIncrement = meta.getPixelsTimeIncrement(series);
+    if (timeIncrement != null) {
+      double timeIncValue = timeIncrement.value(UNITS.SECOND).doubleValue();
+      if (timeIncValue != 0) { 
+        fps = new Double(1 / timeIncValue).intValue();
+      }
+    }
 
     xPad = 0;
     int xMod = xDim % 4;


### PR DESCRIPTION
This PR is in response to an Issue raised (https://github.com/ome/bioformats/issues/3702)
With the sample file provided you can see the time increment is 0.039 which matches the plane delta T times, however when the file is converted to an AVI the resulting file plays with an fps value of 10 which is the default for all format writers.

With this PR the converted sample file should now playback for ~5secs with the correct fps set.

fixes https://github.com/ome/bioformats/issues/3702