### PR TITLE
Don't fail on non-4:4:4 JPEG

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -424,9 +424,10 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     // JpegSnoop or identify -verbose show subsampling rates
     // convert -sampling rate 2x2 or ffmpeg -i .. -vf format=yuv420p for making images
 
-    // MCU size in X direction divided by 8 is the ratio of largest X to smallest X
-    // likewise for Y. The first 4 bits is X, the next 4 bits make up Y.
-    // some examples: 2x1,2x1,2x1 (0x21,0x21,0x21) is 8x8. because 2/2 = 1, 1/1 = 1
+    // MCU size in X direction divided by 8 is lcm(x1,x2,x3)/gcd(x1,x2,x3)
+    // but use a simpler formula here: max x_i / min x_i.
+    // Likewise for Y. For each coomponent, first 4 bits is X, the next 4 bits make up Y.
+    // some examples: 2x1,2x1,2x1 (0x21,0x21,0x21) is 8x8.
     // 2x1,1x1,1x1 is 16x8. 3x2,1x1,1x1 is 24x16
 
     // No need to shift now

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -186,12 +186,6 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
       }
     }
 
-    if (mcuWidth == 0) {
-      LOGGER.warn("assume MCU width and height 8");
-      mcuWidth = 8;
-      mcuHeight = 8;
-    }
-
     if (restartMarkers.size() == 1) {
       in.seek(restartMarkers.get(0));
 

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -449,8 +449,8 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
       int quantTableNumber = in.readByte() & 0xff;
     }
 
-    mcuHeight = maxX / minX * 8;
-    mcuWidth = maxY / minY * 8;
+    mcuWidth = maxX / minX * 8;
+    mcuHeight = maxY / minY * 8;
   }
 
 }


### PR DESCRIPTION
The previous pull request description was hard to read, so I'm rewriting it: MCU size is 8x8 for 4:4:4. We should read relative subsampling "numbers" from SOF0 and calculate MCU size accordingly. This way, we won't get IndexOutOfBounds when we read 4:2:0 etc.Closes #3616