### PR TITLE
Bump json dependency to 20220924

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
     	<groupId>org.json</groupId>
     	<artifactId>json</artifactId>
-    	<version>20090211</version>
+    	<version>20220924</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>

--- a/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
@@ -163,7 +163,7 @@ public class IonpathMIBITiffReader extends BaseTiffReader {
             while (keySet.hasNext()) {
               String key = (String) keySet.next();
               if (key.startsWith("mibi.")) {
-                simsDescription.put(key, jsonDescription.getString(key));
+                simsDescription.put(key, jsonDescription.get(key).toString());
               }
             }
           } catch (JSONException e) {

--- a/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
@@ -130,13 +130,10 @@ public class IonpathMIBITiffReader extends BaseTiffReader {
         jsonDescription = new JSONObject(imageDescription);
         imageType = jsonDescription.getString("image.type");
         if (imageType.equals("SIMS")) {
-          String mass = jsonDescription.getString("channel.mass");
-          if (mass == null) {
-            throw new FormatException("Channel masses are mandatory.");
-          }
+          Double mass = jsonDescription.getDouble("channel.mass");
           String target = jsonDescription.getString("channel.target");
-          channelIDs.add(mass);
-          channelNames.add(target != null && target != "null" ? target : mass);
+          channelIDs.add(mass.toString());
+          channelNames.add(target != null && target != "null" ? target : mass.toString());
         }
       } catch (JSONException e) {
         throw new FormatException("Unexpected format in SIMS description JSON.");


### PR DESCRIPTION
This is a follow up to issue #3961. In the ImageJ environment, json-20220924 is available as a dependency through the updater. When used alongside Bio-Formats 6.12.0 this caused a failure in the Ionpath MIBITIFF reader due to an unexpected return type.

This PR will cause breakages in the repo tests and is aimed to test the full impact of readers affected and issues caused by the upgrade.