### PR TITLE
Update CV7000 isThisType test to skip extended type checking

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2500,6 +2500,13 @@ public class FormatReaderTest {
         IFormatReader[] readers = ir.getReaders();
         String[] used = reader.getUsedFiles();
         for (int i=0; i<used.length && success; i++) {
+          // ignore anything other than .wpi for CV7000
+          if (!used[i].toLowerCase().endsWith(".wpi") &&
+            r instanceof CV7000Reader)
+          {
+            continue;
+          }
+
           // for each used file, make sure that one reader,
           // and only one reader, identifies the dataset as its own
           for (int j=0; j<readers.length; j++) {
@@ -2745,13 +2752,6 @@ public class FormatReaderTest {
 
             // Operetta only reliably detects from Index.*.xml
             if (!result && r instanceof OperettaReader) {
-              continue;
-            }
-
-            // ignore anything other than .wpi for CV7000
-            if (!used[i].toLowerCase().endsWith(".wpi") &&
-              r instanceof CV7000Reader)
-            {
               continue;
             }
 


### PR DESCRIPTION
There is no need to iterate over each file and check the type if the results are just ignored anyway.

See https://github.com/openmicroscopy/data_repo_config/pull/572#issuecomment-1560636849. I'd expect this to noticeably reduce test run time for CV7000/8000 plates with lots of files.

If we're happy with this approach, it looks like there are a few other similar checks that could also be moved outside the file loop.