### PR TITLE
Add `-quality` option to bfconvert

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -71,6 +71,7 @@ import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
 import loci.formats.codec.CodecOptions;
+import loci.formats.codec.JPEG2000CodecOptions;
 import loci.formats.gui.Index16ColorModel;
 import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
@@ -1279,7 +1280,7 @@ public final class ImageConverter {
 
   private void setCodecOptions(IFormatWriter writer) {
     if (compressionQuality != null) {
-      CodecOptions codecOptions = CodecOptions.getDefaultOptions();
+      CodecOptions codecOptions = JPEG2000CodecOptions.getDefaultOptions();
       codecOptions.quality = compressionQuality;
       writer.setCodecOptions(codecOptions);
     }

--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -532,7 +532,7 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     }
     else {
       Codec codec = getCodec();
-      CodecOptions options = new CodecOptions();
+      CodecOptions options = new CodecOptions(getCodecOptions());
       options.width = tileWidth[resolutionIndex];
       options.height = tileHeight[resolutionIndex];
       options.channels = getSamplesPerPixel();


### PR DESCRIPTION
Fixes #3370.

Builds on work in https://github.com/ome/ome-codecs/pull/26 to pass a quality value (0.0 to 1.0) through to the JPEG codec. This can be tested by comparing conversions with different quality values, e.g.:

```
$ bfconvert -compression JPEG -quality 0.1 test.fake test_10percent.tiff
$ bfconvert -compression JPEG -quality 0.5 test.fake test_50percent.tiff
$ bfconvert -compression JPEG -quality 1.0 test.fake test_100percent.tiff
```

and different output formats (TIFF, OME-TIFF, DICOM). The output file size should increase as the quality increases.

Note that the JPEG writer does not currently make use of this, as it bypasses the `JPEGCodec` API.

Adding to 7.3.0 for now, but we can also push to 8.0.0 if this seems more suited to a major version.