### PR TITLE
TIFF metadata fix

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -33,6 +33,7 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -329,8 +330,8 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     }
     put("SampleFormat", sampleFormat);
 
-    putInt("SMinSampleValue", firstIFD, IFD.S_MIN_SAMPLE_VALUE);
-    putInt("SMaxSampleValue", firstIFD, IFD.S_MAX_SAMPLE_VALUE);
+    put("SMinSampleValue", firstIFD, IFD.S_MIN_SAMPLE_VALUE);
+    put("SMaxSampleValue", firstIFD, IFD.S_MAX_SAMPLE_VALUE);
     putInt("TransferRange", firstIFD, IFD.TRANSFER_RANGE);
 
     int jpeg = firstIFD.getIFDIntValue(IFD.JPEG_PROC);
@@ -539,6 +540,23 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
   protected void put(String key, Object value) {
     if (value == null) return;
     if (value instanceof String) value = ((String) value).trim();
+
+    try {
+      int length = Array.getLength(value);
+      StringBuffer sb = new StringBuffer("[");
+      for (int i=0; i<length; i++) {
+        sb.append(Array.get(value, i));
+        if (i < length - 1) {
+          sb.append(", ");
+        }
+      }
+      sb.append("]");
+      value = sb.toString();
+    }
+    catch (IllegalArgumentException e) {
+      // not an array
+    }
+
     addGlobalMeta(key, value);
   }
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -551,7 +551,7 @@ public class TiffParser implements Closeable {
 
     if (type == IFDType.BYTE) {
       // 8-bit unsigned integer
-      if (count == 1) return Short.valueOf(in.readByte());
+      if (count == 1) return in.readUnsignedByte();
       byte[] bytes = new byte[count];
       in.readFully(bytes);
       // bytes are unsigned, so use shorts


### PR DESCRIPTION
Backported from a private PR.

Compare `showinf -nopix -noflat | grep SampleValue` on the files in `curated/vectra-qptiff/public/perkinelmer` with and without this PR. With this PR, the results should match `tiffinfo -0 | grep "Sample Value"` on the same files.

This shouldn't impact memo files, but test results and run times need to be checked since these changes potentially affect all TIFF-based formats.