### PR TITLE
VSI: respect tile origin metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -530,11 +530,22 @@ public class CellSensReader extends FormatReader {
         getRGBChannelCount() * FormatTools.getBytesPerPixel(getPixelType());
       int outputRowLen = w * pixel;
 
+      Pyramid pyramid = getCurrentPyramid();
+
       for (int row=0; row<tileRows; row++) {
         for (int col=0; col<tileCols; col++) {
           int width = tileX.get(getCoreIndex());
           int height = tileY.get(getCoreIndex());
           Region tile = new Region(col * width, row * height, width, height);
+
+          // the pixel data in the stored tiles may be larger than the defined image size
+          // the "tile origin" information indicates how to crop the pixel data
+          if (pyramid.tileOriginX != null && pyramid.tileOriginY != null) {
+            int resScale = (int) Math.pow(2, getResolutionIndex());
+            tile.x += (pyramid.tileOriginX / resScale);
+            tile.y += (pyramid.tileOriginY / resScale);
+          }
+
           if (!tile.intersects(image)) {
             continue;
           }
@@ -974,6 +985,9 @@ public class CellSensReader extends FormatReader {
 
   // -- Helper methods --
 
+  /**
+   * Get the expected decompressed size of a single tile, in bytes.
+   */
   private int getTileSize() {
     int channels = getRGBChannelCount();
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
@@ -981,18 +995,12 @@ public class CellSensReader extends FormatReader {
     return bpp * channels * tileX.get(index) * tileY.get(index);
   }
 
-  private byte[] decodeTile(int no, int row, int col)
-    throws FormatException, IOException
-  {
-    if (tileMap.get(getCoreIndex()) == null) {
-      return new byte[getTileSize()];
-    }
-
-    int[] zct = getZCTCoords(no);
-    TileCoordinate t = new TileCoordinate(nDimensions.get(getCoreIndex()));
-    t.coordinate[0] = col;
-    t.coordinate[1] = row;
-
+  /**
+   * Get an object representing the pyramid which contains the
+   * current series/resolution. Accounts for flattened resolutions
+   * as needed.
+   */
+  private Pyramid getCurrentPyramid() {
     int resIndex = getResolution();
     int pyramidIndex = getSeries();
     if (hasFlattenedResolutions()) {
@@ -1011,7 +1019,46 @@ public class CellSensReader extends FormatReader {
       }
     }
 
-    Pyramid pyramid = pyramids.get(pyramidIndex);
+    return pyramids.get(pyramidIndex);
+  }
+
+  /**
+   * Get the current pyramid resolution, accounting for flattened resolutions
+   * as needed.
+   */
+  private int getResolutionIndex() {
+    int resIndex = getResolution();
+    if (hasFlattenedResolutions()) {
+      int index = 0;
+      for (int i=0; i<core.size(); ) {
+        if (index + core.get(i).resolutionCount <= getSeries()) {
+          index += core.get(i).resolutionCount;
+          i += core.get(i).resolutionCount;
+        }
+        else {
+          resIndex = getSeries() - index;
+          break;
+        }
+      }
+    }
+    return resIndex;
+  }
+
+  private byte[] decodeTile(int no, int row, int col)
+    throws FormatException, IOException
+  {
+    if (tileMap.get(getCoreIndex()) == null) {
+      return new byte[getTileSize()];
+    }
+
+    int[] zct = getZCTCoords(no);
+    TileCoordinate t = new TileCoordinate(nDimensions.get(getCoreIndex()));
+    t.coordinate[0] = col;
+    t.coordinate[1] = row;
+
+    int resIndex = getResolutionIndex();
+    Pyramid pyramid = getCurrentPyramid();
+
     for (String dim : pyramid.dimensionOrdering.keySet()) {
       int index = pyramid.dimensionOrdering.get(dim) + 2;
 
@@ -1062,7 +1109,6 @@ public class CellSensReader extends FormatReader {
       }
       options.maxBytes = (int) (offset + tileSize);
 
-      
       long end = index < tileOffsets.get(getCoreIndex()).length - 1 ?
         tileOffsets.get(getCoreIndex())[index + 1] : ets.length();
 
@@ -1657,6 +1703,12 @@ public class CellSensReader extends FormatReader {
                   if (pyramid != null && pyramid.width == null) {
                     pyramid.width = intValues[2];
                     pyramid.height = intValues[3];
+                  }
+                }
+                else if (tag == TILE_ORIGIN) {
+                  if (pyramid != null) {
+                    pyramid.tileOriginX = intValues[0];
+                    pyramid.tileOriginY = intValues[1];
                   }
                 }
                 break;
@@ -2476,6 +2528,8 @@ public class CellSensReader extends FormatReader {
 
     public Integer width;
     public Integer height;
+    public Integer tileOriginX;
+    public Integer tileOriginY;
     public Double originX;
     public Double originY;
     public Double physicalSizeX;


### PR DESCRIPTION
Fixes #3822.

Without this PR, opening the .vsi file in `curated/cellsens/gh-3822` in QuPath or ImageJ vs. Olympus' OlyVIA shows a subtle difference between the left and right edges, as noted in the initial issue report. The associated .jp2 file visually approximates what OlyVIA shows, but cannot be used for quantitative comparison as it has a different pixel type and channel count.

With this PR, opening the largest resolution from the .vsi file in ImageJ or similar should show that the image is now shifted 34 pixels in X and 1 pixel in Y, matching what OlyVIA shows. This is easiest to see when zooming in on the corners of the image.
The pixel shift is scaled with the resolution index, so opening smaller resolutions should also show a slight difference with this PR. 

This requires a minor release, as additional fields are added to the `Pyramid` inner class (which I expect will break memo files). Assigning to 6.12.0 for now, but can but can push to the next non-patch release as needed.