### PR TITLE
Exporter plugin: remove any extra Channel elements

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -446,6 +446,15 @@ public class Exporter {
             store.setPixelsSizeC(new PositiveInteger(channels*imp.getNChannels()), 0);
             store.setPixelsSizeT(new PositiveInteger(imp.getNFrames()), 0);
 
+            try {
+              // if a subset of the data was opened, the number of Channels
+              // in the OME-XML may not match the ImagePlus channel count
+              // channel count mismatches can cause problems when actually writing pixels
+              service.removeChannels(service.getOMEMetadata(store), 0, imp.getNChannels());
+            }
+            catch (ServiceException e) {
+            }
+
             if (store.getImageID(0) == null) {
                 store.setImageID(MetadataTools.createLSID("Image", 0), 0);
             }


### PR DESCRIPTION
Fixes #3539.

Without this PR, the problem is reproduceable by following the steps in the issue; in particular, the image needs to be opened with `Specify range for each series` checked and at least one channel omitted from the range.

With this PR, the same test should successfully write an .ics file. The converted file should also be readable, and have the correct (smaller) dimensions.