### PR TITLE
Prairie: look for "<PV" string instead of just "PV"

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -184,7 +184,7 @@ public class PrairieReader extends FormatReader {
     final int blockLen = (int) Math.min(1048608, stream.length());
     if (!FormatTools.validStream(stream, blockLen, false)) return false;
     String s = stream.readString(blockLen);
-    if (s.indexOf("xml") != -1 && s.indexOf("PV") != -1) return true;
+    if (s.indexOf("xml") != -1 && s.indexOf("<PV") != -1) return true;
 
     TiffParser tp = new TiffParser(stream);
     IFD ifd = tp.getFirstIFD();


### PR DESCRIPTION
Type checking is meant to verify that there is an XML element named something like `PVScan` or `PVStateShard`, so checking for `<PV` is a little more accurate.

I'd expect `isThisType` tests to fail for some of the data in #4147 without this PR. Actual Prairie data should continue to pass with this change.