### PR TITLE
testSaneUsedFiles: check getCurrentFile is the first file in the getUsedFiles list

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1866,9 +1866,19 @@ public class FormatReaderTest {
         msg = "Used files list contains duplicates";
       }
 
-      if (!base[0].equals(file)) {
+      if (!(reader.getFormat().equals("Bio-Rad PIC")) &&
+          !(reader.getFormat().equals("Metamorph STK")) &&
+          !(reader.getFormat().equals("Evotec Flex")) &&
+          !(reader.getFormat().equals("CellSens VSI")) &&
+          !(reader.getFormat().equals("PerkinElmer")) &&
+          !(reader.getFormat().equals("Fuji LAS 3000")) &&
+          !(reader.getFormat().equals("Micro-Manager")) &&
+          !(reader.getFormat().equals("BDV")) &&
+          !(reader.getFormat().equals("Zeiss AxioVision TIFF")) &&
+          !(reader.getFormat().equals("Olympus ScanR")) &&
+          !base[0].equals(file)) {
           success = false;
-          msg = "Used files does not start with getCurrentFile";
+          msg = "Used files list does not start with getCurrentFile";
       }
 
       if (success) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1866,10 +1866,12 @@ public class FormatReaderTest {
         msg = "Used files list contains duplicates";
       }
 
-      if (base.length == 1) {
-        if (!base[0].equals(file)) success = false;
+      if (!base[0].equals(file)) {
+          success = false;
+          msg = "Used files does not start with getCurrentFile";
       }
-      else if (success) {
+
+      if (success) {
         Arrays.sort(base);
         IFormatReader r =
           /*config.noStitching() ? new ImageReader() :*/ new ImageReader();


### PR DESCRIPTION
From an discussion with @melissalinkert and @jburel, this was opening initially to assess how many formats deviate from this assumption in the nightly CI builds

`FormatReaderTest.testSaneUsedFiles ` is currently testing that the first item of [IFormatReader.getUsedFiles()](https://downloads.openmicroscopy.org/bio-formats/8.0.0/api/loci/formats/IFormatReader.html#getUsedFiles--) is equal to [IFormatReader.getCurrentFile()](https://downloads.openmicroscopy.org/bio-formats/8.0.0/api/loci/formats/IFormatReader.html#getCurrentFile--) for single-file formats.

This change extends the test logic to assert this condition for all file formats manually excluding the 10 readers where the automated tests have identified the condition was not met.

As next steps, the individual readers can be updated individually to meet the condition and reincluded in the tests. Once all readers have been updated, the API contract could be updated to clarify the expectation and the relationship between the first file of `getUsedFiles` and the output of `getCurrentFile` although doing this will likely require a major version increment.