### PR TITLE
HitachiReader updates

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -187,6 +187,7 @@ loci.formats.in.IonpathMIBITiffReader   # tif, tiff
 
 # DICOM reader must go before standard TIFF reader to correctly handle DICOM-TIFF files
 loci.formats.in.DicomReader           # dcm, dicom
+loci.formats.in.HitachiReader         # txt, tif, jpg, bmp
 
 # standard TIFF reader must go last (it accepts any TIFF)
 loci.formats.in.TiffDelegateReader    # tif, tiff
@@ -200,7 +201,6 @@ loci.formats.in.OpenlabReader         # liff
 loci.formats.in.SMCameraReader        # (no extension)
 loci.formats.in.SBIGReader            # (no extension)
 loci.formats.in.HRDGDFReader          # (no extension)
-loci.formats.in.HitachiReader         # txt, tif, jpg, bmp
 loci.formats.in.BrukerReader          # fid, acqp
 loci.formats.in.CanonRawReader        # cr2, crw, jpg, thm, wav
 loci.formats.in.OBFReader             # obf, msr

--- a/components/formats-gpl/src/loci/formats/in/HitachiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HitachiReader.java
@@ -268,8 +268,8 @@ public class HitachiReader extends FormatReader {
     final Length stagePosYl = new Length(stagePosYn, UNITS.REFERENCEFRAME);
     final Length stagePosZl = new Length(stagePosZn, UNITS.REFERENCEFRAME);
 
-    Length sizeX = FormatTools.getPhysicalSizeX(pixelSize);
-    Length sizeY = FormatTools.getPhysicalSizeY(pixelSize);
+    Length sizeX = FormatTools.getPhysicalSizeX(pixelSize, UNITS.NANOMETER);
+    Length sizeY = FormatTools.getPhysicalSizeY(pixelSize, UNITS.NANOMETER);
     if (sizeX != null) {
       store.setPixelsPhysicalSizeX(sizeX, 0);
     }

--- a/components/formats-gpl/src/loci/formats/in/HitachiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HitachiReader.java
@@ -235,8 +235,36 @@ public class HitachiReader extends FormatReader {
     String date = image.get("Date");
     String time = image.get("Time");
 
-    Location parent = new Location(id).getAbsoluteFile().getParentFile();
-    pixelsFile = new Location(parent, pixelsFile).getAbsolutePath();
+    Location baseFile = new Location(id).getAbsoluteFile();
+    Location parent = baseFile.getParentFile();
+    Location pixels = new Location(parent, pixelsFile);
+    if (pixels.exists()) {
+      pixelsFile = pixels.getAbsolutePath();
+    }
+    else {
+      LOGGER.warn("Stored file name {} not found, attempting to find pixels file", pixelsFile);
+
+      String base = baseFile.getAbsolutePath();
+      if (base.indexOf('.') >= 0) {
+        base = base.substring(0, base.lastIndexOf("."));
+      }
+
+      Location bmp = new Location(base + ".bmp");
+      Location jpg = new Location(base + ".jpg");
+      Location tif = new Location(base + ".tif");
+      if (tif.exists()) {
+        pixelsFile = tif.getAbsolutePath();
+      }
+      else if (jpg.exists()) {
+        pixelsFile = jpg.getAbsolutePath();
+      }
+      else if (bmp.exists()) {
+        pixelsFile = bmp.getAbsolutePath();
+      }
+      else {
+        throw new FormatException("Could not find pixels file");
+      }
+    }
 
     ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
     Class<? extends IFormatReader>[] classArray = classes.getClasses();


### PR DESCRIPTION
Backported from a private PR.

Fixes a variety of issues with Hitachi datasets, which consist of one text file and one pixels file (e.g. TIFF):

- allow the text file to be UTF-16 instead of UTF-8 or ASCII
- assume the physical pixel size units are nanometers instead of micrometers
- use `HitachiReader` when a TIFF pixels file is initialized (so it doesn't matter which file in the dataset is chosen)
- log and attempt to handle renamed pixels files

All of these changes can be tested with existing datasets in `curated/hitachi`.
The physical pixel size change can be tested by comparing the physical size against the burned-in scale bar on the images. This is probably easiest to do by opening in ImageJ and drawing a line over the scale bar.

`showinf` on `curated/hitachi/*/*.tif` should now match the output of `showinf` on the similarly-named .txt file. Picking one dataset and renaming both files should now work and log that the pixels file was renamed, e.g.:

```
$ cp 001_q09.txt test.txt
$ mv 001_q09.tif test.tif
$ showinf test.txt
...
Stored file name 001_q09.tif not found, attempting to find pixels file
...
```

Converting one of the .txt files to UTF-16 (e.g. by resaving in Notepad) should still allow the file to be initialized correctly.

ea3aef1 has the highest likelihood of causing test failures, in which case `isThisType` may need to be refined here.