### PR TITLE
OIR: Fix NullPointerException for Laser Data ID

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -1224,7 +1224,7 @@ public class OIRReader extends FormatReader {
           if (laserId != null) {
             for (int l=0; l<lasers.size(); l++) {
               Laser laser = lasers.get(l);
-              if (laser.dataId.equals(laserId.getTextContent())) {
+              if (laser.dataId != null && laser.dataId.equals(laserId.getTextContent())) {
                 ch.laserIndex = l;
                 break;
               }
@@ -1239,7 +1239,7 @@ public class OIRReader extends FormatReader {
         if (laserId != null) {
           for (int l=0; l<lasers.size(); l++) {
             Laser laser = lasers.get(l);
-            if (laser.dataId.equals(laserId.getTextContent())) {
+            if (laser.dataId != null && laser.dataId.equals(laserId.getTextContent())) {
               c.laserIndex = l;
               break;
             }


### PR DESCRIPTION
This issue was raised on forum thread https://forum.image.sc/t/nullpointerexception-when-opening-oir-files-with-bio-formats/58487 and a sample file was provided which reproduces the exception with Bio-Formats 6.7.0

To test:
- Builds and repo tests should remain green
- Without this PR opening the sample file from the thread should result in `java.lang.NullPointerException`
- With this PR included the file should be opened without exception and the pixel and metadata look sensible