### PR TITLE
CZI: fix pyramid dimension calculation

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1835,9 +1835,16 @@ public class ZeissCZIReader extends FormatReader {
     int minY = Integer.MAX_VALUE;
     int maxY = Integer.MIN_VALUE;
 
+    int dimensionCount = 0;
     for (SubBlock plane : planes) {
       if (xyOnly && plane.coreIndex != coreIndex) {
         continue;
+      }
+      boolean moreDimensions = plane.directoryEntry.dimensionEntries.length > dimensionCount;
+      if (moreDimensions) {
+        dimensionCount = plane.directoryEntry.dimensionEntries.length;
+        ms0.sizeX = 0;
+        ms0.sizeY = 0;
       }
       for (DimensionEntry dimension : plane.directoryEntry.dimensionEntries) {
         if (dimension == null) {


### PR DESCRIPTION
Ported from a private PR.

This addresses a problem where the XY dimensions of a slide were incorrectly set to the XY dimensions of a single tile. Aside from just being wrong, the sizes were small enough that smaller resolutions were calculated to have 0 pixels, which caused other errors.

I expect this to have limited impact on existing datasets; a configuration PR will be opened shortly.