### PR TITLE
Fix some Java 9+ warnings in formats-bsd

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -162,13 +162,13 @@ public class FilePattern {
     while (true) {
       left = pattern.indexOf(FilePatternBlock.BLOCK_START, left + 1);
       if (left < 0) break;
-      lt.add(new Integer(left));
+      lt.add(left);
     }
     int right = -1;
     while (true) {
       right = pattern.indexOf(FilePatternBlock.BLOCK_END, right + 1);
       if (right < 0) break;
-      gt.add(new Integer(right));
+      gt.add(right);
     }
 
     // assemble numerical block indices

--- a/components/formats-bsd/src/loci/formats/ImageTools.java
+++ b/components/formats-bsd/src/loci/formats/ImageTools.java
@@ -118,7 +118,7 @@ public final class ImageTools {
 
     if (pixels instanceof byte[]) b = (byte[]) pixels;
     else if (pixels instanceof short[]) {
-      if (max == null) max = new Double(0xffff);
+      if (max == null) max = Double.valueOf(0xffff);
       double range = max.doubleValue() - min.doubleValue();
       double mult = newRange / range;
 
@@ -129,7 +129,7 @@ public final class ImageTools {
       }
     }
     else if (pixels instanceof int[]) {
-      if (max == null) max = new Double(0xffffffffL);
+      if (max == null) max = Double.valueOf(0xffffffffL);
       double range = max.doubleValue() - min.doubleValue();
       double mult = newRange / range;
 
@@ -140,7 +140,7 @@ public final class ImageTools {
       }
     }
     else if (pixels instanceof float[]) {
-      if (max == null) max = new Double(Float.MAX_VALUE);
+      if (max == null) max = Double.valueOf(Float.MAX_VALUE);
       double range = max.doubleValue() - min.doubleValue();
       double mult = newRange / range;
 
@@ -151,7 +151,7 @@ public final class ImageTools {
       }
     }
     else if (pixels instanceof double[]) {
-      if (max == null) max = new Double(Double.MAX_VALUE);
+      if (max == null) max = Double.MAX_VALUE;
       double range = max.doubleValue() - min.doubleValue();
       double mult = newRange / range;
 
@@ -517,8 +517,8 @@ public final class ImageTools {
     }
 
     Double[] rtn = new Double[2];
-    rtn[0] = new Double(min);
-    rtn[1] = new Double(max);
+    rtn[0] = Double.valueOf(min);
+    rtn[1] = Double.valueOf(max);
     return rtn;
   }
 

--- a/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
+++ b/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
@@ -119,7 +119,7 @@ public class MinMaxCalculator extends ReaderWrapper {
     if (minMaxDone == null || minMaxDone[series] < getImageCount()) {
       return null;
     }
-    return new Double(chanMin[series][theC]);
+    return chanMin[series][theC];
   }
 
   /**
@@ -141,7 +141,7 @@ public class MinMaxCalculator extends ReaderWrapper {
     if (minMaxDone == null || minMaxDone[series] < getImageCount()) {
       return null;
     }
-    return new Double(chanMax[series][theC]);
+    return chanMax[series][theC];
   }
 
   /**
@@ -155,7 +155,7 @@ public class MinMaxCalculator extends ReaderWrapper {
     throws FormatException, IOException
   {
     FormatTools.assertId(getCurrentFile(), true, 2);
-    return chanMin == null ? null : new Double(chanMin[getCoreIndex()][theC]);
+    return chanMin == null ? null : chanMin[getCoreIndex()][theC];
   }
 
   /**
@@ -169,7 +169,7 @@ public class MinMaxCalculator extends ReaderWrapper {
     throws FormatException, IOException
   {
     FormatTools.assertId(getCurrentFile(), true, 2);
-    return chanMax == null ? null : new Double(chanMax[getCoreIndex()][theC]);
+    return chanMax == null ? null : chanMax[getCoreIndex()][theC];
   }
 
   /**
@@ -192,7 +192,7 @@ public class MinMaxCalculator extends ReaderWrapper {
 
     Double[] min = new Double[numRGB];
     for (int c=0; c<numRGB; c++) {
-      min[c] = new Double(planeMin[series][pBase + c]);
+      min[c] = planeMin[series][pBase + c];
     }
     return min;
   }
@@ -217,7 +217,7 @@ public class MinMaxCalculator extends ReaderWrapper {
 
     Double[] max = new Double[numRGB];
     for (int c=0; c<numRGB; c++) {
-      max[c] = new Double(planeMax[series][pBase + c]);
+      max[c] = planeMax[series][pBase + c];
     }
     return max;
   }

--- a/components/formats-bsd/src/loci/formats/gui/CacheComponent.java
+++ b/components/formats-bsd/src/loci/formats/gui/CacheComponent.java
@@ -314,7 +314,7 @@ public class CacheComponent extends JPanel
         int[] rng = strategy.getRange();
         for (int i=0; i<rng.length; i++) {
           range[i].removeChangeListener(this);
-          range[i].setValue(new Integer(rng[i]));
+          range[i].setValue(rng[i]);
           range[i].addChangeListener(this);
         }
         break;

--- a/components/formats-bsd/src/loci/formats/gui/DataConverter.java
+++ b/components/formats-bsd/src/loci/formats/gui/DataConverter.java
@@ -343,7 +343,7 @@ public class DataConverter extends JFrame implements
         }
         else if (series != null) {
           ((SpinnerNumberModel) series.getModel()).setMaximum(
-            new Integer(swap.getSeriesCount()));
+            swap.getSeriesCount());
           pack();
         }
         else if (swap.getSeriesCount() == 1 && series != null) {

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -803,8 +803,8 @@ public class AVIReader extends FormatReader {
                   foundPixels = true;
                   if (check.startsWith("d")) {
                     if (size > 0 || bmpCompression != 0) {
-                      offsets.add(new Long(in.getFilePointer()));
-                      lengths.add(new Long(size));
+                      offsets.add(in.getFilePointer());
+                      lengths.add(Long.valueOf(size));
                       in.skipBytes(size);
                     }
                   }
@@ -878,9 +878,9 @@ public class AVIReader extends FormatReader {
                           offsets.add(offsets.get(offsets.size() - 1));
                         }
                         else if (chunkSize > 0 || offsets.size() > 0) {
-                          offsets.add(new Long(useSOM ? startOfMovi + offset : offset));
+                          offsets.add(Long.valueOf(useSOM ? startOfMovi + offset : offset));
                         }
-                        lengths.add(new Long(chunkSize));
+                        lengths.add(Long.valueOf(chunkSize));
                       }
                     }
                   }

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -566,14 +566,14 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
   }
 
   protected void put(String key, boolean value) {
-    put(key, new Boolean(value));
+    put(key, Boolean.valueOf(value));
   }
-  protected void put(String key, byte value) { put(key, new Byte(value)); }
-  protected void put(String key, char value) { put(key, new Character(value)); }
-  protected void put(String key, double value) { put(key, new Double(value)); }
-  protected void put(String key, float value) { put(key, new Float(value)); }
-  protected void put(String key, long value) { put(key, new Long(value)); }
-  protected void put(String key, short value) { put(key, new Short(value)); }
+  protected void put(String key, byte value) { put(key, Byte.valueOf(value)); }
+  protected void put(String key, char value) { put(key, Character.valueOf(value)); }
+  protected void put(String key, double value) { put(key, Double.valueOf(value)); }
+  protected void put(String key, float value) { put(key, Float.valueOf(value)); }
+  protected void put(String key, long value) { put(key, Long.valueOf(value)); }
+  protected void put(String key, short value) { put(key, Short.valueOf(value)); }
 
   protected void put(String key, IFD ifd, int tag) {
     put(key, ifd.getIFDValue(tag));

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1079,11 +1079,11 @@ public class FakeReader extends FormatReader {
   }
 
   private Double getX(int i) {
-      return new Double(ROI_SPACING * i % sizeX);
+      return (double) (ROI_SPACING * i % sizeX);
   }
 
   private Double getY(int i) {
-      return new Double(ROI_SPACING * ((int) ROI_SPACING * i / sizeX) % sizeY);
+      return (double) (ROI_SPACING * ((int) ROI_SPACING * i / sizeX) % sizeY);
   }
 
   private String getPoints(int i) {
@@ -1111,8 +1111,8 @@ public class FakeReader extends FormatReader {
         store.setEllipseID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setEllipseX(getX(i) + ROI_SPACING / 2, roiCount, 0);
         store.setEllipseY(getY(i) + ROI_SPACING / 2, roiCount, 0);
-        store.setEllipseRadiusX(new Double(ROI_SPACING / 2), roiCount, 0);
-        store.setEllipseRadiusY(new Double(ROI_SPACING / 2), roiCount, 0);
+        store.setEllipseRadiusX(Double.valueOf(ROI_SPACING / 2), roiCount, 0);
+        store.setEllipseRadiusY(Double.valueOf(ROI_SPACING / 2), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;
@@ -1198,8 +1198,8 @@ public class FakeReader extends FormatReader {
         store.setRectangleID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setRectangleX(getX(i) + ROI_SPACING / 4, roiCount, 0);
         store.setRectangleY(getY(i) + ROI_SPACING / 4, roiCount, 0);
-        store.setRectangleWidth(new Double(ROI_SPACING / 2), roiCount, 0);
-        store.setRectangleHeight(new Double(ROI_SPACING / 2), roiCount, 0);
+        store.setRectangleWidth(Double.valueOf(ROI_SPACING / 2), roiCount, 0);
+        store.setRectangleHeight(Double.valueOf(ROI_SPACING / 2), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -43,6 +43,7 @@ import java.util.StringTokenizer;
 import java.util.Vector;
 import java.util.zip.GZIPInputStream;
 
+import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -950,7 +951,7 @@ public class ICSReader extends FormatReader {
               if (key.equalsIgnoreCase("parameter ch")) {
                 String[] names = value.split(" ");
                 for (int n=0; n<names.length; n++) {
-                  channelNames.put(new Integer(n), names[n].trim());
+                  channelNames.put(n, names[n].trim());
                 }
               }
             }
@@ -964,7 +965,7 @@ public class ICSReader extends FormatReader {
 
             Double doubleValue = null;
             try {
-              doubleValue = new Double(value);
+              doubleValue = DataTools.parseDouble(value);
             }
             catch (NumberFormatException e) {
               // ARG this happens a lot; spurious error in most cases
@@ -1009,10 +1010,10 @@ public class ICSReader extends FormatReader {
                 metadata.remove(key);
               }
               else if (key.startsWith("history gain")) {
-                Integer n = 0;
+                int n = 0;
                 try {
-                  n = new Integer(key.substring(12).trim());
-                  n = new Integer(n.intValue() - 1);
+                  n = Integer.parseInt(key.substring(12).trim());
+                  n--;
                 }
                 catch (NumberFormatException e) { }
                 if (doubleValue != null) {
@@ -1023,7 +1024,7 @@ public class ICSReader extends FormatReader {
                 int laser = Integer.parseInt(key.substring(13, key.indexOf(" ", 13))) - 1;
                 value = value.replaceAll("nm", "").trim();
                 try {
-                  wavelengths.put(new Integer(laser), new Double(value));
+                  wavelengths.put(laser, DataTools.parseDouble(value));
                 }
                 catch (NumberFormatException e) {
                   LOGGER.debug("Could not parse wavelength", e);
@@ -1032,7 +1033,7 @@ public class ICSReader extends FormatReader {
              else if (key.equalsIgnoreCase("history Wavelength*")) {
                String[] waves = value.split(" ");
                for (int i=0; i<waves.length; i++) {
-                 wavelengths.put(new Integer(i), new Double(waves[i]));
+                 wavelengths.put(i, DataTools.parseDouble(waves[i]));
                }
              }
              else if (key.equalsIgnoreCase("history laser manufacturer")) {
@@ -1043,7 +1044,7 @@ public class ICSReader extends FormatReader {
              }
              else if (key.equalsIgnoreCase("history laser power")) {
                try {
-                 laserPower = new Double(value); //TODO ARG i.e. doubleValue
+                 laserPower = DataTools.parseDouble(value); //TODO ARG i.e. doubleValue
                }
                catch (NumberFormatException e) { }
              }
@@ -1052,7 +1053,7 @@ public class ICSReader extends FormatReader {
                if (repRate.indexOf(' ') != -1) {
                  repRate = repRate.substring(0, repRate.lastIndexOf(" "));
                }
-               laserRepetitionRate = new Double(repRate);
+               laserRepetitionRate = DataTools.parseDouble(repRate);
              }
              else if (key.equalsIgnoreCase("history objective type") ||
                       key.equalsIgnoreCase("history objective"))
@@ -1134,7 +1135,7 @@ public class ICSReader extends FormatReader {
                description = value;
              }
              else if (key.startsWith("history step") && key.endsWith("name")) {
-               Integer n = new Integer(key.substring(12, key.indexOf(" ", 12)));
+               Integer n = Integer.valueOf(key.substring(12, key.indexOf(" ", 12)));
                channelNames.put(n, value);
              }
              else if (key.equalsIgnoreCase("history cube")) {
@@ -1144,13 +1145,13 @@ public class ICSReader extends FormatReader {
                if (emWaves == null) {
                  emWaves = new Double[1];
                }
-               emWaves[0] = new Double(value.split(" ")[1].trim());
+               emWaves[0] = DataTools.parseDouble(value.split(" ")[1].trim());
              }
              else if (key.equalsIgnoreCase("history cube exc nm")) {
                if (exWaves == null) {
                  exWaves = new Double[1];
                }
-               exWaves[0] = new Double(value.split(" ")[1].trim());
+               exWaves[0] = DataTools.parseDouble(value.split(" ")[1].trim());
              }
              else if (key.equalsIgnoreCase("history microscope")) {
                microscopeModel = value;
@@ -1163,7 +1164,7 @@ public class ICSReader extends FormatReader {
                if (expTime.indexOf(' ') != -1) {
                  expTime = expTime.substring(0, expTime.indexOf(' '));
                }
-               Double expDouble = new Double(expTime);
+               Double expDouble = DataTools.parseDouble(expTime);
                if (expDouble != null) {
                  exposureTime = new Time(expDouble, UNITS.SECOND);
                }
@@ -1204,7 +1205,7 @@ public class ICSReader extends FormatReader {
                emWaves = new Double[waves.length];
                for (int n=0; n<emWaves.length; n++) {
                  try {
-                   emWaves[n] = new Double(Double.parseDouble(waves[n]));
+                   emWaves[n] = DataTools.parseDouble(waves[n]);
                  }
                  catch (NumberFormatException e) {
                    LOGGER.debug("Could not parse emission wavelength", e);
@@ -1216,7 +1217,7 @@ public class ICSReader extends FormatReader {
                exWaves = new Double[waves.length];
                for (int n=0; n<exWaves.length; n++) {
                  try {
-                   exWaves[n] = new Double(Double.parseDouble(waves[n]));
+                   exWaves[n] = DataTools.parseDouble(waves[n]);
                  }
                  catch (NumberFormatException e) {
                    LOGGER.debug("Could not parse excitation wavelength", e);
@@ -1229,7 +1230,7 @@ public class ICSReader extends FormatReader {
               for (int n=0; n<pins.length; n++) {
                 if (pins[n].trim().equals("")) continue;
                 try {
-                  pinholes.put(new Integer(channel++), new Double(pins[n]));
+                  pinholes.put(channel++, DataTools.parseDouble(pins[n]));
                 }
                 catch (NumberFormatException e) {
                   LOGGER.debug("Could not parse pinhole", e);
@@ -1341,7 +1342,7 @@ public class ICSReader extends FormatReader {
       else {
         if (m.sizeC == 0) m.sizeC = axisLengths[i];
         else m.sizeC *= axisLengths[i];
-        channelLengths.add(new Integer(axisLengths[i]));
+        channelLengths.add(axisLengths[i]);
         storedRGB = getSizeX() == 0;
         m.rgb = getSizeX() == 0 && getSizeC() <= 4 && getSizeC() > 1;
         if (getDimensionOrder().indexOf('C') == -1) {
@@ -1919,7 +1920,7 @@ public class ICSReader extends FormatReader {
     for (int n=0; n<values.length; n++) {
       String token = t.nextToken().trim();
       try {
-        values[n] = new Double(token);
+        values[n] = DataTools.parseDouble(token);
       }
       catch (NumberFormatException e) {
         LOGGER.debug("Could not parse double value '{}'", token, e);

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -415,7 +415,7 @@ public class MicromanagerReader extends FormatReader {
 
         for (int c=0; c<p.channels.length; c++) {
           store.setDetectorSettingsBinning(MetadataTools.getBinning(p.binning), i, c);
-          store.setDetectorSettingsGain(new Double(p.gain), i, c);
+          store.setDetectorSettingsGain(Double.valueOf(p.gain), i, c);
           if (c < p.voltage.size()) {
             store.setDetectorSettingsVoltage(
                     new ElectricPotential(p.voltage.get(c), UNITS.VOLT), i, c);
@@ -1167,7 +1167,7 @@ public class MicromanagerReader extends FormatReader {
       Integer major = null;
       try {
         if (version.length > 0) {
-          major = new Integer(version[0]);
+          major = Integer.parseInt(version[0]);
         }
       }
       catch (NumberFormatException e) {

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -357,7 +357,7 @@ public class OBFReader extends FormatReader {
       for (int dimension = 0; dimension != MAXIMAL_NUMBER_OF_DIMENSIONS; ++ dimension) {
         final double length = in.readDouble();
         if (dimension < numberOfDimensions) {
-          lengths.add(new Double(length));
+          lengths.add(length);
         }
       }
       meta_data.seriesMetadata.put("Lengths", lengths);
@@ -366,7 +366,7 @@ public class OBFReader extends FormatReader {
       for (int dimension = 0; dimension != MAXIMAL_NUMBER_OF_DIMENSIONS; ++ dimension) {
         final double offset = in.readDouble();
         if (dimension < numberOfDimensions) {
-          offsets.add(new Double(offset));
+          offsets.add(offset);
         }
       }
       meta_data.seriesMetadata.put("Offsets", offsets);
@@ -462,14 +462,14 @@ public class OBFReader extends FormatReader {
         for (int dimension = 0; dimension != MAXIMAL_NUMBER_OF_DIMENSIONS; ++ dimension) {
           final int present = in.readInt();
           if (dimension < numberOfDimensions) {
-            stepsPresent.add(new Boolean(present != 0));
+            stepsPresent.add(present != 0);
           }
         }
         List<Boolean> stepLabelsPresent = new ArrayList<Boolean>();
         for (int dimension = 0; dimension != MAXIMAL_NUMBER_OF_DIMENSIONS; ++ dimension) {
           final int present = in.readInt();
           if (dimension < numberOfDimensions) {
-            stepLabelsPresent.add(new Boolean(present != 0));
+            stepLabelsPresent.add(present != 0);
           }
         }
 
@@ -536,7 +536,7 @@ public class OBFReader extends FormatReader {
           if (stepsPresent.get(dimension)) {
             for (int position = 0; position != sizes[dimension]; ++ position) {
               final double step = in.readDouble();
-              list.add(new Double(step));
+              list.add(step);
             }
           }
           steps.add(list);

--- a/components/formats-bsd/src/loci/formats/in/QTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/QTReader.java
@@ -513,19 +513,19 @@ public class QTReader extends FormatReader {
           if (numPlanes != getImageCount()) {
             in.seek(in.getFilePointer() - 4);
             int off = in.readInt();
-            offsets.add(new Integer(off));
+            offsets.add(off);
             for (int i=1; i<getImageCount(); i++) {
               if ((chunkSizes.size() > 0) && (i < chunkSizes.size())) {
                 rawSize = chunkSizes.get(i).intValue();
               }
               else i = getImageCount();
               off += rawSize;
-              offsets.add(new Integer(off));
+              offsets.add(off);
             }
           }
           else {
             for (int i=0; i<numPlanes; i++) {
-              offsets.add(new Integer(in.readInt()));
+              offsets.add(in.readInt());
             }
           }
         }
@@ -576,7 +576,7 @@ public class QTReader extends FormatReader {
           if (rawSize == 0) {
             in.seek(in.getFilePointer() - 4);
             for (int b=0; b<getImageCount(); b++) {
-              chunkSizes.add(new Integer(in.readInt()));
+              chunkSizes.add(in.readInt());
             }
           }
         }

--- a/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
@@ -2519,7 +2519,7 @@ public class SlideBook7Reader  extends FormatReader {
 
 									// set exposure time
 									int expTime = theCurrentImageGroup.GetExposureTime(channel);
-									store.setPlaneExposureTime(new Time(new Double(expTime), UNITS.MILLISECOND), capture, imageIndex);
+									store.setPlaneExposureTime(new Time(Double.valueOf(expTime), UNITS.MILLISECOND), capture, imageIndex);
 
 									// set tile xy position
 									double numberX = theCurrentImageGroup.GetXPosition( position);

--- a/components/formats-bsd/src/loci/formats/out/AVIWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/AVIWriter.java
@@ -128,7 +128,7 @@ public class AVIWriter extends FormatWriter {
 
     out.seek(idx1Pos);
     out.writeBytes(DATA_SIGNATURE);
-    savedbLength.add(new Long(out.getFilePointer()));
+    savedbLength.add(out.getFilePointer());
 
     // Write the data length
     out.writeInt(bytesPerPixel * xDim * yDim);
@@ -285,8 +285,8 @@ public class AVIWriter extends FormatWriter {
     Time timeIncrement = meta.getPixelsTimeIncrement(series);
     if (timeIncrement != null) {
       double timeIncValue = timeIncrement.value(UNITS.SECOND).doubleValue();
-      if (timeIncValue != 0) { 
-        fps = new Double(1 / timeIncValue).intValue();
+      if (timeIncValue != 0) {
+        fps = Double.valueOf(1 / timeIncValue).intValue();
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -124,9 +124,9 @@ public class TiffWriter extends FormatWriter {
     else if (compression.equals(COMPRESSION_ZLIB)) {
       compressType = TiffCompression.DEFLATE;
     }
-    Object v = ifd.get(new Integer(IFD.COMPRESSION));
+    Object v = ifd.get(IFD.COMPRESSION);
     if (v == null)
-      ifd.put(new Integer(IFD.COMPRESSION), compressType.getCode());
+      ifd.put(IFD.COMPRESSION, compressType.getCode());
   }
 
   // -- Constructors --
@@ -230,8 +230,8 @@ public class TiffWriter extends FormatWriter {
     int currentTileSizeY = getTileSizeY();
     boolean usingTiling = currentTileSizeX > 0 && currentTileSizeY > 0;
     if (usingTiling) {
-      ifd.put(new Integer(IFD.TILE_WIDTH), new Long(currentTileSizeX));
-      ifd.put(new Integer(IFD.TILE_LENGTH), new Long(currentTileSizeY));
+      ifd.put(IFD.TILE_WIDTH, Long.valueOf(currentTileSizeX));
+      ifd.put(IFD.TILE_LENGTH, Long.valueOf(currentTileSizeY));
     }
     if (usingTiling && (currentTileSizeX < w || currentTileSizeY < h)) {
       int numTilesX = (w + (x % currentTileSizeX) + currentTileSizeX - 1) / currentTileSizeX;
@@ -355,8 +355,8 @@ public class TiffWriter extends FormatWriter {
 
     int width = getSizeX();
     int height = getSizeY();
-    ifd.put(new Integer(IFD.IMAGE_WIDTH), new Long(width));
-    ifd.put(new Integer(IFD.IMAGE_LENGTH), new Long(height));
+    ifd.put(IFD.IMAGE_WIDTH, Long.valueOf(width));
+    ifd.put(IFD.IMAGE_LENGTH, Long.valueOf(height));
 
     Length px = retrieve.getPixelsPhysicalSizeX(series);
     Double physicalSizeX = px == null || px.value(UNITS.MICROMETER) == null ? null : px.value(UNITS.MICROMETER).doubleValue();
@@ -387,7 +387,7 @@ public class TiffWriter extends FormatWriter {
     }
 
     // write the image
-    ifd.put(new Integer(IFD.LITTLE_ENDIAN), new Boolean(littleEndian));
+    ifd.put(IFD.LITTLE_ENDIAN, Boolean.valueOf(littleEndian));
     if (!ifd.containsKey(IFD.REUSE)) {
       ifd.put(IFD.REUSE, out.length());
       out.seek(out.length());


### PR DESCRIPTION
I was working on something else and didn't want to scroll through as many warnings to find compile errors. See for example https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Double.html#%3Cinit%3E(double).

Only touches the formats-bsd component (others could use the same treatment though), and tried not to modify things that are actively being worked on in other PRs.

Very low priority for review and can be excluded if needed.