### PR TITLE
Photoshop TIFF: fix plane reading with memoization

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
@@ -101,6 +101,7 @@ public class PhotoshopTiffReader extends BaseTiffReader {
       offsetIndex += core.get(i, 0).sizeC;
     }
 
+    openPixelTag();
     tag.seek(layerOffset[offsetIndex]);
 
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
@@ -149,18 +150,7 @@ public class PhotoshopTiffReader extends BaseTiffReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
-    Object sourceData = ifds.get(0).getIFDValue(IMAGE_SOURCE_DATA);
-    byte[] b = null;
-    if (sourceData instanceof byte[]) {
-      b = (byte[]) sourceData;
-    }
-    else if (sourceData instanceof TiffIFDEntry) {
-      b = (byte[]) tiffParser.getIFDValue((TiffIFDEntry) sourceData);
-    }
-    if (b == null) return;
-
-    tag = new RandomAccessInputStream(b);
-    tag.order(isLittleEndian());
+    openPixelTag();
 
     String checkString = tag.readCString();
 
@@ -294,6 +284,24 @@ public class PhotoshopTiffReader extends BaseTiffReader {
         store.setImageName(layerNames[layer], layer + 1);
       }
     }
+  }
+
+  private void openPixelTag() throws IOException {
+    if (tag != null) {
+      return;
+    }
+    Object sourceData = ifds.get(0).getIFDValue(IMAGE_SOURCE_DATA);
+    byte[] b = null;
+    if (sourceData instanceof byte[]) {
+      b = (byte[]) sourceData;
+    }
+    else if (sourceData instanceof TiffIFDEntry) {
+      b = (byte[]) tiffParser.getIFDValue((TiffIFDEntry) sourceData);
+    }
+    if (b == null) return;
+
+    tag = new RandomAccessInputStream(b);
+    tag.order(isLittleEndian());
   }
 
 }


### PR DESCRIPTION
Fixes #4033

To test, use the `imagesc-82872/WT...` file. Without this PR, the original problem can be reproduced with two successive calls to `showinf -cache -series 1`. Memoization combined with non-0 series index is important; this is why the problem appeared with `bioformats2raw` but wasn't immediately reproduceable with `showinf`.

With this PR, the same test should display an image without exception.