### PR TITLE
PCI: Make use of magnification value when calculating physical size

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -208,6 +208,7 @@ public class PCIReader extends FormatReader {
     initPOIService();
 
     double scaleFactor = 1;
+    double magnification = 1;
 
     final List<String> allFiles = poi.getDocumentList();
     if (allFiles.isEmpty()) {
@@ -329,6 +330,13 @@ public class PCIReader extends FormatReader {
                     }
                     scaleFactor = Double.parseDouble(value.trim());
                   }
+
+                  if (key.equals("magnification")) {
+                    if (value.indexOf(';') != -1) {
+                      value = value.substring(0, value.indexOf(';'));
+                    }
+                    magnification = Double.parseDouble(value.trim());
+                  }
                 }
               }
             }
@@ -399,8 +407,8 @@ public class PCIReader extends FormatReader {
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor);
-      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor);
+      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor * magnification);
+      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor * magnification);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import loci.common.Constants;
+import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -328,14 +329,14 @@ public class PCIReader extends FormatReader {
                     if (value.indexOf(';') != -1) {
                       value = value.substring(0, value.indexOf(';'));
                     }
-                    scaleFactor = Double.parseDouble(value.trim());
+                    scaleFactor = DataTools.parseDouble(value.trim());
                   }
 
                   if (key.equals("magnification")) {
                     if (value.indexOf(';') != -1) {
                       value = value.substring(0, value.indexOf(';'));
                     }
-                    magnification = Double.parseDouble(value.trim());
+                    magnification = DataTools.parseDouble(value.trim());
                   }
                 }
               }


### PR DESCRIPTION
This PR is in response to an issue raised on the forum thread https://forum.image.sc/t/calibration-data-of-pixels-in-cxd-file/72023

A sample file has been provided (https://zenodo.org/record/7107758#.Yy2igHbP1dg) which reproduces the issue with Bio-Formats 6.10.1. I will shortly add the sample file to the data repo and open a follow up config PR.