### PR TITLE
ICS: image name

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+import java.util.regex.Matcher;
 
 import loci.common.DateTools;
 import loci.common.Location;
@@ -597,7 +598,7 @@ public class ImagePlusReader implements StatusReporter {
     if (imageName == null) imageName = "Series" + series;
     filename = sliceLabelPattern;
     
-    filename = filename.replaceAll(FormatTools.SERIES_NUM, String.format("%d", series));
+    filename = filename.replaceAll(FormatTools.SERIES_NUM, Matcher.quoteReplacement(String.format("%d", series)));
     filename = filename.replaceAll(FormatTools.SERIES_NAME, imageName);
     if (sizeC > 1) {
       int[] subC;

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -32,6 +32,7 @@
 
 package loci.formats.in;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1477,7 +1478,7 @@ public class ICSReader extends FormatReader {
     MetadataTools.populatePixels(store, this, true);
 
     // populate Image data
-
+    imageName = imageName.substring(imageName.lastIndexOf(File.separator) + 1);
     store.setImageName(imageName, 0);
 
     if (date != null) store.setImageAcquisitionDate(new Timestamp(date), 0);


### PR DESCRIPTION
PR is an attempt to resolve an issue raised on forum thread https://forum.image.sc/t/issue-with-bio-formats-and-ics-ids/74494

In the report the user has filepaths containing the $ char. For the ICS format this full file path is used as the Image Name. 
When attempting to open these files in FIJI with the `%n` pattern in the slice label configuration an error is thrown as below. This is due to the Java String replaceAll recognising the $ char in the filename as a special character.

```
java.lang.IllegalArgumentException: Illegal group reference
	at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
	at java.util.regex.Matcher.replaceAll(Matcher.java:955)
	at java.lang.String.replaceAll(String.java:2223)
	at loci.plugins.in.ImagePlusReader.constructSliceLabel(ImagePlusReader.java:601)
	at loci.plugins.in.ImagePlusReader.readPlanes(ImagePlusReader.java:392)
	at loci.plugins.in.ImagePlusReader.readImage(ImagePlusReader.java:282)
	at loci.plugins.in.ImagePlusReader.readImages(ImagePlusReader.java:243)
	at loci.plugins.in.ImagePlusReader.readImages(ImagePlusReader.java:221)
	at loci.plugins.in.ImagePlusReader.openImagePlus(ImagePlusReader.java:116)
	at loci.plugins.in.Importer.readPixels(Importer.java:149)
	at loci.plugins.in.Importer.run(Importer.java:86)
	at loci.plugins.LociImporter.run(LociImporter.java:78) 
```

I have included 2 potential fixes for the issue in this PR, with the option of implementing one or potentially both.
- A fix in the ICS reader to remove the full path from the Image Name in favour of the shorter filename
- Update the plugin to use quoteReplacement when constructing the slice label and avoid the issue with special chars