### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,15 +48,15 @@
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.20</ome-common.version>
+    <ome-common.version>6.0.21</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.3.3</ome-model.version>
+    <ome-model.version>6.3.4</ome-model.version>
     <ome-poi.version>5.3.7</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>1.0.0</ome-codecs.version>
+    <ome-codecs.version>1.0.1</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
-    <xalan.version>2.7.2</xalan.version>
+    <xalan.version>2.7.3</xalan.version>
     <sqlite.version>3.28.0</sqlite.version>
 
     <!-- Maven plugin versions -->


### PR DESCRIPTION
Bumping the various dependency versions ahead of release.
I have also bumped the Xalan dependency to match that in ome-common: https://github.com/ome/ome-common-java/pull/84