### PR TITLE
Remove duplicate enum check and add clarifying comment

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -1862,10 +1862,11 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
       return sizeC * sizeZ * sizeT == 1;
     }
 
+    // check that there is a single channel or Z section (so order doesn't matter)
+    // or the dimension order indicates that Z is before C
     DimensionOrder order = retrieve.getPixelsDimensionOrder(series);
     return sequential && (sizeC == 1 || sizeZ == 1 ||
       order == DimensionOrder.XYZCT ||
-      order == DimensionOrder.XYZTC ||
       order == DimensionOrder.XYZTC ||
       order == DimensionOrder.XYTZC);
   }


### PR DESCRIPTION
Fixes #4143.

There should be no change in behavior, this is just removing an accidentally duplicated line.