### PR TITLE
Fix artifact uploading in GitHub Actions Ant workflow

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -23,7 +23,7 @@ jobs:
             ant docs
       - name: Upload artifacts
         # upload just one set of artifacts for easier PR review
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
         uses: actions/upload-artifact@v3
         with:
           path: artifacts/


### PR DESCRIPTION
#3933 accidentally disabled the artifact uploading on each Java 8 Ant build in GitHub Actions. This should restore that functionality, so the artifact zip should be available from the bottom of each run summary page.

This is included in #3992 to fix the immediate use case, but I can remove it there if this gets merged first.