### PR TITLE
ImagePlusReader: handle IndexColorModel

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -34,6 +34,7 @@ import ij.process.ImageProcessor;
 import ij.process.LUT;
 
 import java.awt.image.ColorModel;
+import java.awt.image.IndexColorModel;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -198,6 +199,13 @@ public class ImagePlusReader implements StatusReporter {
         if (cm instanceof LUT) {
           // plane has custom LUT attached; save it to the list
           final LUT lut = (LUT) cm;
+          luts.add(lut);
+          // discard custom LUT from ImageProcessor
+          ip.setColorModel(ip.getDefaultColorModel());
+        }
+        else if (cm instanceof IndexColorModel) {
+          // plane has custom LUT attached; save it to the list
+          final LUT lut = new LUT((IndexColorModel) cm,0,0);
           luts.add(lut);
           // discard custom LUT from ImageProcessor
           ip.setColorModel(ip.getDefaultColorModel());


### PR DESCRIPTION
This is a follow up to forum thread https://forum.image.sc/t/bio-formats-color-wrong-for-imagej-images/76021/7 and existing issue https://github.com/ome/bioformats/issues/3730

The GitHub Issue has a comment with further details on the need to handle IndexColorModel alonside LUT: https://github.com/ome/bioformats/issues/3730#issuecomment-1387258241

This was a quick initial test fix and will require further testing and work before it is ready for review.

Fixes #3730