### PR TITLE
CZI: Remove condition for first detector gain

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2565,7 +2565,7 @@ public class ZeissCZIReader extends FormatReader {
           
           gain = getFirstNodeValue(detector, "Gain");
           if (gain != null && !gain.isEmpty()) {
-            if (detectorIndex == 0 || detectorIndex >= gains.size()) {
+            if (detectorIndex >= gains.size()) {
               store.setDetectorGain(DataTools.parseDouble(gain), 0, detectorIndex);
             }
             else {


### PR DESCRIPTION
Opening this to test a fix for an issue raised on https://forum.image.sc/t/czi-metadata-recording-bug-detector-1-gain/80767

The issue appears to be that the detector gain metadata is incorrect for the first detector. This was consistently reproducible and  a sample file was provided that reproduces the issue and is available at `scratch/inbox/imagesc-80767`.

In this sample the first detector always has a gain of 1. The correct values should be as below:
![b152e8fefcf65a47f04033100c9f55438de0de41](https://github.com/ome/bioformats/assets/1628865/17ca0396-e548-4b53-bf5a-82e4ba4b4c46)


The sample showing the issue was acquired with the older ZEN black which was afterwards processed in ZEN blue. I expect that this will likely result in repo test failures for some other CZI files, using this initial commit to highlight the extent of the impact.