### PR TITLE
Metamorph: parse doubles with DataTools

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.util.Hashtable;
 import java.util.Vector;
 
+import loci.common.DataTools;
 import loci.common.xml.BaseHandler;
 
 import ome.units.UNITS;
@@ -215,17 +216,44 @@ public class MetamorphHandler extends BaseHandler {
 
   /** Check if the value needs to be saved. */
   private void checkKey(String key, String value) {
-    if (key.equals("Temperature")) {
-      temperature = Double.parseDouble(value);
-    }
-    else if (key.equals("spatial-calibration-x")) {
-      pixelSizeX = Double.parseDouble(value);
-    }
-    else if (key.equals("spatial-calibration-y")) {
-      pixelSizeY = Double.parseDouble(value);
-    }
-    else if (key.equals("z-position")) {
-      zPositions.add(new Double(value));
+    Double doubleValue = DataTools.parseDouble(value);
+    if (doubleValue != null) {
+      if (key.equals("Temperature")) {
+        temperature = doubleValue;
+      }
+      else if (key.equals("spatial-calibration-x")) {
+        pixelSizeX = doubleValue;
+      }
+      else if (key.equals("spatial-calibration-y")) {
+        pixelSizeY = doubleValue;
+      }
+      else if (key.equals("z-position")) {
+        zPositions.add(doubleValue);
+      }
+      else if (key.equals("_MagNA_")) {
+        lensNA = doubleValue;
+      }
+      else if (key.equals("_MagRI_")) {
+        lensRI = doubleValue;
+      }
+      else if (key.equals("Readout Frequency")) {
+        readOutRate = doubleValue;
+      }
+      else if (key.equals("zoom-percent")) {
+        zoom = doubleValue;
+      }
+      else if (key.equals("stage-position-x")) {
+        positionX = new Length(doubleValue, UNITS.REFERENCEFRAME);
+        if (metadata != null) {
+          metadata.put("X position for position #1", positionX);
+        }
+      }
+      else if (key.equals("stage-position-y")) {
+        positionY = new Length(doubleValue, UNITS.REFERENCEFRAME);
+        if (metadata != null) {
+          metadata.put("Y position for position #1", positionY);
+        }
+      }
     }
     else if (key.equals("wavelength")) {
       wavelengths.add(new Integer(value));
@@ -238,45 +266,26 @@ public class MetamorphHandler extends BaseHandler {
     else if (key.equals("Binning")) {
       binning = value;
     }
-    else if (key.equals("Readout Frequency")) {
-      readOutRate = Double.parseDouble(value);
-    }
-    else if (key.equals("zoom-percent")) {
-      zoom = Double.parseDouble(value);
-    }
-    else if (key.equals("stage-position-x")) {
-      final Double number = Double.valueOf(value);
-      positionX = new Length(number, UNITS.REFERENCEFRAME);
-      if (metadata != null) {
-        metadata.put("X position for position #1", positionX);
-      }
-    }
-    else if (key.equals("stage-position-y")) {
-      final Double number = Double.valueOf(value);
-      positionY = new Length(number, UNITS.REFERENCEFRAME);
-      if (metadata != null) {
-        metadata.put("Y position for position #1", positionY);
-      }
-    }
     else if (key.equals("Speed")) {
       int space = value.indexOf(' ');
       if (space > 0) {
         value = value.substring(0, space);
       }
-      try {
-        readOutRate = Double.parseDouble(value.trim());
+      Double rate = DataTools.parseDouble(value.trim());
+      if (rate != null) {
+        readOutRate = rate;
       }
-      catch (NumberFormatException e) { }
     }
     else if (key.equals("Exposure")) {
       if (value.indexOf(' ') != -1) {
         value = value.substring(0, value.indexOf(' '));
       }
       // exposure times are stored in milliseconds, we want them in seconds
-      try {
-        exposures.add(new Double(Double.parseDouble(value) / 1000));
+      Double exposure = DataTools.parseDouble(value);
+      if (exposure != null) {
+        exposure /= 1000;
       }
-      catch (NumberFormatException e) { }
+      exposures.add(exposure);
     }
     else if (key.equals("_IllumSetting_")) {
       if (channelName == null) {
@@ -288,16 +297,10 @@ public class MetamorphHandler extends BaseHandler {
       stageLabel = value;
     }
     else if (key.endsWith("Gain") && gain == null) {
-      try {
-        gain = new Double(value.replaceAll("[xX]", ""));
+      Double v = DataTools.parseDouble(value.replaceAll("[xX]", ""));
+      if (v != null) {
+        gain = v;
       }
-      catch (NumberFormatException e) { }
-    }
-    else if (key.equals("_MagNA_")) {
-      lensNA = Double.parseDouble(value);
-    }
-    else if (key.equals("_MagRI_")) {
-      lensRI = Double.parseDouble(value);
     }
     else if (key.startsWith("Dual Camera")) {
       // Determine if image has been already split by Metamorph.
@@ -310,6 +313,10 @@ public class MetamorphHandler extends BaseHandler {
             dualCamera = true;
       } else {
           try {
+            // this Double.parseDouble(...) instead of
+            // DataTools.parseDouble(...) is intentional,
+            // because we want NumberFormatException to be thrown
+            // if the value is not a valid double
             Double.parseDouble(value.substring(space));
             // last number is a wavelength and indicates this dual camera
             // image has been split
@@ -317,7 +324,7 @@ public class MetamorphHandler extends BaseHandler {
           }
           catch (NumberFormatException e) {
             // last token is not a number, so image has not been split
-            dualCamera = true; 
+            dualCamera = true;
           }
       }
     }


### PR DESCRIPTION
Fixes #3776.

To test, compare ```showinf -omexml``` on the file in ``` inbox/qa/30870/``` with and without this PR. Without this PR, a ```NumberFormatException``` should be thrown as indicated in #3776. With this PR, the OME-XML and images should display without an exception.