### PR TITLE
Bump ome-common and ome-poi versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@
     <slf4j.version>1.7.30</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.9</ome-common.version>
+    <ome-common.version>6.0.11</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.3.1</ome-model.version>
-    <ome-poi.version>5.3.6</ome-poi.version>
+    <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.3.2</ome-codecs.version>


### PR DESCRIPTION
These include dependency version bumps that should address https://github.com/ome/openmicroscopy/pull/6328