### PR TITLE
LSID validation

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -927,4 +927,27 @@ public final class MetadataTools {
     }
   }
 
+  /**
+   * Get a valid LSID based on a stored ID.
+   * The returned ID is expected to match the "(\S+):(\S+)" pattern.
+   * If the srcID matches this pattern already, it is returned intact.
+   * If the srcID is null or empty, the altID (expected to be the result of
+   * calling createLSID(...)) is returned instead.
+   * If the srcID is not valid but also not empty, then the srcID is appended
+   * to the altID and separated by ":".
+   *
+   * This is mainly intended for use with formats that store metadata in a
+   * structure similar to OME-XML. The ID recorded in the metadata may not be
+   * quite valid, but is worth saving if possible.
+   */
+  public static String sanitizeID(String srcID, String altID) {
+    if (srcID == null || srcID.isEmpty()) {
+      return altID;
+    }
+    if (srcID.indexOf(":") >= 0) {
+      return srcID;
+    }
+    return altID + ":" + srcID;
+  }
+
 }

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -336,6 +336,28 @@ public final class MetadataTools {
   }
 
   /**
+   * Construct a valid LSID based on a stored ID.
+   * The returned ID is expected to match the "(\S+):(\S+)" pattern.
+   * If the srcID matches this pattern already, it is returned intact.
+   * If the srcID is null or empty, this falls back to createLSID(String, int...)
+   * If the srcID is not valid but also not empty, then the srcID is appended
+   * to the return value of createLSID(String, int...) and separated by ":".
+   *
+   * This is mainly intended for use with formats that store metadata in a
+   * structure similar to OME-XML. The ID recorded in the metadata may not be
+   * quite valid, but is worth saving if possible.
+   */
+  public static String createLSID(String srcID, String type, int... indices) {
+    if (srcID == null || srcID.isEmpty()) {
+      return createLSID(type, indices);
+    }
+    if (srcID.startsWith(type + ":") || srcID.startsWith("urn:lsid:")) {
+      return srcID;
+    }
+    return createLSID(type, indices) + ":" + srcID;
+  }
+
+  /**
    * Checks whether the given metadata object has the minimum metadata
    * populated to successfully describe an Image.
    *
@@ -925,29 +947,6 @@ public final class MetadataTools {
     catch (EnumerationException e) {
       throw new FormatException("Pulse creation failed", e);
     }
-  }
-
-  /**
-   * Get a valid LSID based on a stored ID.
-   * The returned ID is expected to match the "(\S+):(\S+)" pattern.
-   * If the srcID matches this pattern already, it is returned intact.
-   * If the srcID is null or empty, the altID (expected to be the result of
-   * calling createLSID(...)) is returned instead.
-   * If the srcID is not valid but also not empty, then the srcID is appended
-   * to the altID and separated by ":".
-   *
-   * This is mainly intended for use with formats that store metadata in a
-   * structure similar to OME-XML. The ID recorded in the metadata may not be
-   * quite valid, but is worth saving if possible.
-   */
-  public static String sanitizeID(String srcID, String altID) {
-    if (srcID == null || srcID.isEmpty()) {
-      return altID;
-    }
-    if (srcID.indexOf(":") >= 0) {
-      return srcID;
-    }
-    return altID + ":" + srcID;
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/FlowSightReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FlowSightReader.java
@@ -257,8 +257,9 @@ public class FlowSightReader extends FormatReader {
         String[] descs = isMask ? maskDescs : channelDescs;
         for (int channel=0; channel < channelCount; channel++) {
           store.setChannelName(descs[channel], series, channel);
-          String cid = MetadataTools.createLSID("Channel", series, channel) + ":";
-          store.setChannelID(cid + channelNames[channel], series, channel);
+          String cid = MetadataTools.createLSID("Channel", series, channel) + ":" + channelNames[channel];
+          cid = MetadataTools.createLSID(cid, "Channel", series, channel);
+          store.setChannelID(cid, series, channel);
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -955,7 +955,8 @@ public abstract class BaseZeissReader extends FormatReader {
           store.setObjectiveNominalMagnification(magnification, 0, 0);
         }
         else if (key.startsWith("Objective ID")) {
-          store.setObjectiveID("Objective:" + value, 0, 0);
+          String objectiveID = MetadataTools.createLSID("Objective:" + value, "Objective", 0, 0);
+          store.setObjectiveID(objectiveID, 0, 0);
           store.setObjectiveCorrection(MetadataTools.getCorrection("Other"), 0, 0);
           store.setObjectiveImmersion(MetadataTools.getImmersion("Other"), 0, 0);
         }

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -1290,7 +1290,7 @@ public class DeltavisionReader extends FormatReader {
             value = value.substring(value.indexOf(' ') + 1);
           }
           if (!value.equals("null")) {
-            String objectiveID = "Objective:" + value;
+            String objectiveID = MetadataTools.createLSID("Objective:" + value, "Objective", 0, 0);
             store.setObjectiveID(objectiveID, 0, 0);
             for (int series=0; series<getSeriesCount(); series++) {
               store.setObjectiveSettingsID(objectiveID, series);
@@ -3089,7 +3089,7 @@ public class DeltavisionReader extends FormatReader {
           lensID);
     }
 
-    String objectiveID = "Objective:" + lensID;
+    String objectiveID = MetadataTools.createLSID("Objective:" + lensID, "Objective", 0, 0);
     store.setObjectiveID(objectiveID, 0, 0);
     for (int series=0; series<getSeriesCount(); series++) {
       store.setObjectiveSettingsID(objectiveID, series);

--- a/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
@@ -36,6 +36,7 @@ import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.PhotoInterp;
@@ -210,20 +211,24 @@ public class IonpathMIBITiffReader extends BaseTiffReader {
     MetadataStore store = makeFilterMetadata();
     int simsIndex = seriesTypes.get("SIMS");
     String instrument = (String) simsDescription.get("mibi.instrument");
-    store.setInstrumentID(formatMetadata("Instrument", instrument), simsIndex);
+    instrument = formatMetadata("Instrument", instrument);
+    store.setInstrumentID(MetadataTools.createLSID(instrument, "Instrument", simsIndex), simsIndex);
     store.setImageDescription((String) simsDescription.get("mibi.description"), simsIndex);
 
     String currentFile = FilenameUtils.getName(this.getCurrentFile());
     for (Map.Entry<String, Integer> entry : seriesTypes.entrySet()) {
       String key = entry.getKey();
       if (key != null) {
-        store.setImageID(formatMetadata("Image", entry.getKey()), entry.getValue());
-        store.setImageName(currentFile + " " + entry.getKey(), entry.getValue());
+        String imageID = formatMetadata("Image", entry.getKey());
+        Integer index = entry.getValue();
+        store.setImageID(MetadataTools.createLSID(imageID, "Image", index), index);
+        store.setImageName(currentFile + " " + entry.getKey(), index);
       }
     }
 
     for (int j = 0; j < channelIDs.size(); j++) {
-      store.setChannelID(formatMetadata("Channel", channelIDs.get(j)), simsIndex, j);
+      String channel = formatMetadata("Channel", channelIDs.get(j));
+      store.setChannelID(MetadataTools.createLSID(channel, "Channel", simsIndex, j), simsIndex, j);
       if (channelNames.get(j) != null) {
         store.setChannelName(formatMetadata("Target", channelNames.get(j)), simsIndex, j);
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2706,7 +2706,10 @@ public class ZeissCZIReader extends FormatReader {
             getFirstNodeValue(manufacturerNode, "SerialNumber");
           String lotNumber = getFirstNodeValue(manufacturerNode, "LotNumber");
 
-          store.setDichroicID(dichroic.getAttribute("Id"), 0, i);
+          String dichroicID = dichroic.getAttribute("Id");
+          dichroicID = MetadataTools.sanitizeID(dichroicID, MetadataTools.createLSID("Dichroic", 0, i));
+
+          store.setDichroicID(dichroicID, 0, i);
           store.setDichroicManufacturer(manufacturer, 0, i);
           store.setDichroicModel(model, 0, i);
           store.setDichroicSerialNumber(serialNumber, 0, i);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2707,7 +2707,7 @@ public class ZeissCZIReader extends FormatReader {
           String lotNumber = getFirstNodeValue(manufacturerNode, "LotNumber");
 
           String dichroicID = dichroic.getAttribute("Id");
-          dichroicID = MetadataTools.sanitizeID(dichroicID, MetadataTools.createLSID("Dichroic", 0, i));
+          dichroicID = MetadataTools.createLSID(dichroicID, "Dichroic", 0, i);
 
           store.setDichroicID(dichroicID, 0, i);
           store.setDichroicManufacturer(manufacturer, 0, i);


### PR DESCRIPTION
Backported from a private PR.

This is intended to make it easier to set valid IDs when the file format's metadata provides an ID that might be usable. This won't apply to most formats, but Zeiss CZI (as demonstrated here) and a few other readers that store OME-XML-like metadata could use this feature.

The new `MetadataTools.createLSID(String, String, int...)` signature checks the ID stored in the file's metadata and returns it if it matches the expectations of https://github.com/ome/ome-model/blob/46a69d3b3478997c80fb4c4928624494bf54f371/specification/src/main/resources/released-schema/2016-06/ome.xsd#L3248-L3252. Otherwise, it delegates to the original `MetadataTools.createLSID(String, int...)` signature to create a new ID.

The .czi file that prompted this change is private, but the Dichroic ID stored in the file was `BeamsplitterLsm.2412-296`. Without this change, `showinf -nopix -omexml` showed OME-XML validation errors. With this change, there were no more validation errors as the Dichroic ID was set to `Dichroic:0:0:BeamsplitterLsm.2412-296` in the OME-XML.