### PR TITLE
SVS: check for label/macro instead of assuming they exist

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -283,6 +283,7 @@ public class SVSReader extends BaseTiffReader {
       if (comment == null) {
         continue;
       }
+      comments[i] = comment;
       String[] lines = comment.split("\n");
       String[] tokens;
       String key, value;
@@ -299,10 +300,10 @@ public class SVSReader extends BaseTiffReader {
               zPosition[index] = DataTools.parseDouble(value);
             }
           }
-          else if (t.toLowerCase().startsWith("label")) {
+          else if (t.toLowerCase().indexOf("label") >= 0) {
             labelIndex = i;
           }
-          else if (t.toLowerCase().startsWith("macro")) {
+          else if (t.toLowerCase().indexOf("macro") >= 0) {
             macroIndex = i;
           }
         }


### PR DESCRIPTION
Backported from a private PR.  Instead of assuming that exactly two extra images (label and macro) exist, this adds a check on the IFD descriptions for any non-pyramid IFDs to determine whether a label and/or macro exist.

I would not expect this to cause any test failures ~or memo file changes~, but it may help with #3682.