### PR TITLE
matlab/bfGetPlane.m: avoid use of makeDataArray2D when Octave (ome/bio-formats-octave-docker#29)

### DIFF
--- a/components/formats-bsd/matlab/bfGetPlane.m
+++ b/components/formats-bsd/matlab/bfGetPlane.m
@@ -82,9 +82,20 @@ plane = r.openBytes(...
     ip.Results.iPlane - 1, ip.Results.x - 1, ip.Results.y - 1, ...
     ip.Results.width, ip.Results.height);
 
-% Convert byte array to MATLAB image
-I = javaMethod('makeDataArray2D', 'loci.common.DataTools', plane, ...
-    bpp, fp, little, ip.Results.height);
+% Convert byte array into the appropriate primitive type array which
+% Octave and Matlab then autobox into their own array type.
+if is_octave()
+    % Octave will not autobox multi-dimensional arrays, so use
+    % makeDataArray (returns 1D vector) instead of makeDataArray2D
+    % See https://github.com/ome/bio-formats-octave-docker/issues/29
+    I = javaMethod('makeDataArray', 'loci.common.DataTools', plane, ...
+        bpp, fp, little);
+    I = reshape(I, [ip.Results.width ip.Results.height]).';
+else
+    I = javaMethod('makeDataArray2D', 'loci.common.DataTools', plane, ...
+        bpp, fp, little, ip.Results.height);
+end
+
 if ~sgn
     % Java does not have explicitly unsigned data types;
     % hence, we must inform MATLAB when the data is unsigned


### PR DESCRIPTION
This fixes ome/bio-formats-octave-docker#29

Octave does not autobox multi-dimensional arrays (Matlab does) so `makeDataArray2D` can't be used in Octave. this commit makes use of `makeDataArray` to get a 1D array and then reshapes it.  This commit partially reverts 3aa468e9 (see ome/bioformats#3301) for Octave only. the data copy that that commit was meant to prevent is back but is limited to Octave.

For reference, the issue of Octave not autoboxing ND Java arrays is [Octave bug #58745](https://savannah.gnu.org/bugs/?func=detailitem&item_id=58745) (the issue description references a function `java2mat` that in theory should make this conversion but that function never worked for me and newer Octave functions have marked it somewhat internal by renaming it `__java2mat__`).