### PR TITLE
bfconvert: fix overwrite checking when output path is a pattern

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -137,6 +137,11 @@ public final class ImageConverter {
   private boolean firstTile = true;
   private DynamicMetadataOptions options = new DynamicMetadataOptions();
 
+  // record paths that have been checked for overwriting
+  // this is mostly useful when "out" is a file name pattern
+  // that may be expanded into multiple actual files
+  private HashMap<String, Boolean> checkedPaths = new HashMap<String, Boolean>();
+
   // -- Constructor --
 
   public ImageConverter() { }
@@ -447,21 +452,9 @@ public final class ImageConverter {
     CommandLineTools.runUpgradeCheck(args);
 
     if (new Location(out).exists()) {
-      if (overwrite == null) {
-        LOGGER.warn("Output file {} exists.", out);
-        LOGGER.warn("Do you want to overwrite it? ([y]/n)");
-        BufferedReader r = new BufferedReader(
-          new InputStreamReader(System.in, Constants.ENCODING));
-        String choice = r.readLine().trim().toLowerCase();
-        overwrite = !choice.startsWith("n");
-      }
-      if (!overwrite) {
-        LOGGER.warn("Exiting; next time, please specify an output file that " +
-          "does not exist.");
+      boolean ok = overwriteCheck(out, false);
+      if (!ok) {
         return false;
-      }
-      else {
-        new Location(out).delete();
       }
     }
 
@@ -713,7 +706,13 @@ public final class ImageConverter {
           }
 
           String outputName = FormatTools.getFilename(q, i, reader, out, zeroPadding);
-          if (outputName.equals(FormatTools.getTileFilename(0, 0, 0, outputName))) {
+          String tileName = FormatTools.getTileFilename(0, 0, 0, outputName);
+
+          if (outputName.equals(tileName)) {
+            boolean ok = overwriteCheck(outputName, false);
+            if (!ok) {
+              return false;
+            }
             writer.setId(outputName);
             if (compression != null) writer.setCompression(compression);
           }
@@ -728,7 +727,12 @@ public final class ImageConverter {
             }
             if (saveTileWidth == 0 && saveTileHeight == 0) {
               // Using tile output name but not tiled reading
-              writer.setId(FormatTools.getTileFilename(0, 0, 0, outputName));
+
+              boolean ok = overwriteCheck(tileName, false);
+              if (!ok) {
+                return false;
+              }
+              writer.setId(tileName);
               if (compression != null) writer.setCompression(compression);
             }
           }
@@ -892,6 +896,8 @@ public final class ImageConverter {
           }
 
           writer.setMetadataRetrieve(retrieve);
+
+          overwriteCheck(tileName, true);
           writer.setId(tileName);
           if (compression != null) writer.setCompression(compression);
 
@@ -1131,6 +1137,34 @@ public final class ImageConverter {
     }
     return DataTools.safeMultiply64(width, height) >= DataTools.safeMultiply64(4096, 4096) ||
       saveTileWidth > 0 || saveTileHeight > 0;
+  }
+
+  private boolean overwriteCheck(String path, boolean throwOnExist) throws IOException {
+    if (checkedPaths.containsKey(path)) {
+      return checkedPaths.get(path);
+    }
+    if (overwrite == null) {
+      LOGGER.warn("Output file {} exists.", path);
+      LOGGER.warn("Do you want to overwrite it? ([y]/n)");
+      BufferedReader r = new BufferedReader(
+        new InputStreamReader(System.in, Constants.ENCODING));
+      String choice = r.readLine().trim().toLowerCase();
+      overwrite = !choice.startsWith("n");
+    }
+    if (!overwrite) {
+      String msg = "Exiting; next time, please specify an output file that does not exist.";
+      checkedPaths.put(path, false);
+      if (throwOnExist) {
+        throw new IOException(msg);
+      }
+      LOGGER.warn(msg);
+      return false;
+    }
+    else {
+      new Location(path).delete();
+    }
+    checkedPaths.put(path, true);
+    return true;
   }
 
   // -- Main method --

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1143,6 +1143,10 @@ public final class ImageConverter {
     if (checkedPaths.containsKey(path)) {
       return checkedPaths.get(path);
     }
+    if (!new Location(path).exists()) {
+      checkedPaths.put(path, true);
+      return true;
+    }
     if (overwrite == null) {
       LOGGER.warn("Output file {} exists.", path);
       LOGGER.warn("Do you want to overwrite it? ([y]/n)");

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -338,6 +338,7 @@ public class ImageConverterTest {
     String[] tileArgs = {"-tilex", "256", "-tiley", "256"};
     ArrayList<String> argsList = new ArrayList<String>();
     argsList.add("test&sizeZ=3&sizeC=2&sizeT=4&series=3&sizeX=512&sizeY=512.fake");
+    argsList.add("-overwrite");
     argsList.addAll(Arrays.asList(optionsArgs));
     argsList.addAll(Arrays.asList(tileArgs));
     argsList.add(outFile.getAbsolutePath());

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -186,8 +186,7 @@ public class ImageConverterTest {
   }
 
   public void testConstructor() throws FormatException, IOException {
-    outFile = tempDir.resolve("test.ome.tiff").toFile();
-    outFile.deleteOnExit();
+    outFile = getOutFile("test.ome.tiff");
     ImageConverter converter = new ImageConverter();
     boolean status = converter.testConvert(new ImageWriter(), new String[] {"test.fake", outFile.getAbsolutePath()});
     assertEquals(status, 0);
@@ -196,14 +195,14 @@ public class ImageConverterTest {
 
   @Test(dataProvider = "suffixes")
   public void testDefault(String suffix) throws FormatException, IOException {
-    outFile = tempDir.resolve("test" + suffix).toFile();
+    outFile = getOutFile("test" + suffix);
     String[] args = {"test.fake", outFile.getAbsolutePath()};
     assertConversion(args);
   }
 
   @Test(dataProvider = "options")
   public void testOptions(String options) throws FormatException, IOException {
-    outFile = tempDir.resolve("test.ome.tiff").toFile();
+    outFile = getOutFile("test.ome.tiff");
     String[] optionsArgs = options.split(" ");
     ArrayList<String> argsList = new ArrayList<String>();
     argsList.add("test&sizeZ=3&sizeC=2&sizeT=4&series=2.fake");
@@ -224,7 +223,7 @@ public class ImageConverterTest {
   public void testBadArgument() throws FormatException, IOException {
     ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     System.setOut(new PrintStream(outContent));
-    outFile = tempDir.resolve("test.ome.tiff").toFile();
+    outFile = getOutFile("test.ome.tiff");
     String[] args = {"-foo", "test.fake", outFile.getAbsolutePath()};
     try {
       ImageConverter.main(args);
@@ -238,8 +237,9 @@ public class ImageConverterTest {
 
   @Test
   public void testCompanion() throws FormatException, IOException {
-    outFile = tempDir.resolve("test.ome.tiff").toFile();
-    File compFile = tempDir.resolve("test.companion.ome").toFile();
+    Path tempSubdir = getTempSubdir();
+    outFile = tempSubdir.resolve("test.ome.tiff").toFile();
+    File compFile = tempSubdir.resolve("test.companion.ome").toFile();
     String[] args = {
       "-option", OMETiffWriter.COMPANION_KEY, compFile.getAbsolutePath(),
       "test.fake", outFile.getAbsolutePath()
@@ -257,7 +257,7 @@ public class ImageConverterTest {
 
   @Test
   public void testSPWSeries() throws FormatException, IOException {
-    outFile = tempDir.resolve("plate.ome.tiff").toFile();
+    outFile = getOutFile("plate.ome.tiff");
     String[] args = {
             "-series", "0",
             "plate&plates=1&fields=2.fake", outFile.getAbsolutePath()
@@ -267,7 +267,7 @@ public class ImageConverterTest {
 
   @Test
   public void testCrop() throws FormatException, IOException {
-    outFile = tempDir.resolve("test.ome.tiff").toFile();
+    outFile = getOutFile("test.ome.tiff");
     String[] args = {
       "-tilex", "128", "-tiley", "128",
       "-crop", "256,256,256,256", "test.fake", outFile.getAbsolutePath()};
@@ -283,7 +283,7 @@ public class ImageConverterTest {
 
   @Test
   public void testCropOddTileSize() throws FormatException, IOException {
-    outFile = tempDir.resolve("odd-test.ome.tiff").toFile();
+    outFile = getOutFile("odd-test.ome.tiff");
     String[] args = {
       "-tilex", "128", "-tiley", "128",
       "-crop", "123,127,129,131", "test.fake", outFile.getAbsolutePath()
@@ -298,10 +298,10 @@ public class ImageConverterTest {
       checkImage();
     }
   }
-  
+
   @Test
   public void testCropLargerThanTileSize() throws FormatException, IOException {
-    outFile = tempDir.resolve("large-crop.ome.tiff").toFile();
+    outFile = getOutFile("large-crop.ome.tiff");
     String[] args = {
       "-tilex", "128", "-tiley", "128",
       "-crop", "0,0,256,256", "test&sizeX=128&sizeY=128.fake", outFile.getAbsolutePath()
@@ -319,7 +319,7 @@ public class ImageConverterTest {
 
   @Test(dataProvider = "options")
   public void testTileOptions(String options) throws FormatException, IOException {
-    outFile = tempDir.resolve("tile-options.ome.tiff").toFile();
+    outFile = getOutFile("tile-options.ome.tiff");
     String[] optionsArgs = options.split(" ");
     String[] tileArgs = {"-tilex", "128", "-tiley", "128"};
     ArrayList<String> argsList = new ArrayList<String>();
@@ -333,23 +333,28 @@ public class ImageConverterTest {
 
   @Test(dataProvider = "options")
   public void testIndividualTiles(String options) throws FormatException, IOException {
-    outFile = tempDir.resolve("seperate-tiles_%x_%y_%m.ome.tiff").toFile();
+    Path tempSubdir = getTempSubdir();
+    outFile = tempSubdir.resolve("seperate-tiles_%x_%y_%m.ome.tiff").toFile();
     String[] optionsArgs = options.split(" ");
     String[] tileArgs = {"-tilex", "256", "-tiley", "256"};
     ArrayList<String> argsList = new ArrayList<String>();
     argsList.add("test&sizeZ=3&sizeC=2&sizeT=4&series=3&sizeX=512&sizeY=512.fake");
-    argsList.add("-overwrite");
     argsList.addAll(Arrays.asList(optionsArgs));
     argsList.addAll(Arrays.asList(tileArgs));
     argsList.add(outFile.getAbsolutePath());
     String [] args = new String[argsList.size()];
-    File outFileToCheck = outFile = tempDir.resolve("seperate-tiles_0_0_0.ome.tiff").toFile();
+    File outFileToCheck = outFile = tempSubdir.resolve("seperate-tiles_0_0_0.ome.tiff").toFile();
     assertConversion(argsList.toArray(args), outFileToCheck.getAbsolutePath(), 256);
+
+    // otherwise all except the first tile file will be kept
+    for (File subfile : tempSubdir.toFile().listFiles()) {
+      subfile.deleteOnExit();
+    }
   }
 
   @Test(dataProvider = "options")
   public void testTileGranularity(String options) throws FormatException, IOException {
-    outFile = tempDir.resolve("tile-options.tiff").toFile();
+    outFile = getOutFile("tile-options.tiff");
     String[] optionsArgs = options.split(" ");
     String[] tileArgs = {"-tilex", "42", "-tiley", "42"};
     ArrayList<String> argsList = new ArrayList<String>();
@@ -360,10 +365,10 @@ public class ImageConverterTest {
     String [] args = new String[argsList.size()];
     assertConversion(argsList.toArray(args), outFile.getAbsolutePath(), 512, 48);
   }
-  
+
   @Test
   public void testConvertResolutionsFlattened() throws FormatException, IOException {
-    outFile = tempDir.resolve("resoutions_flat.ome.tiff").toFile();
+    outFile = getOutFile("resoutions_flat.ome.tiff");
     String[] args = {
       "test&resolutions=2.fake", outFile.getAbsolutePath()
     };
@@ -372,11 +377,21 @@ public class ImageConverterTest {
 
   @Test
   public void testConvertResolutions() throws FormatException, IOException {
-    outFile = tempDir.resolve("resolutions_noflat.ome.tiff").toFile();
+    outFile = getOutFile("resolutions_noflat.ome.tiff");
     String[] args = {
       "-noflat", "test&resolutions=2.fake", outFile.getAbsolutePath()
     };
     resolutionCount = 2;
     assertConversion(args);
+  }
+
+  private Path getTempSubdir() throws IOException {
+    Path subdir = Files.createTempDirectory(tempDir, "ImageConverterTest");
+    subdir.toFile().deleteOnExit();
+    return subdir;
+  }
+
+  private File getOutFile(String name) throws IOException {
+    return getTempSubdir().resolve(name).toFile();
   }
 }


### PR DESCRIPTION
Fixes #3746.

This changes how the `-overwrite`/`-no-overwrite` options and corresponding user prompt work with a use case such as `bfconvert  "test&sizeZ=10.fake" "test_z%z.ome.tiff"`. Without this change, running that command twice with any combination of overwriting options will always result in `test_z0.ome.tiff`, `test_z1.ome.tiff`, etc. being appended to instead of deleted/overwritten or left as-is.

With this change, `bfconvert  "test&sizeZ=10.fake" "test_z%z.ome.tiff"` when run twice with any combination of overwriting options should behave the same as `bfconvert "test&sizeZ=10.fake" test.ome.tiff` when run twice with the same options. There should be no case where the second `bfconvert` command appends to files that already existed.

Right now, if neither `-overwrite` nor `-no-overwrite` is specified this will only prompt to overwrite for the first existing file. If overwriting is enabled, that is assumed to apply to any other existing files. I think that's probably what we want, but open to other thoughts (or suggestions on how to log that more clearly).

This should be safe for a patch release.