### PR TITLE
DICOM writer: throw an exception if the provided tiles don't match the expected tile size

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -188,6 +188,10 @@ public class DicomWriter extends FormatWriter {
   {
     checkParams(no, buf, x, y, w, h);
 
+    int resolutionIndex = getIndex(series, resolution);
+    int thisTileWidth = tileWidth[resolutionIndex];
+    int thisTileHeight = tileHeight[resolutionIndex];
+
     MetadataRetrieve r = getMetadataRetrieve();
     if ((!(r instanceof IPyramidStore) ||
       ((IPyramidStore) r).getResolutionCount(series) == 1) &&
@@ -195,11 +199,17 @@ public class DicomWriter extends FormatWriter {
     {
       throw new FormatException("DicomWriter does not allow tiles for non-pyramid images");
     }
+    else if (x % thisTileWidth != 0 || y % thisTileHeight != 0 ||
+      (w != thisTileWidth && x + w != getSizeX()) ||
+      (h != thisTileHeight && y + h != getSizeY()))
+    {
+      throw new FormatException("Tile too small, expected " + thisTileWidth + "x" + thisTileHeight +
+        ". Setting the tile size to " + getSizeX() + "x" + getSizeY() + " or smaller may work.");
+    }
     checkPixelCount(false);
 
     boolean first = x == 0 && y == 0;
     boolean last = x + w == getSizeX() && y + h == getSizeY();
-    int resolutionIndex = getIndex(series, resolution);
 
     // the compression type isn't supplied to the writer until
     // after setId is called, so metadata that indicates or
@@ -264,8 +274,6 @@ public class DicomWriter extends FormatWriter {
 
     byte[] paddedBuf = null;
 
-    int thisTileWidth = tileWidth[resolutionIndex];
-    int thisTileHeight = tileHeight[resolutionIndex];
     int thisTilePixels = thisTileWidth * thisTileHeight;
 
     // pad the last row and column of tiles to match specified tile size


### PR DESCRIPTION
Without this PR, viewing the smallest resolution from the output of:

```
bfconvert HandEcompressed_Scan1.qptiff test.dcm -tilex 2048 -tiley 2048 -noflat
```

shows an almost all black image; only the top 16 rows of pixels are present. Viewing in OMERO, QuPath, or `showinf -noflat -resolution 4 test_0_0.dcm` will show the problem. `HandEcompressed_Scan1.qptiff` is from https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/perkinelmer/PKI_scans/.

The source of the problem is a combination of things:
- the chosen 2048x2048 tile size is smaller than all resolutions except resolution 4 (the last one)
- for tile sizes larger than a particular resolution, `bfconvert` reverts to the reader's optimal tile size
- the reader's optimal size is 1920x16 for resolution 4 (all others have an optimal size of 512x512)
- `DicomWriter` expects full tiles matching the chosen tile size to be supplied to `saveBytes`, and will pad any smaller tiles to the correct dimensions. So in this case, the first 1920x16 tile supplied gets padded to 2048x2048, and the image is considered completely written.

The proposed solution here is to throw an exception in `saveBytes` if a tile is provided that is not on an expected tile boundary (`x` and `y` coordinates not a multiple of tile size) or is the wrong width or height without being bottom or right edge tile. I think that's most compatible with #3992, minimizes impact by not changing `bfconvert`, and catches cases where the provided tile might not be the correct size when `bfconvert` is not being used.

With this PR, the conversion command above should throw `FormatException`. Changing the tile size parameters to `-tilex 1024 -tiley 1024` or similar should work, and each resolution should be readable.

Updating `bfconvert` to use the full image instead of the reader's optimal size in cases such as resolution 4 would also potentially work, but I'm not convinced that's appropriate in general.