### PR TITLE
fix aplreader throwing nullptrexception

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -91,12 +91,12 @@ public class APLReader extends FormatReader {
         try {
           parent = parent.getParentFile();
           parent = parent.getParentFile();
+          Location aplFile = new Location(parent, parent.getName() + ".apl");
+          return aplFile.exists();
         }
         catch (NullPointerException e) {
           return false;
         }
-        Location aplFile = new Location(parent, parent.getName() + ".apl");
-        return aplFile.exists();
       }
     }
     return false;


### PR DESCRIPTION
If you run this with `/images/a.tif`, you get a nullptr exception. However not for `/a.tif` or for `/images/img/a.tif`. So our case wasn't tested.