### PR TITLE
Display all channel info in .lif metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1657,7 +1657,7 @@ public class LIFReader extends FormatReader {
           lineIndex == null || lineIndex.trim().isEmpty() ? 0 :
           Integer.parseInt(lineIndex.trim());
         int qualifier =
-          qual == null || qual.trim().isEmpty() ? 20:
+          qual == null || qual.trim().isEmpty() ? 0:
           Integer.parseInt(qual.trim());
 
         index += (2 - (qualifier / 10));

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1657,7 +1657,7 @@ public class LIFReader extends FormatReader {
           lineIndex == null || lineIndex.trim().isEmpty() ? 0 :
           Integer.parseInt(lineIndex.trim());
         int qualifier =
-          qual == null || qual.trim().isEmpty() ? 0:
+          qual == null || qual.trim().isEmpty() ? 20:
           Integer.parseInt(qual.trim());
 
         index += (2 - (qualifier / 10));


### PR DESCRIPTION
Proposed fix for #3513. Also a change in how laser indices are calculated in the absence of a qualifier. The main reason for the latter is I think this helps line 754 evaluate properly.