### PR TITLE
ND2 metadata updates

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1508,7 +1508,9 @@ public class NativeND2Reader extends SubResolutionFormatReader {
 
       if (getSizeC() > 1 && getDimensionOrder().indexOf('C') == -1) {
         core.get(0, 0).dimensionOrder = "C" + getDimensionOrder();
-        fieldIndex++;
+        if (getSizeZ() > 1 && getSizeT() > 1) {
+          fieldIndex++;
+        }
       }
 
       core.get(0, 0).dimensionOrder = "XY" + getDimensionOrder();

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -554,6 +554,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
       int zCount = 1;
 
       in.seek(0);
+      int validBits = 0;
 
       while (in.getFilePointer() < in.length() - 1 && in.getFilePointer() >= 0)
       {
@@ -895,6 +896,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
                   valueOrLength / 8, false, true);
               }
               else if (attributeName.equals("uiBpcSignificant")) {
+                validBits = valueOrLength;
                 core.get(0, 0).bitsPerPixel = valueOrLength;
               }
               else if (attributeName.equals("dCompressionParam")) {
@@ -1391,6 +1393,13 @@ public class NativeND2Reader extends SubResolutionFormatReader {
       }
       else if (getPixelType() == FormatTools.INT8) {
         core.get(0, 0).pixelType = FormatTools.UINT8;
+      }
+
+      // now that pixel type is est, restore number of valid bits per pixel
+      if (core.get(0, 0).bitsPerPixel == 0 && validBits > 0 &&
+        validBits <= 8 * FormatTools.getBytesPerPixel(core.get(0, 0).pixelType))
+      {
+        core.get(0, 0).bitsPerPixel = validBits;
       }
 
       if (getSizeX() == 0) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2398,7 +2398,10 @@ public class NativeND2Reader extends SubResolutionFormatReader {
         setSeries(i);
         for (int n=0; n<getImageCount(); n++) {
           int[] coords = getZCTCoords(n);
-          int stampIndex = getIndex(coords[0], split ? 0 : coords[1], 0);
+          int stampIndex = coords[0];
+          if (!split) {
+            stampIndex = getIndex(coords[0], coords[1], 0);
+          }
           stampIndex += (coords[2] * getSeriesCount() + i) * zcPlanes;
           if (tsT.size() == getImageCount()) stampIndex = n;
           else if (tsT.size() == getSizeZ()) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2829,4 +2829,21 @@ public class NativeND2Reader extends SubResolutionFormatReader {
     ms0.imageCount = ms0.sizeZ * ms0.sizeC * ms0.sizeT;
   }
 
+  /**
+   * @return offsets to pixel data
+   */
+  public long[][] getOffsets() {
+    return offsets;
+  }
+
+  /**
+   * Change the underlying file path and pixel data offsets,
+   * keeping all other metadata the same.
+   */
+  public void setOffsets(String file, long[][] newOffsets) throws IOException {
+    close(true);
+    in = new RandomAccessInputStream(file);
+    offsets = newOffsets;
+  }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2368,28 +2368,29 @@ public class NativeND2Reader extends SubResolutionFormatReader {
     for (Double time : exposureTime) {
       addGlobalMetaList("Exposure time (text)", time);
     }
-    if (handler != null && handler.getExposureTimes().size() > 0) {
+    boolean validHandler = handler != null && handler.getExposureTimes().size() > 0;
+    if (validHandler) {
       for (Double time : handler.getExposureTimes()) {
         addGlobalMetaList("Exposure time (primary XML)", time);
       }
-      if (backupHandler != null) {
-        for (Double time : backupHandler.getExposureTimes()) {
-          addGlobalMetaList("Exposure time (secondary XML)", time);
-        }
+    }
+    if (backupHandler != null) {
+      for (Double time : backupHandler.getExposureTimes()) {
+        addGlobalMetaList("Exposure time (secondary XML)", time);
       }
+    }
 
-      if (exposureTime.size() == 0 || handler.getExposureTimes().size() == 1 || exposureTime.size() % getSizeC() != 0) {
-        exposureTime = handler.getExposureTimes();
-        if (backupHandler != null && backupHandler.getExposureTimes().size() > exposureTime.size()) {
-          exposureTime = backupHandler.getExposureTimes();
-        }
-      }
-      else if (backupHandler == null || backupHandler.getExposureTimes().size() == 0) {
-        exposureTime = handler.getExposureTimes();
-      }
-      else if (backupHandler != null && backupHandler.getExposureTimes().size() == exposureTime.size()) {
+    if (validHandler && (exposureTime.size() == 0 || handler.getExposureTimes().size() == 1 || exposureTime.size() % getSizeC() != 0)) {
+      exposureTime = handler.getExposureTimes();
+      if (backupHandler != null && backupHandler.getExposureTimes().size() > exposureTime.size()) {
         exposureTime = backupHandler.getExposureTimes();
       }
+    }
+    else if (validHandler && (backupHandler == null || backupHandler.getExposureTimes().size() == 0)) {
+      exposureTime = handler.getExposureTimes();
+    }
+    else if (backupHandler != null && backupHandler.getExposureTimes().size() % exposureTime.size() == 0) {
+      exposureTime = backupHandler.getExposureTimes();
     }
     int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
     for (int i=0; i<getSeriesCount(); i++) {


### PR DESCRIPTION
Attempts to improve some ND2 metadata parsing, particularly around objective data, timestamps, and exposure times.

This is backported from a private PR; corresponding files aren't available. I would expect at least a few of the existing .nd2 files to be affected though (hopefully for the better).

I wouldn't expect this to break memo files, but there are a couple of new API methods in the reader.