### PR TITLE
Gatan DM3: be more defensive in parsing acquisition mode

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -347,8 +347,15 @@ public class GatanReader extends FormatReader {
       for (String token : scopeInfo) {
         token = token.trim();
         if (token.startsWith("Mode")) {
-          token = token.substring(token.indexOf(' ')).trim();
-          mode = token.substring(0, token.indexOf(' ')).trim();
+          if (token.indexOf(' ') > 0) {
+            token = token.substring(token.indexOf(' ')).trim();
+          }
+          if (token.indexOf(' ') > 0) {
+            mode = token.substring(0, token.indexOf(' ')).trim();
+          }
+          else {
+            mode = token;
+          }
           if (mode.equals("TEM")) mode = "Other";
         }
       }


### PR DESCRIPTION
Fixes #3938.

To test, use the artificial file in `curated/gatan/samples/mode-metadata`. Without this PR, `showinf` should result in an exception matching what is in #3938. With this PR, the file should initialize without error. 