### PR TITLE
Operetta: Use stream for parsing XML

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -327,9 +327,10 @@ public class OperettaReader extends FormatReader {
 
     // parse plate layout and image dimensions from the XML file
 
-    String xmlData = DataTools.readFile(id);
     OperettaHandler handler = new OperettaHandler();
-    XMLTools.parseXML(xmlData, handler);
+    try (RandomAccessInputStream xml = new RandomAccessInputStream(id)) {
+      XMLTools.parseXML(xml, handler);
+    }
 
     // sort the list of images by well and field indices
 


### PR DESCRIPTION
This PR is in response to an issue raised on forum thread https://forum.image.sc/t/operetta-bioformats-reading-error-with-big-dataset-and-xml-parsing-crazy-slow/62768/3

In this case the initial XML file is > 800Mb, reading the entire file into a byte array and then String was very memory intensive and time consuming. Reading it in from a Stream provide much improved performance. Without this PR I was struggling to profile the issue as I would run into out of memory exceptions even with what should have been plenty of available memory (8Gb).

With the PR the initial parsing completes in around 26 seconds without the same memory issues.

The later indexing of each of the planes in the dataset still however takes a long time, I will continue profiling that code section to see if further improvements can be made. 