### PR TITLE
Upload one set of artifacts from the GitHub Actions ant build

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,9 +18,10 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Ant
         run: ./tools/test-build ant
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifacts
         # upload just one set of artifacts for easier PR review
-        if: ${{ matrix.java }} == 1.8 && ${{ matrix.os }} == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
+        uses: actions/upload-artifact@v3
         with:
           path: artifacts/
           retention-days: 30

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,3 +18,9 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Ant
         run: ./tools/test-build ant
+      - uses: actions/upload-artifact@v3
+        # upload just one set of artifacts for easier PR review
+        if: ${{ matrix.java }} == 1.8 && ${{ matrix.os }} == "ubuntu-latest"
+        with:
+          path: artifacts/
+          retention-days: 30


### PR DESCRIPTION
As discussed with @ome/formats earlier today.

For the Java 1.8/ubuntu-latest ant build only, artifacts should be now be archived, for 30 days only (instead of default 90). Hopefully that's enough to prevent any problems with usage limits.

I did not do anything extra to add commit hashes as suggested in discussions. All of the Bio-Formats builds should already include the commit hash in the `Implementation-Build` of the manifest and the `FormatTools.VCS_REVISION` variable. Using the `bioformats_package.jar` archived here with ImageJ (`Help > About Plugins > Bio-Formats Plugins...`), `showinf -version`, or `java -jar bioformats_package.jar` and then `Help > About...` should all show the 938eca1... commit hash.