### PR TITLE
CellWorX/MetaXpress: fix an off-by-one when retrieving channel metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -395,7 +395,7 @@ public class CellWorxReader extends FormatReader {
       planeIndex = c;
       file = getFile(seriesIndex, planeIndex);
       while (!new Location(file).exists()) {
-        if (planeIndex < zSteps * nTimepoints * wavelengths.length) {
+        if (planeIndex < zSteps * nTimepoints * (wavelengths.length - 1)) {
           planeIndex += (zSteps * nTimepoints);
         }
         else if (seriesIndex < seriesCount - 1) {


### PR DESCRIPTION
This only happened when the files for the entire first field were missing (in a multi-field dataset). The problem was introduced in https://github.com/ome/bioformats/pull/3806. Backported from a private PR.

To test, use the new artificial sample in `curated/metaxpress/samples/multi-channel-missing-corner`. This was generated from existing sample data to mimic the plates for which the problem was initially noticed.

Without this PR, `showinf -nopix -omexml multi-channel.HTD` should throw an exception indicating that the plane index exceeds the plane count. With this PR, `showinf -omexml -series 13 -minmax multi-channel.HTD` should successfully show two channels, neither of which is empty. The first 12 series should be readable, but with all 0 pixel values as the .HTD file shows these fields/wells as acquired but the files are missing.

I'd expect this to be safe for a patch release.