### PR TITLE
Olympus .vsi: only read pixels from frame_*.ets files

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2010,7 +2010,15 @@ public class FormatReaderTest {
           {
             continue;
           }
-          
+
+          // .vsi datasets can only be detected with .vsi and frame*.ets
+          if (reader.getFormat().equals("CellSens VSI") &&
+            ((!base[i].toLowerCase().endsWith(".vsi") && !base[i].toLowerCase().endsWith(".ets")) ||
+            (base[i].toLowerCase().endsWith(".ets") && !base[i].toLowerCase().startsWith("frame"))))
+          {
+            continue;
+          }
+
           // XLef datasets not detected from xlif/lof file
           if (reader.getFormat().equals("Extended leica file") &&
             (base[i].toLowerCase().endsWith("xlif") || base[i].toLowerCase().endsWith("lof") 
@@ -2801,7 +2809,15 @@ public class FormatReaderTest {
             {
               continue;
             }
-            
+
+            // .vsi data can only be detected from .vsi and frame*.ets
+            if (!result && r instanceof CellSensReader &&
+              ((!used[i].endsWith(".vsi") && !used[i].endsWith(".ets")) ||
+              (used[i].endsWith(".ets") && !used[i].startsWith("frame"))))
+            {
+              continue;
+            }
+
             // XLEF data can only be detected from xlef file
             if (!result && readers[j] instanceof XLEFReader &&
                 (used[i].endsWith(".xlif") || used[i].endsWith(".xlcf") ||


### PR DESCRIPTION
Backported from a private PR. This is expected to fix #3859.

~`inbox/gh-3859`~`curated/cellsens/gh-3859` can be used to test. I may have additional test datasets, but am waiting for confirmation that they can be shared.

Without this change, `showinf -nopix -noflat` on the .vsi file should throw an exception. With this change, usual `showinf` commands, opening in ImageJ, etc. should display images and metadata without error. The `blob*.ets` and `blob*.meta` files should be included at the end of the used files list.

I would expect this to impact memo files, so requires a minor release.