### PR TITLE
POM: Update deprecated git:// protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
   </mailingLists>
 
   <scm>
-    <connection>scm:git:git://github.com/openmicroscopy/bioformats</connection>
+    <connection>scm:git:https://github.com/openmicroscopy/bioformats</connection>
     <developerConnection>scm:git:git@github.com:openmicroscopy/bioformats</developerConnection>
     <tag>HEAD</tag>
     <url>http://github.com/openmicroscopy/bioformats</url>


### PR DESCRIPTION
Replacing the deprecated protocol, see https://github.blog/2021-09-01-improving-git-protocol-security-github/

Based on https://maven.apache.org/pom.html#SCM using https for the connection as it should only require read access and  git@ for developerConnection as it requires write access