### PR TITLE
SVS: fix a variety of small issues

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -658,7 +658,7 @@ public class SVSReader extends BaseTiffReader {
   }
 
   protected double getMagnification() {
-    return magnification;
+    return magnification == null ? Double.NaN : magnification;
   }
 
   protected ArrayList<String> getDyeNames() {


### PR DESCRIPTION
c574360 fixes #3986. Most data is unaffected, but `CMU-1.svs` now has different behavior. Compare `showinf -noflat -omexml -series 1` and `showinf -noflat -omexml series 2` with and without this PR. Without this PR, a label image is shown the one named `macro image` and a macro image is shown for the one named `label image`. With this PR, the names and images should match. I think this behavior change warrants a minor release, but happy to hear other opinions.

1b6da10 trivially fixes #4036.

593c819 fixes #3743 by setting the X and Y position on the full-resolution image to the `Left` and `Top` values respectively from the image description. This is different from what `TIFFToDicom` (as referenced in #3743) does; `TIFFToDicom` assumes both that the macro image is 1 inch (25.4 mm) high and that the full-resolution image is rotated 90 degrees with respect to the macro. With `CMU-1.svs`, `TIFFToDicom` sets the macro image to 0.0589mm/pixel with a plane position of (X=25.4mm, Y=75.434mm). The full-resolution image is set to 0.000499mm/pixel (which is correct), with a plane position of (X=23.449873mm, Y=49.7423mm). I am not entirely comfortable with applying those assumptions to all SVS files, so for now just the full-resolution positions are set with no correction or rotation applied. That's enough information for downstream applications to replicate the behavior in `TIFFToDicom` though.

#3682 was also tested in the context of this PR; I could not duplicate issues with removed label/macro images, so propose to close that issue as well. A few examples with removed macro and label images are added to the test repo as part of the corresponding configuration PR.