### PR TITLE
IFormatReader: add default implementations for new setFillValue/getFillValue

### DIFF
--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -359,16 +359,23 @@ public interface IFormatReader extends IFormatHandler, IPyramidHandler {
    * This can be used to override the default fill value
    * defined in a reader.
    *
+   * The default implementation in IFormatReader is a no-op.
+   *
    * @param color value that will be used to fill pixel byte arrays
    */
-  void setFillColor(Byte color);
+  default void setFillColor(Byte color) {
+  }
 
   /**
    * Return the fill value for undefined pixels.
    *
+   * The default implementation in IFormatReader always returns 0.
+   *
    * @see #setFillColor(Byte)
    */
-  Byte getFillColor();
+  default Byte getFillColor() {
+    return 0;
+  }
 
   /** Returns true if this format's metadata is completely parsed. */
   boolean isMetadataComplete();


### PR DESCRIPTION
Provides backwards compatibility, for any external readers that implement `IFormatReader` but do not extend an existing implementation.

This is a follow-up to #3963 and was suggested by @sbesson. There should be no change in behavior compared to #3963, since all of our readers extend `FormatReader`.