### PR TITLE
OME-TIFF: faster initialization when there are lots of planes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1096,10 +1096,15 @@ public class OMETiffReader extends SubResolutionFormatReader {
             info[s][0].ifd = 0;
           }
         }
-        TiffParser tp = new TiffParser(testFile);
-        tp.setDoCaching(false);
-        IFD checkIFD = tp.getIFD(tp.getIFDOffsets()[info[s][0].ifd]);
-        hasSubIFDs = hasSubIFDs || checkIFD.containsKey(IFD.SUB_IFD);
+        else {
+          try (TiffParser tp = new TiffParser(firstFile)) {
+            tp.setDoCaching(false);
+            IFD checkIFD = tp.getIFD(tp.getIFDOffsets()[info[s][0].ifd]);
+            hasSubIFDs = hasSubIFDs || checkIFD.containsKey(IFD.SUB_IFD);
+            m.tileWidth = (int) checkIFD.getTileWidth();
+            m.tileHeight = (int) checkIFD.getTileLength();
+          }
+        }
         if (testFile != null) {
           testFile.close();
         }
@@ -1124,9 +1129,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
             }
           }
         }
-
-        m.tileWidth = (int) checkIFD.getTileWidth();
-        m.tileHeight = (int) checkIFD.getTileLength();
 
         m.sizeX = meta.getPixelsSizeX(i).getValue();
         int tiffWidth = (int) firstIFD.getImageWidth();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1098,7 +1098,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
           }
         }
         else {
-          try (TiffParser tp = new TiffParser(firstFile)) {
+          try (TiffParser tp = new TiffParser(testFile)) {
             tp.setDoCaching(false);
             long[] offsets = ifdOffsets.get(firstFile);
             if (offsets == null) {

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -850,6 +850,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
     // process TiffData elements
     Hashtable<String, IFormatReader> readers = new Hashtable<>();
+    Hashtable<String, long[]> ifdOffsets = new Hashtable<String, long[]>();
     boolean adjustedSamples = false;
     boolean hasSubIFDs = false;
     for (int i=0; i<seriesCount; i++) {
@@ -1099,10 +1100,16 @@ public class OMETiffReader extends SubResolutionFormatReader {
         else {
           try (TiffParser tp = new TiffParser(firstFile)) {
             tp.setDoCaching(false);
-            IFD checkIFD = tp.getIFD(tp.getIFDOffsets()[info[s][0].ifd]);
+            long[] offsets = ifdOffsets.get(firstFile);
+            if (offsets == null) {
+              offsets = tp.getIFDOffsets();
+            }
+            IFD checkIFD = tp.getIFD(offsets[info[s][0].ifd]);
             hasSubIFDs = hasSubIFDs || checkIFD.containsKey(IFD.SUB_IFD);
             m.tileWidth = (int) checkIFD.getTileWidth();
             m.tileHeight = (int) checkIFD.getTileLength();
+
+            ifdOffsets.put(firstFile, offsets);
           }
         }
         if (testFile != null) {


### PR DESCRIPTION
Backported from a private PR. Opening to see if repo tests fail, will exclude tomorrow if they do. 

This is meant to speed up `setId` time for cases such as the output of `bfconvert "test&sizeZ=4000.fake" test.ome.tiff`.

Unit tests fail without 2ebbc58, which I think actually exposes an issue with bfconvert. `bfconvert "test&sizeC=2&series=3.fake" -tilex 256 -tiley 256 -channel 1 test-split_%x_%y_%m.ome.tiff` results in in this OME-XML:

```
<?xml version="1.0" encoding="UTF-8"?>
<!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/. -->
<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="OME Bio-Formats 6.10.0-SNAPSHOT" UUID="urn:uuid:aa1ec1c8-4f03-4f22-9634-345a61d7275a" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
  <Image ID="Image:0" Name="test">
    <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:0" Interleaved="false" SignificantBits="8" SizeC="1" SizeT="1" SizeX="256" SizeY="256" SizeZ="1" Type="uint8">
      <Channel ID="Channel:0:0" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
      <Channel ID="Channel:0:1" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
      <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
        <UUID FileName="test-split_0_0_0.ome.tiff">urn:uuid:aa1ec1c8-4f03-4f22-9634-345a61d7275a</UUID>
      </TiffData>
    </Pixels>
  </Image>
  <Image ID="Image:1" Name="test 2">
    <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:1" Interleaved="false" SignificantBits="8" SizeC="1" SizeT="1" SizeX="256" SizeY="256" SizeZ="1" Type="uint8">
      <Channel ID="Channel:1:0" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
      <Channel ID="Channel:1:1" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
    </Pixels>
  </Image>
  <Image ID="Image:2" Name="test 3">
    <Pixels BigEndian="false" DimensionOrder="XYZCT" ID="Pixels:2" Interleaved="false" SignificantBits="8" SizeC="1" SizeT="1" SizeX="256" SizeY="256" SizeZ="1" Type="uint8">
      <Channel ID="Channel:2:0" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
      <Channel ID="Channel:2:1" SamplesPerPixel="1">
        <LightPath/>
      </Channel>
      <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
        <UUID FileName="test-split_1_0_1.ome.tiff">urn:uuid:25c6d8cb-ed9d-4f80-99cf-cb4d0e343882</UUID>
      </TiffData>
    </Pixels>
  </Image>
</OME>
```

That's not introduced by the PR, and fixing is outside the scope, but noting here for discussion.