### PR TITLE
DICOM: fix certain types of data with multiple optical paths

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1628,7 +1628,7 @@ public class DicomReader extends SubResolutionFormatReader {
       }
       else {
         // plane is not compressed
-        if (originalX > 0 && originalY > 0) {
+        if (originalX > 0 && originalY > 0 && originalX <= getSizeX() && originalY <= getSizeY()) {
           readPlane(stream, x, y, w, h, 0, originalX, originalY, buf);
         }
         else {


### PR DESCRIPTION
See https://forum.image.sc/t/dicom-folder-to-ometiff/61402/10. Test dataset is in `inbox/imagesc-61402`.

Without this PR, `showinf -nopix -noflat` on any of the files will show a pyramid with 5 resolutions and 12 Z sections. Examining the files with `dcdump` indicates that there should be 12 channels, not 12 Z sections.

`showinf -nopix -noflat` with this PR should correctly detect 12 channels and 1 Z section. Reading any of the resolutions with `showinf -noflat -resolution r` should successfully read all 12 channels, with obvious data in each channel.

Keeping this as a draft for the moment, since I haven't yet checked this against any of our other data.