### PR TITLE
OME-TIFF: improve performance with open file handle reduction

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -289,7 +289,9 @@ public class OMETiffReader extends SubResolutionFormatReader {
     for (int i=0; i<info.length; i++) {
       if (i != series && info[i] != null) {
         for (OMETiffPlane p : info[i]) {
-          if (p != null && p.reader != null) {
+          if (p != null && p.reader != null &&
+            !getCurrentFile().equals(p.reader.getCurrentFile()))
+          {
             try {
               p.reader.close();
             }
@@ -1432,7 +1434,13 @@ public class OMETiffReader extends SubResolutionFormatReader {
         }
         core.add(s, c);
       }
-      r.close();
+      // if we have multiple OME-TIFF files, close to reduce the
+      // number of open file handles
+      // keep the "main" file's handle open though, to improve
+      // performance when there is only one file
+      if (!getCurrentFile().equals(r.getCurrentFile())) {
+        r.close();
+      }
     }
     core.reorder();
 


### PR DESCRIPTION
Continuation of #3766.

#3766 introduced degraded `setId` performance for single file OME-TIFF datasets with a larger number of series. `bfconvert "test&sizeZ=20&series=300.fake" lots-of-series.ome.tiff` produces a file that demonstrates the issue.

With this PR, `showinf -nopix -omexml lots-of-series.ome.tiff` should be noticeably faster than the same command using 6.9.1 or 6.10.0. There should also be fewer `Reading IFDs` lines in the `showinf` output with this PR.

The file handle test case in #3766 should still work with these changes, and tests should continue to pass.

Technically should be safe for a patch release, but given how much we rely on OME-TIFF will definitely need some careful testing to make sure this doesn't make anything worse.