### PR TITLE
TiffParser: fix non-sequential offset correction for TIFF files between 2 and 4 GB

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1393,6 +1393,9 @@ public class TiffParser implements Closeable {
     // offsets to be accurate; otherwise, we're making the incorrect assumption
     // that IFDs are stored sequentially.
     if (offset < previous && offset != 0 && in.length() > Integer.MAX_VALUE) {
+      if (in.length() <=  Math.pow(2, 32)) {
+        throw new RuntimeException("previous: " + previous + ", offset: " + offset + ", in.length: " + in.length());
+      }
       offset += 0x100000000L;
     }
     return offset;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1392,10 +1392,7 @@ public class TiffParser implements Closeable {
     // Only adjust the offset if we know that the file is too large for 32-bit
     // offsets to be accurate; otherwise, we're making the incorrect assumption
     // that IFDs are stored sequentially.
-    if (offset < previous && offset != 0 && in.length() > Integer.MAX_VALUE) {
-      if (in.length() <=  Math.pow(2, 32)) {
-        throw new RuntimeException("previous: " + previous + ", offset: " + offset + ", in.length: " + in.length());
-      }
+    if (offset < previous && offset != 0 && in.length() >= Math.pow(2, 32)) {
       offset += 0x100000000L;
     }
     return offset;


### PR DESCRIPTION
See https://forum.image.sc/t/bio-formats-and-lavision-ultramicroscope-ii-issue-a-bug/57663

Debugging the sample file indicates that there is a discrepancy between the number of IFDs reported by `tiffinfo` (820) versus `TiffParser.getMainIFDs` (1) which explains the error message and the zero-value behavior described in the issue.

Looking at the file, the first series IFDs offsets is `3309764368 8068354 12104652 16140950` and the code adjusts for the second offset via the following block which specifically handles the case of non-sequential IFDs for large TIFFs:

https://github.com/ome/bioformats/blob/b67dfcac19b898e9a8e2481e5288bdc4b7aa782d/components/formats-bsd/src/loci/formats/tiff/TiffParser.java#L1392-L1397

I suspect the issue lies with the usage of `Integer.MAX_VALUE` which is the maximal value of signed integers `2^31-1` rather than the maximal value of unsigned integers `2^32-1`. Locally updating the check to 

```diff
-  if (offset < previous && offset != 0 && in.length() > Integer.MAX_VALUE) { 
+  if (offset < previous && offset != 0 && in.length() >= Math.pow(2, 32)) { 
```

suffices to open the sample file correctly.

As discussed during the @ome/formats weekly meeting, f5635e3 was first opened to flag all the TIFF samples in our curated repository in this particular scenario. No other sample TIFF file was found which exhibited the same behavior (non sequential IFDs and file size between 2GB and 4GB). 
77ffe5a adjusts the offset adjustment logic to only work on files length > 2^32 -1

To test this PR, open the `UltraII.ome.tif` file from the image.sc thread. Without this PR, warning messages should report an Error while untangling IFDs and all planes except for the first one should be black. With this PR included, the messages should disappear and the reader should correctly read all planes.