### PR TITLE
Bio-Rad Gel: fix pixel data offsets for cropped images

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
@@ -100,11 +100,20 @@ public class BioRadGelReader extends FormatReader {
       else if (in.length() - planeSize > 61000) {
         in.seek(PIXEL_OFFSET - 196);
 
-        while (!in.readString(3).equals("scn")) {
-          in.seek(in.getFilePointer() - 2);
+        while (!in.readString(5).equals("scn0x")) {
+          in.seek(in.getFilePointer() - 4);
         }
 
-        in.skipBytes(91);
+        in.skipBytes(69);
+
+        // check byte indicates presence of additional metadata
+        // possibly specific to cropped images?
+        int check = in.read();
+        in.skipBytes(19);
+        if (check != 0) {
+          in.skipBytes(in.readShort() - 2);
+        }
+
         int len = in.readShort();
         in.skipBytes(len);
         in.skipBytes(32);


### PR DESCRIPTION
Fixes #3603.

To test, use `bad*.1sc` files in `curated/biorad-gel/qa-294*`. Without this PR, each should be shifted and have noise at the top and/or bottom of the image. This is easiest to see when opening in ImageJ.

With this PR, each of the `*.1sc` files should look correct - no shifting or obviously wrong pixels along the edges. `showinf -minmax -autoscale -fast` with this PR should also show a reasonable image, since the max pixel value is no longer at the upper end of the range.

Should be fine for a patch release, so assigning to 6.12.1 for now. I would not expect this to cause any test failures. 