### PR TITLE
Automated tests: make sure the file is initialized before all tests

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -161,7 +161,7 @@ public class FormatReaderTest {
 
   // -- Setup/teardown methods --
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setup() throws IOException {
     initFile();
   }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -163,7 +163,14 @@ public class FormatReaderTest {
 
   @BeforeClass(alwaysRun = true)
   public void setup() throws IOException {
-    initFile();
+    try {
+      initFile();
+    }
+    catch (RuntimeException e) {
+      // implies that the configuration does not exist
+      // this is expected if the "config" group is run
+      LOGGER.trace("File initialization failed", e);
+    }
   }
 
   @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Fixes #3792.

To test, pick an existing configured directory of test data, or set up something simple:

```
$ export TEST_DIR=~/tmp-test
$ mkdir $TEST_DIR
$ touch $TEST_DIR/test.fake
$ ant -Dtestng.memory=1g -Dtestng.directory=$TEST_DIR -Dtestng.configDirectory=$TEST_DIR test-config
```

Run ```ant -Dtestng.memory=1g -Dtestng.directory=$TEST_DIR -Dtestng.configDirectory=$TEST_DIR test-fast``` without this PR and note that 10 tests are skipped, and the log file in `components/test-suite/target` does not reference all of the tests in the `fast` group (e.g. `ChannelNames`, `ExposureTimes`).

Run the same `test-fast` command with this PR; there should be no skipped tests, and all tests in the `fast` group should be in the log file.