### PR TITLE
DICOM: fix raw RGB tile reading

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1670,9 +1670,16 @@ public class DicomReader extends SubResolutionFormatReader {
     if (baseOffset == in.length()) {
       return;
     }
+    // for tiled images, the RGB channel count will likely be 0,
+    // as the image count has not yet been set correctly
+    // for RGB tiles, the channel count needs to be adjusted
+    // so that the correct number of pixel bytes are anticipated
     int channelCount = getRGBChannelCount();
     if (lut != null || channelCount == 0) {
       channelCount = 1;
+    }
+    if (isRGB()) {
+      channelCount = getSizeC() / channelCount;
     }
 
     int bpp = FormatTools.getBytesPerPixel(getPixelType());


### PR DESCRIPTION
Fixes an incorrect tile offset calculation issue when working with uncompressed brightfield WSI data. I don't currently have permission to share the original test dataset, but will try to make an artificial dataset that demonstrates the issue once tests are confirmed to pass.

Without this PR, `showinf -noflat -resolution 3` on the affected dataset showed scrambled tiles. With this PR, `showinf -noflat -resolution 3` should match `showinf -format MinimalTiff` on the corresponding file for resolution 3.

I would not expect this to change behavior for anything other than the uncompressed brightfield WSI case, so tests should continue to pass.

/cc @dclunie.