### PR TITLE
QPTIFF: preserve biomarker data in channel name

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -476,6 +476,11 @@ public class VectraReader extends BaseTiffReader {
 
           if (name.equals("Name")) {
             for (int series=0; series<omeImageCount; series++) {
+              store.setChannelFluor(value, series, c);
+            }
+          }
+          else if (name.equals("Biomarker")) {
+            for (int series=0; series<omeImageCount; series++) {
               store.setChannelName(value, series, c);
             }
           }


### PR DESCRIPTION
Backported from a private PR.

If a biomarker is set in the original metadata, it will now be saved as the `Name` on `Channel`. The previous name will be saved as `Fluor` on `Channel`, as this is a better match for what the name attribute actually is.

If no biomarker is present, there should be no change in behavior. This seems to be the more common case, as I don't believe we have any example files in the repo that contain a biomarker. The files used to test the private PR unfortunately can't be shared.