### PR TITLE
OME-TIFF reader: reduce open file handle count during setId

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1193,6 +1193,10 @@ public class OMETiffReader extends SubResolutionFormatReader {
         if (testFile != null) {
           testFile.close();
         }
+        // close the file handle, but keep all other metadata
+        if (info[s][0].reader != null) {
+          info[s][0].reader.close(true);
+        }
       }
     }
 


### PR DESCRIPTION
Without this PR, creating a fake plate:

```
bfconvert "test&plateRows=16&plateCols=24&fields=40.fake" "test_s%s.ome.tiff" -option ometiff.companion true
```
and then attempting to initialize:

```
 showinf -nopix -omexml test_s0.ome.tiff
```

throws an exception due to too many open files. With this PR, the same ```showinf``` command should eventually display OME-XML without an error.

@sbesson reported seeing a similar problem with real data, so hopefully this fixes that case too.