### PR TITLE
Fixes Null Pointer Exception in case no plane is present in OperettaReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -438,6 +438,9 @@ public class OperettaReader extends FormatReader {
                 String key = rows[row]+":"+cols[col]+":"+fields[field]+":"+cs[c]+":"+zs[z]+":"+ts[t];
                 if (hashToPlane.containsKey(key)) {
                   planes[nextSeries][nextPlane] = hashToPlane.get(key);
+                } else {
+                  LOGGER.warn("No plane found for key {}",key);
+                  planes[nextSeries][nextPlane] = new Plane();
                 }
                 nextPlane++;
               }


### PR DESCRIPTION
Using this xml file: https://drive.google.com/file/d/1JTfk48qBCQQdb5_jIrZzLKLfPjFt_C7r/view?usp=share_link
the Operetta Reader creates a null pointer exception on the line:

filename = planes[i][planeIndex].filename;

This PR fixes the issue by creating an empty plane. 

Maybe this bug was introduced with my previous PR on Operetta performance improvement (can't find the previous PR link, sorry)

