### PR TITLE
PCI: Parse units for physical size

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -347,8 +347,8 @@ public class PCIReader extends FormatReader {
                   if (key.equals("units")) {
                     if (value.indexOf(';') != -1) {
                       value = value.substring(0, value.indexOf(';'));
-                      if (value.toLowerCase().equals("pixels")) {
-                        value = UNITS.PIXEL.toString();
+                      if (value.toLowerCase().trim().equals("pixels")) {
+                        value = UNITS.PIXEL.getSymbol();
                       }
                       try {
                         units = UnitsLengthEnumHandler.getBaseUnit(UnitsLength.fromString(value));

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -48,10 +48,14 @@ import loci.formats.services.POIService;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.TiffParser;
 import ome.xml.model.enums.Binning;
+import ome.xml.model.enums.EnumerationException;
+import ome.xml.model.enums.UnitsLength;
+import ome.xml.model.enums.handlers.UnitsLengthEnumHandler;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
+import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
@@ -210,6 +214,7 @@ public class PCIReader extends FormatReader {
 
     double scaleFactor = 1;
     double magnification = 1;
+    Unit<Length> units = UNITS.MICROMETER;
 
     final List<String> allFiles = poi.getDocumentList();
     if (allFiles.isEmpty()) {
@@ -338,6 +343,20 @@ public class PCIReader extends FormatReader {
                     }
                     magnification = DataTools.parseDouble(value.trim());
                   }
+
+                  if (key.equals("units")) {
+                    if (value.indexOf(';') != -1) {
+                      value = value.substring(0, value.indexOf(';'));
+                      if (value.toLowerCase().equals("pixels")) {
+                        value = UNITS.PIXEL.toString();
+                      }
+                      try {
+                        units = UnitsLengthEnumHandler.getBaseUnit(UnitsLength.fromString(value));
+                      } catch (EnumerationException e) {
+                        LOGGER.info("Failed to parse calibration units", e);
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -408,8 +427,12 @@ public class PCIReader extends FormatReader {
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor * magnification);
-      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor * magnification);
+      
+      if (!units.equals(UNITS.PIXEL)) {
+        scaleFactor *= magnification;
+      }
+      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor, units);
+      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor, units);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -431,8 +431,8 @@ public class PCIReader extends FormatReader {
       if (!units.equals(UNITS.PIXEL)) {
         scaleFactor *= magnification;
       }
-      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor, units);
-      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor, units);
+      Length sizeX = FormatTools.getPhysicalSizeX(scaleFactor);
+      Length sizeY = FormatTools.getPhysicalSizeY(scaleFactor);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);


### PR DESCRIPTION
This is a follow up to the original PR https://github.com/ome/bioformats/pull/3880

Comparing the data repo updates to the equivalent HCImage  data suggests that the magnification value should not be used for physical size when the units are Pixels. https://github.com/openmicroscopy/data_repo_config/pull/539

This may mean further repo updates if there are other datasets with pixel units.