### PR TITLE
Add test for image names when resolutions are not flattened

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -42,8 +42,9 @@ import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
-import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.MetadataTools;
 import loci.formats.ReaderWrapper;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
 
 import ome.xml.model.primitives.PositiveInteger;
@@ -108,6 +109,7 @@ public class Configuration {
   private static final String EXCITATION_WAVELENGTH_UNIT = "ExcitationWavelengthUnit_";
   private static final String DETECTOR = "Detector_";
   private static final String NAME = "Name";
+  private static final String UNFLATTENED_NAME = "Alternate_Name";
   private static final String DESCRIPTION = "Description";
   private static final String SERIES_COUNT = "series_count";
   private static final String RESOLUTION_COUNT = "resolution_count";
@@ -418,6 +420,10 @@ public class Configuration {
     return currentTable.get(NAME);
   }
 
+  public String getUnflattenedImageName() {
+    return currentTable.get(UNFLATTENED_NAME);
+  }
+
   public boolean hasImageDescription() {
     return currentTable.containsKey(DESCRIPTION);
   }
@@ -551,6 +557,7 @@ public class Configuration {
     IFormatReader unflattenedReader = reader;
     if (seriesCount > 1) {
       unflattenedReader = new ImageReader();
+      unflattenedReader.setMetadataStore(MetadataTools.createOMEXMLMetadata());
       unflattenedReader.setFlattenedResolutions(false);
       unflattenedReader.setMetadataOptions(new DynamicMetadataOptions());
       try {
@@ -559,6 +566,7 @@ public class Configuration {
       catch (FormatException | IOException e) { }
       seriesCount = unflattenedReader.getSeriesCount();
     }
+    IMetadata unflattenedRetrieve = (IMetadata) unflattenedReader.getMetadataStore();
 
     globalTable.put(SERIES_COUNT, String.valueOf(seriesCount));
 
@@ -650,6 +658,7 @@ public class Configuration {
         }
 
         seriesTable.put(NAME, retrieve.getImageName(index));
+        seriesTable.put(UNFLATTENED_NAME, unflattenedRetrieve.getImageName(series));
         seriesTable.put(DESCRIPTION, retrieve.getImageDescription(index));
 
         Length physicalX = retrieve.getPixelsPhysicalSizeX(index);

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -657,8 +657,12 @@ public class Configuration {
           // TODO
         }
 
-        seriesTable.put(NAME, retrieve.getImageName(index));
-        seriesTable.put(UNFLATTENED_NAME, unflattenedRetrieve.getImageName(series));
+        String flattenedName = retrieve.getImageName(index);
+        seriesTable.put(NAME, flattenedName);
+        String unflattenedName = unflattenedRetrieve.getImageName(series);
+        if ((flattenedName == null && unflattenedName != null) || !flattenedName.equals(unflattenedName)) {
+          seriesTable.put(UNFLATTENED_NAME, unflattenedName);
+        }
         seriesTable.put(DESCRIPTION, retrieve.getImageDescription(index));
 
         Length physicalX = retrieve.getPixelsPhysicalSizeX(index);

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -109,7 +109,7 @@ public class Configuration {
   private static final String EXCITATION_WAVELENGTH_UNIT = "ExcitationWavelengthUnit_";
   private static final String DETECTOR = "Detector_";
   private static final String NAME = "Name";
-  private static final String UNFLATTENED_NAME = "Alternate_Name";
+  private static final String UNFLATTENED_NAME = "Unflattened_Name";
   private static final String DESCRIPTION = "Description";
   private static final String SERIES_COUNT = "series_count";
   private static final String RESOLUTION_COUNT = "resolution_count";

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -554,18 +554,15 @@ public class Configuration {
     putTableName(globalTable, reader, " global");
 
     int seriesCount = reader.getSeriesCount();
-    IFormatReader unflattenedReader = reader;
-    if (seriesCount > 1) {
-      unflattenedReader = new ImageReader();
-      unflattenedReader.setMetadataStore(MetadataTools.createOMEXMLMetadata());
-      unflattenedReader.setFlattenedResolutions(false);
-      unflattenedReader.setMetadataOptions(new DynamicMetadataOptions());
-      try {
-        unflattenedReader.setId(reader.getCurrentFile());
-      }
-      catch (FormatException | IOException e) { }
-      seriesCount = unflattenedReader.getSeriesCount();
+    IFormatReader unflattenedReader = new ImageReader();
+    unflattenedReader.setMetadataStore(MetadataTools.createOMEXMLMetadata());
+    unflattenedReader.setFlattenedResolutions(false);
+    unflattenedReader.setMetadataOptions(new DynamicMetadataOptions());
+    try {
+      unflattenedReader.setId(reader.getCurrentFile());
     }
+    catch (FormatException | IOException e) { }
+    seriesCount = unflattenedReader.getSeriesCount();
     IMetadata unflattenedRetrieve = (IMetadata) unflattenedReader.getMetadataStore();
 
     globalTable.put(SERIES_COUNT, String.valueOf(seriesCount));

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -963,7 +963,7 @@ public class FormatReaderTest {
 
     if (expected == null && real == null) {
       return true;
-    } else if (expected.equals("null")  && real == null) {
+    } else if ("null".equals(expected) && real == null) {
       return true;
     } else if (expected == null) {
       return false;
@@ -1419,6 +1419,51 @@ public class FormatReaderTest {
       }
     }
     result(testName, true);
+  }
+
+  @Test(groups = {"all", "fast", "automated"})
+  public void testUnflattenedImageNames() {
+    if (config == null) throw new SkipException("No config tree");
+    String testName = "testUnflattenedImageNames";
+    if (!initFile()) result(testName, false, "initFile");
+
+    boolean success = true;
+    String msg = null;
+    IFormatReader resolutionReader = setupReader(false, true);
+    try {
+      IMetadata retrieve = (IMetadata) resolutionReader.getMetadataStore();
+
+      if (resolutionReader.getSeriesCount() != config.getSeriesCount(false)) {
+        success = false;
+        msg = "incorrect unflattened series count";
+      }
+
+      for (int i=0; i<resolutionReader.getSeriesCount() && success; i++) {
+        config.setSeries(i, false);
+
+        String realName = retrieve.getImageName(i);
+        String expectedName = config.getImageName();
+
+        if (!isEqual(expectedName, realName)) {
+          String unflattenedName = config.getUnflattenedImageName();
+          if (!isEqual(unflattenedName, realName)) {
+            msg = "Series " + i + " (got '" + realName +
+              "', expected '" + expectedName + "' or '" + unflattenedName + "')";
+            success = false;
+          }
+        }
+      }
+    }
+    finally {
+      try {
+        resolutionReader.close();
+      }
+      catch (IOException e) {
+        success = false;
+        msg = "Could not close reader";
+      }
+    }
+    result(testName, success, msg);
   }
 
   @Test(groups = {"all", "fast", "automated"})


### PR DESCRIPTION
In most cases, the `Image` names stored in a `MetadataStore` will not depend on `hasFlattenedResolutions()`. For some pyramid formats (e.g. SVS, CZI), the `Image` names are noticeably different.

This updates the config file generation to add an `Alternate_Name` representing the unflattened `Image` name, if the unflattened `Image` name is different from the flattened `Image` name for a particular series/resolution. The new `testUnflattenedImageNames` checks this value, and errors if the name provided by an unflattened reader does not match either configured name.

I would expect this to cause test failures for SVS, CZI, and potentially others. I am happy for this to be excluded once at least test run has completed (so we know the scope of config changes required).