### PR TITLE
VirtualImagePlus: retain contrast in setSlice

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java
@@ -84,6 +84,8 @@ public class VirtualImagePlus extends ImagePlus {
       if (methods != null) {
         proc.applyMethodStack(methods);
       }
+      // Keep the user-defined color limits
+      proc.getChild().setMinAndMax(this.getDisplayRangeMin(), this.getDisplayRangeMax());
       // if we call setProcessor(getTitle(), proc), the type will be set
       // to GRAY32 (regardless of the actual processor type)
       setProcessor(getTitle(), proc.getChild());


### PR DESCRIPTION
## Problem

When one loads a virtual image stack and changes the contrast by e.g. the contrast dialog, the changes are lost when the stack is scrolled, which makes it very inconvenient to look at sequences which need contrast adjustment. In classical ImageJ the contrast is retained. I noticed this behavior with 16 and 32 bit bigtiff files but assume it happens for other file formats as well. 

This issue has been mentioned also in [forum.image.sc](https://forum.image.sc/t/b-c-for-a-whole-virtual-stack-cont/57811). 

## Solution

If one comments [these lines](https://github.com/ome/bioformats/blob/develop/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java#L80-L95), all works as expected. The problem seems to be in the fact that `proc.getChild()`'s min and max values do not reflect the set display range, so when it is used in [setProcessor](https://github.com/ome/bioformats/blob/develop/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java#L89) it is lost.