### PR TITLE
Bump low level component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,13 @@
     <slf4j.version>1.7.30</slf4j.version>
     <kryo.version>4.0.2</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.14</ome-common.version>
+    <ome-common.version>6.0.16</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.3.2</ome-model.version>
+    <ome-model.version>6.3.3</ome-model.version>
     <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.4.4</ome-codecs.version>
+    <ome-codecs.version>0.4.5</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>


### PR DESCRIPTION
Bumping the version of low level components as part of the dependency update work in https://github.com/ome/bioformats/issues/3970

- ome-common to 6.0.16
- ome-model to 6.3.3
- ome-codecs to 0.4.5
