### PR TITLE
DICOM reader: better handling of nested sequences that include pixel data

### DIFF
--- a/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
+++ b/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
@@ -310,15 +310,33 @@ public class DicomTag implements Comparable<DicomTag> {
                 break;
               }
               else if (child.attribute == PIXEL_DATA) {
-                stop = fp;
-                break;
+                child.parent = this;
+                children.add(child);
+                if (child.elementLength == -1) {
+                  // look for end of sequence
+                  long seek = fp - 2;
+                  int nextTag = 0;
+                  while (seek < in.length() && (nextTag != SEQUENCE_DELIMITATION_ITEM.getTag() && nextTag != ITEM_DELIMITATION_ITEM.getTag())) {
+                    seek += 2;
+                    in.seek(seek);
+                    try {
+                      nextTag = getNextTag(in);
+                    }
+                    catch (Exception e) {
+                    }
+                    if (nextTag == 0xfeffdde0 || nextTag == 0xfeff0d0e) {
+                      in.order(!in.isLittleEndian());
+                      break;
+                    }
+                  }
+                }
               }
               else if (child.attribute != ITEM && child.attribute != ITEM_DELIMITATION_ITEM) {
                 child.parent = this;
                 children.add(child);
               }
             }
-            if (elementLength == 0) {
+            if (elementLength <= 0) {
               elementLength = (int) (stop - start);
             }
             in.seek(stop);
@@ -438,6 +456,7 @@ public class DicomTag implements Comparable<DicomTag> {
 
     switch (vr) {
       case OB:
+      case OV:
       case OW:
       case SQ:
       case UN:

--- a/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
+++ b/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
@@ -719,6 +719,17 @@ public class DicomTag implements Comparable<DicomTag> {
     }
   }
 
+  /**
+   * See https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.8.html
+   *
+   * @return true if this is a private content creator tag
+   */
+  public boolean isPrivateContentCreator() {
+    int highWord = (tag >> 16) & 0xffff;
+    int lowWord = tag & 0xffff;
+    return highWord % 2 == 1 && lowWord == 0x0010;
+  }
+
   @Override
   public String toString() {
     if (key == null) {


### PR DESCRIPTION
Fixes #4165.

Using the data in `inbox/gh-4165`, `showinf` should show that each pyramid resolution starts with "scrambled" tiles. `showinf -noflat -resolution 2 img_0.dcm` or `showinf -nogroup img_3.dcm` in particular can easily reproduce the issue.

With this change, each resolution and extra image in the dataset should display correctly.

As described in #4165, there are PixelData elements (which Bio-Formats' reader should ignore) that are nested within a private sequence element. The reader will no longer stop at the first PixelData encountered, and instead should skip over any PixelData contained within a sequence. 