### PR TITLE
Add API to configure the value of undefined pixels

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -128,6 +128,7 @@ public final class ImageConverter {
   private boolean originalMetadata = true;
   private boolean noSequential = false;
   private String swapOrder = null;
+  private Byte fillColor = null;
 
   private IFormatReader reader;
   private MinMaxCalculator minMax;
@@ -259,6 +260,10 @@ public final class ImageConverter {
         else if (args[i].equals("-swap")) {
           swapOrder = args[++i].toUpperCase();
         }
+        else if (args[i].equals("-fill")) {
+          // allow specifying 0-255
+          fillColor = (byte) Integer.parseInt(args[++i]);
+        }
         else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
@@ -334,7 +339,7 @@ public final class ImageConverter {
       "    [-nolookup] [-autoscale] [-version] [-no-upgrade] [-padded]",
       "    [-option key value] [-novalid] [-validate] [-tilex tileSizeX]", 
       "    [-tiley tileSizeY] [-pyramid-scale scale]", 
-      "    [-swap dimensionsOrderString]",
+      "    [-swap dimensionsOrderString] [-fill color]",
       "    [-pyramid-resolutions numResolutionLevels] in_file out_file",
       "",
       "            -version: print the library version and exit",
@@ -378,6 +383,7 @@ public final class ImageConverter {
       "-pyramid-resolutions: generates a pyramid image with the given number of resolution levels ",
       "      -no-sequential: do not assume that planes are written in sequential order",
       "               -swap: override the default input dimension order; argument is f.i. XYCTZ",
+      "               -fill: byte value to use for undefined pixels (0-255)",
       "",
       "The extension of the output file specifies the file format to use",
       "for the conversion. The list of available formats and extensions is:",
@@ -500,6 +506,7 @@ public final class ImageConverter {
     reader.setMetadataFiltered(true);
     reader.setOriginalMetadataPopulated(originalMetadata);
     reader.setFlattenedResolutions(flat);
+    reader.setFillColor(fillColor);
     OMEXMLService service = null;
     try {
       ServiceFactory factory = new ServiceFactory();

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -133,6 +133,7 @@ public class ImageInfo {
   private String cachedir = null;
   private int xmlSpaces = 3;
   private DynamicMetadataOptions options = new DynamicMetadataOptions();
+  private Byte fillColor = null;
 
   private IFormatReader reader;
   private IFormatReader baseReader;
@@ -186,6 +187,7 @@ public class ImageInfo {
     shuffleOrder = null;
     map = null;
     cachedir = null;
+    fillColor = null;
     if (args == null) return false;
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-")) {
@@ -275,6 +277,10 @@ public class ImageInfo {
         else if (args[i].equals("-option")) {
           options.set(args[++i], args[++i]);
         }
+        else if (args[i].equals("-fill")) {
+          // allow specifying 0-255
+          fillColor = (byte) Integer.parseInt(args[++i]);
+        }
         else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
@@ -301,7 +307,7 @@ public class ImageInfo {
       "    [-resolution num] [-swap inputOrder] [-shuffle outputOrder]",
       "    [-map id] [-preload] [-crop x,y,w,h] [-autoscale] [-novalid]",
       "    [-omexml-only] [-no-sas] [-no-upgrade] [-noflat] [-format Format]",
-      "    [-cache] [-cache-dir dir] [-option key value]",
+      "    [-cache] [-cache-dir dir] [-option key value] [-fill color]",
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
@@ -343,6 +349,7 @@ public class ImageInfo {
       "              initialized reader. If unspecified, the cached reader",
       "              will be stored under the same folder as the image file",
       "     -option: add the specified key/value pair to the reader's options list",
+      "       -fill: byte value to use for undefined pixels (0-255)",
       "",
       "* = may result in loss of precision",
       ""
@@ -480,6 +487,7 @@ public class ImageInfo {
     options.setValidate(validate);
     reader.setMetadataOptions(options);
     reader.setFlattenedResolutions(flat);
+    reader.setFillColor(fillColor);
   }
 
   public void configureReaderPostInit() {

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -180,6 +180,9 @@ public abstract class FormatReader extends FormatHandler
   /** Whether or not to group multi-file formats. */
   protected boolean group = true;
 
+  /** Fill value for undefined pixels. */
+  protected Byte fillColor = null;
+
   /** List of domains in which this format is used. */
   protected String[] domains = new String[0];
 
@@ -996,6 +999,26 @@ public abstract class FormatReader extends FormatHandler
     throws FormatException, IOException
   {
     return FormatTools.CANNOT_GROUP;
+  }
+
+  /* @see IFormatReader#setFillColor(Byte) */
+  @Override
+  public void setFillColor(Byte color) {
+    fillColor = color;
+  }
+
+  /**
+   * @see IFormatReader#getFillColor()
+   *
+   * If a fill color was not defined by the reader or
+   * {@link #setFillColor(Byte)}, then 0 is returned.
+   */
+  @Override
+  public Byte getFillColor() {
+    if (fillColor == null) {
+      return 0;
+    }
+    return fillColor;
   }
 
   /* @see IFormatReader#isMetadataComplete() */

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -354,6 +354,22 @@ public interface IFormatReader extends IFormatHandler, IPyramidHandler {
    */
   boolean isGroupFiles();
 
+  /**
+   * Set the fill value for undefined pixels.
+   * This can be used to override the default fill value
+   * defined in a reader.
+   *
+   * @param color value that will be used to fill pixel byte arrays
+   */
+  void setFillColor(Byte color);
+
+  /**
+   * Return the fill value for undefined pixels.
+   *
+   * @see #setFillColor(Byte)
+   */
+  Byte getFillColor();
+
   /** Returns true if this format's metadata is completely parsed. */
   boolean isMetadataComplete();
 

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -614,6 +614,20 @@ public class ImageReader implements IFormatReader {
     return getReader(id).fileGroupOption(id);
   }
 
+  /* @see IFormatReader#setFillColor(Byte) */
+  @Override
+  public void setFillColor(Byte fill) {
+    for (IFormatReader r : readers) {
+      r.setFillColor(fill);
+    }
+  }
+
+  /* @see IFormatReader#getFillColor() */
+  @Override
+  public Byte getFillColor() {
+    return getReader().getFillColor();
+  }
+
   /* @see IFormatReader#isMetadataComplete() */
   @Override
   public boolean isMetadataComplete() {

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -396,6 +396,16 @@ public abstract class ReaderWrapper implements IFormatReader {
   }
 
   @Override
+  public void setFillColor(Byte color) {
+    reader.setFillColor(color);
+  }
+
+  @Override
+  public Byte getFillColor() {
+    return reader.getFillColor();
+  }
+
+  @Override
   public boolean isMetadataComplete() {
     return reader.isMetadataComplete();
   }

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -498,7 +498,7 @@ public class FileStitcher extends ReaderWrapper {
 
     // return a blank image to cover for the fact that
     // this file does not contain enough image planes
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     return buf;
   }
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -362,7 +362,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
       info[series][no].reader == null ||
       info[series][no].id == null)
     {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -156,7 +156,7 @@ public class AFIReader extends FormatReader {
       return reader[channel].openBytes(index, buf, x, y, w, h);
     }
     else if (diff > 0) {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
       byte[] tmp = reader[channel].openBytes(index, x, y, w, h);
       for (int i=0, dest=0; i<tmp.length; i+=srcBytes, dest+=destBytes) {
         if (isLittleEndian()) {

--- a/components/formats-gpl/src/loci/formats/in/AmiraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AmiraReader.java
@@ -496,7 +496,7 @@ public class AmiraReader extends FormatReader {
       if (maxOffsetIndex < no) {
         in.seek(offsets[maxOffsetIndex]);
         while (maxOffsetIndex <= no) {
-          Arrays.fill(buf, (byte) 0);
+          Arrays.fill(buf, getFillColor());
           read(currentNo, buf);
           currentNo++;
         }
@@ -504,7 +504,7 @@ public class AmiraReader extends FormatReader {
       else {
         in.seek(offsets[no]);
         currentNo = no;
-        Arrays.fill(buf, (byte) 0);
+        Arrays.fill(buf, getFillColor());
         read(buf, planeSize);
         if (maxOffsetIndex == no) {
           offsets[++maxOffsetIndex] = lastCodeOffset;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -218,7 +218,7 @@ public class CV7000Reader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     Plane p = lookupPlane(getSeries(), no);
     LOGGER.trace("series = {}, no = {}, file = {}", series, no, p == null ? null : p.file);
     if (p != null && p.file != null) {

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -207,7 +207,7 @@ public class CellWorxReader extends FormatReader {
     String file = getFile(getSeries(), no);
     LOGGER.trace("Series {} plane {} using file = {}", getSeries(), no, file);
     if (file == null) {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -138,7 +138,7 @@ public class CellomicsReader extends FormatReader {
       }
     }
     else {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
     }
 
     return buf;

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -193,7 +193,7 @@ public class ColumbusReader extends FormatReader {
       }
     }
 
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     if (p != null && new Location(p.file).exists()) {
       reader.setId(p.file);
       if (p.fileIndex < reader.getImageCount()) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -256,7 +256,7 @@ public class FlexReader extends FormatReader {
             factor = 1d;
           }
           else {
-            Arrays.fill(buf, (byte) 0);
+            Arrays.fill(buf, getFillColor());
             return buf;
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -322,8 +322,8 @@ public class LIFReader extends FormatReader {
 
     int index = getTileIndex(series);
     if (index >= offsets.size()) {
-      // truncated file; imitate LAS AF and return black planes
-      Arrays.fill(buf, (byte) 0);
+      // truncated file; imitate LAS AF and return blank planes
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 
@@ -339,8 +339,8 @@ public class LIFReader extends FormatReader {
     if ((getSizeX() % 4) == 0) bytesToSkip = 0;
 
     if (offset + (planeSize + bytesToSkip * getSizeY()) * no >= in.length()) {
-      // truncated file; imitate LAS AF and return black planes
-      Arrays.fill(buf, (byte) 0);
+      // truncated file; imitate LAS AF and return blank planes
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/LOFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LOFReader.java
@@ -276,8 +276,8 @@ public class LOFReader extends LMSFileReader {
 
     int tileIndex = getTileIndex(series);
     if (tileIndex >= offsets.size()) {
-      // truncated file; imitate LAS AF and return black planes
-      Arrays.fill(buf, (byte) 0);
+      // truncated file; imitate LAS AF and return blank planes
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 
@@ -294,8 +294,8 @@ public class LOFReader extends LMSFileReader {
       bytesToSkip = 0;
 
     if (offset + (planeSize + bytesToSkip * getSizeY()) * no >= in.length()) {
-      // truncated file; imitate LAS AF and return black planes
-      Arrays.fill(buf, (byte) 0);
+      // truncated file; imitate LAS AF and return blank planes
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -200,7 +200,7 @@ public class OIRReader extends FormatReader {
 
     if (startIndex < 0) {
       LOGGER.warn("No pixel blocks for plane #{}", no);
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -223,7 +223,7 @@ public class OperettaReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     if (getSeries() < planes.length && no < planes[getSeries()].length) {
       Plane p = planes[getSeries()][no];
 

--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -755,7 +755,7 @@ public class PrairieReader extends FormatReader {
   /** Blanks out and returns the given buffer. */
   private byte[] blank(final byte[] buf) {
     // missing data; return empty plane
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     return buf;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -253,7 +253,7 @@ public class ScanrReader extends FormatReader {
       }
       catch (FormatException e) {
         reader.close();
-        Arrays.fill(buf, (byte) 0);
+        Arrays.fill(buf, getFillColor());
         return buf;
       }
 

--- a/components/formats-gpl/src/loci/formats/in/TecanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TecanReader.java
@@ -220,7 +220,7 @@ public class TecanReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     Image img = lookupImage(getSeries(), no, false, false);
     if (img != null && img.file != null) {
       if (helperReader == null) {

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -206,7 +206,7 @@ public class VentanaReader extends BaseTiffReader {
     if (tiffParser == null) {
       initTiffParser();
     }
-    Arrays.fill(buf, (byte) 0);
+    Arrays.fill(buf, getFillColor());
     IFD ifd = ifds.get(getIFDIndex(getCoreIndex(), no));
 
     if (splitTiles()) {

--- a/components/formats-gpl/src/loci/formats/in/VolocityReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VolocityReader.java
@@ -150,7 +150,7 @@ public class VolocityReader extends FormatReader {
     Stack stack = stacks.get(getSeries());
 
     if (!new Location(stack.pixelsFiles[zct[1]]).exists()) {
-      Arrays.fill(buf, (byte) 0);
+      Arrays.fill(buf, getFillColor());
       return buf;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -315,6 +315,27 @@ public class ZeissCZIReader extends FormatReader {
   }
 
   /**
+   * @see loci.formats.FormatReader#getFillColor()
+   *
+   * If the fill value was set explicitly, use that.
+   * Otherwise, return 255 (white) for RGB data with a pyramid,
+   * and 0 in all other cases. RGB data with a pyramid can
+   * reasonably be assumed to be a brightfield slide.
+   */
+  @Override
+  public Byte getFillColor() {
+    if (fillColor != null) {
+      return fillColor;
+    }
+
+    byte fill = (byte) 0;
+    if (isRGB() && maxResolution > 0) {
+      fill = (byte) 255;
+    }
+    return fill;
+  }
+
+  /**
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */
   @Override
@@ -356,11 +377,7 @@ public class ZeissCZIReader extends FormatReader {
       validScanDim = false;
     }
 
-    byte fillColor = (byte) 0;
-    if (isRGB() && maxResolution > 0) {
-      fillColor = (byte) 255;
-    }
-    Arrays.fill(buf, fillColor);
+    Arrays.fill(buf, getFillColor());
     boolean emptyTile = true;
     int compression = -1;
     try {


### PR DESCRIPTION
Fixes #3800.

This generalizes the work in https://github.com/glencoesoftware/bioformats2raw/pull/65 to allow a fill value to be set on all readers. Unless otherwise specified, the fill value will be 0, so the default behavior should be unchanged.

`ZeissCZIReader` is currently the only reader that overrides the default fill value. This is an extension of #3795.

`showinf` and `bfconvert` also have a new `-fill byte` option that uses the new API.

Any of the files in https://github.com/openmicroscopy/data_repo_config/pull/518 could be used to test the new API, but something like this should clearly demonstrate this feature:

```
$ showinf -crop 0,0,512,512 zeiss-czi/qa-10972/01042015-36.czi
# white tile is displayed (default for brightfield)
$ showinf -crop 0,0,512,512 zeiss-czi/qa-10972/01042015-36.czi -fill 0
# black tile is displayed (matching `-fill` value)
$ bfconvert -series 0 -crop 0,0,512,512 zeiss-czi/qa-10972/01042015-36.czi default.png
# resulting PNG is all white
$ bfconvert -series 0 -crop 0,0,512,512 zeiss-czi/qa-10972/01042015-36.czi fill-0.png -fill 0
# resulting PNG is all black
```

The original proposal in #3800 was to allow a `Color` to be specified. A `Byte` is used instead here as in https://github.com/glencoesoftware/bioformats2raw/pull/65. This is simpler to implement, as the specified byte value is just stored directly in pixel byte arrays without checking pixel type, channel count/RGB, etc. If anyone feels strongly that a `Color` needs to be specified, we can discuss, but that opens up other questions around how to handle anything that isn't 3 RGB channels.

Assigning to 6.13.0 for initial discussion; this will obviously require a non-patch release. Since the default behavior is unchanged, I would not expect tests to fail.
