### PR TITLE
Fake: move configurable sleep to the end of initFile

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -535,9 +535,6 @@ public class FakeReader extends FormatReader {
 
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-
-    sleep("initFile", sleepInitFile);
-
     if (!checkSuffix(id, "fake")) {
       if (checkSuffix(id, "fake.ini")) {
         id = id.substring(0, id.lastIndexOf("."));
@@ -911,6 +908,7 @@ public class FakeReader extends FormatReader {
       }
       // NB: Other pixel types will have null LUTs.
     }
+    sleep("initFile", sleepInitFile);
   }
 
   @Override


### PR DESCRIPTION
If it's at the beginning of initFile, then the sleep happens before `sleepInitFile` can be parsed.

Noticed while trying to write a test for https://github.com/glencoesoftware/bioformats2raw/issues/136.

Compare `showinf test&sleepInitFile=1000.fake` with and without this PR; with this PR, the printed initialization time should be approximately 1 second longer.