### PR TITLE
ND2: remove chunkmap skipping logic

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -545,7 +545,6 @@ public class NativeND2Reader extends SubResolutionFormatReader {
         }
       }
 
-      int chunkmapSkips = 0;
       Boolean currentCountSetted = false;
       int XYCount = 1;
       int timeCount = 1;
@@ -677,7 +676,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
             useLastText = true;
           }
 
-          if(useChunkMap && chunkmapSkips == 0) {
+          if(useChunkMap) {
             ChunkMapEntry lastImage = null;
 
             // sanity check: see if the chunk we just found is actually in the chunkmap ...
@@ -700,13 +699,6 @@ public class NativeND2Reader extends SubResolutionFormatReader {
 
               if(!entry.name.startsWith("ImageDataSeq")) {
                 continue;
-              }
-
-              if(lastImage!=null) {
-                chunkmapSkips = (int)(((entry.position - lastImage.position) / entry.length) - 1);
-                if(chunkmapSkips > 0) {
-                  break;
-                }
               }
 
               lastImage = entry;
@@ -733,10 +725,6 @@ public class NativeND2Reader extends SubResolutionFormatReader {
 
             continue;
 
-          }
-
-          if(chunkmapSkips > 0) {
-            chunkmapSkips -= 1;
           }
 
           dataLength -= 31;


### PR DESCRIPTION
Fixes #3838.

This logic did not appear to be used by any files in the current data repo, and causes problems for files with very small images.

Opening the file in #3838 (copied to `curated/nd2/gh-3838`) without this PR should show a single plane. Without this PR and with `nativend2.chunkmap` set to `false`, there should be 5 timepoints as expected. With this PR and default options, there should be 5 timepoints as well.

Probably safe for a patch release assuming tests pass.