### PR TITLE
Add deprecation flags for LegacyQTTools/LegacyQTReader/LegacyQTWriter

### DIFF
--- a/components/formats-bsd/src/loci/formats/gui/LegacyQTTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/LegacyQTTools.java
@@ -53,7 +53,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for working with QuickTime for Java.
+ *
+ * @Deprecated LegacyQTTools will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LegacyQTTools {
 
   // -- Constants --

--- a/components/formats-bsd/src/loci/formats/in/LegacyQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/LegacyQTReader.java
@@ -57,7 +57,10 @@ import loci.formats.meta.MetadataStore;
  *
  * Much of this code was based on the QuickTime Movie Opener for ImageJ
  * (available at http://rsb.info.nih.gov/ij/plugins/movie-opener.html).
+ *
+ * @Deprecated LegacyQTReader will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LegacyQTReader extends BIFormatReader {
 
   // -- Fields --

--- a/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
@@ -61,7 +61,11 @@ import loci.formats.meta.MetadataStore;
  * Additional video codecs will be added as time permits.
  *
  * @author Melissa Linkert melissa at glencoesoftware.com
+ *
+ * @Deprecated NativeQTReader will be unified with QTReader in Bio-Formats 7.0.0
+ * and should no longer be used
  */
+@Deprecated
 public class NativeQTReader extends FormatReader {
 
   // -- Constants --

--- a/components/formats-bsd/src/loci/formats/out/LegacyQTWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/LegacyQTWriter.java
@@ -52,7 +52,10 @@ import loci.formats.meta.MetadataRetrieve;
  *
  * Much of this code was based on the QuickTime Movie Writer for ImageJ
  * (available at http://rsb.info.nih.gov/ij/plugins/movie-writer.html).
+ *
+ * @Deprecated LegacyQTWriter will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LegacyQTWriter extends FormatWriter {
 
   // -- Constants --


### PR DESCRIPTION
These classes depended on the external QuickTime for Java library which is long obsolete. This commit marks them as deprecated in preparation for removal in the upcoming major release of Bio-Formats

The removal of these classes will affect the following components:

- `components/bio-formats-plugins/src/loci/plugins/config/ConfigWindow.java`
- `components/formats-bsd/src/loci/formats/gui/DataConverter.java`
- `components/formats-bsd/src/loci/formats/in/PictReader.java`
- `components/formats-bsd/src/loci/formats/in/QTReader.java`
- `components/formats-bsd/src/loci/formats/out/QTWriter.java`

For `LegacyQTReader`, the same range of options as the one discussed in https://github.com/ome/bioformats/pull/4030 are available ranging from minimal changes to removing the reader delegation logic. 