### PR TITLE
Bump native-lib-loader for ARM-readiness

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -142,7 +142,7 @@ Logback
     License:   EPL v1.0 and LGPL 2.1
 
 Native library loader
-    JAR file:  native-lib-loader-2.0.2.jar
+    JAR file:  native-lib-loader-2.4.0.jar
     URL:       http://github.com/scijava/native-lib-loader
     Notes:     required for loading native libraries
     License:   BSD

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>native-lib-loader</artifactId>
-      <version>2.1.4</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.jgoodies</groupId>


### PR DESCRIPTION
I receive the warning:

```
[main] WARN org.scijava.nativelib.NativeLibraryUtil - No native library available for this platform.
```

and this was because native-lib-loader labeled ARM64 platforms as unknown and was unable to do anything with them (relevant code: https://github.com/scijava/native-lib-loader/blob/21d6c1e9f9e296e5cdbb151d20e0861e1ee3261d/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java#L329-L331). Version 2.4.0 was released in 2021 and so it's mature enough.