### PR TITLE
Update xercesImpl to version 2.12.2

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -122,10 +122,16 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.8.1</version>
+      <version>2.12.2</version>
     </dependency>
 
-    <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
+    <!-- xml-apis is a transitive dependency of xercesImpl but this allows downstream components to resolve to the latest version -->
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
+    </dependency>
+
 
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->


### PR DESCRIPTION
Also declare xml-apis 1.4.01 in the dependency tree of formats-bsd to avoid downstream components to resolve xml-apis 1.3.02, which is a transitive dependency of ome-common but incompatible with the recent version of xercesImpl
