### PR TITLE
Turn off file-leak-detector if tests are run with Java 21

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -6,7 +6,7 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="tests" default="jar" basedir="." xmlns:if="ant:if">
+<project name="tests" default="jar" basedir=".">
   <description>Build file for Bio-Formats testing framework project</description>
   <property name="root.dir" location="../.."/>
   <import file="${root.dir}/ant/java.xml"/>
@@ -236,12 +236,6 @@ Type "ant -p" for a list of targets.
   <target name="test-automated" depends="compile-tests"
     description="run automated tests in group 'automated'">
 
-    <condition property="compatibleJavaVersion">
-      <not>
-        <equals arg1="${ant.java.version}" arg2="21"/>
-      </not>
-    </condition>
-
     <testng groups="automated" testname="Automated tests"
       listeners="loci.tests.testng.OrderingListener"
       suitename="Bio-Formats software test suite"
@@ -271,7 +265,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
       <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
-      <jvmarg if:set="compatibleJavaVersion" value="-javaagent:${dep.org.kohsuke:file-leak-detector:jar:jar-with-dependencies}=strong"/>
+      <jvmarg value="-javaagent:${dep.org.kohsuke:file-leak-detector:jar:jar-with-dependencies}=strong"/>
     </testng>
     <fail if="failedTest"/>
   </target>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -6,7 +6,7 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="tests" default="jar" basedir=".">
+<project name="tests" default="jar" basedir="." xmlns:if="ant:if">
   <description>Build file for Bio-Formats testing framework project</description>
   <property name="root.dir" location="../.."/>
   <import file="${root.dir}/ant/java.xml"/>
@@ -236,6 +236,12 @@ Type "ant -p" for a list of targets.
   <target name="test-automated" depends="compile-tests"
     description="run automated tests in group 'automated'">
 
+    <condition property="compatibleJavaVersion">
+      <not>
+        <equals arg1="${ant.java.version}" arg2="21"/>
+      </not>
+    </condition>
+
     <testng groups="automated" testname="Automated tests"
       listeners="loci.tests.testng.OrderingListener"
       suitename="Bio-Formats software test suite"
@@ -265,7 +271,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
       <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
-      <jvmarg value="-javaagent:${dep.org.kohsuke:file-leak-detector:jar:jar-with-dependencies}=strong"/>
+      <jvmarg if:set="compatibleJavaVersion" value="-javaagent:${dep.org.kohsuke:file-leak-detector:jar:jar-with-dependencies}=strong"/>
     </testng>
     <fail if="failedTest"/>
   </target>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -83,19 +83,6 @@
       <artifactId>assumeng</artifactId>
       <version>1.2.4</version>
     </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>file-leak-detector</artifactId>
-      <version>1.15</version>
-      <!-- the regular jar does not specify a main class -->
-      <classifier>jar-with-dependencies</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <properties>
@@ -128,6 +115,51 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jdk8-compatible</id>
+      <activation>
+        <jdk>(,11)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.kohsuke</groupId>
+          <artifactId>file-leak-detector</artifactId>
+          <version>1.15</version>
+          <!-- the regular jar does not specify a main class -->
+          <classifier>jar-with-dependencies</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>com.sun</groupId>
+              <artifactId>tools</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>jdk21-compatible</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.kohsuke</groupId>
+          <artifactId>file-leak-detector</artifactId>
+          <version>1.18</version>
+          <!-- the regular jar does not specify a main class -->
+          <classifier>jar-with-dependencies</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>com.sun</groupId>
+              <artifactId>tools</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <developers>
     <developer>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -83,6 +83,19 @@
       <artifactId>assumeng</artifactId>
       <version>1.2.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>file-leak-detector</artifactId>
+      <version>${file-leak-detector.version}</version>
+      <!-- the regular jar does not specify a main class -->
+      <classifier>jar-with-dependencies</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -122,42 +135,18 @@
       <activation>
         <jdk>(,11)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>file-leak-detector</artifactId>
-          <version>1.15</version>
-          <!-- the regular jar does not specify a main class -->
-          <classifier>jar-with-dependencies</classifier>
-          <exclusions>
-            <exclusion>
-              <groupId>com.sun</groupId>
-              <artifactId>tools</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
+      <properties>
+        <file-leak-detector.version>1.15</file-leak-detector.version>
+      </properties>
     </profile>
     <profile>
       <id>jdk21-compatible</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>file-leak-detector</artifactId>
-          <version>1.18</version>
-          <!-- the regular jar does not specify a main class -->
-          <classifier>jar-with-dependencies</classifier>
-          <exclusions>
-            <exclusion>
-              <groupId>com.sun</groupId>
-              <artifactId>tools</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
+      <properties>
+        <file-leak-detector.version>1.18</file-leak-detector.version>
+      </properties>
     </profile>
   </profiles>
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -67,6 +67,8 @@ public class FormatReaderTestFactory {
 
   @Factory
   public Object[] createInstances() {
+    LOGGER.info("java.version = {}", System.getProperty("java.version"));
+
     List<String> files = new ArrayList<String>();
 
     // parse explicit filename, if any


### PR DESCRIPTION
See discussion in #4158.

Not sure if there is a better way to do this (in particular, to exclude >= 21), but this should at least allow tests to run on Java 21 for now.