### PR TITLE
KLB: Use z index to increment block input offset

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/KLBReader.java
+++ b/components/formats-bsd/src/loci/formats/in/KLBReader.java
@@ -269,7 +269,7 @@ public class KLBReader extends FormatReader {
           if (coordBlock[1] < y && coordBlock[0] < x && blockSizeAux[1] != dims_blockSize[1] && blockSizeAux[0] != dims_blockSize[0]) outputOffset = 0;
 
           // Location within the block for required XY plane
-          int inputOffset = (coordBlock[2] % dims_blockSize[2]) * blockRowSize * blockSizeAux[1];
+          int inputOffset = (currentCoords[0] % dims_blockSize[2]) * blockRowSize * blockSizeAux[1];
           if (coordBlock[0] < x && coordBlock[1] < y && blockSizeAux[1] != dims_blockSize[1] && blockSizeAux[0] != dims_blockSize[0]) inputOffset += ((dims_blockSize[0] * (dims_blockSize[1] - blockSizeAux[1])) + (x - coordBlock[0])) * bytesPerPixel;
           // Partial block at the start of x tile
           else if (coordBlock[0] < x && blockSizeAux[0] != dims_blockSize[0]) inputOffset += (dims_blockSize[0] - blockSizeAux[0]) * bytesPerPixel;

--- a/components/formats-bsd/src/loci/formats/in/KLBReader.java
+++ b/components/formats-bsd/src/loci/formats/in/KLBReader.java
@@ -269,7 +269,7 @@ public class KLBReader extends FormatReader {
           if (coordBlock[1] < y && coordBlock[0] < x && blockSizeAux[1] != dims_blockSize[1] && blockSizeAux[0] != dims_blockSize[0]) outputOffset = 0;
 
           // Location within the block for required XY plane
-          int inputOffset = (currentCoords[0] % dims_blockSize[2]) * blockRowSize * blockSizeAux[1];
+          int inputOffset = (currentCoords[0] % dims_blockSize[2]) * fullBlockRowSize * dims_blockSize[1];
           if (coordBlock[0] < x && coordBlock[1] < y && blockSizeAux[1] != dims_blockSize[1] && blockSizeAux[0] != dims_blockSize[0]) inputOffset += ((dims_blockSize[0] * (dims_blockSize[1] - blockSizeAux[1])) + (x - coordBlock[0])) * bytesPerPixel;
           // Partial block at the start of x tile
           else if (coordBlock[0] < x && blockSizeAux[0] != dims_blockSize[0]) inputOffset += (dims_blockSize[0] - blockSizeAux[0]) * bytesPerPixel;


### PR DESCRIPTION
This is a follow up to an issue discovered on idr0044 in which scrolling through z planes only incremented every 8 frames.

The issue can be reproduced with Bio-Formats 6.13.0 using all of the sample files from https://downloads.openmicroscopy.org/images/KLB/

In each of the samples above the z dimension has a block size of 8. The reader was choosing the correct block but was not correctly setting the Z offset within the block, which is why the planes updated every 8 steps.

To test use any of the public samples, img.klb from https://downloads.openmicroscopy.org/images/KLB/samples/ makes for a nice quick test file, but this should also be tested against the idr0044 data. With the PR, scrolling through Z should show the planes update with each step.
