### PR TITLE
Plugins: Close reader after format exception in Importer

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
@@ -72,32 +72,37 @@ public class Importer {
 
       ImportProcess process = new ImportProcess(options);
 
-      BF.debug("display option dialogs");
-      showDialogs(process);
-      if (plugin.canceled) return;
-
-      BF.debug("display metadata");
-      DisplayHandler displayHandler = new DisplayHandler(process);
-      displayHandler.displayOriginalMetadata();
-      displayHandler.displayOMEXML();
-
-      BF.debug("read pixel data");
-      ImagePlusReader reader = new ImagePlusReader(process);
-      ImagePlus[] imps = readPixels(reader, options, displayHandler);
-
-      BF.debug("display pixels");
-      displayHandler.displayImages(imps);
-
-      BF.debug("display ROIs");
-      displayHandler.displayROIs(imps);
-
-      BF.debug("finish");
-      finish(process);
-    }
-    catch (FormatException exc) {
-      boolean quiet = options == null ? false : options.isQuiet();
-      WindowTools.reportException(exc, quiet,
-        "Sorry, there was a problem during import.");
+      try {
+        BF.debug("display option dialogs");
+        showDialogs(process);
+        if (plugin.canceled) return;
+  
+        BF.debug("display metadata");
+        DisplayHandler displayHandler = new DisplayHandler(process);
+        displayHandler.displayOriginalMetadata();
+        displayHandler.displayOMEXML();
+  
+        BF.debug("read pixel data");
+        ImagePlusReader reader = new ImagePlusReader(process);
+        ImagePlus[] imps = readPixels(reader, options, displayHandler);
+  
+        BF.debug("display pixels");
+        displayHandler.displayImages(imps);
+  
+        BF.debug("display ROIs");
+        displayHandler.displayROIs(imps);
+  
+        BF.debug("finish");
+        finish(process);
+      }
+      catch (FormatException exc) {
+        if (!process.getOptions().isVirtual() && process.getReader() != null) {
+          process.getReader().close();
+        }
+        boolean quiet = options == null ? false : options.isQuiet();
+        WindowTools.reportException(exc, quiet,
+          "Sorry, there was a problem during import.");
+      }
     }
     catch (IOException exc) {
       boolean quiet = options == null ? false : options.isQuiet();

--- a/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
@@ -95,7 +95,7 @@ public class Importer {
         BF.debug("finish");
         finish(process);
       }
-      catch (FormatException exc) {
+      catch (Exception exc) {
         if (!process.getOptions().isVirtual() && process.getReader() != null) {
           process.getReader().close();
         }


### PR DESCRIPTION
This is in response to an issue encountered in forum thread https://forum.image.sc/t/exception-issue-when-opening-nd2-files-with-bio-formats/40462/9

When using the BFImport command in a macro, if a FormatException occurred the underlying reader was not properly closed and the file was unable to be renamed.

This will not impact any repo tests and is safe for a patch release.