### PR TITLE
MicroManager: Prevent infinite loop and don't swallow IOException

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -599,7 +599,8 @@ public class MicromanagerReader extends FormatReader {
         plane += ifds.size();
       }
       catch (IOException e) {
-        LOGGER.debug("Failed to read metadata from " + path, e);
+        LOGGER.error("Failed to read metadata from " + path, e);
+        throw new FormatException(e);
       }
     }
   }


### PR DESCRIPTION
Issue was raised in https://github.com/ome/bioformats/issues/4018

The cause of the problem is a truncated file with an invalid IFD, when attempting to read the file an infite loop is encountered. This is due to the IOException being swallowed by the reader and the current loop continuing without incrementing. As the exception is due to an invalid truncated file, I believe it is best to throw an exception in this instance rather than continuing to increment the loop.

A sample file is available in the issue which can be used to test the PR.
Without the PR it should result in an infinite loop
With the PR the exception should be thrown and the user alerted to the error.

Fixes #4018 