### PR TITLE
Bump ome-common version to 6.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.11</ome-common.version>
+    <ome-common.version>6.0.13</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.3.1</ome-model.version>
     <ome-poi.version>5.3.7</ome-poi.version>


### PR DESCRIPTION
Bumping ome-common to 6.0.13 for release to pick up the latest dependency updates.