### PR TITLE
TiffReader: mark order as certain if metadata is read from ImageJ tag

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -320,6 +320,7 @@ public class TiffReader extends BaseTiffReader {
       t = getImageCount();
     }
     m.dimensionOrder = "XYCZT";
+    m.orderCertain = true;
 
     if (z * t * (isRGB() ? 1 : c) == ifds.size()) {
       m.sizeZ = z;


### PR DESCRIPTION
Fixes #4134 

If `parseCommentImageJ` is invoked, sets the `orderCertain` flag to true alongside the `dimensionOrder` and sizes read from the INI-style metadata.

This commit can be tested by following the scenario of the original issue i.e.:
- in Fiji, open the Mitosis sample (5D) and save it as a TIFF (with ImageJ metadata) using `Save as`
- without this PR, check that `showinf -noflat` reports the dimension order as `Uncertain`
- with this PR, check  that `showinf -noflat` reports the dimension order as `Certain`
