### PR TITLE
Improve tile read speeds for some pyramid OME-TIFFs

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -345,8 +345,11 @@ public class OMETiffReader extends SubResolutionFormatReader {
     try (RandomAccessInputStream s = new RandomAccessInputStream(info[series][no].id, 16)) {
       TiffParser p = new TiffParser(s);
       if (resolution > 0) {
-        IFDList subifds = p.getSubIFDs(ifd);
-        ifd = subifds.get(((OMETiffCoreMetadata)core.get(series, resolution)).subresolutionOffset);
+        p.setDoCaching(false);
+        long offset = ifd.getIFDLongArray(IFD.SUB_IFD)[((OMETiffCoreMetadata)core.get(series, resolution)).subresolutionOffset];
+        ifd = p.getIFD(offset);
+        ifd.remove(IFD.IMAGE_DESCRIPTION);
+        p.fillInIFD(ifd);
       }
       p.getSamples(ifd, buf, x, y, w, h);
     }

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -345,6 +345,10 @@ public class OMETiffReader extends SubResolutionFormatReader {
     try (RandomAccessInputStream s = new RandomAccessInputStream(info[series][no].id, 16)) {
       TiffParser p = new TiffParser(s);
       if (resolution > 0) {
+        // read the required SubIFD, but don't attempt to read the ImageDescription
+        // the ImageDescription will be completely ignored anyway
+        // it may be quite large (> 10 MB) in which case this has a significant
+        // impact on read time and memory usage
         p.setDoCaching(false);
         long offset = ifd.getIFDLongArray(IFD.SUB_IFD)[((OMETiffCoreMetadata)core.get(series, resolution)).subresolutionOffset];
         ifd = p.getIFD(offset);

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1162,13 +1162,6 @@ public class TiffParser implements Closeable {
           }
         }
       }
-
-      // this tile is completely below the requested image
-      // all subsequent tile rows will also be below the image,
-      // so don't bother checking them
-      if (tileBounds.y > imageBounds.y + imageBounds.height) {
-        break;
-      }
     }
 
     return buf;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1104,6 +1104,13 @@ public class TiffParser implements Closeable {
           tileBounds.y = (int) ((row % nrows) * (tileLength - overlapY));
         }
 
+        // this tile is completely to the right of the requested image
+        // all subsequent tile columns will also be to the right of the image,
+        // so don't bother checking them
+        if (tileBounds.x > imageBounds.x + imageBounds.width) {
+          break;
+        }
+
         if (!imageBounds.intersects(tileBounds)) continue;
 
         getTile(ifd, cachedTileBuffer, row, col);
@@ -1154,6 +1161,13 @@ public class TiffParser implements Closeable {
             }
           }
         }
+      }
+
+      // this tile is completely below the requested image
+      // all subsequent tile rows will also be below the image,
+      // so don't bother checking them
+      if (tileBounds.y > imageBounds.y + imageBounds.height) {
+        break;
       }
     }
 


### PR DESCRIPTION
Backported from a private PR.  This addresses the pyramid performance problem discussed with @sbesson.

Any time a SubIFD contains large amounts of non-pixel data (e.g. a full copy of the OME-XML), ```openBytes``` is slowed down substantially.  This changes the SubIFD reading in ```openBytes``` to only request a single SubIFD, and not even try to read the corresponding ```ImageDescription``` tag since it will be ignored anyway.

7cee004 is a minor improvement to reduce the number of tiles that are checked when reading pixel data.  It could be reverted if any objections.

I wouldn't expect this to address other issues with OME-TIFF read performance, but maybe points to IFD size instead of modality as a point for further investigation.

I would not expect tests to fail or memo files to be impacted.