### PR TITLE
CV7000: ignore any extra folders mixed in with the plate data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -130,7 +130,7 @@ public class CV7000Reader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(new Location(currentId).getAbsolutePath());
     for (String file : allFiles) {
-      if (!files.contains(file) && (!noPixels || !checkSuffix(file, "tif"))) {
+      if (file != null && !files.contains(file) && (!noPixels || !checkSuffix(file, "tif"))) {
         files.add(file);
       }
     }
@@ -176,7 +176,7 @@ public class CV7000Reader extends FormatReader {
     }
     files.addAll(extraFiles);
     for (String file : allFiles) {
-      if (!checkSuffix(file, "tif") && !(new Location(file).isDirectory())) {
+      if (file != null && !checkSuffix(file, "tif") && !(new Location(file).isDirectory())) {
         files.add(file);
       }
     }
@@ -242,7 +242,13 @@ public class CV7000Reader extends FormatReader {
     allFiles = parent.list(true);
     Arrays.sort(allFiles);
     for (int i=0; i<allFiles.length; i++) {
-      allFiles[i] = new Location(parent, allFiles[i]).getAbsolutePath();
+      Location file = new Location(parent, allFiles[i]);
+      if (!file.isDirectory() && file.canRead()) {
+        allFiles[i] = file.getAbsolutePath();
+      }
+      else {
+        allFiles[i] = null;
+      }
     }
     Location measurementData = new Location(parent, MEASUREMENT_FILE);
 


### PR DESCRIPTION
Backported from a private PR.

This fixes an issue where if a CV7000 plate directory contains a subdirectory, the subdirectory path gets added to the used files list. The contents of the subdirectory (if any) were not included in the used files list.

To test, use `curated/cv7000/samples/extra-dirs`, which is created from an existing dataset. Without this PR, `showinf -nopix` on the .wpi file should include the subdirectory path (`.../DW 0003...`) in the used files list. With this PR, the same test should not show the subdirectory path at all.

Should be safe for a patch release.