### PR TITLE
BFConvert: Ensure crop size is used for all series

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -599,9 +599,14 @@ public final class ImageConverter {
           writer.setMetadataRetrieve((MetadataRetrieve) meta);
         }
         else {
-          meta.setPixelsSizeX(new PositiveInteger(width), 0);
-          meta.setPixelsSizeY(new PositiveInteger(height), 0);
           for (int i=0; i<reader.getSeriesCount(); i++) {
+            reader.setSeries(i);
+            if (width_crop != 0 || height_crop != 0) {
+              width = Math.min(reader.getSizeX(), width_crop);
+              height = Math.min(reader.getSizeY(), height_crop);
+            }
+            meta.setPixelsSizeX(new PositiveInteger(width), i);
+            meta.setPixelsSizeY(new PositiveInteger(height), i);
             if (autoscale) {
               store.setPixelsType(PixelType.UINT8, i);
             }

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -601,6 +601,8 @@ public final class ImageConverter {
         else {
           for (int i=0; i<reader.getSeriesCount(); i++) {
             reader.setSeries(i);
+            width = reader.getSizeX();
+            height = reader.getSizeY();
             if (width_crop != 0 || height_crop != 0) {
               width = Math.min(reader.getSizeX(), width_crop);
               height = Math.min(reader.getSizeY(), height_crop);


### PR DESCRIPTION
This PR is in response to an issue reported on https://forum.image.sc/t/bfconvert-throwing-an-error-for-an-vsi-file/37185/7

I was able to reproduce the same exception with Bio-Formats 6.13.0 and the file from https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/sub-resolutions/Brightfield/Leica-1/

Without this PR, running the below command will result in an exception:

`bfconvert -crop 0,0,512,512 Leica-1.ome.tiff Leica-1-crop.ome.tiff`

```
Switching to BigTIFF (by file size)
	Series 0: converted 1/1 planes (100%)
Exception in thread "main" loci.formats.FormatException: Buffer is too small; expected 1414404 bytes, got 620544 bytes.
	at loci.formats.FormatWriter.checkParams(FormatWriter.java:476)
	at loci.formats.out.TiffWriter.saveBytes(TiffWriter.java:229)
	at loci.formats.out.OMETiffWriter.saveBytes(OMETiffWriter.java:219)
	at loci.formats.out.PyramidOMETiffWriter.saveBytes(PyramidOMETiffWriter.java:89)
	at loci.formats.out.OMETiffWriter.saveBytes(OMETiffWriter.java:209)
	at loci.formats.FormatWriter.saveBytes(FormatWriter.java:132)
	at loci.formats.ImageWriter.saveBytes(ImageWriter.java:252)
	at loci.formats.tools.ImageConverter.convertPlane(ImageConverter.java:830)
	at loci.formats.tools.ImageConverter.testConvert(ImageConverter.java:753)
	at loci.formats.tools.ImageConverter.main(ImageConverter.java:1186)
```

This is due to ImageConverter failing to correctly set the adjusted cropped dimensions for any series other than the first.

To test, rerun the above scenario and the conversion should complete without exception. The converted file should be able to open and display, with the correct cropped dimensions being used for each series.