### PR TITLE
ND2: fix reading of blocks larger than 2 GB

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -252,7 +252,7 @@ public class FormatReaderTest {
         }
 
         if (c > 4 || plane < 0 || plane != checkPlane ||
-          !TestTools.canFitInMemory(plane * 3))
+          !TestTools.canFitInMemory(checkPlane * 3))
         {
           continue;
         }
@@ -322,7 +322,7 @@ public class FormatReaderTest {
           continue;
         }
 
-        if (!TestTools.canFitInMemory(expected * 3) || expected < 0) {
+        if (!TestTools.canFitInMemory((long) expected * 3) || expected < 0) {
           continue;
         }
 


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/issues/184

To test, use the provided test file, which is copied to `curated/nd2/bioformats2raw-184`. Without this PR, `showinf -nopix` should throw `NegativeArraySizeException` eventually. Adding `-option nativend2.chunkmap false` results in the same exception.

With this PR, `showinf -nopix` should initialize without exception, though it may be a little slow. Reading tiles from the image should result in reasonable looking images. I was not able to open the full image in Nikon's NIS Elements viewer for comparison, but can view a thumbnail and the basic metadata (a screenshot is included in the configuration PR).

The source of the problem was the `CustomDataSeq|edfbox_d` block, which has a data length greater than 2GB. I would expect files which do not have a data block larger than 2GB (including files smaller than 2GB) to be unaffected.

Assuming tests pass, this should be safe for a patch release. Assigning to 6.12.1 for initial review.