### PR TITLE
Issues 4150 + 4110: Consider ZSTD with pyramid levels and fix integer arithmetic scale problem 

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -4187,7 +4187,7 @@ public class ZeissCZIReader extends FormatReader {
             }
           }
           else {
-            LOGGER.warn("ZSTD-1 compression used, but no high/low byte unpacking");
+            LOGGER.debug("ZSTD-1 compression used, but no high/low byte unpacking");
             data = decoded;
           }
 


### PR DESCRIPTION
The PR aims to fix issues [4110 ](https://github.com/ome/bioformats/issues/4110) and [4150](https://github.com/ome/bioformats/issues/4102) that are concerned with CZIs and pyramid levels.
 
Issue 4110: Consider ZSTD_0 and ZSTD_1 compressed datasets to also be considered for pyramid level evaluation.
Issue 4150: Fix an integer arithmetic issue by using floating point arithmetic. -> divide with floating point precision and make sure to round to up or down to the next integer value - not truncation rounding. 