### PR TITLE
NDPI: fix non-number tag handling for files > 4GB

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -377,7 +377,7 @@ public class NDPIReader extends BaseTiffReader {
                   entry.getValueCount(), newOffset);
                 ifd.put(tag[t], newEntry);
               }
-              else {
+              else if (value instanceof Number) {
                 ifd.put(tag[t], ((Number) value).longValue() + highOrder[t]);
               }
             }


### PR DESCRIPTION
Tag 65459 in particular has ASCII type. The tag type may be stored incorrectly in the file, since the value is more consistent with
a LONG type. We have no documentation on this tag, though, so for now just preventing a ClassCastException is enough.

Fixes #3725. Should be safe for a patch release.