### PR TITLE
TIFF: throw exception on 64-bit int data

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -615,6 +615,9 @@ public class IFD extends HashMap<Integer, Object> {
       case 24:
         return FormatTools.FLOAT;
       case 64:
+        if (bitFormat != 3) {
+          throw new FormatException("64-bit int data not supported");
+        }
         return FormatTools.DOUBLE;
       case 32:
         if (bitFormat == 3) return FormatTools.FLOAT;


### PR DESCRIPTION
Fixes #4089. Test file in `inbox/gh-4089`, generated as described in https://forum.image.sc/t/saving-and-loading-64-bit-int-tiffs/85523/2.

Without this PR, `showinf im-i8.tif` should display an image with `double` type. `tiffinfo` or `tiffdump` should confirm that there 64 bits per sample, but with a `SampleFormat` of 2 indicating signed int data.

With this PR, `showinf -debug im-i8.tif` should throw `FormatException` indicating that the pixel type is unsupported.

We have no real way of supporting this data in Bio-Formats right now, since the OME model does not allow for 64-bit ints. https://trac.openmicroscopy.org/ome/ticket/11860 and https://trello.com/c/FxSUHfGp/273-add-more-model-enum-values are the closest relevant discussions to updating supported pixel types.