### PR TITLE
CZI: use alternate source for well identifiers when available

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1395,7 +1395,7 @@ public class ZeissCZIReader extends FormatReader {
         else {
           if (i < imageNames.size()) {
             String completeName = imageNames.get(i);
-            if (i < fieldNames.size()) {
+            if (i < fieldNames.size() && !fieldNames.get(i).equals(completeName)) {
               completeName += " " + fieldNames.get(i);
             }
             store.setImageName(completeName, i);
@@ -2330,10 +2330,19 @@ public class ZeissCZIReader extends FormatReader {
         }
       }
 
+
       Element sNode = getFirstNode(dimensions, "S");
       if (sNode != null) {
         NodeList scenes = sNode.getElementsByTagName("Scene");
         int nextPosition = 0;
+
+        boolean isPlate = platePositions.size() > 0;
+        if (isPlate) {
+          platePositions.clear();
+          fieldNames.clear();
+          imageNames.clear();
+        }
+
         for (int i=0; i<scenes.getLength(); i++) {
           Element scene = (Element) scenes.item(i);
           NodeList positions = scene.getElementsByTagName("Position");
@@ -2358,6 +2367,21 @@ public class ZeissCZIReader extends FormatReader {
               positionsY[nextPosition] = new Length(DataTools.parseDouble(pos[1]), UNITS.MICROMETER);
             }
             nextPosition++;
+          }
+
+          if (isPlate) {
+            String sceneName = scene.getAttribute("Name");
+            NodeList shapes = scene.getElementsByTagName("Shape");
+            for (int shapeIndex=0; shapeIndex<shapes.getLength(); shapeIndex++) {
+              Element shape = (Element) shapes.item(shapeIndex);
+              String id = shape.getAttribute("Id");
+              if (!platePositions.contains(id)) {
+                platePositions.add(id);
+              }
+              String name = shape.getAttribute("Name");
+              imageNames.add(name);
+              fieldNames.add(sceneName);
+            }
           }
         }
       }


### PR DESCRIPTION
Backported from a private PR. This fixes Image/Well mapping for "meander" acquisitions.

Several of our existing test plates are affected, see the forthcoming configuration PR which includes video of the affected data in ZEN. Without this PR, `showinf -nopix -omexml` on the affected plates should show that each row of wells starts at the left-most (smallest index) column and proceeds to the right-most (largest index) column. With this PR, the same command should show that  rows alternate between left-to-right and right-to-left column indexing. The order of rows is unaffected.

This is a really subtle problem and not obvious from visually inspecting the images or even a cursory look at ZEN. Even a basic stitching workflow wouldn't necessarily have picked this up. It's really only obvious when carefully scrolling through each image in ZEN, so reviewing the videos in the configuration PR is important.

Importantly, well metadata can exist in multiple places in CZI datasets, and appears to not necessarily be consistent. That might reflect the physical plate vs the actual acquisition, and can be seen by looking at the original metadata (look for names like `A1` and IDs like `1-1`).

Added to 7.2.0 for a first look, but since this is a later addition I'm OK with it being bumped to the next milestone if needed.