### PR TITLE
Memoizer: minor API updates

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -471,7 +471,8 @@ public class Memoizer extends ReaderWrapper {
    *  call to {@link #setId} takes longer than
    *  {@value DEFAULT_MINIMUM_ELAPSED} in milliseconds.
    *
-   *  @param r an {@link IFormatReader} instance
+   *  @param r an {@link IFormatReader} instance.
+   *         If {@code null}, a new {@link ImageReader} is created.
    */
   public Memoizer(IFormatReader r) {
     // setting the directory to null explicitly disables memo files
@@ -488,6 +489,7 @@ public class Memoizer extends ReaderWrapper {
    *  milliseconds.
    *
    *  @param r an {@link IFormatReader} instance
+   *         If {@code null}, a new {@link ImageReader} is created.
    *  @param minimumElapsed a long specifying the number of milliseconds which
    *         must elapse during the call to {@link #setId} before a memo file
    *         will be created.
@@ -507,6 +509,7 @@ public class Memoizer extends ReaderWrapper {
    * {@value DEFAULT_MINIMUM_ELAPSED} in milliseconds.
    *
    * @param r an {@link IFormatReader} instance
+   *        If {@code null}, a new {@link ImageReader} is created.
    * @param directory a {@link File} specifying the directory where all memo
    *        files should be created. If {@code null}, disable memoization.
    */
@@ -521,6 +524,7 @@ public class Memoizer extends ReaderWrapper {
    *  {@code minimumElapsed} in milliseconds.
    *
    *  @param r an {@link IFormatReader} instance
+   *         If {@code null}, a new {@link ImageReader} is created.
    *  @param minimumElapsed a long specifying the number of milliseconds which
    *         must elapse during the call to {@link #setId} before a memo file
    *         will be created.

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -442,6 +442,9 @@ public class Memoizer extends ReaderWrapper {
    *         will be created.
    */
   public Memoizer(long minimumElapsed) {
+    // setting the directory to null explicitly disables memo files
+    // setting doInPlaceCaching allows a memo file to be written to the
+    // original file's directory only - see getMemoFile
     this(null, minimumElapsed, null);
     this.doInPlaceCaching = true;
   }
@@ -471,6 +474,9 @@ public class Memoizer extends ReaderWrapper {
    *  @param r an {@link IFormatReader} instance
    */
   public Memoizer(IFormatReader r) {
+    // setting the directory to null explicitly disables memo files
+    // setting doInPlaceCaching allows a memo file to be written to the
+    // original file's directory only - see getMemoFile
     this(r, DEFAULT_MINIMUM_ELAPSED, null);
     this.doInPlaceCaching = true;
   }
@@ -487,6 +493,9 @@ public class Memoizer extends ReaderWrapper {
    *         will be created.
    */
   public Memoizer(IFormatReader r, long minimumElapsed) {
+    // setting the directory to null explicitly disables memo files
+    // setting doInPlaceCaching allows a memo file to be written to the
+    // original file's directory only - see getMemoFile
     this(r, minimumElapsed, null);
     this.doInPlaceCaching = true;
   }

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -442,13 +442,13 @@ public class Memoizer extends ReaderWrapper {
    *         will be created.
    */
   public Memoizer(long minimumElapsed) {
-    this(minimumElapsed, null);
+    this(null, minimumElapsed, null);
     this.doInPlaceCaching = true;
   }
 
   /**
-   *  Constructs a memoizer around a new {@link ImageReader} creating memo file
-   *  files under the {@code directory} argument including the full path of the
+   *  Constructs a memoizer around a new {@link ImageReader} creating memo files
+   *  under the {@code directory} argument including the full path of the
    *  original file only if the call to {@link #setId} takes longer than
    *  {@code minimumElapsed} in milliseconds.
    *
@@ -459,9 +459,7 @@ public class Memoizer extends ReaderWrapper {
    *         files should be created. If {@code null}, disable memoization.
    */
   public Memoizer(long minimumElapsed, File directory) {
-    super();
-    this.minimumElapsed = minimumElapsed;
-    this.directory = directory;
+    this(null, minimumElapsed, directory);
   }
 
   /**
@@ -473,7 +471,8 @@ public class Memoizer extends ReaderWrapper {
    *  @param r an {@link IFormatReader} instance
    */
   public Memoizer(IFormatReader r) {
-    this(r, DEFAULT_MINIMUM_ELAPSED);
+    this(r, DEFAULT_MINIMUM_ELAPSED, null);
+    this.doInPlaceCaching = true;
   }
 
   /**
@@ -493,6 +492,20 @@ public class Memoizer extends ReaderWrapper {
   }
 
   /**
+   * Constructs a memoizer around the given {@link IFormatReader} creating
+   * memo file under the {@code directory} argument including the full path of the
+   * original file only if the call to {@link #setId} takes longer than
+   * {@value DEFAULT_MINIMUM_ELAPSED} in milliseconds.
+   *
+   * @param r an {@link IFormatReader} instance
+   * @param directory a {@link File} specifying the directory where all memo
+   *        files should be created. If {@code null}, disable memoization.
+   */
+  public Memoizer(IFormatReader r, File directory) {
+    this(r, DEFAULT_MINIMUM_ELAPSED, directory);
+  }
+
+  /**
    *  Constructs a memoizer around the given {@link IFormatReader} creating
    *  memo files under the {@code directory} argument including the full path
    *  of the original file only if the call to {@link #setId} takes longer than
@@ -506,11 +519,15 @@ public class Memoizer extends ReaderWrapper {
    *         files should be created. If {@code null}, disable memoization.
    */
   public Memoizer(IFormatReader r, long minimumElapsed, File directory) {
-    super(r);
+    if (r == null) {
+      reader = new ImageReader();
+    }
+    else {
+      reader = r;
+    }
     this.minimumElapsed = minimumElapsed;
     this.directory = directory;
   }
-
 
   /**
    *  Returns whether the {@link #reader} instance currently active was loaded
@@ -1003,6 +1020,21 @@ public class Memoizer extends ReaderWrapper {
     return rv;
   }
 
+  /**
+   * Force the current memo file to be deleted, if it exists.
+   *
+   * @return true if the delete succeeded
+   */
+  public boolean deleteMemo() {
+    return deleteQuietly(memoFile);
+  }
+
+  /**
+   * @return current memo file (may be null)
+   */
+  public File getMemoFile() {
+    return memoFile;
+  }
 
   /**
    * Return the {@link IFormatReader} instance that is passed in or null if

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -120,8 +120,15 @@ public class MemoizerTest {
     recursiveDeleteOnExit(idDir);
   }
 
+  @Test
   public void testDefaultConstructor() throws Exception {
     Memoizer memoizer = new Memoizer();
+    checkMemoFile(memoizer.getMemoFile(id));
+  }
+
+  @Test
+  public void testNullReader() throws Exception {
+    Memoizer memoizer = new Memoizer(null);
     checkMemoFile(memoizer.getMemoFile(id));
   }
 
@@ -237,6 +244,23 @@ public class MemoizerTest {
     assertTrue(memoizer.isLoadedFromMemo());
     assertFalse(memoizer.isSavedToMemo());
     recursiveDeleteOnExit(newidDir);
+  }
+
+  @Test
+  public void testDeleteMemo() throws Exception {
+    // Create an in-place memo file
+    Memoizer memoizer = new Memoizer(reader, 0);
+    memoizer.setId(id);
+    memoizer.close();
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
+
+    // attempt to delete the memo file, and make sure it's really gone
+    File currentMemoFile = memoizer.getMemoFile();
+    assertTrue(currentMemoFile.exists());
+    boolean success = memoizer.deleteMemo();
+    assertTrue(success);
+    assertFalse(currentMemoFile.exists());
   }
 
   @Test


### PR DESCRIPTION
Fixes #3820.

This allows a null reader to be specified in the constructors, in which case a new `ImageReader` will be wrapped. The memo file can also now be deleted and retrieved from public methods.

Unit tests should cover the new functionality, but can certainly add more tests if I've missed anything.

Requires a minor release due to API additions.