### PR TITLE
Update GitHub actions versions and add M1/Java 21 build

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Upload artifacts
         # upload just one set of artifacts for easier PR review
         if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: artifacts/
           retention-days: 30

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrieve version
         id: get_version
         run: |
@@ -66,7 +66,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrieve version
         id: get_version
         run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -48,7 +48,7 @@ jobs:
               echo server='ome.releases' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: 'zulu'
@@ -81,7 +81,7 @@ jobs:
             echo server='ome.releases' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: 'zulu'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: 'macos-14'
+            java: '21'
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install # default is install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,8 +16,8 @@ jobs:
         java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - os: 'macos-14'
-            java: '21'
+          - java: '21'
+            os: 'macos-14'
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install # default is install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: 'zulu'

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -61,6 +61,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -72,44 +73,15 @@ public class ImageConverterTest {
   private File outFile;
   private int width = 512;
   private int resolutionCount;
-  private final SecurityManager oldSecurityManager = System.getSecurityManager();
   private final PrintStream oldOut = System.out;
   private final PrintStream oldErr = System.err;
 
-  protected static class ExitException extends SecurityException {
-    public final int status;
-    public ExitException(int status) {
-      this.status = status;
-    }
-  }
-
-  private static class NoExitSecurityManager extends SecurityManager {
-    @Override
-    public void checkPermission(Permission perm) {}
-
-    @Override
-    public void checkPermission(Permission perm, Object context) {}
-
-    @Override
-    public void checkExit(int status) {
-      super.checkExit(status);
-      throw new ExitException(status);
-    }
-  }
-
   @BeforeMethod
   public void setUp() throws IOException {
-    System.setSecurityManager(new NoExitSecurityManager());
-
     tempDir = Files.createTempDirectory(this.getClass().getName());
     tempDir.toFile().deleteOnExit();
     width = 512;
     resolutionCount = 1;
-  }
-
-  @AfterMethod
-  public void resetSecurityManager() {
-    System.setSecurityManager(oldSecurityManager);
   }
 
   @AfterClass
@@ -166,21 +138,25 @@ public class ImageConverterTest {
   }
 
   public void assertConversion(String[] args, String outFileToCheck, int expectedWidth, int expectedTileWidth) throws FormatException, IOException {
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    } catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       checkImage(outFileToCheck, expectedWidth, expectedTileWidth);
     }
   }
 
   public void assertConversion(String[] args, String outFileToCheck, int expectedWidth) throws FormatException, IOException {
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    } catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       checkImage(outFileToCheck, expectedWidth);
     }
   }
@@ -225,13 +201,15 @@ public class ImageConverterTest {
     System.setOut(new PrintStream(outContent));
     outFile = getOutFile("test.ome.tiff");
     String[] args = {"-foo", "test.fake", outFile.getAbsolutePath()};
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    } catch (ExitException e) {
-      assertEquals(e.status, 1);
-      assertEquals(
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
+      assertFalse(success);
+      assertTrue(outContent.toString().endsWith(
         "Found unknown command flag: -foo; exiting." +
-        System.getProperty("line.separator"), outContent.toString());
+        System.getProperty("line.separator")));
     }
   }
 
@@ -244,12 +222,14 @@ public class ImageConverterTest {
       "-option", OMETiffWriter.COMPANION_KEY, compFile.getAbsolutePath(),
       "test.fake", outFile.getAbsolutePath()
     };
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    } catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
       compFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       assertTrue(compFile.exists());
       checkImage();
     }
@@ -272,11 +252,13 @@ public class ImageConverterTest {
       "-tilex", "128", "-tiley", "128",
       "-crop", "256,256,256,256", "test.fake", outFile.getAbsolutePath()};
     width = 256;
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    } catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       checkImage();
     }
   }
@@ -289,12 +271,13 @@ public class ImageConverterTest {
       "-crop", "123,127,129,131", "test.fake", outFile.getAbsolutePath()
     };
     width = 129;
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    }
-    catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       checkImage();
     }
   }
@@ -307,12 +290,13 @@ public class ImageConverterTest {
       "-crop", "0,0,256,256", "test&sizeX=128&sizeY=128.fake", outFile.getAbsolutePath()
     };
     width = 128;
+    boolean success = false;
     try {
-      ImageConverter.main(args);
-    }
-    catch (ExitException e) {
+      ImageConverter converter = new ImageConverter();
+      success = converter.testConvert(new ImageWriter(), args);
+    } finally {
       outFile.deleteOnExit();
-      assertEquals(e.status, 0);
+      assertTrue(success);
       checkImage();
     }
   }

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>cisd</groupId>
       <artifactId>jhdf5</artifactId>
-      <version>19.04.0</version>
+      <version>19.04.1</version>
     </dependency>
     <dependency>
 	    <groupId>com.drewnoakes</groupId>


### PR DESCRIPTION
First 3 commits are just cleaning up versions, which hopefully should remove the warnings about Node.js 16 actions being deprecated (e.g. https://github.com/ome/bioformats/actions/runs/7829106830).

Last commit here adds a single configuration to the Maven build, which runs on M1 with Java 21. I intentionally added this separately instead of fully expanding the matrix to `java: [8, 11, 17, 21]` and `os: [ubuntu-latest, windows-latest, macos-latest, macos-14]`, as discussed previously with @ome/formats. If we feel that running M1 + Java 21 every time is too much, we can debate other options; this is just a place to start.