### PR TITLE
FEI TIFF: fix physical pixel sizes for Phenom data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
@@ -424,10 +424,14 @@ public class FEITiffReader extends BaseTiffReader {
           magnification = new Double(value);
         }
 
-        else if (key.endsWith("X") && "PixelSize".equals(parent)) {
+        else if ((key.endsWith("X") && "PixelSize".equals(parent)) ||
+          (key.endsWith(" pixelWidth") && "FeiImage".equals(parent)))
+        {
           sizeX = new Double(value);
         }
-        else if (key.endsWith("Y") && "PixelSize".equals(parent)) {
+        else if ((key.endsWith("Y") && "PixelSize".equals(parent)) ||
+          (key.endsWith(" pixelHeight") && "FeiImage".equals(parent)))
+        {
           sizeY = new Double(value);
         }
       }


### PR DESCRIPTION
Backported from a private PR.

I don't yet have a file that can be used for testing, but as the title suggests this should fix a problem with pixel sizes not being detected in TIFFs acquired by FEI/Thermo Fisher/? Phenom instruments.  The XML schema for Phenom metadata is slightly different from other FEI TIFFs.

I would not expect this to cause test failures or memo file issues.