### PR TITLE
Plugins: Attempt to close readers after exception

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
@@ -96,12 +96,23 @@ public class Importer {
         finish(process);
       }
       catch (Exception exc) {
-        if (!process.getOptions().isVirtual() && process.getReader() != null) {
-          process.getReader().close();
-        }
         boolean quiet = options == null ? false : options.isQuiet();
         WindowTools.reportException(exc, quiet,
           "Sorry, there was a problem during import.");
+        
+        // Try to close the reader, if the exception occurred before file 
+        // initialization then this may not be possible 
+        try {
+          if (!process.getOptions().isVirtual() && process.getReader() != null) {
+            process.getReader().close();
+          }
+        }
+        catch(IllegalStateException argExcep) {
+          // If the ImageProcessReader could not be closed then instead close the baseReader
+          if (!process.getOptions().isVirtual() && process.getBaseReader() != null) {
+            process.getBaseReader().close();
+          }
+        }
       }
     }
     catch (IOException exc) {


### PR DESCRIPTION
This is a follow up to a previous PR https://github.com/ome/bioformats/pull/3868

The previous attempt at solving this issue was partially successful depending on the location at which the exception occurred. The previous attempt aimed at closing the ImageProcessReader, but if the caught exception occurred before the STACK step, then this was not possible and a further exception was thrown.

This results in a different exception being displayed to the user and is less informative and helpful for debugging issues. This PR aims to catch that further exception and use that as an opportunity to instead close the lower level baseReader instead.


To test:
- FIJI should be used for testing. The bio-formats_plugins jar should be replaced when testing the PR.
- Choose a suitable sample file that currently results in an exception. Something such as QA-32932 from https://github.com/ome/bioformats/issues/3996 should work

- Without this PR attempting to open the file will result in an unhelpful exception as below:
```
java.lang.IllegalStateException: Too early in import process: current step is FILE, but must be after STACK
	at loci.plugins.in.ImportProcess.assertStep(ImportProcess.java:778)
	at loci.plugins.in.ImportProcess.getReader(ImportProcess.java:306)
```
- With the PR included, you should now see the original exception displayed. For the example of QA-32932 this would be:
```
Exception in thread "main" java.lang.IllegalArgumentException: Invalid C index: 1/1
	at loci.formats.FormatTools.getIndex(FormatTools.java:481)
	at loci.formats.FormatTools.getIndex(FormatTools.java:408)
	at loci.formats.FormatReader.getIndex(FormatReader.java:1150)
	at loci.formats.in.ZeissCZIReader.assignPlaneIndices(ZeissCZIReader.java:2181)
	at loci.formats.in.ZeissCZIReader.initFile(ZeissCZIReader.java:1002)
	at loci.formats.FormatReader.setId(FormatReader.java:1466)
	at loci.formats.ImageReader.setId(ImageReader.java:863)
```


Fixes #3899