### PR TITLE
FV1000: Use DataTools to parse Double values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -495,8 +495,8 @@ public class FV1000Reader extends FormatReader {
       code[i] = commonParams.get("AxisCode");
       size[i] = commonParams.get("MaxSize");
 
-      double end = Double.parseDouble(commonParams.get("EndPosition"));
-      double start = Double.parseDouble(commonParams.get("StartPosition"));
+      double end = DataTools.parseDouble(commonParams.get("EndPosition"));
+      double start = DataTools.parseDouble(commonParams.get("StartPosition"));
       pixelSize[i] = end - start;
     }
 
@@ -515,7 +515,7 @@ public class FV1000Reader extends FormatReader {
     while (laser != null) {
       laserEnabled = laser.get("Laser Enable").equals("1");
       if (laserEnabled) {
-        wavelengths.add(new Double(laser.get("LaserWavelength")));
+        wavelengths.add(DataTools.parseDouble(laser.get("LaserWavelength")));
       }
 
       creationDate = laser.get("ImageCaputreDate");
@@ -1006,14 +1006,14 @@ public class FV1000Reader extends FormatReader {
       // populate Dimensions data
 
       if (pixelSizeX != null) {
-        Double sizeX = new Double(pixelSizeX);
+        Double sizeX = DataTools.parseDouble(pixelSizeX);
         Length size = FormatTools.getPhysicalSizeX(sizeX);
         if (size != null) {
           store.setPixelsPhysicalSizeX(size, i);
         }
       }
       if (pixelSizeY != null) {
-        Double sizeY = new Double(pixelSizeY);
+        Double sizeY = DataTools.parseDouble(pixelSizeY);
         Length size = FormatTools.getPhysicalSizeY(sizeY);
         if (size != null) {
           store.setPixelsPhysicalSizeY(size, i);
@@ -1103,8 +1103,8 @@ public class FV1000Reader extends FormatReader {
             emValues[i] = emValues[i].replaceAll("\\D", "");
           }
           try {
-            Double cutIn = new Double(emValues[0]);
-            Double cutOut = new Double(emValues[1]);
+            Double cutIn = DataTools.parseDouble(emValues[0]);
+            Double cutOut = DataTools.parseDouble(emValues[1]);
 
             Length in = FormatTools.getCutIn(cutIn);
             Length out = FormatTools.getCutOut(cutOut);
@@ -1155,14 +1155,14 @@ public class FV1000Reader extends FormatReader {
 
     // populate Objective data
 
-    if (lensNA != null) store.setObjectiveLensNA(new Double(lensNA), 0, 0);
+    if (lensNA != null) store.setObjectiveLensNA(DataTools.parseDouble(lensNA), 0, 0);
     store.setObjectiveModel(objectiveName, 0, 0);
     if (magnification != null) {
       Double mag = Double.parseDouble(magnification);
       store.setObjectiveNominalMagnification(mag, 0, 0);
     }
     if (workingDistance != null) {
-      store.setObjectiveWorkingDistance(new Length(new Double(workingDistance), UNITS.MICROMETER), 0, 0);
+      store.setObjectiveWorkingDistance(new Length(DataTools.parseDouble(workingDistance), UNITS.MICROMETER), 0, 0);
     }
     store.setObjectiveCorrection(MetadataTools.getCorrection("Other"), 0, 0);
     store.setObjectiveImmersion(MetadataTools.getImmersion("Other"), 0, 0);
@@ -1285,8 +1285,8 @@ public class FV1000Reader extends FormatReader {
             Length l = new Length((double) lineWidth, UNITS.PIXEL);
             store.setPointStrokeWidth(l, nextROI, shape);
 
-            store.setPointX(new Double(xc[0]), nextROI, shape);
-            store.setPointY(new Double(yc[0]), nextROI, shape);
+            store.setPointX(DataTools.parseDouble(xc[0]), nextROI, shape);
+            store.setPointY(DataTools.parseDouble(yc[0]), nextROI, shape);
           }
           else if (shapeType == GRID || shapeType == RECTANGLE) {
             if (shapeType == RECTANGLE) divide = 1;


### PR DESCRIPTION
This PR is in response to https://forum.image.sc/t/cannot-open-oib-files-in-imagej/71616/5
Sample files have been provided which use a different Locale format for the double values.

With the current release (6.10.1) this results in an exception as below:

```
java.lang.NumberFormatException: For input string: “211,761.0”
at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
at java.lang.Double.parseDouble(Double.java:538)
at loci.formats.in.FV1000Reader.initFile(FV1000Reader.java:498)
at loci.formats.FormatReader.setId(FormatReader.java:1443)
at loci.plugins.in.ImportProcess.initializeFile(ImportProcess.java:499)
at loci.plugins.in.ImportProcess.execute(ImportProcess.java:142)
at loci.plugins.in.Importer.showDialogs(Importer.java:140)
```

With this PR there should be no exception and the files open and display without error.
I will add a new config for the sample files from the imagesc thread.