### PR TITLE
Update top-level Git mailmap to normalize commit author variants

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,54 +1,57 @@
-Aaron Avery <aaron.avery@healthmyne.com>
+Aaron Avery <aaron.avery@healthmyne.com> <aaron@Aarons-MacBook-Pro.local>
 Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
-Alex Herbert <a.herbert@sussex.ac.uk>
+Alex Herbert <a.herbert@sussex.ac.uk> aherbert <a.herbert@sussex.ac.uk>
 Alexandr Virodov <alexandr.vir@gmail.com> <alexandr.virodov@uky.edu>
 Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
-Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> Andrew J Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
-Balaji Ramalingam <b.ramalingam@dundee.ac.uk>
-Brian Long <berl@users.noreply.github.com>
+Balaji Ramalingam <b.ramalingam@dundee.ac.uk> bramalingam <b.ramalingam@dundee.ac.uk>
+Brian Long <berl@users.noreply.github.com> berl <berl@users.noreply.github.com>
 Brian Long <berl@users.noreply.github.com> <brianl@OSXLTZDV30.local>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee.ac.uk>
 Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
 Chris Allan <callan@glencoesoftware.com> <callan@lifesci.dundee.ac.uk>
-Christian Niedworok <ch-n@gmx.net>
+Christian Niedworok <ch-n@gmx.net> cniedwor <ch-n@gmx.net>
 Christian Sachs <c.sachs@fz-juelich.de> <chris@sachs.im>
 Christian Sachs <c.sachs@fz-juelich.de> <sachs.christian@gmail.com>
-Claire McQuin <mcquin@broadinstitute.org>
+Claire McQuin <mcquin@broadinstitute.org> mcquin <mcquin@broadinstitute.org>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Curtis Rueden <ctrueden@wisc.edu> <unknown@unknown>
 Constanze Wendtland <constanze.wendlandt@leica-microsystems.com> 
 Constanze Wendtland <constanze.wendlandt@leica-microsystems.com> <88091453+XLEFReaderForBioformats@users.noreply.github.com>
-David Gault <d.gault@dundee.ac.uk>
+David Gault <d.gault@dundee.ac.uk> dgault <d.gault@dundee.ac.uk>
 David Pinto <david.pinto@bioch.ox.ac.uk> <carandraug+dev@gmail.com>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@lifesci.dundee.ac.uk>
-Eliana Andreica <e.andreica@oxinst.com>
+Eliana Andreica <e.andreica@oxinst.com> dinelia <e.andreica@oxinst.com>
+Eliana Andreica <e.andreica@oxinst.com> ANDREICA Eliana <e.andreica@oxinst.com>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
-Ian Munro <i.munro@imperial.ac.uk>
-Ilya Parmon <ilya.parm@gmail.com>
+Ian Munro <i.munro@imperial.ac.uk> imunro <i.munro@imperial.ac.uk>
+Ilya Parmon <ilya.parm@gmail.com> Parm0n <ilya.parm@gmail.com>
 Jan Eglinger <jan.eglinger@fmi.ch> <jan.eglinger@gmail.com>
-Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jean-marie burel <j.burel@dundee.ac.uk>
 Jean-Yves Tinevez <jean-yves.tinevez@pasteur.fr> <jeanyves.tinevez@gmail.com>
 Jeremy Muhlich <jeremy_muhlich@hms.harvard.edu> <jmuhlich@bitflood.org>
-Jim Crowe <jimc@mikroscan.com>
+Jim Crowe <jimc@mikroscan.com> redcrow <jimc@mikroscan.com>
 Johan Herz <johan@lambertinstruments.com> <45658761+LambertJohan@users.noreply.github.com>
 Johannes Schindelin <johannes.schindelin@gmx.de> <Johannes.Schindelin@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
-Kristian Kjærgaard <kkjaergaard@gmail.com>
-Kristin Briney <briney@wisc.edu>
+Kristian Kjaergaard <kkjaergaard@gmail.com> kkjaergaard <kkjaergaard@gmail.com>
+Kristin Briney <briney@wisc.edu> Kristin <briney@wisc.edu>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
 Mark Hiner <hiner@wisc.edu> <hinerm@gmail.com>
 Mark Kittisopikul <mark.kittisopikul@utsouthwestern.edu> <mark.kittisopikul@northwestern.edu>
-Matthieu Moisse <matthieu.moisse@kuleuven.vib.be>
+Matthieu Moisse <matthieu.moisse@kuleuven.vib.be> mmoisse <matthieu.moisse@kuleuven.vib.be>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
 Nicholas Chiaruttini <nicholas.chiaruttini@epfl.ch> <nicolas.chiaruttini@epfl.ch>
-Nicola Papp <nicola.papp@intelligent-imaging.com>
+Nicola Papp <nicola.papp@intelligent-imaging.com> nicola <nicola.papp@intelligent-imaging.com>
 Nils Gladitz <nilsgladitz@gmail.com> <n.gladitz@abberior-instruments.com>
-Paul van Schayck <polleke@gmail.com>
-Pete Bankhead <pete.bankhead@gmail.com>
-Premysl Fiala <premysl.fiala@lim.cz>
+Paul van Schayck <polleke@gmail.com> pvc-local <polleke@gmail.com>
+Peter Bankhead <pete.bankhead@gmail.com> Pete <pete.bankhead@gmail.com>
+Premysl Fiala <premysl.fiala@lim.cz> PremyslFiala <premysl.fiala@lim.cz>
+Premysl Fiala <premysl.fiala@lim.cz> Premysl.Fiala <premysl.fiala@lim.cz>
 Richard Myers <richard@intelligent-imaging.com> <RichardMyers@users.noreply.github.com>
 Richard Myers <richard@intelligent-imaging.com> <venicebeach+github@gmail.com>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
@@ -62,4 +65,4 @@ Stefan Helfrich <stefan.helfrich@uni-konstanz.de> <stefan.helfrich@googlemail.co
 Stephan Wagner-Conrad <stephan.wagner-conrad@zeiss.com> <46338941+swg08@users.noreply.github.com>
 Tomas Farago <tomas.farago@kit.edu> <sensej007@email.cz>
 Wim Pomp <wimpomp@gmail.com> <w.pomp@nki.nl>
-Zach Marin <zach.marin@yale.edu>
+Zachary Connerty-Marin <zach.marin@yale.edu> zacsimile <zach.marin@yale.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -2,7 +2,6 @@ Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
 Alex Herbert <a.herbert@sussex.ac.uk>
 Alexandr Virodov <alexandr.vir@gmail.com> <alexandr.virodov@uky.edu>
 Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
-Andreica Eliana <e.andreica@oxinst.com>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
 Balaji Ramalingam <b.ramalingam@dundee.ac.uk>
@@ -23,6 +22,7 @@ Constanze Wendtland <constanze.wendlandt@leica-microsystems.com> <88091453+XLEFR
 David Gault <d.gault@dundee.ac.uk>
 David Pinto <david.pinto@bioch.ox.ac.uk> <carandraug+dev@gmail.com>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@lifesci.dundee.ac.uk>
+Eliana Andreica <e.andreica@oxinst.com>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
 Ian Munro <i.munro@imperial.ac.uk>
 Jan Eglinger <jan.eglinger@fmi.ch> <jan.eglinger@gmail.com>
@@ -42,7 +42,7 @@ Mark Kittisopikul <mark.kittisopikul@utsouthwestern.edu> <mark.kittisopikul@nort
 Matthieu Moisse <matthieu.moisse@kuleuven.vib.be>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
 Nicholas Chiaruttini <nicholas.chiaruttini@epfl.ch> <nicolas.chiaruttini@epfl.ch>
-Nicholas Papp <nicola.papp@intelligent-imaging.com>
+Nicola Papp <nicola.papp@intelligent-imaging.com>
 Nils Gladitz <nilsgladitz@gmail.com> <n.gladitz@abberior-instruments.com>
 Paul van Schayck <polleke@gmail.com>
 Pete Bankhead <pete.bankhead@gmail.com>
@@ -57,7 +57,7 @@ Shaquille Louisa <shaquille@lambertinstruments.com> <118732057+ShaquilleLouisa-L
 Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
 Stefan Helfrich <stefan.helfrich@uni-konstanz.de> <s.helfrich@fz-juelich.de>
 Stefan Helfrich <stefan.helfrich@uni-konstanz.de> <stefan.helfrich@googlemail.com>
-Stefan Wagner-Conrad <stephan.wagner-conrad@zeiss.com> <46338941+swg08@users.noreply.github.com>
+Stephan Wagner-Conrad <stephan.wagner-conrad@zeiss.com> <46338941+swg08@users.noreply.github.com>
 Tomas Farago <tomas.farago@kit.edu> <sensej007@email.cz>
 Wim Pomp <wimpomp@gmail.com> <w.pomp@nki.nl>
 Zach Marin <zach.marin@yale.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
+Aaron Avery <aaron.avery@healthmyne.com>
 Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
 Alex Herbert <a.herbert@sussex.ac.uk>
 Alexandr Virodov <alexandr.vir@gmail.com> <alexandr.virodov@uky.edu>
@@ -25,12 +26,13 @@ Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@lifesci.dundee.ac.uk
 Eliana Andreica <e.andreica@oxinst.com>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
 Ian Munro <i.munro@imperial.ac.uk>
+Ilya Parmon <ilya.parm@gmail.com>
 Jan Eglinger <jan.eglinger@fmi.ch> <jan.eglinger@gmail.com>
 Jean-Marie Burel <j.burel@dundee.ac.uk>
 Jean-Yves Tinevez <jean-yves.tinevez@pasteur.fr> <jeanyves.tinevez@gmail.com>
 Jeremy Muhlich <jeremy_muhlich@hms.harvard.edu> <jmuhlich@bitflood.org>
 Jim Crowe <jimc@mikroscan.com>
-Johan Herz <45658761+LambertJohan@users.noreply.github.com>
+Johan Herz <johan@lambertinstruments.com> <45658761+LambertJohan@users.noreply.github.com>
 Johannes Schindelin <johannes.schindelin@gmx.de> <Johannes.Schindelin@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,12 +1,63 @@
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
+Alex Herbert <a.herbert@sussex.ac.uk>
+Alexandr Virodov <alexandr.vir@gmail.com> <alexandr.virodov@uky.edu>
+Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
+Andreica Eliana <e.andreica@oxinst.com>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
+Balaji Ramalingam <b.ramalingam@dundee.ac.uk>
+Brian Long <berl@users.noreply.github.com>
+Brian Long <berl@users.noreply.github.com> <brianl@OSXLTZDV30.local>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee.ac.uk>
 Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
 Chris Allan <callan@glencoesoftware.com> <callan@lifesci.dundee.ac.uk>
+Christian Niedworok <ch-n@gmx.net>
+Christian Sachs <c.sachs@fz-juelich.de> <chris@sachs.im>
+Christian Sachs <c.sachs@fz-juelich.de> <sachs.christian@gmail.com>
+Claire McQuin <mcquin@broadinstitute.org>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Curtis Rueden <ctrueden@wisc.edu> <unknown@unknown>
+Constanze Wendtland <constanze.wendlandt@leica-microsystems.com> 
+Constanze Wendtland <constanze.wendlandt@leica-microsystems.com> <88091453+XLEFReaderForBioformats@users.noreply.github.com>
+David Gault <d.gault@dundee.ac.uk>
+David Pinto <david.pinto@bioch.ox.ac.uk> <carandraug+dev@gmail.com>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@lifesci.dundee.ac.uk>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Ian Munro <i.munro@imperial.ac.uk>
+Jan Eglinger <jan.eglinger@fmi.ch> <jan.eglinger@gmail.com>
 Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Yves Tinevez <jean-yves.tinevez@pasteur.fr> <jeanyves.tinevez@gmail.com>
+Jeremy Muhlich <jeremy_muhlich@hms.harvard.edu> <jmuhlich@bitflood.org>
+Jim Crowe <jimc@mikroscan.com>
+Johan Herz <45658761+LambertJohan@users.noreply.github.com>
 Johannes Schindelin <johannes.schindelin@gmx.de> <Johannes.Schindelin@gmx.de>
-Josh Moore <josh@glencoesoftware.com> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Kristian Kjærgaard <kkjaergaard@gmail.com>
 Kristin Briney <briney@wisc.edu>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
 Mark Hiner <hiner@wisc.edu> <hinerm@gmail.com>
+Mark Kittisopikul <mark.kittisopikul@utsouthwestern.edu> <mark.kittisopikul@northwestern.edu>
+Matthieu Moisse <matthieu.moisse@kuleuven.vib.be>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
+Nicholas Chiaruttini <nicholas.chiaruttini@epfl.ch> <nicolas.chiaruttini@epfl.ch>
+Nicholas Papp <nicola.papp@intelligent-imaging.com>
+Nils Gladitz <nilsgladitz@gmail.com> <n.gladitz@abberior-instruments.com>
+Paul van Schayck <polleke@gmail.com>
+Pete Bankhead <pete.bankhead@gmail.com>
 Premysl Fiala <premysl.fiala@lim.cz>
+Richard Myers <richard@intelligent-imaging.com> <RichardMyers@users.noreply.github.com>
+Richard Myers <richard@intelligent-imaging.com> <venicebeach+github@gmail.com>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Shaquille Louisa <shaquille@lambertinstruments.com> <118732057+ShaquilleLouisa-LambertInstruments@users.noreply.github.com>
+Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
+Stefan Helfrich <stefan.helfrich@uni-konstanz.de> <s.helfrich@fz-juelich.de>
+Stefan Helfrich <stefan.helfrich@uni-konstanz.de> <stefan.helfrich@googlemail.com>
+Stefan Wagner-Conrad <stephan.wagner-conrad@zeiss.com> <46338941+swg08@users.noreply.github.com>
+Tomas Farago <tomas.farago@kit.edu> <sensej007@email.cz>
+Wim Pomp <wimpomp@gmail.com> <w.pomp@nki.nl>
+Zach Marin <zach.marin@yale.edu>


### PR DESCRIPTION
This PR updates the top-level mailmap to normalise all historical Bio-Formats contributors and have a single canonical real name and email address per contributor. The following rules are used for the construction of the .mailmap file:

- for all contributors who were also employees of the University of Dundee, Glencoe Software or the University of Wisconsin, the @dundee.ac.uk,  @glencoesoftware.com or @wisc.edu email address is used as the canonical email address
- for all contributors with an executed CLA, the real name and email address sent via the CLA is used as the canonical address
- for all contributors, the name used in https://www.openmicroscopy.org/teams/ or https://www.openmicroscopy.org/contributors/ is used as the canonical real name.

The .mailmap is constructed according to the official [documentation](https://git-scm.com/docs/gitmailmap) using one of the two forms:

```
Proper Name <proper@email.xx> <commit@email.xx>
```

for mapping different email addresses and

```
Proper Name <proper@email.xx> Commit Name <commit@email.xx>
```
for mapping different real names.

The unique list of commit authors can be generated and reviewing using `git shortlog -se`


See also https://github.com/ome/openmicroscopy/pull/6349 for a discussion about the format of `mailmap`