### PR TITLE
SVS: remove thumbnails and improve label/macro detection

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataList.java
+++ b/components/formats-api/src/loci/formats/MetadataList.java
@@ -132,6 +132,27 @@ public class MetadataList<T> {
   }
 
   /**
+   * Remove the array element at the specified indexes.
+   *
+   * @param i1 The primary array index
+   * @param i2 The secondary array index
+   * @return the removed element
+   */
+  public T remove(int i1, int i2) {
+    return data.get(i1).remove(i2);
+  }
+
+  /**
+   * Remove the entire primary array element at the specified index.
+   *
+   * @param i1 The primary array index
+   * @return the removed element
+   */
+  public List<T> remove(int i1) {
+    return data.remove(i1);
+  }
+
+  /**
    * Add a empty primary array element.
    */
   public void add() {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -389,10 +389,13 @@ public class SVSReader extends BaseTiffReader {
     for (int i=0; i<seriesCount; i++) {
       setSeries(i);
       int index = i;
-      tiffParser.fillInIFD(ifds.get(index));
 
-      String comment = ifds.get(index).getComment();
-      if (comment == null) {
+      IFD currentIFD = ifds.get(index);
+      tiffParser.fillInIFD(currentIFD);
+
+      String comment = currentIFD.getComment();
+      int subfileType = currentIFD.getIFDIntValue(IFD.NEW_SUBFILE_TYPE);
+      if (comment == null || subfileType != 0) {
         if (labelIndex == -1) {
           labelIndex = i;
         }


### PR DESCRIPTION
Fixes #3757.

As discussed at the end of #3757, thumbnail images are now removed by default. The `svs.remove_thumbnail` option controls this behavior; it is `false` by default but setting to `true` should cause thumbnails to be included (matching behavior without this PR).

816a588 and 2fd4489 have related updates to label/macro detection, so that the corresponding image names are set correctly for either value of `svs.remove_thumbnail`. Those commits also add support for the case where a label or macro image has a non-null comment that does not include `label` or `macro`; this is typically the result of anonymization/de-identification.

Configuration changes are needed to remove the thumbnails; corresponding PRs are forthcoming.