### PR TITLE
OIR: channel order and missing pixel block fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -687,7 +687,9 @@ public class OIRReader extends FormatReader {
     }
     // total block length could include multiple strings of XML
     int totalBlockLength = s.readInt();
+    LOGGER.debug("total block length = {}", totalBlockLength);
     long end = s.getFilePointer() + totalBlockLength - 4;
+    LOGGER.debug("end = {}", end);
     s.skipBytes(4);
 
     while (s.getFilePointer() < end) {
@@ -735,6 +737,9 @@ public class OIRReader extends FormatReader {
       long fp = s.getFilePointer();
       String xml = s.readString(xmlLength).trim();
       LOGGER.trace("xml = {}", xml);
+      if (!xml.startsWith("<?xml")) {
+        break;
+      }
       if (isCurrentFile(file) || xml.indexOf("lut:LUT") > 0) {
         parseXML(s, xml, fp);
       }
@@ -1249,6 +1254,15 @@ public class OIRReader extends FormatReader {
           parseChannel(channel, appendChannels);
         }
       }
+
+      // calls to parseChannel may have reset the channels list
+      // so there may be null elements that need to be removed
+      for (int i=0; i<channels.size(); i++) {
+        if (channels.get(i) == null) {
+          channels.remove(i);
+          i--;
+        }
+      }
     }
   }
 
@@ -1277,9 +1291,14 @@ public class OIRReader extends FormatReader {
       channelName = name.getTextContent();
     }
 
+    int index = Integer.parseInt(channel.getAttribute("order")) - 1;
+
     if (id != null) {
       boolean foundChannel = false;
       for (Channel ch : channels) {
+        if (ch == null) {
+          continue;
+        }
         if (ch.id.equals(id)) {
           foundChannel = true;
           if (laserId != null) {
@@ -1306,7 +1325,16 @@ public class OIRReader extends FormatReader {
             }
           }
         }
-        channels.add(c);
+
+        while (index > channels.size()) {
+          channels.add(null);
+        }
+        if (index == channels.size()) {
+          channels.add(c);
+        }
+        else {
+          channels.set(index, c);
+        }
       }
     }
   }


### PR DESCRIPTION
Backported from a private PR.

Changes through line 742 were meant to address a single missing pixel block issue. Unfortunately, the data for that case is private and I have not successfully made an artificial example that demonstrates the problem.

The remainder of the changes are meant to address an issue with channel ordering. The problem occurs when the primary channel elements (whose `order` attributes were respected) are deemed invalid, and the secondary channel elements are used instead. The changes here update the secondary channel element handling in `parseChannel` to respect the `order` attribute, so that both sets of channel handling logic match. An artificial example that demonstrates is in `curated/olympus-oir/samples/channel-reorder`.