### PR TITLE
Gel: check IFD count in isThisType

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -90,7 +90,11 @@ public class GelReader extends BaseTiffReader {
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
     TiffParser parser = new TiffParser(stream);
     parser.setDoCaching(false);
-    IFD ifd = parser.getFirstIFD();
+    long[] offsets = parser.getIFDOffsets();
+    if (offsets.length == 0 || offsets.length > 2) {
+      return false;
+    }
+    IFD ifd = parser.getIFD(offsets[0]);
     if (ifd == null) return false;
     return ifd.containsKey(MD_FILETAG);
   }


### PR DESCRIPTION
Fixes #4034.

Actual gel images have a single plane, and a maximum of 2 IFDs (one image, one extra metadata).

The `imagesc-82872/SG...` file from #4034 is not actually a gel, but was incorrectly identified as it has some of the same tags that `GelReader` expects. With this PR, the file should be picked up by `TiffDelegateReader`, and have 4 single-plane series all of which are readable. 

There is some additional metadata in the file which doesn't appear to correspond to an existing reader. I would guess that this data should be represented as a single series with 2 resolutions and 2 channels, but that would require a new reader.
