### PR TITLE
Metamorph TIFF: prevent NPE on missing stage positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -282,7 +282,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
         xPositions.add(x);
         yPositions.add(y);
       }
-      else {
+      else if (x != null && y != null) {
         final Length previousX = xPositions.get(xPositions.size() - 1);
         final Length previousY = yPositions.get(yPositions.size() - 1);
 


### PR DESCRIPTION
Fixes #3900.

To test, use the file from QA 31304. Without this PR, `showinf` should throw a NullPointerException as noted in #3900. With this PR, `showinf` should display 44 planes.

Based on the images, I'm not entirely convinced that the planes represent 44 timepoints, but `tiffinfo` will confirm that there is very little metadata in this file - definitely not enough to say for sure what the correct ZCT dimensions might be. The metadata suggests this is an export from an Incucyte system, and not "real" Metamorph data.

Adding to 6.13.0 since 6.12.1 has a lot in it already. This should be safe for a patch release though.