### PR TITLE
Bump file-leak-detector to version 1.18 for JDK 21 support

### DIFF
--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>file-leak-detector</artifactId>
-      <version>1.15</version>
+      <version>1.18</version>
       <!-- the regular jar does not specify a main class -->
       <classifier>jar-with-dependencies</classifier>
       <exclusions>


### PR DESCRIPTION
With the current infrastructure, the file-leak-detector fails with

```
test-automated:
   [testng] Could not load field socket from SocketImpl: java.lang.NoSuchFieldException: socket
   [testng] Could not load field serverSocket from SocketImpl: java.lang.NoSuchFieldException: serverSocket
   [testng] File leak detector installed
   [testng] FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
   [testng] Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
   [testng] V  [libjvm.so+0x974f64]  jni_FatalError+0x74
   [testng] Exception in thread "main" java.lang.reflect.InvocationTargetException
   [testng] V  [libjvm.so+0xaddf24]  JvmtiExport::post_vm_initialized()+0x394
   [testng] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
   [testng] V  [libjvm.so+0xea50c4]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x8a4
   [testng] 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
   [testng] V  [libjvm.so+0x97651e]  JNI_CreateJavaVM+0x4e
   [testng] 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:560)
   [testng] C  [libjli.so+0x42cb]  JavaMain+0x8b
   [testng] 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:572)
   [testng] C  [libjli.so+0x7e49]  ThreadJavaMain+0x9
   [testng] Caused by: java.lang.ClassNotFoundException: java.net.PlainSocketImpl
   [testng] 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
   [testng] 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
   [testng] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
   [testng] 	at java.base/java.lang.Class.forName0(Native Method)
   [testng] 	at java.base/java.lang.Class.forName(Class.java:421)
   [testng] 	at java.base/java.lang.Class.forName(Class.java:412)
   [testng] 	at org.kohsuke.file_leak_detector.AgentMain.premain(AgentMain.java:135)
   [testng] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
   [testng] 	... 3 more
   [testng] *** java.lang.instrument ASSERTION FAILED ***: "!errorOutstanding" with message Outstanding error when calling method in invokeJavaAgentMainMethod at open/src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 627
   [testng] *** java.lang.instrument ASSERTION FAILED ***: "success" with message invokeJavaAgentMainMethod failed at open/src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 466
   [testng] *** java.lang.instrument ASSERTION FAILED ***: "result" with message agent load/premain call failed at open/src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 429
```
This tries to upgrade the version of the file leak detector library to `1.18` which has allegedly JDK 21 support