### PR TITLE
Metamorph: don't try to read metadata keys that don't exist

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2114,6 +2114,9 @@ public class MetamorphReader extends BaseTiffReader {
   private void readPlaneData() throws IOException {
     in.skipBytes(4);
     int keyLength = in.read();
+    if (keyLength < 0 || keyLength >= in.length() - in.getFilePointer()) {
+      return;
+    }
     String key = in.readString(keyLength);
     in.skipBytes(4);
 


### PR DESCRIPTION
Prevents a NegativeArraySizeException (or IOException) if the key length is too small or too large. This is expected when the key/value pair is not actually defined in the file. Fixes #3578.

To test, use the datasets in `curated/metamorph/imagesc-39526`. Without this PR, `showinf -nopix -omexml` on the .nd files should throw a `NegativeArraySizeException` as noted in #3578. With this PR, both files should initialize without error.

Should be safe for any patch release; adding to 6.12.1 for initial review.