### PR TITLE
Zeiss CZI: Use new ZSTD codec

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -167,11 +167,6 @@
       <artifactId>snakeyaml</artifactId>
       <version>1.29</version>
     </dependency>
-    <dependency>
-      <groupId>io.airlift</groupId>
-      <artifactId>aircompressor</artifactId>
-      <version>0.18</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
@@ -1,59 +1,39 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2022 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 package loci.formats.codec;
 
-import loci.common.RandomAccessInputStream;
-import loci.formats.FormatException;
-import java.io.EOFException;
-import java.io.IOException;
-import io.airlift.compress.zstd.ZstdDecompressor;
-import loci.formats.UnsupportedCompressionException;
-
-/**
- * This class implements Zstandard decompression.
- *
- * @author Wim Pomp w.pomp at nki.nl
- */
-public class ZstdCodec extends BaseCodec {
-
-    @Override
-    public byte[] compress(byte[] data, CodecOptions options)
-        throws FormatException
-    {
-        if (data == null || data.length == 0)
-            throw new IllegalArgumentException("No data to compress");
-        // TODO: Add compression support.
-        throw new UnsupportedCompressionException("Zstandard Compression not currently supported.");
-    }
-
-    @Override
-    public byte[] decompress(RandomAccessInputStream in, CodecOptions options)
-        throws FormatException, IOException
-    {
-        ByteVector bytes = new ByteVector();
-        byte[] buf = new byte[8192];
-        int r;
-        // read until eof reached
-        try {
-            while ((r = in.read(buf, 0, buf.length)) > 0) bytes.add(buf, 0, r);
-        }
-        catch (EOFException ignored) { }
-
-        byte[] data = bytes.toByteArray();
-        return decompress(data);
-    }
-    
-    @Override
-    public byte[] decompress(byte[] data)
-        throws FormatException
-    {
-        return decompress(data, 0, data.length);
-    }
-    
-    public byte[] decompress(byte[] data, int inputOffset, int length)
-        throws FormatException
-    {
-        ZstdDecompressor decompressor = new ZstdDecompressor();
-        byte[] output = new byte[(int) ZstdDecompressor.getDecompressedSize(data, inputOffset, length)];
-        decompressor.decompress(data, inputOffset, length, output, 0, output.length);
-        return output;
-    }
+public class ZstdCodec extends WrappedCodec {
+  public ZstdCodec() {
+    super(new ome.codecs.ZstdCodec());
+  }
 }

--- a/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
@@ -38,9 +38,22 @@ public class ZstdCodec extends BaseCodec {
         catch (EOFException ignored) { }
 
         byte[] data = bytes.toByteArray();
+        return decompress(data);
+    }
+    
+    @Override
+    public byte[] decompress(byte[] data)
+        throws FormatException
+    {
+        return decompress(data, 0, data.length);
+    }
+    
+    public byte[] decompress(byte[] data, int inputOffset, int length)
+        throws FormatException
+    {
         ZstdDecompressor decompressor = new ZstdDecompressor();
-        byte[] output = new byte[(int) ZstdDecompressor.getDecompressedSize(data, 0, data.length)];
-        decompressor.decompress(data, 0, data.length, output, 0, output.length);
+        byte[] output = new byte[(int) ZstdDecompressor.getDecompressedSize(data, inputOffset, length)];
+        decompressor.decompress(data, inputOffset, length, output, 0, output.length);
         return output;
     }
 }

--- a/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/ZstdCodec.java
@@ -32,8 +32,20 @@
 
 package loci.formats.codec;
 
+import loci.formats.FormatException;
+
 public class ZstdCodec extends WrappedCodec {
   public ZstdCodec() {
     super(new ome.codecs.ZstdCodec());
+  }
+
+  public byte[] decompress(byte[] data, int pointer, int length) 
+      throws FormatException {
+    try {
+      return ((ome.codecs.ZstdCodec)codec).decompress(data, pointer, length);
+    }
+    catch (ome.codecs.CodecException e) {
+      throw unwrapCodecException(e);
+    }
   }
 }

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -130,11 +130,6 @@
       <artifactId>kryo</artifactId>
       <version>${kryo.version}</version>
     </dependency>
-    <dependency>
-      <groupId>io.airlift</groupId>
-      <artifactId>aircompressor</artifactId>
-      <version>0.18</version>
-    </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -25,8 +25,6 @@
 
 package loci.formats.in;
 
-import io.airlift.compress.zstd.ZstdDecompressor;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +54,7 @@ import loci.formats.codec.CodecOptions;
 import loci.formats.codec.JPEGCodec;
 import loci.formats.codec.JPEGXRCodec;
 import loci.formats.codec.LZWCodec;
+import loci.formats.codec.ZstdCodec;
 import loci.formats.meta.MetadataStore;
 
 import ome.xml.model.enums.AcquisitionMode;
@@ -4071,10 +4070,7 @@ public class ZeissCZIReader extends FormatReader {
           }
           break;
         case ZSTD_0:
-          ZstdDecompressor decompressor = new ZstdDecompressor();
-          byte[] output = new byte[(int) decompressor.getDecompressedSize(data, 0, data.length)];
-          decompressor.decompress(data, 0, data.length, output, 0, output.length);
-          data = output;
+          data = new ZstdCodec().decompress(data);
           break;
         case ZSTD_1:
           boolean highLowUnpacking = false;
@@ -4097,11 +4093,7 @@ public class ZeissCZIReader extends FormatReader {
             pointer = (int) stream.getFilePointer();
           }
 
-          ZstdDecompressor zstd = new ZstdDecompressor();
-          long decompressedSize = zstd.getDecompressedSize(data, pointer, data.length - pointer);
-          byte[] decoded = new byte[(int) decompressedSize];
-          zstd.decompress(data, pointer, data.length - pointer, decoded, 0, decoded.length);
-
+          byte[] decoded =  new ZstdCodec().decompress(data, pointer, data.length - pointer);
           // ZSTD_1 implies high/low byte unpacking, so it would be weird
           // if this flag were unset
           if (highLowUnpacking) {

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.4.0</ome-codecs.version>
+    <ome-codecs.version>0.4.1</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.3.2</ome-codecs.version>
+    <ome-codecs.version>0.4.0</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>


### PR DESCRIPTION
This PR is an initial follow up to https://github.com/ome/bioformats/pull/3867

It replaces the existing Zstd implementation in the ZeissCZIReader with the new ZstdCodec. I added some additional methods to the codec to also enable the usage of an offset and length for decompression.

If the repo tests continue to pass then I will open a second PR to migrate the new ZstdCodec to https://github.com/ome/ome-codecs and then update this PR once `ome-codecs` has been released.

I have removed the duplicate `aircompressor` dependency, which will eventually end up living in `ome-codecs` also.