### PR TITLE
Deprecate LegacyND2Reader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
@@ -38,7 +38,10 @@ import loci.formats.meta.MetadataStore;
 /**
  * LegacyND2Reader is a file format reader for Nikon ND2 files that uses
  * the Nikon ND2 SDK - it is only usable on Windows machines.
+ *
+ * @Deprecated LegacyND2Reader will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LegacyND2Reader extends FormatReader {
 
   // -- Constants --

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -70,7 +70,11 @@ import ome.units.UNITS;
  * (2) the JAI jar file precedes JJ2000 in the classpath.
  *
  * Thanks to Tom Caswell for additions to the ND2 metadata parsing logic.
+ *
+ * @Deprecated NativeND2Reader will be unified with ND2Reader in Bio-Formats 7.0.0
+ * and should no longer be used
  */
+@Deprecated
 public class NativeND2Reader extends SubResolutionFormatReader {
 
   // -- Constants --


### PR DESCRIPTION
This reader depends on an outdated DLL which has not been built in years, is untested and fully superseded by the new NativeND2Reader

In addition to the Java reader, the following components are scheduled for removal in Bio-Formats 7:
- `lib/LegacyND2Reader.dll`
- `components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp`
- `components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.h`

Possibly biggest question is whether we want to keep the delegation logic implemented in `ND2Reader` which allows to select between the `LegacyND2Reader` and `NativeND2Reader`. Listing a series of options briefly discussed with @melissalinkert are:

1. redirect https://github.com/ome/bioformats/blob/971fb341745e5c7e4b0cbf8c2af59deacc73db75/components/formats-gpl/src/loci/formats/in/ND2Reader.java#L47 to `NativeND2Reader`.
2. keep `ND2Reader` but have it simply extend `NativeND2Reader`
3. remove `ND2Reader` and update `readers.txt` to use `NativeND2Reader`
4. remove the delegate reader and rename `NativeND2Reader` as `ND2Reader`

Given this is a backwards-incompatible change, my personal preference would go towards options 3 or 4 but definitely open to feedback. In case we go for the latter options, we might want to add other deprecation flags to some of these classes