### PR TITLE
InCell 1000/2000 field count and plane metadata fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -1026,8 +1026,12 @@ public class InCellReader extends FormatReader {
         int z = Integer.parseInt(attributes.getValue("z_index"));
         int c = Integer.parseInt(attributes.getValue("wave_index"));
         int t = Integer.parseInt(attributes.getValue("time_index"));
+        int channels = channelsPerTimepoint.get(t).intValue();
+
         currentImage = t;
-        currentPlane = z * getSizeC() + c;
+        currentPlane = FormatTools.getIndex("XYZCT", getSizeZ(),
+          channels, 1, getSizeZ() * channels, z, c, 0);
+
         int well = currentRow * wellCols + currentCol;
         Image img = imageFiles[well][currentField][currentImage][currentPlane];
         if (img != null) {

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -898,7 +898,7 @@ public class InCellReader extends FormatReader {
           lastImage.max = DataTools.parseDouble(attributes.getValue("max"));
         }
       }
-      else if (qName.equals("offset_point")) {
+      else if (qName.equals("offset_point") || qName.equals("Point")) {
         fieldCount++;
       }
       else if (qName.equals("TimePoint") && doT) {

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -102,6 +102,8 @@ public class Configuration {
   private static final String CHANNEL_NAME = "ChannelName_";
   private static final String EXPOSURE_TIME = "ExposureTime_";
   private static final String EXPOSURE_TIME_UNIT = "ExposureTimeUnit_";
+  private static final String PLANE_EXPOSURE_TIME = "PlaneExposureTime_";
+  private static final String PLANE_EXPOSURE_TIME_UNIT = "PlaneExposureTimeUnit_";
   private static final String EMISSION_WAVELENGTH = "EmissionWavelength_";
   private static final String EMISSION_WAVELENGTH_UNIT = "EmissionWavelengthUnit_";
   private static final String EXCITATION_WAVELENGTH = "ExcitationWavelength_";
@@ -339,6 +341,21 @@ public class Configuration {
     }
     catch (NumberFormatException e) { 
       return null; 
+    }
+  }
+
+  public boolean hasPlaneExposureTime(int plane) {
+    return currentTable.containsKey(PLANE_EXPOSURE_TIME + plane);
+  }
+
+  public Time getPlaneExposureTime(int plane) {
+    String exposure = currentTable.get(PLANE_EXPOSURE_TIME + plane);
+    String exposureUnits = currentTable.get(PLANE_EXPOSURE_TIME_UNIT + plane);
+    try {
+      return exposure == null ? null : FormatTools.getTime(new Double(exposure), exposureUnits);
+    }
+    catch (NumberFormatException e) {
+      return null;
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1136,25 +1136,32 @@ public class FormatReaderTest {
       }
 
       for (int c=0; c<config.getChannelCount(); c++) {
-        if (config.hasExposureTime(c)) {
-          Time exposureTime = config.getExposureTime(c);
+        Time exposureTime = config.getExposureTime(c);
 
-          for (int p=0; p<reader.getImageCount(); p++) {
-            int[] zct = reader.getZCTCoords(p);
-            if (zct[1] == c && p < retrieve.getPlaneCount(i)) {
-              Time planeExposureTime = retrieve.getPlaneExposureTime(i, p);
+        for (int p=0; p<reader.getImageCount(); p++) {
+          int[] zct = reader.getZCTCoords(p);
+          if (zct[1] == c && p < retrieve.getPlaneCount(i)) {
+            Time planeExposureTime = retrieve.getPlaneExposureTime(i, p);
 
-              if (exposureTime == null && planeExposureTime == null) {
-                continue;
-              }
+            // usually, the exposure time will be the same for every plane in a channel
+            // sometimes a particular plane is expected to have a slightly different exposure time
+            // the channel-wide exposure time is checked by default, but a plane-specific time
+            // will be used instead if it is present
+            // plane-specific times are not automatically written to the configuration file
+            if (config.hasPlaneExposureTime(p)) {
+              exposureTime = config.getPlaneExposureTime(p);
+            }
 
-              if (exposureTime == null || planeExposureTime == null ||
-                !exposureTime.equals(planeExposureTime))
-              {
-                result(testName, false, "Series " + i + " plane " + p +
-                  " channel " + c + " (got " + planeExposureTime +
-                  ", expected " + exposureTime + ")");
-              }
+            if (exposureTime == null && planeExposureTime == null) {
+              continue;
+            }
+
+            if (exposureTime == null || planeExposureTime == null ||
+              !exposureTime.equals(planeExposureTime))
+            {
+              result(testName, false, "Series " + i + " plane " + p +
+                " channel " + c + " (got " + planeExposureTime +
+                ", expected " + exposureTime + ")");
             }
           }
         }


### PR DESCRIPTION
Fixes #3895 and https://trello.com/c/gFmUKSp6/362-incell-exposure-times

`showinf -nopix -omexml` on the .xdce file in QA 31270 should show an exception similar to what is noted in #3895. With this PR, the same command should show 8 series, each of which is a field in well A1.

That's almost but not quite correct with respect to what's in the .xdce. The .xdce defines 8 fields, but each field is only present in one of 3 wells (A1, A2, A3). So 8 total series makes sense, but the `Well`/`WellSample` mapping does not. We would need to decide how to best represent sparse fields here - does 24 series (16 of which are blank) make sense instead? Or is it better to have 8 series and ignore the fact that they are 8 distinct fields?

QA 31270 also exposes the exposure time issue noted in https://trello.com/c/gFmUKSp6/362-incell-exposure-times, so the last 2 commits here address that problem as well. This requires some configuration updates, which are in a forthcoming PR.

Opening as draft for now since this requires some discussion around sparse field handling.  