### PR TITLE
Tiff performance

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -221,7 +221,7 @@ public class IFD extends HashMap<Integer, Object> {
 
   /** Gets the given directory entry value from this IFD. */
   public Object getIFDValue(int tag) {
-    return get(new Integer(tag));
+    return get(Integer.valueOf(tag));
   }
 
   /**
@@ -229,7 +229,7 @@ public class IFD extends HashMap<Integer, Object> {
    * performing some error checking.
    */
   public Object getIFDValue(int tag, Class checkClass) throws FormatException {
-    Object value = get(new Integer(tag));
+    Object value = get(Integer.valueOf(tag));
     if (checkClass != null && value != null && !checkClass.isInstance(value)) {
       // wrap object in array of length 1, if appropriate
       Class cType = checkClass.getComponentType();
@@ -523,8 +523,8 @@ public class IFD extends HashMap<Integer, Object> {
   }
 
   public boolean isTiled() throws FormatException {
-    Object offsets = get(new Integer(STRIP_OFFSETS));
-    Object tileWidth = get(new Integer(TILE_WIDTH));
+    Object offsets = get(Integer.valueOf(STRIP_OFFSETS));
+    Object tileWidth = get(Integer.valueOf(TILE_WIDTH));
     return offsets == null && tileWidth != null;
   }
 
@@ -934,22 +934,22 @@ public class IFD extends HashMap<Integer, Object> {
 
   /** Adds a directory entry to this IFD. */
   public void putIFDValue(int tag, Object value) {
-    put(new Integer(tag), value);
+    put(Integer.valueOf(tag), value);
   }
 
   /** Adds a directory entry of type BYTE to this IFD. */
   public void putIFDValue(int tag, short value) {
-    putIFDValue(tag, new Short(value));
+    putIFDValue(tag, Short.valueOf(value));
   }
 
   /** Adds a directory entry of type SHORT to this IFD. */
   public void putIFDValue(int tag, int value) {
-    putIFDValue(tag, new Integer(value));
+    putIFDValue(tag, Integer.valueOf(value));
   }
 
   /** Adds a directory entry of type LONG to this IFD. */
   public void putIFDValue(int tag, long value) {
-    putIFDValue(tag, new Long(value));
+    putIFDValue(tag, Long.valueOf(value));
   }
 
   // -- Debugging --

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -219,7 +219,7 @@ public class TiffParser implements Closeable {
       return null;
     }
 
-    return new Boolean(littleEndian);
+    return Boolean.valueOf(littleEndian);
   }
 
   /** Returns whether or not the current TIFF file contains BigTIFF data. */
@@ -442,8 +442,8 @@ public class TiffParser implements Closeable {
     IFD ifd = new IFD();
 
     // save little-endian flag to internal LITTLE_ENDIAN tag
-    ifd.put(new Integer(IFD.LITTLE_ENDIAN), new Boolean(in.isLittleEndian()));
-    ifd.put(new Integer(IFD.BIG_TIFF), new Boolean(bigTiff));
+    ifd.put(Integer.valueOf(IFD.LITTLE_ENDIAN), Boolean.valueOf(in.isLittleEndian()));
+    ifd.put(Integer.valueOf(IFD.BIG_TIFF), Boolean.valueOf(bigTiff));
 
     // read in directory entries for this IFD
     LOGGER.trace("getIFD: seeking IFD at {}", offset);
@@ -494,8 +494,8 @@ public class TiffParser implements Closeable {
       }
       else value = getIFDValue(entry);
 
-      if (value != null && !ifd.containsKey(new Integer(tag))) {
-        ifd.put(new Integer(tag), value);
+      if (value != null && !ifd.containsKey(Integer.valueOf(tag))) {
+        ifd.put(Integer.valueOf(tag), value);
       }
     }
 
@@ -523,7 +523,7 @@ public class TiffParser implements Closeable {
       if ((entry.getValueCount() < 10 * 1024 * 1024 || entry.getTag() < 32768) &&
         entry.getTag() != IFD.COLOR_MAP)
       {
-        ifd.put(new Integer(entry.getTag()), getIFDValue(entry));
+        ifd.put(Integer.valueOf(entry.getTag()), getIFDValue(entry));
       }
     }
   }
@@ -551,7 +551,7 @@ public class TiffParser implements Closeable {
 
     if (type == IFDType.BYTE) {
       // 8-bit unsigned integer
-      if (count == 1) return new Short(in.readByte());
+      if (count == 1) return Short.valueOf(in.readByte());
       byte[] bytes = new byte[count];
       in.readFully(bytes);
       // bytes are unsigned, so use shorts
@@ -591,7 +591,7 @@ public class TiffParser implements Closeable {
     }
     else if (type == IFDType.SHORT) {
       // 16-bit (2-byte) unsigned integer
-      if (count == 1) return new Integer(in.readUnsignedShort());
+      if (count == 1) return Integer.valueOf(in.readUnsignedShort());
       int[] shorts = new int[count];
       for (int j=0; j<count; j++) {
         shorts[j] = in.readUnsignedShort();
@@ -600,7 +600,7 @@ public class TiffParser implements Closeable {
     }
     else if (type == IFDType.LONG || type == IFDType.IFD) {
       // 32-bit (4-byte) unsigned integer
-      if (count == 1) return new Long(in.readUnsignedInt());
+      if (count == 1) return Long.valueOf(in.readUnsignedInt());
       long[] longs = new long[count];
       for (int j=0; j<count; j++) {
         if (in.getFilePointer() + 4 <= in.length()) {
@@ -611,7 +611,7 @@ public class TiffParser implements Closeable {
     }
     else if (type == IFDType.LONG8 || type == IFDType.SLONG8
              || type == IFDType.IFD8) {
-      if (count == 1) return new Long(in.readLong());
+      if (count == 1) return Long.valueOf(in.readLong());
       long[] longs = null;
 
       if (equalStrips && (entry.getTag() == IFD.STRIP_BYTE_COUNTS ||
@@ -649,35 +649,35 @@ public class TiffParser implements Closeable {
       // SBYTE: An 8-bit signed (twos-complement) integer
       // UNDEFINED: An 8-bit byte that may contain anything,
       // depending on the definition of the field
-      if (count == 1) return new Byte(in.readByte());
+      if (count == 1) return Byte.valueOf(in.readByte());
       byte[] sbytes = new byte[count];
       in.read(sbytes);
       return sbytes;
     }
     else if (type == IFDType.SSHORT) {
       // A 16-bit (2-byte) signed (twos-complement) integer
-      if (count == 1) return new Short(in.readShort());
+      if (count == 1) return Short.valueOf(in.readShort());
       short[] sshorts = new short[count];
       for (int j=0; j<count; j++) sshorts[j] = in.readShort();
       return sshorts;
     }
     else if (type == IFDType.SLONG) {
       // A 32-bit (4-byte) signed (twos-complement) integer
-      if (count == 1) return new Integer(in.readInt());
+      if (count == 1) return Integer.valueOf(in.readInt());
       int[] slongs = new int[count];
       for (int j=0; j<count; j++) slongs[j] = in.readInt();
       return slongs;
     }
     else if (type == IFDType.FLOAT) {
       // Single precision (4-byte) IEEE format
-      if (count == 1) return new Float(in.readFloat());
+      if (count == 1) return Float.valueOf(in.readFloat());
       float[] floats = new float[count];
       for (int j=0; j<count; j++) floats[j] = in.readFloat();
       return floats;
     }
     else if (type == IFDType.DOUBLE) {
       // Double precision (8-byte) IEEE format
-      if (count == 1) return new Double(in.readDouble());
+      if (count == 1) return Double.valueOf(in.readDouble());
       double[] doubles = new double[count];
       for (int j=0; j<count; j++) {
         doubles[j] = in.readDouble();

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -37,7 +37,6 @@ import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
@@ -83,7 +82,7 @@ public class TiffSaver implements Closeable {
   private boolean sequentialWrite = false;
   
   /** Store tile offsets and original file pointer when writing sequentially. */
-  private List<Long> sequentialTileOffsets;
+  private long[] sequentialTileOffsets;
   private Long sequentialTileFilePointer;
 
   /** The codec options if set. */
@@ -501,6 +500,10 @@ public class TiffSaver implements Closeable {
       }
     }
   }
+  
+  // Retain a record of the longest byte array needed for an IFD,
+  // so this can be used to define the initial capacity later
+  private long longestIfd = 0L;
 
   public void writeIFD(IFD ifd, long nextOffset)
     throws FormatException, IOException
@@ -508,9 +511,9 @@ public class TiffSaver implements Closeable {
     TreeSet<Integer> keys = new TreeSet<Integer>(ifd.keySet());
     int keyCount = keys.size();
 
-    if (ifd.containsKey(new Integer(IFD.LITTLE_ENDIAN))) keyCount--;
-    if (ifd.containsKey(new Integer(IFD.BIG_TIFF))) keyCount--;
-    if (ifd.containsKey(new Integer(IFD.REUSE))) keyCount--;
+    if (ifd.containsKey(Integer.valueOf(IFD.LITTLE_ENDIAN))) keyCount--;
+    if (ifd.containsKey(Integer.valueOf(IFD.BIG_TIFF))) keyCount--;
+    if (ifd.containsKey(Integer.valueOf(IFD.REUSE))) keyCount--;
 
     long fp = out.getFilePointer();
     int bytesPerEntry = bigTiff ? TiffConstants.BIG_TIFF_BYTES_PER_ENTRY :
@@ -519,8 +522,12 @@ public class TiffSaver implements Closeable {
 
     if (bigTiff) out.writeLong(keyCount);
     else out.writeShort(keyCount);
-
-    ByteArrayHandle extra = new ByteArrayHandle();
+    
+    // Preallocate byte array according to previous longest byte array
+    long initialLength = Math.min(Math.max(longestIfd + 1024, 1000000), Integer.MAX_VALUE-32);
+    ByteArrayHandle extra = new ByteArrayHandle((int)initialLength);
+    extra.getByteBuffer().limit(0);
+    
     RandomAccessOutputStream extraStream = new RandomAccessOutputStream(extra);
 
     for (Integer key : keys) {
@@ -533,6 +540,7 @@ public class TiffSaver implements Closeable {
     if (bigTiff) out.seek(out.getFilePointer());
     writeIntValue(out, nextOffset);
     out.write(extra.getBytes(), 0, (int) extra.length());
+    longestIfd = Math.max(extra.length(), longestIfd);
     extraStream.close();
   }
 
@@ -1031,8 +1039,8 @@ public class TiffSaver implements Closeable {
     boolean isTiled = ifd.isTiled();
 
     // record strip byte counts and offsets
-    List<Long> byteCounts = new ArrayList<Long>();
-    List<Long> offsets = new ArrayList<Long>();
+    long[] byteCounts;
+    long[] offsets;
     long totalTiles = tilesPerRow * tilesPerColumn;
 
     if (!interleaved) {
@@ -1044,14 +1052,17 @@ public class TiffSaver implements Closeable {
     {
       long[] ifdByteCounts = isTiled ?
         ifd.getIFDLongArray(IFD.TILE_BYTE_COUNTS) : ifd.getStripByteCounts();
-      for (long stripByteCount : ifdByteCounts) {
-        byteCounts.add(stripByteCount);
-      }
+      byteCounts = ifdByteCounts;
+//      for (long stripByteCount : ifdByteCounts) {
+//        byteCounts.add(stripByteCount);
+//      }
     }
     else {
-      while (byteCounts.size() < totalTiles) {
-        byteCounts.add(defaultByteCount);
-      }
+    	byteCounts = new long[(int)totalTiles];
+    	Arrays.fill(byteCounts, defaultByteCount);
+//      while (byteCounts.size() < totalTiles) {
+//        byteCounts.add(defaultByteCount);
+//      }
     }
     int tileOrStripOffsetX = x / (int) ifd.getTileWidth();
     int tileOrStripOffsetY = y / (int) ifd.getTileLength();
@@ -1060,14 +1071,16 @@ public class TiffSaver implements Closeable {
         || ifd.containsKey(IFD.TILE_OFFSETS)) {
       long[] ifdOffsets = isTiled ?
         ifd.getIFDLongArray(IFD.TILE_OFFSETS) : ifd.getStripOffsets();
-      for (int i = 0; i < ifdOffsets.length; i++) {
-        offsets.add(ifdOffsets[i]);
-      }
+      	offsets = ifdOffsets.clone();
+//      for (int i = 0; i < ifdOffsets.length; i++) {
+//        offsets.add(ifdOffsets[i]);
+//      }
     }
     else {
-      while (offsets.size() < totalTiles) {
-        offsets.add(0L);
-      }
+//      while (offsets.size() < totalTiles) {
+//        offsets.add(0L);
+//      }
+      offsets = new long[(int)totalTiles];
       if (isTiled && tileOrStripOffsetX == 0 && tileOrStripOffsetY == 0) {
         sequentialTileOffsets = offsets;
       }
@@ -1077,12 +1090,12 @@ public class TiffSaver implements Closeable {
     }
 
     if (isTiled) {
-      ifd.putIFDValue(IFD.TILE_BYTE_COUNTS, toPrimitiveArray(byteCounts));
-      ifd.putIFDValue(IFD.TILE_OFFSETS, toPrimitiveArray(offsets));
+      ifd.putIFDValue(IFD.TILE_BYTE_COUNTS, byteCounts);
+      ifd.putIFDValue(IFD.TILE_OFFSETS, offsets);
     }
     else {
-      ifd.putIFDValue(IFD.STRIP_BYTE_COUNTS, toPrimitiveArray(byteCounts));
-      ifd.putIFDValue(IFD.STRIP_OFFSETS, toPrimitiveArray(offsets));
+      ifd.putIFDValue(IFD.STRIP_BYTE_COUNTS, byteCounts);
+      ifd.putIFDValue(IFD.STRIP_OFFSETS, offsets);
     }
 
     long fp = out.getFilePointer();
@@ -1134,23 +1147,25 @@ public class TiffSaver implements Closeable {
       int index = interleaved ? i : (i / nChannels) * nChannels;
       int c = interleaved ? 0 : i % nChannels;
       int thisOffset = firstOffset + index + (c * tileCount);
-      offsets.set(thisOffset, out.getFilePointer());
-      byteCounts.set(thisOffset, new Long(strips[i].length));
+      offsets[thisOffset] = out.getFilePointer();
+//      byteCounts.set(thisOffset, new Long(strips[i].length));
+      byteCounts[thisOffset] = strips[i].length;
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(String.format(
             "Writing tile/strip %d/%d size: %d offset: %d",
-            thisOffset + 1, totalTiles, byteCounts.get(thisOffset),
-            offsets.get(thisOffset)));
+//            thisOffset + 1, totalTiles, byteCounts.get(thisOffset),
+            thisOffset + 1, totalTiles, byteCounts[thisOffset],
+            offsets[thisOffset]));
       }
       out.write(strips[i]);
     }
     if (isTiled) {
-      ifd.putIFDValue(IFD.TILE_BYTE_COUNTS, toPrimitiveArray(byteCounts));
-      ifd.putIFDValue(IFD.TILE_OFFSETS, toPrimitiveArray(offsets));
+      ifd.putIFDValue(IFD.TILE_BYTE_COUNTS, byteCounts);
+      ifd.putIFDValue(IFD.TILE_OFFSETS, offsets);
     }
     else {
-      ifd.putIFDValue(IFD.STRIP_BYTE_COUNTS, toPrimitiveArray(byteCounts));
-      ifd.putIFDValue(IFD.STRIP_OFFSETS, toPrimitiveArray(offsets));
+      ifd.putIFDValue(IFD.STRIP_BYTE_COUNTS, byteCounts);
+      ifd.putIFDValue(IFD.STRIP_OFFSETS, offsets);
     }
     long endFP = out.getFilePointer();
     if (LOGGER.isDebugEnabled()) {
@@ -1161,9 +1176,9 @@ public class TiffSaver implements Closeable {
 
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Writing tile/strip offsets: {}",
-          Arrays.toString(toPrimitiveArray(offsets)));
+          Arrays.toString(offsets));
       LOGGER.debug("Writing tile/strip byte counts: {}",
-          Arrays.toString(toPrimitiveArray(byteCounts)));
+          Arrays.toString(byteCounts));
     }
     writeIFD(ifd, last ? 0 : endFP);
     if (LOGGER.isDebugEnabled()) {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -38,7 +38,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.List;
 import java.util.TreeSet;
 
 import loci.common.ByteArrayHandle;
@@ -83,6 +82,7 @@ public class TiffSaver implements Closeable {
   
   /** Store tile offsets and original file pointer when writing sequentially. */
   private long[] sequentialTileOffsets;
+  private long[] sequentialTileByteCounts;
   private Long sequentialTileFilePointer;
 
   /** The codec options if set. */
@@ -508,6 +508,7 @@ public class TiffSaver implements Closeable {
   public void writeIFD(IFD ifd, long nextOffset)
     throws FormatException, IOException
   {
+
     TreeSet<Integer> keys = new TreeSet<Integer>(ifd.keySet());
     int keyCount = keys.size();
 
@@ -951,20 +952,6 @@ public class TiffSaver implements Closeable {
   // -- Helper methods --
 
   /**
-   * Coverts a list to a primitive array.
-   * @param l The list of <code>Long</code> to convert.
-   * @return A primitive array of type <code>long[]</code> with the values from
-   * </code>l</code>.
-   */
-  private long[] toPrimitiveArray(List<Long> l) {
-    long[] toReturn = new long[l.size()];
-    for (int i = 0; i < l.size(); i++) {
-      toReturn[i] = l.get(i);
-    }
-    return toReturn;
-  }
-
-  /**
    * Write the given value to the given RandomAccessOutputStream.
    * If the 'bigTiff' flag is set, then the value will be written as an 8 byte
    * long; otherwise, it will be written as a 4 byte integer.
@@ -1083,9 +1070,11 @@ public class TiffSaver implements Closeable {
       offsets = new long[(int)totalTiles];
       if (isTiled && tileOrStripOffsetX == 0 && tileOrStripOffsetY == 0) {
         sequentialTileOffsets = offsets;
+        sequentialTileByteCounts = byteCounts;
       }
       else if (isTiled) {
         offsets = sequentialTileOffsets;
+        byteCounts = sequentialTileByteCounts;
       }
     }
 


### PR DESCRIPTION
This PR aims to address https://github.com/ome/bioformats/issues/3752 while slightly improving TIFF read/write performance.

The performance impact when using JPEG compression can be much bigger when combined with https://github.com/ome/ome-codecs/pull/19

To test, I converted *CMU-1-Small-Region.svs* and *CMU-1.svs* to JPEG with 2 pyramid levels (to avoid memory errors) with bfconvert, with and without the `-no-sequential` flag on a MacBook Pro (M1). I also converted the larger image with Bio-Formats via QuPath.

The changes here were made after using VisualVM to identify which aspects of conversion were slow. Sampling with VisualVM suggested the modifications helped reduce time spent in the relevant methods, and pushed compression/decompression to be the main bottlenecks (along with writing IFDs and creating BufferedImages) - although I find the real-world impact a bit harder to decipher.

Summary:
* Conversion time with this PR is similar to that with 6.7.0 and 6.8.0, but the compression problem in 6.8.0 goes away, at least in my test
* There appears to be some minor performance improvement in this PR (but it depends on image size, number of tiles - so may be inconsistent across images)
* The codec PR makes a much bigger difference
* Parallel reading/writing in QuPath + these PRs can reduce the time converting the image to <20% of using bfconvert currently - although it's mostly achieved by the parallelisation + reduced tile reading

## Convert with bfconvert

### CMU-1-Small-Region.svs

```
./bfconvert -overwrite -no-upgrade -series 0 -compression JPEG -tilex 256 -tiley 256 -pyramid-scale 4 -pyramid-resolutions 2 "/path/to/CMU-1-Small-Region.svs" "/path/to/converted.ome.tif"
```

Method                  | Sequential | Time (s) | Valid
------------------------|------------|----------|------
v6.7.0                  | :white_check_mark:          | 5.36     | :white_check_mark:
v6.8.0                  | :white_check_mark:          | 5.31     | :x:
v6.8.0                  | :x:          | 5.59     | :white_check_mark:
Proposed                | :white_check_mark:          | 5.38     | :white_check_mark:
Proposed                | :x:          | 5.58     | :white_check_mark:
**Proposed + Codec PR** | :white_check_mark:          | 3.48     | :white_check_mark:
Proposed + Codec PR     | :x:          | 3.57     | :white_check_mark:

### CMU-1.svs

```
./bfconvert -overwrite -no-upgrade -series 0 -compression JPEG -tilex 512 -tiley 512 -pyramid-scale 4 -pyramid-resolutions 2 "/path/to/CMU-1.svs" "/path/to/converted.ome.tif"
```

Method                  | Sequential | Time (s) |
------------------------|------------|----------|
v6.7.0                  | :white_check_mark:          | 224.6    |
v6.8.0                  | :x:          | 231.6    |
Proposed                | :white_check_mark:          | 216.5    |
Proposed                | :x:          | 227.8    |
**Proposed + Codec PR** | :white_check_mark:          | 120.4    |
Proposed + Codec PR     | :x:         | 133.6    

> Opening the images isn't easy because only 2 pyramid levels results in high memory use.


## Convert with QuPath + Bio-Formats

The image is opened in QuPath's viewer using Bio-Formats, and exported via *File &rarr; Export images... &rarr; OME TIFF*, with the tile size and JPEG compression set in the dialog.

This calls Bio-Formats, but uses multiple threads and readers, along with tile caching and use of pyramid levels, to try to improve performance. The export image has 4 pyramid levels.

### CMU-1.svs

#### Using 256 x 256 tiles

Method                                  |  Time (s) |
----------------------------------------|-----------|
QuPath v0.3.0 + Bio-Formats v6.7.0      | 62.1      |
QuPath v0.3.0 + Proposed                | 51.5      |
**QuPath v0.3.0 + Proposed + Codec PR** | 51.3      |


#### Using 512 x 512 tiles

Method                                  |  Time (s) |
----------------------------------------|-----------|
QuPath v0.3.0 + Bio-Formats v6.7.0      | 45.7      |
QuPath v0.3.0 + Proposed                | 44.5      |
**QuPath v0.3.0 + Proposed + Codec PR** | 42.3      |