### PR TITLE
Add writer options to preserve the OME Creator attribute

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -53,6 +53,8 @@ import loci.formats.codec.CompressionType;
 import loci.formats.codec.JPEG2000Codec;
 import loci.formats.codec.JPEGCodec;
 import loci.formats.codec.ZlibCodec;
+import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -69,6 +69,8 @@ public class OMEXMLWriter extends FormatWriter {
 
   // -- Fields --
 
+  public static final String CREATOR_KEY = "omexml.preserve_creator";
+
   private List<String> xmlFragments;
   private String currentFragment;
   private OMEXMLService service;
@@ -104,7 +106,13 @@ public class OMEXMLWriter extends FormatWriter {
       service.removeBinData(noBin);
 
       OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) noBin.getRoot();
-      root.setCreator(FormatTools.CREATOR);
+      String creator = root.getCreator();
+      if (!preserveCreator() || creator == null) {
+        if (creator != null) {
+          LOGGER.warn("Overwriting existing Creator attribute: {}", creator);
+        }
+        root.setCreator(FormatTools.CREATOR);
+      }
       xml = service.getOMEXML(noBin);
     }
     catch (DependencyException de) {
@@ -216,6 +224,28 @@ public class OMEXMLWriter extends FormatWriter {
       return new int[] {FormatTools.INT8, FormatTools.UINT8};
     }
     return super.getPixelTypes(codec);
+  }
+
+  // -- OMEXMLWriter-specific methods --
+
+  /**
+   * Get the value of the {@link CREATOR_KEY} option.
+   * This toggles whether or not the OME Creator attribute will be
+   * overwritten with the current Bio-Formats version. For input
+   * data that does not have a Creator attribute defined, this makes
+   * no difference.
+   *
+   * By default, returns false, i.e. the Creator will be overwritten
+   * if it exists.
+   *
+   * @return true if the Creator attribute should be preserved (if it exists)
+   */
+  public boolean preserveCreator() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(CREATOR_KEY, false);
+    }
+    return false;
   }
 
   // -- Helper methods --


### PR DESCRIPTION
By default, the OME-XML and OME-TIFF writers will still set the Creator to FormatTools.CREATOR, even if that means overwriting an existing value.

This is option 1 in #3541.

Not super high priority, but opening for 6.13.0 discussion. If we decide that option 2 in #3541 is better, I can update this PR. There is some duplicate code between the two writers now, but not a great common place to put it (though happy to hear other ideas).