### PR TITLE
Zeiss LSM: assume 32 bit data is floating point

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -726,6 +726,16 @@ public class ZeissLSMReader extends FormatReader {
     ms.interleaved = false;
     ms.sizeC = isRGB() ? samples : 1;
     ms.pixelType = ifd.getPixelType();
+
+    // Known DataType values suggest that uint32 data is not possible.
+    // We know that some TIFF metadata (e.g. RowsPerStrip) is missing
+    // or incorrect for many .lsm files, and a uint32 pixel type here
+    // suggests that the SampleFormat tag is missing.
+    // For now, assume that all 32 bit data is floating point.
+    if (ms.pixelType == FormatTools.UINT32) {
+      ms.pixelType = FormatTools.FLOAT;
+    }
+
     ms.imageCount = ifds.size();
     ms.sizeZ = getImageCount();
     ms.sizeT = 1;


### PR DESCRIPTION
Fixes #3604.

Compare the pixel type and values in QA 29464 with and without this PR. It doesn't look like we have any other 32 bit .lsm files that would be affected.

I'd expect this to be safe (but low priority) for a patch release.