### PR TITLE
Point to Release

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,8 +28,41 @@ jobs:
           cache: 'maven'
       - name: Build
         run: mvn ${{ env.maven_commands }}
-  deploy:
+  deploy_snapshots:
     if: ${{ github.ref == 'refs/heads/develop' && github.repository_owner == 'ome' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Retrieve version
+        id: get_version
+        run: |
+          VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Set server
+        id: set_server
+        run: |
+          if [[ ${{ steps.get_version.outputs.version }} =~ 'SNAPSHOT' ]]; then
+              echo server='ome.snapshots' >> $GITHUB_OUTPUT
+            else
+              echo server='ome.releases' >> $GITHUB_OUTPUT
+          fi
+      - name: Set up Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: 'zulu'
+          server-id: ${{ steps.set_server.outputs.server }}
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Deploy SNAPSHOT
+        if: ${{ steps.set_server.outputs.server == 'ome.snapshots' }}
+        run: mvn deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.CI_DEPLOY_USER }}
+          MAVEN_PASSWORD: ${{ secrets.CI_DEPLOY_PASS }}
+  deploy_tags:
+    if: startsWith(github.ref, 'refs/tags') && github.repository_owner == 'ome'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +88,8 @@ jobs:
           server-id: ${{ steps.set_server.outputs.server }}
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - name: Deploy SNAPSHOT
+      - name: Deploy Tags
+        if: ${{ steps.set_server.outputs.server == 'ome.releases' }}
         run: mvn deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CI_DEPLOY_USER }}

--- a/pom.xml
+++ b/pom.xml
@@ -474,16 +474,16 @@
   </pluginRepositories>
 
   <distributionManagement>
-    <repository>
-      <id>ome.staging</id>
-      <name>OME Staging Repository</name>
-      <url>https://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
-    </repository>
     <snapshotRepository>
       <id>ome.snapshots</id>
       <name>OME Snapshots Repository</name>
       <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ome.releases</id>
+      <name>OME Releases Repository</name>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
+    </repository>
   </distributionManagement>
 
   <profiles>


### PR DESCRIPTION
Switching from staging to releases implies that a commit without snapshot could be pushed to artifacts.o.org under releases.
This PR introduces a new job.
* the artifacts will be pushed to ``snapshots`` only when ``SNAPSHOT`` is in the version
* the artifacts will be pushed to ``releases`` only when ``SNAPSHOT`` is **not** in the version and a tag is pushed. (just in case a tag is made by accident with snapshot)
