### PR TITLE
SVS: Detect label and macro if no image description

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -283,6 +283,12 @@ public class SVSReader extends BaseTiffReader {
 
       String comment = ifds.get(index).getComment();
       if (comment == null) {
+        if (labelIndex == -1) {
+          labelIndex = i;
+        }
+        else if (macroIndex == -1) {
+          macroIndex = i;
+        }
         continue;
       }
       comments[i] = comment;


### PR DESCRIPTION
This is a rather simplistic attempt to deal with the issue detected in https://github.com/ome/bioformats/issues/3757
If no image description is present then it will try to treat the series as a label or macro.

Fixes https://github.com/ome/bioformats/issues/3757

To test:
- All existing builds and repo tests should remain green
- Test manually with the new sample file from the thread (also included in the new config PR)
- Test with the sample files impacted by the original PR in https://github.com/openmicroscopy/data_repo_config/pull/503