### PR TITLE
- Implement zstd decompression for tiffs.

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -167,7 +167,11 @@
       <artifactId>snakeyaml</artifactId>
       <version>1.29</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>0.21</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.21</version>
+      <version>0.18</version>
     </dependency>
   </dependencies>
 

--- a/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
@@ -1,0 +1,46 @@
+package loci.formats.codec;
+
+import loci.common.RandomAccessInputStream;
+import loci.formats.FormatException;
+import java.io.EOFException;
+import java.io.IOException;
+import io.airlift.compress.zstd.ZstdDecompressor;
+import loci.formats.UnsupportedCompressionException;
+
+/**
+ * This class implements Zstandard decompression.
+ *
+ * @author Wim Pomp w.pomp at nki.nl
+ */
+public class ZstdCodec extends BaseCodec {
+
+    @Override
+    public byte[] compress(byte[] data, CodecOptions options)
+        throws FormatException
+    {
+        if (data == null || data.length == 0)
+            throw new IllegalArgumentException("No data to compress");
+        // TODO: Add compression support.
+        throw new UnsupportedCompressionException("Zstandard Compression not currently supported.");
+    }
+
+    @Override
+    public byte[] decompress(RandomAccessInputStream in, CodecOptions options)
+        throws FormatException, IOException
+    {
+        ByteVector bytes = new ByteVector();
+        byte[] buf = new byte[8192];
+        int r;
+        // read until eof reached
+        try {
+            while ((r = in.read(buf, 0, buf.length)) > 0) bytes.add(buf, 0, r);
+        }
+        catch (EOFException ignored) { }
+
+        byte[] data = bytes.toByteArray();
+        ZstdDecompressor decompressor = new ZstdDecompressor();
+        byte[] output = new byte[(int) ZstdDecompressor.getDecompressedSize(data, 0, data.length)];
+        decompressor.decompress(data, 0, data.length, output, 0, output.length);
+        return output;
+    }
+}

--- a/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
@@ -54,6 +54,7 @@ import loci.formats.codec.NikonCodec;
 import loci.formats.codec.PackbitsCodec;
 import loci.formats.codec.PassthroughCodec;
 import loci.formats.codec.ZlibCodec;
+import loci.formats.codec.ZstdCodec;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,7 +196,8 @@ public enum TiffCompression implements CodedEnum {
   },
   NIKON(34713, new NikonCodec(), "Nikon"),
   LURAWAVE(65535, new LuraWaveCodec(), "LuraWave"),
-  JPEGXR(22610, new JPEGXRCodec(), "JPEG-XR");
+  JPEGXR(22610, new JPEGXRCodec(), "JPEG-XR"),
+  ZSTD(50000, new ZstdCodec(), "Zstandard");
 
   // -- Constants --
 


### PR DESCRIPTION
Implement zstandard decompression for tif files.

Test tif files compressed with zstd in https://surfdrive.surf.nl/files/index.php/s/BYO0qLnHE9H7fhn, together with original czi images for comparison.