### PR TITLE
Release artifacts

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -17,4 +17,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Ant
-        run: ./tools/test-build ant
+        run: |
+            ./tools/test-build ant
+            ant docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: "Build and push artifacts"
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Release artifacts
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: 'zulu'
+      - name: Build artifacts
+        run: |
+          ./tools/test-build ant
+          ant release docs
+      - name: Create a release and upload Release Assets
+        run: |
+          cd artifacts
+          sha256sum ./*.zip >> SHASUMS
+          sha256sum ./*.jar >> SHASUMS
+          sha256sum ./*.xz >> SHASUMS
+          sha256sum ./*.gz >> SHASUMS
+          tag_name="${GITHUB_REF##*/}"
+          gh release create "$tag_name" ./*.zip ./*.jar ./*.xz ./*.gz SHASUMS
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -6,15 +6,26 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="bioformats_package" default="bundle" basedir=".">
+<project name="bioformats_package" default="bundle" basedir="."  xmlns:resolver="antlib:org.apache.maven.resolver.ant">
   <description>Build file for Bio-Formats bundle</description>
   <property name="root.dir" location="../../.."/>
-  <import file="${root.dir}/ant/java.xml"/>
+  <import file="${root.dir}/ant/java.xml" />
   <property file="build.properties"/>
+
 
   <target name="docs" depends="javadoc-properties"
     description="generate the Javadocs for most components">
     <echo>----------=========== Javadocs ===========----------</echo>
+    <path id="compile.classpath"/>
+    <path id="runtime.classpath"/>
+
+    <resolver:resolve>
+      <dependencies>
+        <pom refid="pom"/>
+      </dependencies>
+      <path refid="compile.classpath" classpath="compile"/>
+      <path refid="runtime.classpath" classpath="runtime"/>
+    </resolver:resolve>
     <tstamp>
       <format property="YEAR" pattern="yyyy"/>
     </tstamp>


### PR DESCRIPTION
This PR creates and uploads the release artifacts when a tag is pushed
4b1f6859f76cae9feb4865b66c19cb487699b903 is needed since the reference ``compile/runtime.classpath`` is no longer found when ant 1.10 is used (that's the version installed via GHA). Open to alternative is someone knows one

Tested via https://github.com/jburel/bioformats/releases/tag/v6.11.1-m1