### PR TITLE
Logback: components bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.7</ome-common.version>
+    <ome-common.version>6.0.9</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.2.3</ome-model.version>
     <ome-poi.version>5.3.5</ome-poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <ome-common.version>6.0.7</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.2.3</ome-model.version>
-    <ome-poi.version>5.3.4</ome-poi.version>
+    <ome-poi.version>5.3.5</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.3.1</ome-codecs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <ome-stubs.version>5.3.2</ome-stubs.version>
     <lwf-stubs.version>${ome-stubs.version}</lwf-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.3</ome-metakit.version>
+    <ome-metakit.version>5.3.4</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>4.0.2</kryo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <ome-common.version>6.0.9</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.2.3</ome-model.version>
-    <ome-poi.version>5.3.5</ome-poi.version>
+    <ome-poi.version>5.3.6</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.3.1</ome-codecs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.9</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.2.3</ome-model.version>
+    <ome-model.version>6.3.1</ome-model.version>
     <ome-poi.version>5.3.6</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <ome-poi.version>5.3.6</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.3.1</ome-codecs.version>
+    <ome-codecs.version>0.3.2</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>


### PR DESCRIPTION
Companion PR to https://github.com/ome/bioformats/pull/3826, this bumps all the low-level OME components to the latest version including notable the bump of the logback components to 1.2.9.

In terms of testing, the latest versions of all components should already be tested together by our Jenkins infrastructure so mostly check that the GitHub Actions workflows are successful (which should also confirm that the components have been successfully released to Maven Central).