### PR TITLE
CellSens: Set physicalSizeZ

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -917,6 +917,7 @@ public class CellSensReader extends FormatReader {
                   FormatTools.createLength(pyramid.zStart + (z * pyramid.zIncrement),
                   UNITS.MICROMETER), ii, nextPlane);
               }
+              store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(pyramid.zIncrement), ii);
             }
           }
         }


### PR DESCRIPTION
This is an attempt to fix the issues reported in https://forum.image.sc/t/bio-formats-vsi-olympus-cellsens-bug/29879/5 and previously on Trello card https://trello.com/c/v47N2hGC/382-vsi-incorrect-metadata-posz-and-exp-time

Initially this is simply setting the physicalSizeZ based on the zIncrement value which is already being parsed.