### PR TITLE
CV7000 improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -603,6 +603,9 @@ public class CV7000Reader extends FormatReader {
             if (channel.color != null) {
               store.setChannelColor(channel.color, i, c);
             }
+            if (channel.fluor != null && !channel.fluor.isEmpty()) {
+              store.setChannelFluor(channel.fluor, i, c);
+            }
 
             if (channel.excitation != null && channel.lightSourceRefs != null) {
               int index = -1;
@@ -955,6 +958,8 @@ public class CV7000Reader extends FormatReader {
                 currentChannel.excitation = DataTools.parseDouble(wave);
               }
             }
+
+            currentChannel.fluor = attributes.getValue("bts:Fluorophore");
           }
         }
       }
@@ -1018,6 +1023,8 @@ public class CV7000Reader extends FormatReader {
     public Double exposureTime;
     public String binning;
     public Color color;
+
+    public String fluor;
 
     @Override
     public String toString() {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -70,6 +70,9 @@ public class CV7000Reader extends FormatReader {
 
   // -- Constants --
 
+  public static final String DUPLICATE_PLANES_KEY = "cv7000.duplicate_missing_planes";
+  public static final boolean DUPLICATE_PLANES_DEFAULT = true;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
 
   private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
@@ -102,6 +105,17 @@ public class CV7000Reader extends FormatReader {
     hasCompanionFiles = true;
     domains = new String[] {FormatTools.HCS_DOMAIN};
     datasetDescription = "Directory with XML files and one .tif/.tiff file per plane";
+  }
+
+  // -- CV7000Reader API methods --
+
+  public boolean duplicatePlanes() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       DUPLICATE_PLANES_KEY, DUPLICATE_PLANES_DEFAULT);
+    }
+    return DUPLICATE_PLANES_DEFAULT;
   }
 
   // -- IFormatReader API methods --
@@ -227,6 +241,9 @@ public class CV7000Reader extends FormatReader {
     if (p != null && p.file != null) {
       reader.setId(p.file);
       return reader.openBytes(0, buf, x, y, w, h);
+    }
+    else if (duplicatePlanes() && no > 0) {
+      return openBytes(0, buf, x, y, w, h);
     }
     return buf;
   }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -580,7 +580,8 @@ public class CV7000Reader extends FormatReader {
 
             // the index here is the original bts:Ch index in
             // the *.mes and *.mrf files
-            store.setChannelName("Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, i, c);
+            store.setChannelName("Action #" + (channel.actionIndex + 1) +
+              ", Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, i, c);
 
             if (channel.color != null) {
               store.setChannelColor(channel.color, i, c);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -243,7 +243,17 @@ public class CV7000Reader extends FormatReader {
       return reader.openBytes(0, buf, x, y, w, h);
     }
     else if (duplicatePlanes() && no > 0) {
-      return openBytes(0, buf, x, y, w, h);
+      int[] zct = getZCTCoords(no);
+      // pick the first plane in the same channel
+      int dupPlane = getIndex(0, zct[1], 0);
+
+      // very unlikely to happen, but catching the case
+      // where no is the first plane in the channel prevents
+      // a potential infinite loop
+      if (dupPlane == no) {
+        dupPlane = 0;
+      }
+      return openBytes(dupPlane, buf, x, y, w, h);
     }
     return buf;
   }


### PR DESCRIPTION
Backported from a private PR. Adds a few improvements for more complex acquisitions:

- Include the action index in channel names, so that it's easier to distinguish between the same channel acquired in multiple actions
- Set `Channel.Fluor`, if possible
- For mixed 2D/Z stack acquisitions, `SizeZ` was already to be the largest Z size across all channels, but that leaves potentially many planes with no data. 5cd0ea5 and 6058cec switch the default behavior to from returning a blank plane to returning the first plane in the channel, for any missing data. Setting `cv7000.duplicate_missing_planes` to `false` restores the previous behavior.

Any existing plate will demonstrate the channel name changes; I'll add an artificial sample that demonstrates the `Fluor` and plane duplication changes shortly.

This might be better suited to a minor release, as it adds a new reader option and changes all channel names. A corresponding configuration PR is forthcoming.