### PR TITLE
OME-TIFF: optionally fail fast if an invalid file is encountered

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1103,6 +1103,9 @@ public class OMETiffReader extends SubResolutionFormatReader {
         if (firstFile == null ||
           (testFile != null && !info[s][0].reader.isThisType(testFile)))
         {
+          if (failOnMissingTIFF()) {
+            throw new FormatException("Invalid file (may be corrupted): " + info[s][0].id);
+          }
           LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
           info[s][0].id = currentId;
           info[s][0].exists = false;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1103,7 +1103,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
         if (firstFile == null ||
           (testFile != null && !info[s][0].reader.isThisType(testFile)))
         {
-          if (failOnMissingTIFF()) {
+          if (info[s][0].id != null && failOnMissingTIFF()) {
             throw new FormatException("Invalid file (may be corrupted): " + info[s][0].id);
           }
           LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);


### PR DESCRIPTION
See #4010.

As noted in #4010, this can be tested by taking https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/plate-companion/ and replacing `well-C2-2.ome.tiff` with a 0-byte file of the same name. With this PR, `showinf -debug hcs.companion.ome` on the modified dataset should throw `FormatException`.