### PR TITLE
Bump cisd:jhdf5 to version 19.04.0

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -74,6 +74,11 @@
      <version>${kryo.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.perf4j</groupId>
       <artifactId>perf4j</artifactId>
       <version>0.9.16</version>
@@ -100,7 +105,7 @@
     <dependency>
       <groupId>cisd</groupId>
       <artifactId>jhdf5</artifactId>
-      <version>14.12.6</version>
+      <version>19.04.0</version>
     </dependency>
     <dependency>
 	    <groupId>com.drewnoakes</groupId>


### PR DESCRIPTION
See https://github.com/scijava/pom-scijava/issues/181

Also explicitly declare common-langs as dependency. It was previously coming as a transitive dependency of cisd:jhdf5:14.12.6 and is used across a few readers.

The `JHDF5Service` consuming this library is in-use for two formats: `CellH5` and `BDV`