### PR TITLE
Plugin: Update ND2 widget indexing to fix chunkmap exception

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/config/ND2Widgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/ND2Widgets.java
@@ -83,7 +83,7 @@ public class ND2Widgets implements IFormatWidgets, ItemListener {
   @Override
   public void itemStateChanged(ItemEvent e) {
     JCheckBox box = (JCheckBox) e.getSource();
-    if (box.equals(getWidgets()[1])) {
+    if (box.equals(getWidgets()[0])) {
       Prefs.set(LociPrefs.PREF_ND2_CHUNKMAP, box.isSelected());
     }
   }


### PR DESCRIPTION
Issue was raised on forum thread https://forum.image.sc/t/problem-with-nd2-large-image-stitch-opening-strange-with-bioformats-on-fiji/67319/9

An exception is seen when trying to modify the ND2 chunkmap option via the Bio-Formats Plugins Configuration window:

```
Exception in thread "Run$_AWT-EventQueue-0" java.lang.ArrayIndexOutOfBoundsException: 1
	at loci.plugins.config.ND2Widgets.itemStateChanged(ND2Widgets.java:86)
	at javax.swing.AbstractButton.fireItemStateChanged(AbstractButton.java:2050)
	at javax.swing.AbstractButton$Handler.itemStateChanged(AbstractButton.java:2355)
	at javax.swing.DefaultButtonModel.fireItemStateChanged(DefaultButtonModel.java:455)
	at javax.swing.JToggleButton$ToggleButtonModel.setSelected(JToggleButton.java:272)
	at javax.swing.JToggleButton$ToggleButtonModel.setPressed(JToggleButton.java:289)
	at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
	at java.awt.Component.processMouseEvent(Component.java:6539)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
```

This is due to the indexing for the ND2 options being out of date as we previously removed the native reader option from the widget.

To test, use FIJI and ensure that the chunkmap option can be toggled on and off from `Plugins > Bio-Formats > Bio-Formats Plugins Configuration > Formats > Nikon ND2 `