### PR TITLE
Make private Pattern field transient

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -85,7 +85,7 @@ public class CellomicsReader extends FormatReader {
   private static final Pattern PATTERN_O = Pattern.compile("(.*)_(\\p{Alpha}\\d{2})(f\\d{2,3})?(o\\d+)?[^_]+$");
   private static final Pattern PATTERN_D = Pattern.compile("(.*)_(\\p{Alpha}\\d{2})(f\\d{2,3})?(d\\d+)?[^_]+$");
 
-  private Pattern cellomicsPattern;
+  private transient Pattern cellomicsPattern;
 
   private ArrayList<ChannelFile> files = new ArrayList<ChannelFile>();
 


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/issues/139#issuecomment-1068319934

Using Java 17 without this PR:

```
$ cat test.pattern
test_c<1-3>.fake
$ showinf -cache test.pattern
...
failed to save memo file: /Users/melissa/test-case/.test.pattern.bfmemo
...
```

The same test with this PR should successfully save the memo file.

Technically breaks memo files (to fix them!), so probably not OK for a patch release.