### PR TITLE
CZI: use fill color of 255 when brightfield data is suspected

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -356,7 +356,7 @@ public class ZeissCZIReader extends FormatReader {
     }
 
     byte fillColor = (byte) 0;
-    if (isRGB() && getResolutionCount() > 1) {
+    if (isRGB() && maxResolution > 0) {
       fillColor = (byte) 255;
     }
     Arrays.fill(buf, fillColor);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -355,7 +355,11 @@ public class ZeissCZIReader extends FormatReader {
       validScanDim = false;
     }
 
-    Arrays.fill(buf, (byte) 0);
+    byte fillColor = (byte) 0;
+    if (isRGB() && getResolutionCount() > 1) {
+      fillColor = (byte) 255;
+    }
+    Arrays.fill(buf, fillColor);
     boolean emptyTile = true;
     int compression = -1;
     try {


### PR DESCRIPTION
Backported from a private PR. This should result in a white background for brightfield data (instead of black), which better matches Zen and other software.

There are a few different ways we can check for a brightfield pyramid (including by channel name),
but checking for RGB + multiple resolutions seems to be reliable so far and does not require a
memo file update.  @swg08 if you have any thoughts on a better way to determine the correct fill color in general, I'd be happy to hear them.

I would expect some MD5 test failures, and will open a matching configuration PR after the tests have run once.