### PR TITLE
OME-XML: populate original metadata table

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -35,6 +35,7 @@ package loci.formats.in;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Hashtable;
 import java.util.List;
 
 import loci.common.CBZip2InputStream;
@@ -269,9 +270,10 @@ public class OMEXMLReader extends FormatReader {
 
     hasSPW = omexmlMeta.getPlateCount() > 0;
 
-    // TODO
-    //Hashtable originalMetadata = omexmlMeta.getOriginalMetadata();
-    //if (originalMetadata != null) metadata = originalMetadata;
+    Hashtable originalMetadata = service.getOriginalMetadata(omexmlMeta);
+    if (originalMetadata != null) {
+      metadata = originalMetadata;
+    }
 
     int numDatasets = omexmlMeta.getImageCount();
 


### PR DESCRIPTION
Without this PR, `showinf -nopix` on any OME-XML file with `OriginalMetadata` annotations should show that the annotations are not stored in the reader's original metadata table. This issue was originally noticed with `OME/METADATA.ome.xml` files produced by bioformats2raw.

With this PR, `showinf -nopix` on the same test data should show that the original metadata table is populated as expected.

I'm not entirely sure why this was commented out in the first place, but that was ~14 years ago. I suspect we did not have a working method that created a `Hashtable` from `OriginalMetadata` annotations in an `OMEXMLMetadata`.