### PR TITLE
CellWorX/Metaxpress: Read metadata from one file per channel, to preserve all channel data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -390,6 +390,35 @@ public class CellWorxReader extends FormatReader {
 
     reader.close();
 
+    for (int c=1; c<wavelengths.length; c++) {
+      seriesIndex = 0;
+      planeIndex = c;
+      file = getFile(seriesIndex, planeIndex);
+      while (!new Location(file).exists()) {
+        if (planeIndex < zSteps * nTimepoints * wavelengths.length) {
+          planeIndex += (zSteps * nTimepoints);
+        }
+        else if (seriesIndex < seriesCount - 1) {
+          planeIndex = c;
+          seriesIndex++;
+        }
+        else {
+          break;
+        }
+        file = getFile(seriesIndex, planeIndex);
+      }
+      reader = getReader(file, true);
+
+      OMEXMLMetadata channelMetadata = (OMEXMLMetadata) reader.getMetadataStore();
+      OMEXMLMetadataRoot channelRoot = (OMEXMLMetadataRoot) channelMetadata.getRoot();
+
+      reader.close();
+
+      for (int i=0; i<convertRoot.sizeOfImageList(); i++) {
+        MetadataConverter.convertChannels(channelMetadata, 0, 0, convertMetadata, i, c, false);
+      }
+    }
+
     MetadataStore store = makeFilterMetadata();
     MetadataConverter.convertMetadata(convertMetadata, store);
     MetadataTools.populatePixels(store, this, true);


### PR DESCRIPTION
Backported from a private PR.

To test, use ```metaxpress/samples/multi-channel-test/multi-channel.HTD```. Without this PR, ```showinf -nopix -omexml``` should show 2 channels in the OME-XML, but only the first has an ```EmissionWavelength```. With this PR, the same command should show that both channels have an ```EmissionWavelength``` set, and that the two wavelengths are different. The wavelengths can be compared against the configuration for the original pixels files (see ```metaxpress/samples/multi-channel-test/readme.txt```).