### PR TITLE
Flex: ignore files where compression cannot be identified

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1235,7 +1235,7 @@ public class FlexReader extends FormatReader {
         firstIFD = parser.getFirstIFD();
         ifdCount = parser.getIFDOffsets().length;
       }
-      Boolean compressed = null;
+      Boolean compressed = true;
       try {
         compressed =
           firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
@@ -1354,7 +1354,6 @@ public class FlexReader extends FormatReader {
             }
             catch (EnumException e) {
               LOGGER.trace("Could not get compression", e);
-              continue;
             }
 
             if (compressed || firstIFD.getStripOffsets()[0] == 16 ||

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -39,6 +39,7 @@ import loci.common.IRandomAccess;
 import loci.common.Location;
 import loci.common.NIOFileHandle;
 import loci.common.RandomAccessInputStream;
+import loci.common.enumeration.EnumException;
 import loci.common.xml.BaseHandler;
 import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
@@ -1234,8 +1235,14 @@ public class FlexReader extends FormatReader {
         firstIFD = parser.getFirstIFD();
         ifdCount = parser.getIFDOffsets().length;
       }
-      boolean compressed =
-        firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
+      Boolean compressed = null;
+      try {
+        compressed =
+          firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
+      }
+      catch (EnumException e) {
+        LOGGER.trace("Could not get compression for " + file, e);
+      }
       if (firstCompressed == null) {
         firstCompressed = compressed;
         firstIFDCount = ifdCount;
@@ -1341,8 +1348,14 @@ public class FlexReader extends FormatReader {
             LOGGER.info("Parsing IFDs for well {}{}",
               FormatTools.getWellRowName(row), col + 1);
             IFD firstIFD = tp.getFirstIFD();
-            compressed =
-              firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
+            try {
+              compressed =
+                firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
+            }
+            catch (EnumException e) {
+              LOGGER.trace("Could not get compression", e);
+              continue;
+            }
 
             if (compressed || firstIFD.getStripOffsets()[0] == 16 ||
               firstIFD.getStripOffsets().length == 1)


### PR DESCRIPTION
Companion to #4040. This should fix test failures in the `flex` directory without requiring configuration changes.

Files with a compression type not in the `TiffCompression` enum (e.g. Lurawave) will now be skipped instead of throwing an exception.

I had initially added a `continue` between lines 1244 and 1245, but that causes more test failures as it changes the file grouping (since the `else` block starting in line 1283 is not executed).

