### PR TITLE
Update metadata extractor to version 2.18.0

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
 	    <groupId>com.drewnoakes</groupId>
 	    <artifactId>metadata-extractor</artifactId>
-	    <version>2.11.0</version>
+	    <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>ome</groupId>

--- a/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
@@ -58,7 +58,7 @@ public class EXIFServiceImpl extends AbstractService implements EXIFService {
     // check for metadata-extractor.jar
     checkClassDependency(ImageMetadataReader.class);
     // check for xmpcore.jar
-    checkClassDependency(com.adobe.xmp.XMPMeta.class);
+    checkClassDependency(com.adobe.internal.xmp.XMPMeta.class);
   }
 
   // -- EXIFService API methods --


### PR DESCRIPTION
See https://github.com/drewnoakes/metadata-extractor/releases for a list of changes in this version.

This pulls a more recent version of `xmpcore` where packages have been renamed internally but apart from the `EXIFServiceImpl` class, all changes should be internal to the library.

With Bio-Formats 6.10.0 behing us, opening to see the impact on the curated QA repository builds.

