### PR TITLE
push to releases

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ ${{ steps.get_version.outputs.version }} =~ 'SNAPSHOT' ]]; then
             echo server='ome.snapshots' >> $GITHUB_OUTPUT
           else
-            echo server='ome.staging' >> $GITHUB_OUTPUT
+            echo server='ome.releases' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
         uses: actions/setup-java@v3


### PR DESCRIPTION
This PR proposes to change the target on artifactory
This matches the changes introduced in the omero-* repositories e.g. https://github.com/ome/omero-common/blob/master/.github/workflows/gradle.yml#L27
Permissions have been granted to the GitHub user pushing to artifactory
This will remove the manual step 