### PR TITLE
CZI: fix image naming, especially for attachments

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1406,14 +1406,9 @@ public class ZeissCZIReader extends FormatReader {
           }
         }
       }
-      else if (extraIndex == 0) {
-        store.setImageName("label image", i);
-      }
-      else if (extraIndex == 1) {
-        store.setImageName("macro image", i);
-      }
-      else {
-        store.setImageName("thumbnail image", i);
+      else if (extraIndex >= 0 && extraIndex < extraImages.size()) {
+        AttachmentEntry entry = extraImages.get(extraIndex).attachment;
+        store.setImageName(entry.getNormalizedName(), i);
       }
 
       // remaining acquisition settings (esp. channels) do not apply to
@@ -4556,6 +4551,20 @@ public class ZeissCZIReader extends FormatReader {
       return "schemaType = " + schemaType + ", filePosition = " + filePosition +
         ", filePart = " + filePart + ", contentGUID = " + contentGUID +
         ", contentFileType = " + contentFileType;
+    }
+
+    public String getNormalizedName() {
+      if (name == null) {
+        return "";
+      }
+      String n = name.trim();
+      if (n.toLowerCase().startsWith("label")) {
+        return "label image";
+      }
+      else if (n.toLowerCase().startsWith("slidepreview")) {
+        return "macro image";
+      }
+      return n;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3392,7 +3392,8 @@ public class ZeissCZIReader extends FormatReader {
                   platePositions.add(value);
                 }
                 String name = well.getAttribute("Name");
-                for (int f=0; f<well.getElementsByTagName("SingleTileRegion").getLength(); f++) {
+                int tileRegionCount = (int) Math.max(1, well.getElementsByTagName("SingleTileRegion").getLength());
+                for (int f=0; f<tileRegionCount; f++) {
                   imageNames.add(name);
                 }
               }


### PR DESCRIPTION
Fixes #4103. Makes use of the new image name test from #4114.

A configuration PR is forthcoming that demonstrates affected data. For datasets with changed names, compare the name and actual image with and without this PR to verify that this fixes label and macro naming. Multi-scene and plate data should also now have unflattened names that reflect the acquisition type, instead of just `Scene #1` etc.

