### PR TITLE
IVision: improve version and data type checks in isThisType

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/IvisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IvisionReader.java
@@ -94,7 +94,12 @@ public class IvisionReader extends FormatReader {
     String version = stream.readString(3);
     try {
       Double.parseDouble(version);
-      return version.indexOf('.') != -1 && version.indexOf('-') == -1;
+      boolean validVersion = version.indexOf('.') != -1 && version.indexOf('-') == -1;
+      boolean validPatch = Character.isAlphabetic(stream.read());
+      stream.skipBytes(1);
+      int dataType = stream.read();
+      boolean validType = dataType >= 0 && dataType <= 8;
+      return validVersion && validPatch && validType;
     }
     catch (NumberFormatException e) { }
     return false;


### PR DESCRIPTION
Fixes #3582.

Without this PR, `showinf` on the file in `inbox/imagesc-39874/` will incorrectly detect the file type as `Ivision`, and successfully initialize with dimensions that are obviously very wrong. With this PR, the same test should throw `UnknownFormatException`, since the file is not actually something Bio-Formats should read.

Tests of existing Ivision files should continue to pass with this change.