### PR TITLE
SVS: Macro and Label image improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -280,14 +280,15 @@ public class SVSReader extends BaseTiffReader {
       setSeries(i);
       int index = getIFDIndex(i, 0);
       tiffParser.fillInIFD(ifds.get(index));
-
+      long rowsPerStrip = ifds.get(index).getRowsPerStrip()[0];
+      long tileLength = ifds.get(index).getIFDLongValue(IFD.TILE_LENGTH, 0);
       String comment = ifds.get(index).getComment();
-      if (comment == null) {
+      if (comment == null || (tileLength == 0 && rowsPerStrip >=1)) {
         if (labelIndex == -1) {
-          labelIndex = i;
+          labelIndex = index;
         }
         else if (macroIndex == -1) {
-          macroIndex = i;
+          macroIndex = index;
         }
         continue;
       }
@@ -345,6 +346,16 @@ public class SVSReader extends BaseTiffReader {
       if (ifd.getPixelType() != firstIFD.getPixelType()) {
         ifds.set(index, null);
       }
+    }
+    if (labelIndex >= 0) {
+      IFD labelIfd = ifds.get(labelIndex);
+      ifds.set(labelIndex, null);
+      ifds.add(labelIfd);
+    }
+    if (macroIndex >= 0) {
+      IFD macroIfd = ifds.get(macroIndex);
+      ifds.set(macroIndex, null);
+      ifds.add(macroIfd);
     }
     for (int s=0; s<ifds.size(); ) {
       if (ifds.get(s) != null) {


### PR DESCRIPTION
This is a follow up to the previous SVS fix: https://github.com/ome/bioformats/pull/3759

It was reported on thread https://forum.image.sc/t/problem-about-opening-some-svs-slides-in-qupath-v0-3-1-bio-formats-6-8-0/61404/27 and Issue https://github.com/ome/bioformats/issues/3757

The one sample file from the thread that was still causing issues looks as though the extra images can be identified based on tiled vs strips in the IFD. This also raised an issue in that the extra image in this case was not at the end of the indexes and so reordering is needed after identifying the label and/or macro images.

Fixes https://github.com/ome/bioformats/issues/3757