### PR TITLE
Make logback dependencies optional

### DIFF
--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -72,11 +72,13 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -67,6 +67,7 @@
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
@@ -74,6 +75,7 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->


### PR DESCRIPTION
At runtime, the `ch.qos.logback` classes are only accessed via reflection.

Specifically, the IJStatusEchoer class is used only by ome-common (!) [in a `ReflectedUniverse` block](https://github.com/ome/ome-common-java/blob/v6.0.13/src/main/java/loci/common/DebugTools.java#L160-L182).

It is best practice for libraries not to impose any specific SLF4J binding on downstream consumers.

> Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api.

[Source](https://www.slf4j.org/manual.html#libraries)
