### PR TITLE
Remove duplicate org.json:json dependency declaration

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -151,11 +151,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.json</groupId>
-    	<artifactId>json</artifactId>
-    	<version>20231013</version>
-    </dependency>
-    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>${sqlite.version}</version>


### PR DESCRIPTION
Implements https://github.com/ome/bioformats/pull/4123#pullrequestreview-1764908440

Since org.json:json is now a dependency of formats-bsd, this removes the duplicate declaration in formats-gpl so that the version is only managed in one place.

An alternative would be to declare `json.version` as a top-level property