### PR TITLE
Revert RunTimeException when JPEGTurbo cannot be loaded

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -147,6 +147,7 @@ public class TileJPEGReader extends FormatReader {
       service = null;
       throw new IOException("Could not initialize JPEG service", se);
     }
+    if (!service.isLibraryLoaded()) throw new IOException("JPEG service failed to load Turbo JPEG library");
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
@@ -58,5 +58,7 @@ public interface JPEGTurboService extends Service {
   byte[] getTile(int xTile, int yTile) throws IOException;
 
   void close() throws IOException;
+  
+  boolean isLibraryLoaded();
 
 }

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -105,8 +105,7 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     logger = Logger.getLogger(NATIVE_LIB_CLASS);
     logger.setLevel(Level.SEVERE);
     if (!libraryLoaded) {
-      NativeLibraryUtil.loadNativeLibrary(TJ.class, "turbojpeg");
-      libraryLoaded = true;
+      libraryLoaded = NativeLibraryUtil.loadNativeLibrary(TJ.class, "turbojpeg");
     }
   }
 
@@ -379,6 +378,11 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     xTiles = 0;
     yTiles = 0;
     header = null;
+  }
+
+  @Override
+  public boolean isLibraryLoaded() {
+    return libraryLoaded;
   }
 
   // -- Helper methods --

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -105,10 +105,8 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     logger = Logger.getLogger(NATIVE_LIB_CLASS);
     logger.setLevel(Level.SEVERE);
     if (!libraryLoaded) {
-      libraryLoaded = NativeLibraryUtil.loadNativeLibrary(TJ.class, "turbojpeg");
-      if (!libraryLoaded) {
-        throw new RuntimeException("TurboJPEG could not be loaded");
-      }
+      NativeLibraryUtil.loadNativeLibrary(TJ.class, "turbojpeg");
+      libraryLoaded = true;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
@@ -157,6 +157,7 @@ public class HamamatsuVMSReader extends FormatReader {
 
     if (service == null) {
       service = new JPEGTurboServiceImpl();
+      if (!service.isLibraryLoaded()) throw new IOException("JPEG service failed to load Turbo JPEG library");
     }
 
     try {

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -329,6 +329,7 @@ public class NDPIReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    if (!service.isLibraryLoaded()) throw new IOException("JPEG service failed to load Turbo JPEG library");
     RandomAccessInputStream s = new RandomAccessInputStream(id);
     use64Bit = s.length() >= Math.pow(2, 32);
     s.close();


### PR DESCRIPTION
Reverts the changes from  https://github.com/ome/bioformats/pull/4090
Fixes https://github.com/ome/bioformats/issues/4109

To test you should attempt to instance ImageReader reader = new ImageReader(); while using Apple Silicon. This should throw a RunTimeException even if the desired reader does not require JPEGTurbo. 

I opted to revert the change rather than catch the exception in ImageReader as this would negate the original reason for adding the exception.
