### PR TITLE
SVS: Remove broken special case path when there is only one (pyramidal) image.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -169,9 +169,6 @@ public class SVSReader extends BaseTiffReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    if (core.size() == 1) {
-      return super.openBytes(no, buf, x, y, w, h);
-    }
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
     if (tiffParser == null) {
       initTiffParser();


### PR DESCRIPTION
Hello. We deidentify some .svs slides using a fork of https://github.com/pearcetm/svs-deidentifier/blob/master/wsideidentifier.py. That code removes the macro and label images from an .svs file. After that removal, the slide does not show correctly in QuPath anymore. 

I traced the problem to this line:
https://github.com/ome/bioformats/blob/develop/components/formats-gpl/src/loci/formats/in/SVSReader.java#L172
```
  public byte[] openBytes(...)
  {
    if (core.size() == 1) {
      return super.openBytes(no, buf, x, y, w, h);
    }
```

It seems that there is a special case for a slide that contains only one (pyramidal) image. However, that special case does not use the resolution field that is set on the object earlier, and ends up reading the wrong pyramid level - always the 0th one. 

The code below this special case seems to be the general case, and seems to work properly. In my testing, I removed the special case `if (core.size() == 1)` and the deidentified slide works properly with QuPath and seems to pass the unit tests.