### PR TITLE
Leica LIF: throw a nicer exception if no images are found

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1131,6 +1131,10 @@ public class LIFReader extends FormatReader {
     }
 
     NodeList images = getNodes(realRoot, "Image");
+    if (images == null) {
+      throw new FormatException("No images found. This file is not valid.");
+    }
+
     List<Element> imageNodes = new ArrayList<Element>();
     Long[] oldOffsets = null;
     if (images.getLength() > offsets.size()) {


### PR DESCRIPTION
Fixes #4012.

To test, use the file in QA 33019. Note this file is only 1043 bytes; there is no image data, which is confirmed by LAS X.

Without this PR, `showinf` will throw a `NullPointerException` as noted in #4012. With this PR, `showinf -debug` will throw a more informative `FormatException`.