### PR TITLE
Fix min/max calculation for RGB data

### DIFF
--- a/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
+++ b/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
@@ -268,7 +268,7 @@ public class MinMaxCalculator extends ReaderWrapper {
     FormatTools.assertId(getCurrentFile(), true, 2);
     super.openBytes(no, buf, x, y, w, h);
     
-    updateMinMax(no, buf, FormatTools.getBytesPerPixel(getPixelType()) * w * h);
+    updateMinMax(no, buf, FormatTools.getBytesPerPixel(getPixelType()) * w * h * getRGBChannelCount());
     return buf;
   }
 


### PR DESCRIPTION
This fixes an arithmetic error which prevented correct min/max values from being reported for some RGB data. The length supplied to `updateMinMax(...)` is expected to be the total number of bytes, including any RGB channels. `updateMinMax(...)` later performs calculations on the length to determine the number of pixels, which are incorrect if the RGB channels are not included.

Non-RGB data (`getRGBChannelCount() == 1`) is unaffected, so anything that includes `ChannelSeparator` as well as `MinMaxCalculator` in the reader stack should not be impacted by this change.

This issue was exposed during testing of https://github.com/glencoesoftware/raw2ometiff/pull/90. The steps to test are:

- convert `curated/zeiss-zvi/cecilia/*.zvi` with bioformats2raw 0.5.0
- convert the bioformats2raw output with `raw2ometiff --rgb`, using https://github.com/glencoesoftware/raw2ometiff/pull/90
- compare `showinf -autoscale -fast` on the original file and the converted OME-TIFF, without these changes (the two sets of images should be different, and both should look "weird")
- compare `showinf -autoscale -fast` on the original file and the converted OME-TIFF, with these changes (the two sets of images should look the same, and be nicer than before)