### PR TITLE
Update readers.txt to include an external CZI Reader (https://github.com/BIOP/quick-start-czi-reader)

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -18,6 +18,7 @@ loci.formats.in.SlideBook6Reader[type=external]      # sld
 loci.formats.in.SlideBook7Reader[type=external]      # sldy
 loci.formats.in.ScreenReader[type=external]         # .screen
 loci.formats.in.ZarrReader[type=external]         # .zarr
+ch.epfl.biop.formats.in.ZeissQuickStartCZIReader[type=external]         # .czi alternative reader
 
 # standalone readers with unique file extensions
 loci.formats.in.PGMReader             # pgm


### PR DESCRIPTION
Adds ZeissQuickStartCZIReader as an alternative external czi reader. The alternative reader is located in https://github.com/BIOP/quick-start-czi-reader.