### PR TITLE
Operetta/Harmony: ignore any 32-bit TIFF files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -241,7 +241,11 @@ public class OperettaReader extends FormatReader {
           return buf;
         }
 
-        if (reader.getSizeX() >= getSizeX() && reader.getSizeY() >= getSizeY()) {
+        if (reader.getPixelType() != getPixelType()) {
+          throw new FormatException("Pixel type mismatch in " + p.filename +
+            " (got " + FormatTools.getPixelTypeString(reader.getPixelType()) + ")");
+        }
+        else if (reader.getSizeX() >= getSizeX() && reader.getSizeY() >= getSizeY()) {
           reader.openBytes(0, buf, x, y, w, h);
         }
         else {

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -512,7 +512,12 @@ public class OperettaReader extends FormatReader {
               parser.setDoCaching(false);
 
               IFD firstIFD = parser.getFirstIFD();
-              if (firstIFD != null) {
+
+              // ignore any files with a 32-bit pixel type
+              // we expect valid files to be uint16
+              // as noted in openBytes above, uint32 data should be ignored because
+              // it indicates a failure to process images with bright spots
+              if (firstIFD != null && firstIFD.getPixelType() != FormatTools.UINT32) {
                 ms.littleEndian = firstIFD.isLittleEndian();
                 ms.pixelType = firstIFD.getPixelType();
                 validFile = true;


### PR DESCRIPTION
Backported from a private PR.

Some Operetta/Harmony/etc. plates will have one or more 32-bit TIFF files essentially at random. These are not recorded as being any different in the `Index.idx.xml` file. We have been told that these files contain invalid data (even if it "looks OK"), so a blank plane (all 0s) should be returned in place of the 32-bit data.

An artificial example is being uploaded to `curated/perkinelmer-operetta/samples/32-bit-file` (see the readme for how it was created). Without this PR, `showinf -series 2 Index.idx.xml` should throw an exception during `openBytes`. With this PR, the same command should show a warning to indicate that one of the files is 32-bit, but should not throw an exception. The first plane in the series should be all 0s.

Additional reports of this issue are in https://forum.image.sc/t/post-processing-of-plates-in-omero/53700.

I would expect this to be safe for a patch release (assuming tests pass), but am assigning to 6.12.0 so as not to overload 6.11.1.