### PR TITLE
CV7000: adjust channel index if a subset of channels were acquired

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -388,7 +388,7 @@ public class CV7000Reader extends FormatReader {
       planeLengths[2] = core.get(p.series).sizeT;
 
       p.no = FormatTools.positionToRaster(planeLengths,
-        new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
+        new int[] {p.channelIndex - m.minC, p.z - m.minZ, p.timepoint - m.minT});
 
       if (reversePlaneLookup[p.series][p.no] < 0) {
         reversePlaneLookup[p.series][p.no] = i;


### PR DESCRIPTION
Prevents an ArrayIndexOutOfBoundsException when the first acquired channel is not the first defined channel (e.g. 2 and 3 acquired, 1 is not). This problem was introduced in https://github.com/ome/bioformats/pull/3663. Backported from a private PR.

To test, use the new artificial sample currently uploading to `curated/cv7000/samples/channel-subset`. This was created by removing the first and last channels from an existing 4 channel plate, which mimics the plates for which this problem was originally noticed.

Without this PR, `showinf -omexml` on the .wpi file should throw:

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
  at loci.formats.in.CV7000Reader.initFile(CV7000Reader.java:393)
  at loci.formats.FormatReader.setId(FormatReader.java:1443)
  at loci.formats.ImageReader.setId(ImageReader.java:849)
  at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
  at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1035)
  at loci.formats.tools.ImageInfo.main(ImageInfo.java:1121)
```

With this PR, `showinf -omexml` should detect the whole plate, with 2 channels per series/Image. The displayed image should not be all 0s, i.e. the pixels files are read correctly.

Should be safe for a patch release.