### PR TITLE
Bump ome-model version to 6.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.0.13</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.3.1</ome-model.version>
+    <ome-model.version>6.3.2</ome-model.version>
     <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>


### PR DESCRIPTION
Bumping ome-model to the latest 6.3.2 release