### PR TITLE
Fixes a NPE in OperettaReader.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -523,6 +523,13 @@ public class OperettaReader extends FormatReader {
           }
           // Check the next plane if possible
           planeIndex++;
+
+          // The next plane may be null, in which case we need to move to the next non-null one
+          while (planeIndex < planes[i].length && planes[i][planeIndex] == null) {
+            LOGGER.debug("skipping null plane series = {}, plane = {}", i, planeIndex);
+            planeIndex++;
+          }
+
           if (planeIndex >= planes[i].length) {
               break;
           }


### PR DESCRIPTION
The next plane checked in the initializer may be null, in which case the plane needs to be iterated until the end of the series is found or a non-null plane is found.

See https://forum.image.sc/t/null-pointer-exception-in-perkin-elmer-operetta-dataset-with-bio-formats-6-14/83784.

That's hopefully a better fix than https://github.com/ome/bioformats/pull/3924