### PR TITLE
TIFF: check IFD entry offset before seeking

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -546,6 +546,9 @@ public class TiffParser implements Closeable {
         offset &= 0xffffffffL;
         offset += 0x100000000L;
       }
+      if (offset >= in.length()) {
+        return null;
+      }
       in.seek(offset);
     }
 


### PR DESCRIPTION
Fixes #3941 (I think). `showinf -noflat -resolution 6` on each of 3 affected files referenced in #3941 works with this PR, but does not work without this PR. The forthcoming configuration PR will include NDP.view2 screenshots for reference; it's worth noting that all 3 affected files have 3 Z sections.

Assuming tests pass, should be safe for a patch release.