### PR TITLE
Fix NPEs when a no-op file pattern is encountered

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -205,7 +205,7 @@ public class FileStitcher extends ReaderWrapper {
    */
   public int[] getAxisTypes() {
     FormatTools.assertId(getCurrentFile(), true, 2);
-    return externals[getExternalSeries()].getAxisGuesser().getAxisTypes();
+    return getAxisGuesser().getAxisTypes();
   }
 
   /**
@@ -220,7 +220,7 @@ public class FileStitcher extends ReaderWrapper {
    */
   public void setAxisTypes(int[] axes) throws FormatException {
     FormatTools.assertId(getCurrentFile(), true, 2);
-    externals[getExternalSeries()].getAxisGuesser().setAxisTypes(axes);
+    getAxisGuesser().setAxisTypes(axes);
     computeAxisLengths();
   }
 
@@ -237,6 +237,11 @@ public class FileStitcher extends ReaderWrapper {
    */
   public AxisGuesser getAxisGuesser() {
     FormatTools.assertId(getCurrentFile(), true, 2);
+    if (externals == null) {
+      return new AxisGuesser(getFilePattern(), reader.getDimensionOrder(),
+        reader.getSizeZ(), reader.getSizeT(), reader.getEffectiveSizeC(),
+        reader.isOrderCertain());
+    }
     return externals[getExternalSeries()].getAxisGuesser();
   }
 
@@ -902,10 +907,12 @@ public class FileStitcher extends ReaderWrapper {
   @Override
   public void reopenFile() throws IOException {
     reader.reopenFile();
-    for (ExternalSeries s : externals) {
-      for (DimensionSwapper r : s.getReaders()) {
-        if (r.getCurrentFile() != null) {
-          r.reopenFile();
+    if (externals != null) {
+      for (ExternalSeries s : externals) {
+        for (DimensionSwapper r : s.getReaders()) {
+          if (r.getCurrentFile() != null) {
+            r.reopenFile();
+          }
         }
       }
     }
@@ -959,6 +966,7 @@ public class FileStitcher extends ReaderWrapper {
         reader.setId(fp.getFiles()[0]);
       }
       else reader.setId(id);
+      LOGGER.info("File pattern ignored; {} groups files", reader.getFormat());
       return;
     }
 


### PR DESCRIPTION
Backported from a private PR.

If the helper reader performs file grouping, then `externals` will be null and `noStitch` will be set to `true`. This cleans up a few overlooked places where `externals` was assumed to be non-null. It also logs an `INFO` message if the file pattern is discarded in favor of grouping by the helper reader. We can debate whether this should just be logged, or if throwing an exception is more appropriate.

To test, use `curated/ome-tiff/samples/no-op-file-pattern/multifile.pattern`. Without this PR, run `showinf -nopix multifile.pattern -cache` twice. The first time will succeed, the second time will fail with a `NullPointerException`. With this PR, remove the memo file and perform the same test. Both `showinf` calls should succeed without an exception, and there should be a `File pattern ignored...` message in the output.

This can also be tested without memo files by using the following code:

```
try (ImageReader reader = new ImageReader()) {
  reader.setId("multifile.pattern");
  reader.close(true);
  reader.reopenFile();
}
```

Without this PR, the above should throw an exception; with this PR it should not.