### PR TITLE
switch to new output command

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,14 +42,14 @@ jobs:
         id: get_version
         run: |
           VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Set server
         id: set_server
         run: |
           if [[ ${{ steps.get_version.outputs.version }} =~ 'SNAPSHOT' ]]; then
-            echo ::set-output name=server::'ome.snapshots'
+            echo server='ome.snapshots' >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=server::'ome.staging'
+            echo server='ome.staging' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
         uses: actions/setup-java@v1


### PR DESCRIPTION
Check that the build is green
Background https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 