### PR TITLE
OME-TIFF: fix handling of partial filesets

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -781,25 +781,28 @@ public class OMETiffReader extends SubResolutionFormatReader {
           }
         }
 
+        // If no valid file has been identified for the TiffData element,
+        // either throw an exception or register the none-existing path with
+        // an ERROR statement
+        if (filename.isEmpty()) {
+          String msg = "Missing file " + meta.getUUIDFileName(i, td) +
+            " associated with UUID " + uuid + ".";
+          if (failOnMissingTIFF()) {
+            throw new FormatException(msg);
+          } else {
+            LOGGER.error(msg + " Corresponding planes will be black.");
+            filename = normalizeFilename(dir, meta.getUUIDFileName(i, td));
+          }
+        }
+
+        // Run some sanity check on the UUID/filename mapping
         String existing = files.get(uuid);
         if (existing == null) {
-          if (!filename.isEmpty()) {
-            files.put(uuid, filename);
-          } else {
-            String msg = "Missing file " + meta.getUUIDFileName(i, td) +
-             " associated with UUID " + uuid + ".";
-            if (failOnMissingTIFF()) {
-              throw new FormatException(msg);
-            } else {
-              LOGGER.error(msg + " Corresponding planes will be black.");
-              filename = normalizeFilename(dir, meta.getUUIDFileName(i, td));
-              files.put(uuid, filename);
-            }
-          }
+          files.put(uuid, filename);
         } else if (!existing.equals(filename)) {
           throw new FormatException("Inconsistent filenames for UUID " + uuid +
-            ": " + meta.getUUIDFileName(i, td) + "does not match " + existing +
-            ".");
+            ": " + meta.getUUIDFileName(i, td) + " does not match " +
+            existing + ".");
         }
       }
     }

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -768,7 +768,12 @@ public class OMETiffReader extends SubResolutionFormatReader {
             }
           }
           else filename = normalizeFilename(dir, filename);
+          // If OME.UUID was not defined, set currentUUID for future searches
+          if (filename.equals(id) && currentUUID == null) {
+            currentUUID = uuid;
+          }
         }
+
         String existing = files.get(uuid);
         if (existing == null) files.put(uuid, filename);
         else if (!existing.equals(filename)) {

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -773,7 +773,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
         String existing = files.get(uuid);
         if (existing == null) {
-          if (filename != "") {
+          if (!filename.isEmpty()) {
             files.put(uuid, filename);
           } else {
            throw new FormatException(


### PR DESCRIPTION
This Pr aims to fix the scenario of a partial multi-file OME-TIFF fileset where the master file initialized by `setId` has no `OME.UUID` value. With the current release of Bio-Formats, the reader gets initialized and all the planes associated with the missing files gets silently and erroneously assigned to the initialized file.

The proposed fix offers two behaviors controlled by a new reader option `option ometiff.fail_on_missing_tiff`. In the strict behavior (default), the reader will fail at initialisation and provide a meaningful error about the first missing file (previously `Unmmatched UUID: <uuid>`. In the lenient behavior, all planes associated with the missing  files will be read as blakc.

## Implementation

87b23d9 fixes this behavior by setting an unitialized `currentUUID` (initialized with the value of `OME.UUID`) as soon as the reader assigns a `TiffData` element to the current filename. This allows subsequent iterations of the loop to perform its checks and flag missing files/inconsistencies.

73af425 is not strictly required but improves the code readability as well as the error reporting. Previously, the handling of a missing file (`filename == "null"`) was deferred to https://github.com/ome/bioformats/blob/aace49c72dfee2f8d1e29b9cb5a3a2890106e620/components/formats-bsd/src/loci/formats/in/OMETiffReader.java#L780-L793 

Despite the comment, the logic for searching for any associated TIFF files was never implemented (and there is certainly an argument for not doing so). Instead the code is failing on the first empty file and was reporting a semi-cryptic `Unmatched UUID: xxxx` message because of the lost context. 73af425 migrates this logic to the previous loop so that the code fails immediately on the first missing file and includes both the UUID and the filename of the missing element in the error message.

9fb8798 ports the logic of  #3311 into this PR and implements a reader option similar to https://github.com/ome/bioformats/pull/2899 allowing to control the behavior when a plane is missing. By default, the reader will fail with a `FormatException` giving the first missing UUID/Filename. If set to true, the reader will print ERROR logging statements but will continue intializing and the planes for the missing files will be read as black.

## Testing


1. [tubhiswt_C0.ome.tif.zip](https://github.com/ome/bioformats/files/7237185/tubhiswt_C0.ome.tif.zip) is a sample allowing the reproduce the  original scenario. It is the first of the two files from the official [tubhiswt-3D/](https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D/) sample with the metadata modified to remove the `OME.UUID` element. 

   Without this PR, running `showinf` on any of the sample files alone should give no error with the pixel data of the first and second channel being strictly identical. 
  With this PR included:
    - `showinf` should fail at initialization with `showinf -debug` providing a useful error message.
   - `showinf -option ometiff.fail_on_missing false` should initialize the reader but print several ERROR statements. The planes for the missing file should all render as black.

1. Synthetic partial OME-TIFF filesets can generated by using
   ```
   bfconvert "test&series=2.fake" "test_s%s.ome.tiff" && rm test_s1.ome.tiff
   bfconvert "test&sizeZ=2.fake" "test_z%s.ome.tiff" && rm test_z1.ome.tiff
   ```
   Without this PR, `showinf -debug test_s0.ome.tiff` or ``showinf -debug test_z0.ome.tiff` should fail the initialisation but the error message should only contain information about missing UUID
  With this PR included, the same commands should display the expected filename. Additionally `showinf -option ometiff.fail_on_missing false  test_z0.ome.tiff` or `showinf -option ometiff.fail_on_missing false -series 1 test_s0.ome.tiff` should open the image and reveal black planes where the data is missing
