### PR TITLE
OMETiffReader: normalize paths rather than resolving symlinks

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -34,6 +34,7 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -542,14 +543,14 @@ public class OMETiffReader extends SubResolutionFormatReader {
       // overwrite XML with what is in the companion OME-XML file
       Location path = new Location(dir, metadataPath);
       if (path.exists()) {
-        // Since metatadataPath can be relative, use getCanonicalPath()
-        metadataFile = path.getCanonicalPath();
+        // Since metatadataPath can be relative, normalize the path
+        metadataFile = Paths.get(path.toString()).normalize().toString();
         xml = readMetadataFile();
 
         try {
           meta = service.createOMEXMLMetadata(xml);
           // Compute all paths relative to the directory of the metadata file
-          dir = path.getParentFile().getCanonicalPath();
+          dir = path.getParentFile().getAbsolutePath();
           // Set the current ID to the metadata file
           currentId = metadataFile;
         }


### PR DESCRIPTION
Fixes #3853 

`File.getCanonicalPath` normalizes paths containing '.', '..' but also resolves symlinks. This behavior breaks some expectations in terms of containment. This commit makes use of `Path.normalize` to avoid the symlink deferencing

I came back to this issue as part of the testing of #3947 as the sample fileset is constructed on top of an OME-TIFF dataset including a companion file.

Without this PR, after creating a symlink to an OME-TIFF fileset including a companion file (as indicated in the issue), `showinf -nopix` should report different listing of used files depending on whether a TIFF file or the companion are used as the input. With this PR included, the listing should be the same and not resolve to the absolute path if a symlinked file is used.