### PR TITLE
CZI: tile stitching fixes when pyramid does not exist

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -877,10 +877,12 @@ public class ZeissCZIReader extends FormatReader {
         int newY = lastPlane.y;
         if (allowAutostitching() && (ms0.sizeX < newX || ms0.sizeY < newY)) {
           prestitched = true;
-          mosaics = 1;
+          if (maxResolution > 0) {
+            mosaics = 1;
+          }
         }
         else {
-          prestitched = maxResolution > 0;
+          prestitched = true;
         }
 
         // don't shrink the dimensions if prestitching is allowed


### PR DESCRIPTION
Fixes #3710.

See test files in `curated/zeiss-czi/gh-3710`.

Without this PR, `showinf` should report several small series corresponding to individual tiles in a larger image. In some cases, viewing the tiles will show a skewed image.

 With this PR, the tiles should be correctly stitched together into a single series which no longer looks skewed. Screenshots from ZEN for comparison are on the corresponding configuration PR.

I would expect one existing file to be affected by this, as noted in the configuration PR. I believe the previous handling of that file was incorrect, and this PR fixes it. Otherwise, I would not expect this to introduce test failures.

This should be safe for a patch release, so assigning to 6.12.1 for now since it isn't especially urgent and there is already a lot in 6.12.0.