### PR TITLE
CV8000: fix channel indexing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -306,6 +306,7 @@ public class CV7000Reader extends FormatReader {
 
     fields = 0;
     HashSet<Integer> uniqueWells = new HashSet<Integer>();
+    HashSet<Integer> uniqueChannels = new HashSet<Integer>();
 
     for (Plane p : planeData) {
       if (p != null) {
@@ -333,12 +334,17 @@ public class CV7000Reader extends FormatReader {
         if (p.z < m.minZ) {
           m.minZ = p.z;
         }
+
+        // min and max channel indexes not currently used,
+        // but continue to calculate for completeness
+        // they may be needed in future CV7000/8000 work
         if (p.channelIndex > m.maxC) {
           m.maxC = p.channelIndex;
         }
         if (p.channelIndex < m.minC) {
           m.minC = p.channelIndex;
         }
+        uniqueChannels.add(p.channelIndex);
 
         if (p.field.field >= fields) {
           fields = p.field.field + 1;
@@ -360,6 +366,9 @@ public class CV7000Reader extends FormatReader {
     Arrays.sort(wells);
     reversePlaneLookup = new int[realWells * fields][];
 
+    Integer[] channelIndexes = uniqueChannels.toArray(new Integer[uniqueChannels.size()]);
+    Arrays.sort(channelIndexes);
+
     for (int i=0; i<realWells * fields; i++) {
       if (i > 0) {
         core.add(new CoreMetadata(core.get(0)));
@@ -369,7 +378,7 @@ public class CV7000Reader extends FormatReader {
       MinMax m = minMax.get(wellIndex);
       core.get(i).sizeZ = (m.maxZ - m.minZ) + 1;
       core.get(i).sizeT = (m.maxT - m.minT) + 1;
-      core.get(i).sizeC = reader.getSizeC() * ((m.maxC - m.minC) + 1);
+      core.get(i).sizeC = reader.getSizeC() * uniqueChannels.size();
       core.get(i).imageCount = core.get(i).sizeZ * core.get(i).sizeT *
         (core.get(i).sizeC / reader.getSizeC());
       reversePlaneLookup[i] = new int[core.get(i).imageCount];
@@ -382,6 +391,13 @@ public class CV7000Reader extends FormatReader {
     extraFiles = new ArrayList<String>();
     for (int i=0; i<planeData.size(); i++) {
       Plane p = planeData.get(i);
+
+      // reindex so that the plane's channel index is into
+      // the list of unique acquired channels, not the list of all channels
+      // that might have been acquired
+      // this eliminates the need to correct for the minimum C index later on
+      p.channelIndex = Arrays.binarySearch(channelIndexes, p.channelIndex);
+
       Field f = p.field;
       int wellNumber = f.row * plate.getPlateColumns() + f.column;
       int wellIndex = Arrays.binarySearch(wells, wellNumber);
@@ -394,7 +410,7 @@ public class CV7000Reader extends FormatReader {
       planeLengths[2] = core.get(p.series).sizeT;
 
       p.no = FormatTools.positionToRaster(planeLengths,
-        new int[] {p.channelIndex - m.minC, p.z - m.minZ, p.timepoint - m.minT});
+        new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
 
       if (reversePlaneLookup[p.series][p.no] < 0) {
         reversePlaneLookup[p.series][p.no] = i;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -836,6 +836,12 @@ public class CV7000Reader extends FormatReader {
         startTime = attributes.getValue("bts:BeginTime");
         endTime = attributes.getValue("bts:EndTime");
         settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
+
+        String system = attributes.getValue("bts:TargetSystem");
+        addGlobalMeta("Acquisition system", system);
+        if (!system.toLowerCase().startsWith("cv7000")) {
+          LOGGER.warn("Found data from {}; this is not well-supported", system);
+        }
       }
     }
 


### PR DESCRIPTION
Backported from private PR. I don't think this will conflict with #4006.

This is meant to handle a case where multiple channels are defined in `MeasurementDetail.mrf`, but a non-consecutive subset of those channels were acquired. In the original (private) data, 6 channels are defined but only the first and 5th were acquired. Without this PR, that meant that `showinf -omexml` on the .wpi file reported 5 channels per series - but the middle 3 channels were completely blank images.

With this PR, the same test reports 2 channels per series, matching what was actually acquired.

We'll likely need to generate test data that demonstrates the problem; opening this now to verify that it does not break existing data.

The original dataset for this issue was CV8000 (not CV7000), so 4d9c6ea adds some extra logging to help distinguish between CV7000 and CV8000 (or later systems) as the former has better support than the latter.