### PR TITLE
Add deprecation flags for LuraWave/LuraWaveCode/LuraWaveService/LuraWaveServiceImpl

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/LuraWave.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LuraWave.java
@@ -34,7 +34,10 @@ import loci.formats.services.LuraWaveServiceImpl;
 
 /**
  * Utility methods for dealing with proprietary LuraWave licensing.
+ *
+ * @deprecated LuraWave will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public final class LuraWave {
 
   // -- Constants --

--- a/components/formats-bsd/src/loci/formats/codec/LuraWaveCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LuraWaveCodec.java
@@ -54,7 +54,10 @@ import loci.formats.services.LuraWaveServiceImpl;
  * <code>-Dlurawave.license=XXXX</code> on the command line).
  *
  * @author Curtis Rueden ctrueden at wisc.edu
+ *
+ * @deprecated LuraWaveCodec will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LuraWaveCodec extends WrappedCodec {
   public LuraWaveCodec() {
     super(new ome.codecs.LuraWaveCodec());

--- a/components/formats-bsd/src/loci/formats/services/LuraWaveService.java
+++ b/components/formats-bsd/src/loci/formats/services/LuraWaveService.java
@@ -42,7 +42,10 @@ import loci.common.services.ServiceException;
 /**
  *
  * @author callan
+ *
+ * @deprecated LuraWaveService will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public interface LuraWaveService extends Service {
 
   /**

--- a/components/formats-bsd/src/loci/formats/services/LuraWaveServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/LuraWaveServiceImpl.java
@@ -45,7 +45,10 @@ import com.luratech.lwf.lwfDecoder;
 /**
  *
  * @author callan
+ *
+ * @deprecated LuraWaveServiceImpl will be removed in Bio-Formats 7.0.0
  */
+@Deprecated
 public class LuraWaveServiceImpl extends AbstractService
   implements LuraWaveService {
 


### PR DESCRIPTION
This codec depends on a third-party proprietary library with a license code. This commit marks these classes as deprecated in preparation for their removal in the upcoming major release of Bio-Formats

The removal of these classes will minimally affect the following locations:

- `build.xml`
- `components/bio-formats-plugins/src/loci/plugins/config/FlexWidgets.java`
- `components/bio-formats-plugins/src/loci/plugins/config/libraries.txt`
- `components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java`
- `components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java`
- `components/formats-api/src/loci/formats/readers.txt`
- `components/formats-bsd/matlab/bfGetReader.m`
- `components/formats-bsd/matlab/bfopen.m`
- `components/formats-bsd/src/loci/formats/tiff/TiffCompression.java`
- `components/formats-bsd/test/loci/formats/utests/CompressDecompressTest.java`
- `components/formats-gpl/src/loci/formats/in/FlexReader.java`
- `lwf-stubs` dependency (see https://github.com/ome/bioformats/pull/4032#pullrequestreview-1505634706)