### PR TITLE
Deltavision: another fix for incorrect XY tile count detection

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -899,6 +899,19 @@ public class DeltavisionReader extends FormatReader {
         yTiles = 1;
       }
     }
+    else if (xTiles * yTiles < getSeriesCount() && (backwardsStageX || backwardsStageY)) {
+      if (backwardsStageX && yTiles == 1) {
+        xTiles = getSeriesCount();
+      }
+      else if (backwardsStageY && xTiles == 1) {
+        yTiles = getSeriesCount();
+      }
+      else {
+        LOGGER.warn("Could not determine stage position ordering");
+        backwardsStageX = false;
+        backwardsStageY = false;
+      }
+    }
 
     if (getSeriesCount() == 1) {
       xTiles = 1;


### PR DESCRIPTION
This adds better handling for the case when the calculated XY tile count is smaller than the number of panels (series) and at least one of the axes is acquired in reverse order.

Fixes #3601. Without this PR, `showinf` on the .dv file from QA 29449 should throw an exception as indicated in #3601. With this PR, the same command should successfully initialize and display an image. The dimensions should match what is in the .dv.log file:

```
XY Dimensions:              1024 x 1024
ZWT Dimensions (expected):  1 x 1 x 1
Panels:                     86
```

Assuming tests pass, this should be safe for a patch release.