### PR TITLE
OIR: fix off-by-one in XML block reading

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -661,12 +661,12 @@ public class OIRReader extends FormatReader {
         break;
       }
       long fp = s.getFilePointer();
-      String xml = s.readString(length).trim();
+      String xml = s.readString(length);
       if (!xml.startsWith("<?xml")) {
         s.seek(fp - 2);
         continue;
       }
-      LOGGER.trace("xml = {}", xml);
+      xml = xml.trim();
       if (((channels.size() == 0 || getSizeX() == 0 || getSizeY() == 0) &&
         isCurrentFile(file)) || xml.indexOf("lut:LUT") > 0)
       {


### PR DESCRIPTION
Fixes #3779.

Without this PR, `showinf` on the file in `curated/olympus-oir/gh-3779` should initialize the file and display images, but with several logged warnings about missing pixel data blocks as noted in the issue. The corresponding planes will be entirely blank (`-minmax -autoscale -fast` may help to verify).

With this PR, the same test should show no missing pixel data warnings, and all planes should contain reasonable data.

I wouldn't expect tests to fail, but it's probably also worth double-checking that build logs for `olympus-oir` do not contain any `No pixel blocks for plane #` warnings.