### PR TITLE
TIFF: prevent ClassCastException if the SubfileType tag has the wrong type

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -481,7 +481,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
     subResolutionIFDs = new ArrayList<IFDList>();
     for (IFD ifd : allIFDs) {
       tiffParser.fillInIFD(ifd);
-      Number subfile = (Number) ifd.getIFDValue(IFD.NEW_SUBFILE_TYPE);
+      Number subfile = (Number) ifd.getIFDValue(IFD.NEW_SUBFILE_TYPE, Number.class);
       int subfileType = subfile == null ? 0 : subfile.intValue();
       if (subfileType != 1 || allIFDs.size() <= 1) {
         ifds.add(ifd);


### PR DESCRIPTION
Backported from a private PR.

This adds a check for the `Number` class when retrieving the `SubfileType` TIFF tag. Some files incorrectly store an array in this tag, which causes a `ClassCastException` without this PR.

Should be safe for a patch release.