### PR TITLE
FileStitcher: better handling for a single file wrapped in a pattern file

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -935,7 +935,7 @@ public class FileStitcher extends ReaderWrapper {
     if (!patternIds) {
       patternIds = fp.isValid() && fp.getFiles().length > 1;
     }
-    else {
+    else if (canChangePattern() || !Location.getMappedId(id).equals(id)) {
       patternIds =
         !new Location(id).exists() && Location.getMappedId(id).equals(id);
     }


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/issues/139#issuecomment-1075268455

```curated/fake/samples/single-file-pattern``` illustrates the problem.  There are two TIFF files that have similar names (```test1.tiff``` and ```test2.tiff```), and a pattern file that lists one of them but does not include ```<``` or ```>``` which would explicitly indicate a file pattern.

Without this PR, ```showinf test1.pattern``` should throw an exception because both ```test1.tiff``` and ```test2.tiff``` are incorrectly picked up, and the two files have different XY dimensions.

With this PR, ```showinf test1.pattern``` should not throw an exception, because only ```test1.tiff``` is picked up.

The work-arounds for this issue in the meantime are:

- don't use a pattern file for a single image file
- add ```<>``` around the file name in the pattern file (i.e. ```<test1.tiff>```)
- move or rename the other file (e.g. ```mv test2.tiff test-two.tiff```)