### PR TITLE
Fake: if there are RGB channels, dimension order needs to be XYC*

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -778,6 +778,20 @@ public class FakeReader extends FormatReader {
         sizeC + "/" + rgb);
     }
     MetadataTools.getDimensionOrder(dimOrder);
+
+    if (rgb > 1 && !dimOrder.startsWith("XYC")) {
+      String newDimOrder = "XYC";
+      if (dimOrder.indexOf("Z") < dimOrder.indexOf("T")) {
+        newDimOrder += "ZT";
+      }
+      else {
+        newDimOrder += "TZ";
+      }
+      LOGGER.warn("Dimension order {} incorrect for rgb={}; corrected to {}",
+        dimOrder, rgb, newDimOrder);
+      dimOrder = newDimOrder;
+    }
+
     if (falseColor && !indexed) {
       throw new FormatException("False color images must be indexed");
     }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -696,4 +696,30 @@ public class FakeReaderTest {
     assertEquals(reader.getResolutionCount(), 1);
   }
 
+  @Test
+  public void testValidDimensionOrders() throws Exception {
+    // check defaults are as expected for RGB and non-RGB data
+    reader.setId("test&sizeC=3&rgb=3.fake");
+    assertEquals(reader.getDimensionOrder(), "XYCZT");
+    reader.setId("test&sizeC=3&rgb=1.fake");
+    assertEquals(reader.getDimensionOrder(), "XYZCT");
+
+    // check that the provided dimension order is unchanged for non-RGB data
+    reader.setId("test&dimOrder=XYZTC.fake");
+    assertEquals(reader.getDimensionOrder(), "XYZTC");
+
+    // check that the provided dimension order is unchanged if valid for RGB data
+    reader.setId("test&sizeC=3&rgb=3&dimOrder=XYCTZ.fake");
+    assertEquals(reader.getDimensionOrder(), "XYCTZ");
+
+    // check that the dimension order is changed if not valid for RGB data
+    reader.setId("test&sizeC=3&rgb=3&dimOrder=XYZTC.fake");
+    assertEquals(reader.getDimensionOrder(), "XYCZT");
+  }
+
+  @Test(expectedExceptions={FormatException.class})
+  public void testInvalidDimensionOrder() throws Exception {
+    reader.setId("test&dimOrder=CXYZT.fake");
+  }
+
 }


### PR DESCRIPTION
Noticed while working on tests for https://github.com/glencoesoftware/raw2ometiff/pull/90

The default dimension order is `XYZCT`, independent of whether or not there are RGB channels. Without this PR, a simple test such as `showinf "test&sizeC=3&rgb=3&sizeZ=5.fake"` shows 3 channels merged to RGB planes, with a dimension order of `XYZCT`. This is inconsistent with how other readers report RGB data; `C` should be immediately after `XY`.

With this PR, the same test should show that the dimension order is `XYCZT`. A warning should also be logged to indicate that the default dimension order is being changed.

I think I'd be OK with just warning (or throwing an exception?) if that sounds better than trying to change the dimension order. The workaround is to explicitly specify the correct dimension order using the `dimOrder` key.

Low priority and should be safe for a patch release; assigning to 6.12.0 for initial review, but fine to push to a later milestone.