### PR TITLE
Bump ome-common version to 6.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.16</ome-common.version>
+    <ome-common.version>6.0.17</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.3.3</ome-model.version>
     <ome-poi.version>5.3.7</ome-poi.version>


### PR DESCRIPTION
Bumping to latest ome-common version ahead of release, the only difference is a small javadoc change