### PR TITLE
Ventana: fix tile arithmetic for smallest resolutions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -230,8 +230,8 @@ public class VentanaReader extends BaseTiffReader {
     int outputRowLen = w * tilePixel;
 
     int scale = getScale(getCoreIndex());
-    int thisTileWidth = tileWidth / scale;
-    int thisTileHeight = tileHeight / scale;
+    int thisTileWidth = scaleCoordinate(tileWidth, getCoreIndex());
+    int thisTileHeight = scaleCoordinate(tileHeight, getCoreIndex());
 
     byte[] subResTile = null;
     int subResX = -1, subResY = -1;
@@ -250,8 +250,8 @@ public class VentanaReader extends BaseTiffReader {
       }
       tileBox.x = scaleCoordinate(tileBox.x, getCoreIndex());
       tileBox.y = scaleCoordinate(tileBox.y, getCoreIndex());
-      tileBox.width /= scale;
-      tileBox.height /= scale;
+      tileBox.width = scaleCoordinate(tileBox.width, getCoreIndex());
+      tileBox.height = scaleCoordinate(tileBox.height, getCoreIndex());
 
       if (tileBox.intersects(imageBox)) {
         if (scale == 1) {

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -292,9 +292,13 @@ public class VentanaReader extends BaseTiffReader {
             input = inRow * (c * tileHeight + offsetY) + offsetX * tilePixel;
             output = c * thisTileHeight * outRow;
             for (int row=0; row<thisTileHeight; row++) {
-              System.arraycopy(subResTile, input, tilePixels, output, outRow);
-              input += inRow;
-              output += outRow;
+              int copy = (int) Math.min(outRow, tilePixels.length - output);
+              copy = (int) Math.min(copy, subResTile.length - input);
+              if (copy >= 0) {
+                System.arraycopy(subResTile, input, tilePixels, output, copy);
+                input += inRow;
+                output += outRow;
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes #3927.

Any of the .bif files in `curated/ventana` should show the issue, but the 3 files for which the problem was reported are in `curated/ventana/gh-3927`. Without this PR, `showinf -noflat` on the last 2 resolutions in the first series should show a grid of 0-value pixels. With this PR, the same command should show a normal-looking image that matches the larger resolutions in the pyramid.