### PR TITLE
Slidebook7: Remove nested inner class

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
@@ -510,23 +510,19 @@ public class SlideBook7Reader  extends FormatReader {
             File[] theDirectories = new File(theRootDirectory).listFiles(new FileFilter() {
                 @Override
                 public boolean accept(File file) {
-                    if(!file.isDirectory()) return false;
-                    String theDir = file.getAbsolutePath();
-                    if(!theDir.endsWith(kImageDirSuffix)) return false;
-                    // check if directroy is empty - no ImageRecord.yaml file or binary files
-                    File theImgRecFile = new File(theDir + File.separator + kImageRecordFilename);
-                    if(!theImgRecFile.exists()) return false;
-                    File [] theFiles = new File(theDir).listFiles(new FileFilter() {
-                        @Override
-                        public boolean accept(File file) {
-                            String thePath = file.getAbsolutePath();
-                            if(thePath.endsWith(kBinaryFileSuffix)) return true;
-                            else return false;
-                        }
-                    });
-                    if(theFiles.length == 0) return false;
-                    return true;
-                }
+                  if(!file.isDirectory()) return false;
+                  String theDir = file.getAbsolutePath();
+                  if(!theDir.endsWith(kImageDirSuffix)) return false;
+                  // check if directroy is empty - no ImageRecord.yaml file or binary files
+                  File theImgRecFile = new File(theDir + File.separator + kImageRecordFilename);
+                  if(!theImgRecFile.exists()) return false;
+                  File [] theFiles = new File(theDir).listFiles();
+                  for (File innerFile: theFiles) {
+                    String thePath = innerFile.getAbsolutePath();
+                    if(thePath.endsWith(kBinaryFileSuffix)) return true;
+                  }
+                  return false;
+              }
             });
             String []theTitles = new String[theDirectories.length];
             for(int theDir=0;theDir<theDirectories.length;theDir++)


### PR DESCRIPTION
This is an attempt to fix the issue raised in https://github.com/ome/bioformats/issues/3903

From the Fortinet error report it shows the error within `SlideBook7Reader$CSBFile70$1$1.class` which suggests that the issue was within the second anonymous  inner class within CSBFile70. The second nested `FileFilter` looks to be easily removed and results in the jar passing all of the security checks.

To test:
- Ensure builds and tests continue to pass
- Without this PR the compiled `formats-bsd` jar should fail the Fortinet check in https://www.virustotal.com/gui/home/upload
- With this PR the jar should pass all of the virustotal checks

Fixes #3903