### PR TITLE
MRC: read IMOD flags to determine int8 vs uint8 pixel type

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -198,11 +198,21 @@ public class MRCReader extends FormatReader {
     m.rgb = false;
 
     int mode = in.readInt();
+
+    // see the 'imodStamp' and 'imodFlags' fields in
+    // https://bio3d.colorado.edu/imod/doc/mrc_format.txt
+    in.seek(IMODSTAMP_OFFSET);
+    boolean imod = in.readInt() == 1146047817; // little-endian 'IMOD'
+    boolean imodSigned = false;
+    if (imod) {
+      int imodFlags = in.readInt();
+      imodSigned = (imodFlags & 0x1) == 1;
+    }
+
     switch (mode) {
       case 0:
         in.seek(IMODSTAMP_OFFSET);
-        if (in.readInt() == 1146047817)
-        {
+        if (imod && imodSigned) {
           m.pixelType = FormatTools.INT8;
         }
         else

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -211,7 +211,6 @@ public class MRCReader extends FormatReader {
 
     switch (mode) {
       case 0:
-        in.seek(IMODSTAMP_OFFSET);
         if (imod && imodSigned) {
           m.pixelType = FormatTools.INT8;
         }


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/issues/198#issuecomment-1494790737

The test file has been uploaded to `curated/mrc/bioformats2raw-198`. Without this PR, `showinf test_uint8.mrc` should read the file, but will incorrectly identify it as `int8`. With this PR, the same test should show a pixel type of `uint8`.

I would not expect test failures, and this should be safe for a patch release.

cc @blowekamp