### PR TITLE
Fix most Java 9+ deprecation warnings in bio-formats-plugins component

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/config/ConfigWindow.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/ConfigWindow.java
@@ -349,7 +349,7 @@ public class ConfigWindow extends JFrame
     log.println("-- Formats --");
     try {
       Class<?> irClass = Class.forName("loci.formats.ImageReader");
-      Object ir = irClass.newInstance();
+      Object ir = irClass.getDeclaredConstructor().newInstance();
       Method getClasses = irClass.getMethod("getReaders");
       Object[] readers = (Object[]) getClasses.invoke(ir);
       for (int i=0; i<readers.length; i++) {
@@ -395,7 +395,7 @@ public class ConfigWindow extends JFrame
     String matlabVersion = null;
     try {
       Class<?> matlabClass = Class.forName("com.mathworks.jmi.Matlab");
-      Object matlab = matlabClass.newInstance();
+      Object matlab = matlabClass.getDeclaredConstructor().newInstance();
       Method eval = matlabClass.getMethod("eval", new Class[] {String.class});
 
       String ans = (String) eval.invoke(matlab, new Object[] {"version"});

--- a/components/bio-formats-plugins/src/loci/plugins/config/FormatEntry.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/FormatEntry.java
@@ -72,7 +72,7 @@ public class FormatEntry implements Comparable<Object> {
     String fwClassName = "loci.plugins.config." + readerName + "Widgets";
     try {
       Class<?> fwClass = Class.forName(fwClassName);
-      fw = (IFormatWidgets) fwClass.newInstance();
+      fw = (IFormatWidgets) fwClass.getDeclaredConstructor().newInstance();
       log.println("Initialized extra widgets for " + readerName + " reader.");
     }
     catch (Throwable t) {

--- a/components/bio-formats-plugins/src/loci/plugins/in/IdDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/IdDialog.java
@@ -167,7 +167,7 @@ public class IdDialog extends ImporterDialog {
       String group = gd.getNextString();
       Long groupID = null;
       try {
-        groupID = new Long(group);
+        groupID = Long.parseLong(group);
       }
       catch (NumberFormatException e) { }
 

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterMetadata.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterMetadata.java
@@ -82,18 +82,18 @@ public class ImporterMetadata extends HashMap<String, Object> {
 
       // merge core values
       final String pad = " "; // puts core values first when alphabetizing
-      put(pad + s + "SizeX", new Integer(r.getSizeX()));
-      put(pad + s + "SizeY", new Integer(r.getSizeY()));
-      put(pad + s + "SizeZ", new Integer(r.getSizeZ()));
-      put(pad + s + "SizeT", new Integer(r.getSizeT()));
-      put(pad + s + "SizeC", new Integer(r.getSizeC()));
-      put(pad + s + "IsRGB", new Boolean(r.isRGB()));
+      put(pad + s + "SizeX", Integer.valueOf(r.getSizeX()));
+      put(pad + s + "SizeY", Integer.valueOf(r.getSizeY()));
+      put(pad + s + "SizeZ", Integer.valueOf(r.getSizeZ()));
+      put(pad + s + "SizeT", Integer.valueOf(r.getSizeT()));
+      put(pad + s + "SizeC", Integer.valueOf(r.getSizeC()));
+      put(pad + s + "IsRGB", Boolean.valueOf(r.isRGB()));
       put(pad + s + "PixelType",
         FormatTools.getPixelTypeString(r.getPixelType()));
-      put(pad + s + "LittleEndian", new Boolean(r.isLittleEndian()));
+      put(pad + s + "LittleEndian", Boolean.valueOf(r.isLittleEndian()));
       put(pad + s + "DimensionOrder", r.getDimensionOrder());
-      put(pad + s + "IsInterleaved", new Boolean(r.isInterleaved()));
-      put(pad + s + "BitsPerPixel", new Integer(r.getBitsPerPixel()));
+      put(pad + s + "IsInterleaved", Boolean.valueOf(r.isInterleaved()));
+      put(pad + s + "BitsPerPixel", Integer.valueOf(r.getBitsPerPixel()));
 
       String seriesName = process.getOMEMetadata().getImageName(i);
       put(pad + "Series " + i + " Name", seriesName);

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -127,25 +127,25 @@ public class LociFunctions extends MacroFunctions {
   // -- LociFunctions API methods - loci.formats.IFormatReader --
 
   public void getImageCount(Double[] imageCount) {
-    imageCount[0] = new Double(r.getImageCount());
+    imageCount[0] = Double.valueOf(r.getImageCount());
   }
 
-  public void getSizeX(Double[] sizeX) { sizeX[0] = new Double(r.getSizeX()); }
-  public void getSizeY(Double[] sizeY) { sizeY[0] = new Double(r.getSizeY()); }
-  public void getSizeZ(Double[] sizeZ) { sizeZ[0] = new Double(r.getSizeZ()); }
-  public void getSizeC(Double[] sizeC) { sizeC[0] = new Double(r.getSizeC()); }
-  public void getSizeT(Double[] sizeT) { sizeT[0] = new Double(r.getSizeT()); }
+  public void getSizeX(Double[] sizeX) { sizeX[0] = Double.valueOf(r.getSizeX()); }
+  public void getSizeY(Double[] sizeY) { sizeY[0] = Double.valueOf(r.getSizeY()); }
+  public void getSizeZ(Double[] sizeZ) { sizeZ[0] = Double.valueOf(r.getSizeZ()); }
+  public void getSizeC(Double[] sizeC) { sizeC[0] = Double.valueOf(r.getSizeC()); }
+  public void getSizeT(Double[] sizeT) { sizeT[0] = Double.valueOf(r.getSizeT()); }
 
   public void getPixelType(String[] pixelType) {
     pixelType[0] = FormatTools.getPixelTypeString(r.getPixelType());
   }
 
   public void getEffectiveSizeC(Double[] effectiveSizeC) {
-    effectiveSizeC[0] = new Double(r.getEffectiveSizeC());
+    effectiveSizeC[0] = Double.valueOf(r.getEffectiveSizeC());
   }
 
   public void getRGBChannelCount(Double[] rgbChannelCount) {
-    rgbChannelCount[0] = new Double(r.getRGBChannelCount());
+    rgbChannelCount[0] = Double.valueOf(r.getRGBChannelCount());
   }
 
   public void isIndexed(String[] indexed) {
@@ -154,33 +154,33 @@ public class LociFunctions extends MacroFunctions {
 
   public void getChannelDimCount(Double[] channelDimCount) {
     Modulo moduloC = r.getModuloC();
-    channelDimCount[0] = new Double(moduloC.length() > 1 ? 2 : 1);
+    channelDimCount[0] = Double.valueOf(moduloC.length() > 1 ? 2 : 1);
   }
 
   public void getChannelDimLength(Double i, Double[] channelDimLength) {
     Modulo moduloC = r.getModuloC();
     if (i.intValue() == 0) { // index 0
-      channelDimLength[0] = new Double(moduloC.length() > 1 ? r.getSizeC() / moduloC.length() : r.getSizeC());
+      channelDimLength[0] = Double.valueOf(moduloC.length() > 1 ? r.getSizeC() / moduloC.length() : r.getSizeC());
     } else { // index 1
-      channelDimLength[0] = new Double(moduloC.length());
+      channelDimLength[0] = Double.valueOf(moduloC.length());
     }
   }
 
   public void getChannelDimType(Double i, Double[] channelDimType) {
     Modulo moduloC = r.getModuloC();
     if (i.intValue() == 0) { // index 0
-      channelDimType[0] = new Double(moduloC.length() > 1 ? moduloC.parentType : FormatTools.CHANNEL);
+      channelDimType[0] = Double.valueOf(moduloC.length() > 1 ? moduloC.parentType : FormatTools.CHANNEL);
     } else { // index 1
-      channelDimType[0] = new Double(moduloC.type);
+      channelDimType[0] = Double.valueOf(moduloC.type);
     }
   }
 
 //  public void getThumbSizeX(Double[] thumbSizeX) {
-//    thumbSizeX[0] = new Double(r.getThumbSizeX());
+//    thumbSizeX[0] = Double.valueOf(r.getThumbSizeX());
 //  }
 
 //  public void getThumbSizeY(Double[] thumbSizeY) {
-//    thumbSizeY[0] = new Double(r.getThumbSizeY());
+//    thumbSizeY[0] = Double.valueOf(r.getThumbSizeY());
 //  }
 
   public void isLittleEndian(String[] littleEndian) {
@@ -270,7 +270,7 @@ public class LociFunctions extends MacroFunctions {
     throws FormatException, IOException
   {
     openSubImage(title, no, 0d, 0d,
-      new Double(r.getSizeX()), new Double(r.getSizeY()));
+      Double.valueOf(r.getSizeX()), Double.valueOf(r.getSizeY()));
   }
 
   public void openSubImage(String title, Double no, Double x, Double y,
@@ -310,7 +310,7 @@ public class LociFunctions extends MacroFunctions {
   public void closeFileOnly() throws IOException { r.close(true); }
 
   public void getSeriesCount(Double[] seriesCount) {
-    seriesCount[0] = new Double(r.getSeriesCount());
+    seriesCount[0] = Double.valueOf(r.getSeriesCount());
   }
 
   public void setSeries(Double seriesNum) {
@@ -323,7 +323,7 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void getSeries(Double[] seriesNum) {
-    seriesNum[0] = new Double(r.getSeries());
+    seriesNum[0] = Double.valueOf(r.getSeries());
   }
 
   public void setNormalized(Boolean normalize) {
@@ -331,7 +331,7 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void isNormalized(Boolean[] normalize) {
-    normalize[0] = new Boolean(r.isNormalized());
+    normalize[0] = Boolean.valueOf(r.isNormalized());
   }
 
   public void setOriginalMetadataPopulated(Boolean populate) {
@@ -339,7 +339,7 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void isOriginalMetadataPopulated(Boolean[] populate) {
-    populate[0] = new Boolean(r.isOriginalMetadataPopulated());
+    populate[0] = Boolean.valueOf(r.isOriginalMetadataPopulated());
   }
 
   public void setGroupFiles(String groupFiles) {
@@ -373,7 +373,7 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void getUsedFileCount(Double[] count) {
-    count[0] = new Double(r.getUsedFiles().length);
+    count[0] = Double.valueOf(r.getUsedFiles().length);
   }
 
   public void getUsedFile(Double i, String[] used) {
@@ -385,14 +385,14 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void getIndex(Double z, Double c, Double t, Double[] index) {
-    index[0] = new Double(r.getIndex(z.intValue(), c.intValue(), t.intValue()));
+    index[0] = Double.valueOf(r.getIndex(z.intValue(), c.intValue(), t.intValue()));
   }
 
   public void getZCTCoords(Double index, Double[] z, Double[] c, Double[] t) {
     int[] zct = r.getZCTCoords(index.intValue());
-    z[0] = new Double(zct[0]);
-    c[0] = new Double(zct[1]);
-    t[0] = new Double(zct[2]);
+    z[0] = Double.valueOf(zct[0]);
+    c[0] = Double.valueOf(zct[1]);
+    t[0] = Double.valueOf(zct[2]);
   }
 
   public void getMetadataValue(String field, String[] value) {
@@ -472,7 +472,7 @@ public class LociFunctions extends MacroFunctions {
         val = valTime.value(UNITS.SECOND).doubleValue();
       }
     }
-    exposureTime[0] = val == null ? new Double(Double.NaN) : val;
+    exposureTime[0] = val == null ? Double.NaN : val;
   }
 
   public void getPlanePositionX(Double[] positionX, Double no) {
@@ -524,7 +524,7 @@ public class LociFunctions extends MacroFunctions {
     if (x != null) {
       sizeX[0] = x.value(UNITS.MICROMETER).doubleValue();
     }
-    if (sizeX[0] == null) sizeX[0] = new Double(Double.NaN);
+    if (sizeX[0] == null) sizeX[0] = Double.NaN;
   }
 
   public void getPixelsPhysicalSizeY(Double[] sizeY) {
@@ -534,7 +534,7 @@ public class LociFunctions extends MacroFunctions {
     if (y != null) {
       sizeY[0] = y.value(UNITS.MICROMETER).doubleValue();
     }
-    if (sizeY[0] == null) sizeY[0] = new Double(Double.NaN);
+    if (sizeY[0] == null) sizeY[0] = Double.NaN;
   }
 
   public void getPixelsPhysicalSizeZ(Double[] sizeZ) {
@@ -544,14 +544,14 @@ public class LociFunctions extends MacroFunctions {
     if (z != null) {
       sizeZ[0] = z.value(UNITS.MICROMETER).doubleValue();
     }
-    if (sizeZ[0] == null) sizeZ[0] = new Double(Double.NaN);
+    if (sizeZ[0] == null) sizeZ[0] = Double.NaN;
   }
 
   public void getPixelsTimeIncrement(Double[] sizeT) {
     int imageIndex = r.getSeries();
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
     sizeT[0] = retrieve.getPixelsTimeIncrement(imageIndex).value(UNITS.SECOND).doubleValue();
-    if (sizeT[0] == null) sizeT[0] = new Double(Double.NaN);
+    if (sizeT[0] == null) sizeT[0] = Double.NaN;
   }
 
   // -- PlugIn API methods --

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -517,7 +517,7 @@ public class Exporter {
             store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(cal.pixelWidth, cal.getXUnit()), 0);
             store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(cal.pixelHeight, cal.getYUnit()), 0);
             store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(cal.pixelDepth, cal.getZUnit()), 0);
-            store.setPixelsTimeIncrement(FormatTools.getTime(new Double(cal.frameInterval), cal.getTimeUnit()), 0);
+            store.setPixelsTimeIncrement(FormatTools.getTime(Double.valueOf(cal.frameInterval), cal.getTimeUnit()), 0);
 
             if (imp.getImageStackSize() !=
                     imp.getNChannels() * imp.getNSlices() * imp.getNFrames())

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -745,10 +745,10 @@ public class ROIHandler {
   private static void storeLine(Line roi, MetadataStore store,
       int roiNum, int shape, int c, int z, int t)
   {
-    store.setLineX1(new Double(roi.x1), roiNum, shape);
-    store.setLineX2(new Double(roi.x2), roiNum, shape);
-    store.setLineY1(new Double(roi.y1), roiNum, shape);
-    store.setLineY2(new Double(roi.y2), roiNum, shape);
+    store.setLineX1(Double.valueOf(roi.x1), roiNum, shape);
+    store.setLineX2(Double.valueOf(roi.x2), roiNum, shape);
+    store.setLineY1(Double.valueOf(roi.y1), roiNum, shape);
+    store.setLineY2(Double.valueOf(roi.y2), roiNum, shape);
     if (c >= 0) {
       store.setLineTheC(unwrap(c), roiNum, shape);
     }
@@ -787,10 +787,10 @@ public class ROIHandler {
       int roiNum, int shape, int c, int z, int t)
   {
     Rectangle bounds = roi.getBounds();
-    store.setRectangleX(new Double(bounds.x), roiNum, shape);
-    store.setRectangleY(new Double(bounds.y), roiNum, shape);
-    store.setRectangleWidth(new Double(bounds.width), roiNum, shape);
-    store.setRectangleHeight(new Double(bounds.height), roiNum, shape);
+    store.setRectangleX(Double.valueOf(bounds.x), roiNum, shape);
+    store.setRectangleY(Double.valueOf(bounds.y), roiNum, shape);
+    store.setRectangleWidth(Double.valueOf(bounds.width), roiNum, shape);
+    store.setRectangleHeight(Double.valueOf(bounds.height), roiNum, shape);
     if (c >= 0) {
       store.setRectangleTheC(unwrap(c), roiNum, shape);
     }

--- a/components/bio-formats-plugins/src/loci/plugins/util/RecordedImageProcessor.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/RecordedImageProcessor.java
@@ -124,19 +124,19 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void add(double value) {
-    record("add", new Double(value), double.class);
+    record("add", Double.valueOf(value), double.class);
     proc.add(value);
   }
 
   @Override
   public void add(int value) {
-    record("add", new Integer(value), int.class);
+    record("add", Integer.valueOf(value), int.class);
     proc.add(value);
   }
 
   @Override
   public void and(int value) {
-    record("and", new Integer(value), int.class);
+    record("and", Integer.valueOf(value), int.class);
     proc.and(value);
   }
 
@@ -154,7 +154,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public ImageProcessor convertToByte(boolean doScaling) {
-    record("convertToByte", new Boolean(doScaling), boolean.class);
+    record("convertToByte", Boolean.valueOf(doScaling), boolean.class);
     return proc.convertToByte(doScaling);
   }
 
@@ -172,14 +172,14 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public ImageProcessor convertToShort(boolean doScaling) {
-    record("convertToShort", new Boolean(doScaling), boolean.class);
+    record("convertToShort", Boolean.valueOf(doScaling), boolean.class);
     return proc.convertToShort(doScaling);
   }
 
   @Override
   public void convolve(float[] kernel, int kernelWidth, int kernelHeight) {
-    record("convolve", new Object[] {kernel, new Integer(kernelWidth),
-      new Integer(kernelHeight)}, new Class[] {float[].class,
+    record("convolve", new Object[] {kernel, Integer.valueOf(kernelWidth),
+      Integer.valueOf(kernelHeight)}, new Class[] {float[].class,
       int.class, int.class});
     proc.convolve(kernel, kernelWidth, kernelHeight);
   }
@@ -192,8 +192,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void copyBits(ImageProcessor ip, int xloc, int yloc, int mode) {
-    record("copyBits", new Object[] {ip, new Integer(xloc), new Integer(yloc),
-      new Integer(mode)}, new Class[] {ImageProcessor.class, int.class,
+    record("copyBits", new Object[] {ip, Integer.valueOf(xloc), Integer.valueOf(yloc),
+      Integer.valueOf(mode)}, new Class[] {ImageProcessor.class, int.class,
       int.class, int.class});
     proc.copyBits(ip, xloc, yloc, mode);
   }
@@ -316,8 +316,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public ImageProcessor createProcessor(int width, int height) {
-    record("createProcessor", new Object[] {new Integer(width),
-      new Integer(height)}, new Class[] {int.class, int.class});
+    record("createProcessor", new Object[] {Integer.valueOf(width),
+      Integer.valueOf(height)}, new Class[] {int.class, int.class});
     return proc.createProcessor(width, height);
   }
 
@@ -335,30 +335,30 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void drawDot(int xcenter, int ycenter) {
-    record("drawDot", new Object[] {new Integer(xcenter),
-      new Integer(ycenter)}, new Class[] {int.class, int.class});
+    record("drawDot", new Object[] {Integer.valueOf(xcenter),
+      Integer.valueOf(ycenter)}, new Class[] {int.class, int.class});
     proc.drawDot(xcenter, ycenter);
   }
 
   @Override
   public void drawLine(int x1, int y1, int x2, int y2) {
-    record("drawLine", new Object[] {new Integer(x1), new Integer(y1),
-      new Integer(x2), new Integer(y2)}, new Class[] {int.class, int.class,
+    record("drawLine", new Object[] {Integer.valueOf(x1), Integer.valueOf(y1),
+      Integer.valueOf(x2), Integer.valueOf(y2)}, new Class[] {int.class, int.class,
       int.class, int.class});
     proc.drawLine(x1, y1, x2, y2);
   }
 
   @Override
   public void drawOval(int x, int y, int width, int height) {
-    record("drawOval", new Object[] {new Integer(x), new Integer(y),
-      new Integer(width), new Integer(height)}, new Class[] {int.class,
+    record("drawOval", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(width), Integer.valueOf(height)}, new Class[] {int.class,
       int.class, int.class, int.class});
     proc.drawOval(x, y, width, height);
   }
 
   @Override
   public void drawPixel(int x, int y) {
-    record("drawPixel", new Object[] {new Integer(x), new Integer(y)},
+    record("drawPixel", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     proc.drawPixel(x, y);
   }
@@ -371,8 +371,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void drawRect(int x, int y, int width, int height) {
-    record("drawRect", new Object[] {new Integer(x), new Integer(y),
-      new Integer(width), new Integer(height)}, new Class[] {int.class,
+    record("drawRect", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(width), Integer.valueOf(height)}, new Class[] {int.class,
       int.class, int.class, int.class});
     proc.drawRect(x, y, width, height);
   }
@@ -385,7 +385,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void drawString(String s, int x, int y) {
-    record("drawString", new Object[] {s, new Integer(x), new Integer(y)},
+    record("drawString", new Object[] {s, Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {String.class, int.class, int.class});
     proc.drawString(s, x, y);
   }
@@ -422,8 +422,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void fillOval(int x, int y, int width, int height) {
-    record("fillOval", new Object[] {new Integer(x), new Integer(y),
-      new Integer(width), new Integer(height)}, new Class[] {int.class,
+    record("fillOval", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(width), Integer.valueOf(height)}, new Class[] {int.class,
       int.class, int.class, int.class});
     proc.fillOval(x, y, width, height);
   }
@@ -436,7 +436,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void filter(int type) {
-    record("filter", new Integer(type), int.class);
+    record("filter", Integer.valueOf(type), int.class);
     proc.filter(type);
   }
 
@@ -460,19 +460,19 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void gamma(double value) {
-    record("gamma", new Double(value), double.class);
+    record("gamma", Double.valueOf(value), double.class);
     proc.gamma(value);
   }
 
   @Override
   public int get(int index) {
-    record("get", new Integer(index), int.class);
+    record("get", Integer.valueOf(index), int.class);
     return proc.get(index);
   }
 
   @Override
   public int get(int x, int y) {
-    record("get", new Object[] {new Integer(x), new Integer(y)},
+    record("get", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     return proc.get(x, y);
   }
@@ -527,8 +527,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void getColumn(int x, int y, int[] data, int length) {
-    record("getColumn", new Object[] {new Integer(x), new Integer(y), data,
-      new Integer(length)}, new Class[] {int.class, int.class, int[].class,
+    record("getColumn", new Object[] {Integer.valueOf(x), Integer.valueOf(y), data,
+      Integer.valueOf(length)}, new Class[] {int.class, int.class, int[].class,
       int.class});
     proc.getColumn(x, y, data, length);
   }
@@ -547,13 +547,13 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public float getf(int index) {
-    record("getf", new Integer(index), int.class);
+    record("getf", Integer.valueOf(index), int.class);
     return proc.getf(index);
   }
 
   @Override
   public float getf(int x, int y) {
-    record("getf", new Object[] {new Integer(x), new Integer(y)},
+    record("getf", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     return proc.getf(x, y);
   }
@@ -614,15 +614,15 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public double getInterpolatedPixel(double x, double y) {
-    record("getInterpolatedPixel", new Object[] {new Double(x), new Double(y)},
+    record("getInterpolatedPixel", new Object[] {Double.valueOf(x), Double.valueOf(y)},
       new Class[] {double.class, double.class});
     return proc.getInterpolatedPixel(x, y);
   }
 
   @Override
   public double[] getLine(double x1, double y1, double x2, double y2) {
-    record("getLine", new Object[] {new Double(x1), new Double(y1),
-      new Double(x2), new Double(y2)}, new Class[] {double.class, double.class,
+    record("getLine", new Object[] {Double.valueOf(x1), Double.valueOf(y1),
+      Double.valueOf(x2), Double.valueOf(y2)}, new Class[] {double.class, double.class,
       double.class, double.class});
     return proc.getLine(x1, y1, x2, y2);
   }
@@ -677,21 +677,21 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public int getPixel(int x, int y) {
-    record("getPixel", new Object[] {new Integer(x), new Integer(y)},
+    record("getPixel", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     return proc.getPixel(x, y);
   }
 
   @Override
   public int[] getPixel(int x, int y, int[] iArray) {
-    record("getPixel", new Object[] {new Integer(x), new Integer(y), iArray},
+    record("getPixel", new Object[] {Integer.valueOf(x), Integer.valueOf(y), iArray},
       new Class[] {int.class, int.class, int[].class});
     return proc.getPixel(x, y, iArray);
   }
 
   @Override
   public int getPixelInterpolated(double x, double y) {
-    record("getPixelInterpolated", new Object[] {new Double(x), new Double(y)},
+    record("getPixelInterpolated", new Object[] {Double.valueOf(x), Double.valueOf(y)},
       new Class[] {double.class, double.class});
     return proc.getPixelInterpolated(x, y);
   }
@@ -716,7 +716,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public float getPixelValue(int x, int y) {
-    record("getPixelValue", new Object[] {new Integer(x), new Integer(y)},
+    record("getPixelValue", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     return proc.getPixelValue(x, y);
   }
@@ -729,8 +729,8 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void getRow(int x, int y, int[] data, int length) {
-    record("getRow", new Object[] {new Integer(x), new Integer(y), data,
-      new Integer(length)}, new Class[] {int.class, int.class, int[].class,
+    record("getRow", new Object[] {Integer.valueOf(x), Integer.valueOf(y), data,
+      Integer.valueOf(length)}, new Class[] {int.class, int.class, int[].class,
       int.class});
     proc.getRow(x, y, data, length);
   }
@@ -755,7 +755,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void insert(ImageProcessor ip, int xloc, int yloc) {
-    record("insert", new Object[] {ip, new Integer(xloc), new Integer(yloc)},
+    record("insert", new Object[] {ip, Integer.valueOf(xloc), Integer.valueOf(yloc)},
       new Class[] {ImageProcessor.class, int.class, int.class});
     proc.insert(ip, xloc, yloc);
   }
@@ -792,7 +792,7 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   @Override
   public void lineTo(int x2, int y2) {
-    record("lineTo", new Object[] {new Integer(x2), new Integer(y2)},
+    record("lineTo", new Object[] {Integer.valueOf(x2), Integer.valueOf(y2)},
       new Class[] {int.class, int.class});
     proc.lineTo(x2, y2);
   }
@@ -803,7 +803,7 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void max(double value) {
-    record("max", new Double(value), double.class);
+    record("max", Double.valueOf(value), double.class);
     proc.max(value);
   }
 
@@ -818,7 +818,7 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void min(double value) {
-    record("min", new Double(value), double.class);
+    record("min", Double.valueOf(value), double.class);
     proc.min(value);
   }
 
@@ -828,54 +828,54 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void moveTo(int x, int y) {
-    record("moveTo", new Object[] {new Integer(x), new Integer(y)},
+    record("moveTo", new Object[] {Integer.valueOf(x), Integer.valueOf(y)},
       new Class[] {int.class, int.class});
     proc.moveTo(x, y);
   }
 
   public void multiply(double value) {
-    record("multiply", new Double(value), double.class);
+    record("multiply", Double.valueOf(value), double.class);
     proc.multiply(value);
   }
 
   public void noise(double range) {
-    record("noise", new Double(range), double.class);
+    record("noise", Double.valueOf(range), double.class);
     proc.noise(range);
   }
 
   public void or(int value) {
-    record("or", new Integer(value), int.class);
+    record("or", Integer.valueOf(value), int.class);
     proc.or(value);
   }
 
   public void putColumn(int x, int y, int[] data, int length) {
-    record("putColumn", new Object[] {new Integer(x), new Integer(y), data,
-      new Integer(length)}, new Class[] {int.class, int.class, int[].class,
+    record("putColumn", new Object[] {Integer.valueOf(x), Integer.valueOf(y), data,
+      Integer.valueOf(length)}, new Class[] {int.class, int.class, int[].class,
       int.class});
     proc.putColumn(x, y, data, length);
   }
 
   public void putPixel(int x, int y, int value) {
-    record("putPixel", new Object[] {new Integer(x), new Integer(y),
-      new Integer(value)}, new Class[] {int.class, int.class, int.class});
+    record("putPixel", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(value)}, new Class[] {int.class, int.class, int.class});
     proc.putPixel(x, y, value);
   }
 
   public void putPixel(int x, int y, int[] iArray) {
-    record("putPixel", new Object[] {new Integer(x), new Integer(y), iArray},
+    record("putPixel", new Object[] {Integer.valueOf(x), Integer.valueOf(y), iArray},
       new Class[] {int.class, int.class, int[].class});
     proc.putPixel(x, y, iArray);
   }
 
   public void putPixelValue(int x, int y, double value) {
-    record("putPixelValue", new Object[] {new Integer(x), new Integer(y),
-      new Double(value)}, new Class[] {int.class, int.class, double.class});
+    record("putPixelValue", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Double.valueOf(value)}, new Class[] {int.class, int.class, double.class});
     proc.putPixelValue(x, y, value);
   }
 
   public void putRow(int x, int y, int[] data, int length) {
-    record("putRow", new Object[] {new Integer(x), new Integer(y), data,
-      new Integer(length)}, new Class[] {int.class, int.class, int[].class,
+    record("putRow", new Object[] {Integer.valueOf(x), Integer.valueOf(y), data,
+      Integer.valueOf(length)}, new Class[] {int.class, int.class, int[].class,
       int.class});
     proc.putRow(x, y, data, length);
   }
@@ -911,18 +911,18 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public ImageProcessor resize(int dstWidth) {
-    record("resize", new Integer(dstWidth), int.class);
+    record("resize", Integer.valueOf(dstWidth), int.class);
     return proc.resize(dstWidth);
   }
 
   public ImageProcessor resize(int dstWidth, int dstHeight) {
-    record("resize", new Object[] {new Integer(dstWidth),
-      new Integer(dstHeight)}, new Class[] {int.class, int.class});
+    record("resize", new Object[] {Integer.valueOf(dstWidth),
+      Integer.valueOf(dstHeight)}, new Class[] {int.class, int.class});
     return proc.resize(dstWidth, dstHeight);
   }
 
   public void rotate(double angle) {
-    record("rotate", new Double(angle), double.class);
+    record("rotate", Double.valueOf(angle), double.class);
     proc.rotate(angle);
   }
 
@@ -937,36 +937,36 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void scale(double xScale, double yScale) {
-    record("scale", new Object[] {new Double(xScale), new Double(yScale)},
+    record("scale", new Object[] {Double.valueOf(xScale), Double.valueOf(yScale)},
       new Class[] {double.class, double.class});
     proc.scale(xScale, yScale);
   }
 
   public void set(int index, int value) {
-    record("set", new Object[] {new Integer(index), new Integer(value)},
+    record("set", new Object[] {Integer.valueOf(index), Integer.valueOf(value)},
       new Class[] {int.class, int.class});
     proc.set(index, value);
   }
 
   public void set(int x, int y, int value) {
-    record("set", new Object[] {new Integer(x), new Integer(y),
-      new Integer(value)}, new Class[] {int.class, int.class, int.class});
+    record("set", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(value)}, new Class[] {int.class, int.class, int.class});
     proc.set(x, y, value);
   }
 
   public void setAntialiasedText(boolean antialiased) {
-    record("setAntialiasedText", new Boolean(antialiased), boolean.class);
+    record("setAntialiasedText", Boolean.valueOf(antialiased), boolean.class);
     proc.setAntialiasedText(antialiased);
   }
 
   public void setAutoThreshold(int method, int lutUpdate) {
-    record("setAutoThreshold", new Object[] {new Integer(method),
-      new Integer(lutUpdate)}, new Class[] {int.class, int.class});
+    record("setAutoThreshold", new Object[] {Integer.valueOf(method),
+      Integer.valueOf(lutUpdate)}, new Class[] {int.class, int.class});
     proc.setAutoThreshold(method, lutUpdate);
   }
 
   public void setBackgroundValue(double value) {
-    record("setBackgroundValue", new Double(value), double.class);
+    record("setBackgroundValue", Double.valueOf(value), double.class);
     proc.setBackgroundValue(value);
   }
 
@@ -986,7 +986,7 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setColor(int value) {
-    record("setColor", new Integer(value), int.class);
+    record("setColor", Integer.valueOf(value), int.class);
     proc.setColor(value);
   }
 
@@ -996,14 +996,14 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setf(int index, float value) {
-    record("setf", new Object[] {new Integer(index), new Float(value)},
+    record("setf", new Object[] {Integer.valueOf(index), Float.valueOf(value)},
       new Class[] {int.class, float.class});
     proc.setf(index, value);
   }
 
   public void setf(int x, int y, float value) {
-    record("setf", new Object[] {new Integer(x), new Integer(y),
-      new Float(value)}, new Class[] {int.class, int.class, float.class});
+    record("setf", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Float.valueOf(value)}, new Class[] {int.class, int.class, float.class});
     proc.setf(x, y, value);
   }
 
@@ -1018,13 +1018,13 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setHistogramRange(double histMin, double histMax) {
-    record("setHistogramRange", new Object[] {new Double(histMin),
-      new Double(histMax)}, new Class[] {double.class, double.class});
+    record("setHistogramRange", new Object[] {Double.valueOf(histMin),
+      Double.valueOf(histMax)}, new Class[] {double.class, double.class});
     proc.setHistogramRange(histMin, histMax);
   }
 
   public void setHistogramSize(int size) {
-    record("setHistogramSize", new Integer(size), int.class);
+    record("setHistogramSize", Integer.valueOf(size), int.class);
     proc.setHistogramSize(size);
   }
 
@@ -1034,22 +1034,22 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setInterpolate(boolean interpolate) {
-    record("setInterpolate", new Boolean(interpolate), boolean.class);
+    record("setInterpolate", Boolean.valueOf(interpolate), boolean.class);
     proc.setInterpolate(interpolate);
   }
 
   public void setJustification(int justification) {
-    record("setJustification", new Integer(justification), int.class);
+    record("setJustification", Integer.valueOf(justification), int.class);
     proc.setJustification(justification);
   }
 
   public void setLineWidth(int width) {
-    record("setLineWidth", new Integer(width), int.class);
+    record("setLineWidth", Integer.valueOf(width), int.class);
     proc.setLineWidth(width);
   }
 
   public void setLutAnimation(boolean lutAnimation) {
-    record("setLutAnimation", new Boolean(lutAnimation), boolean.class);
+    record("setLutAnimation", Boolean.valueOf(lutAnimation), boolean.class);
     proc.setLutAnimation(lutAnimation);
   }
 
@@ -1059,13 +1059,13 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setMinAndMax(double min, double max) {
-    record("setMinAndMax", new Object[] {new Double(min), new Double(max)},
+    record("setMinAndMax", new Object[] {Double.valueOf(min), Double.valueOf(max)},
       new Class[] {double.class, double.class});
     proc.setMinAndMax(min, max);
   }
 
   public void setPixels(int channelNumber, FloatProcessor fp) {
-    record("setPixels", new Object[] {new Integer(channelNumber), fp},
+    record("setPixels", new Object[] {Integer.valueOf(channelNumber), fp},
       new Class[] {int.class, FloatProcessor.class});
     proc.setPixels(channelNumber, fp);
   }
@@ -1081,8 +1081,8 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setRoi(int x, int y, int rwidth, int rheight) {
-    record("setRoi", new Object[] {new Integer(x), new Integer(y),
-      new Integer(rwidth), new Integer(rheight)}, new Class[] {int.class,
+    record("setRoi", new Object[] {Integer.valueOf(x), Integer.valueOf(y),
+      Integer.valueOf(rwidth), Integer.valueOf(rheight)}, new Class[] {int.class,
       int.class, int.class, int.class});
     proc.setRoi(x, y, rwidth, rheight);
   }
@@ -1103,7 +1103,7 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void setSnapshotCopyMode(boolean b) {
-    record("setSnapshotCopyMode", new Boolean(b), boolean.class);
+    record("setSnapshotCopyMode", Boolean.valueOf(b), boolean.class);
     proc.setSnapshotCopyMode(b);
   }
 
@@ -1115,14 +1115,14 @@ public class RecordedImageProcessor extends ImageProcessor {
   public void setThreshold(double minThreshold, double maxThreshold,
     int lutUpdate)
   {
-    record("setThreshold", new Object[] {new Double(minThreshold),
-      new Double(maxThreshold), new Integer(lutUpdate)},
+    record("setThreshold", new Object[] {Double.valueOf(minThreshold),
+      Double.valueOf(maxThreshold), Integer.valueOf(lutUpdate)},
       new Class[] {double.class, double.class, int.class});
     proc.setThreshold(minThreshold, maxThreshold, lutUpdate);
   }
 
   public void setValue(double value) {
-    record("setValue", new Double(value), double.class);
+    record("setValue", Double.valueOf(value), double.class);
     proc.setValue(value);
   }
 
@@ -1157,12 +1157,12 @@ public class RecordedImageProcessor extends ImageProcessor {
   }
 
   public void threshold(int level) {
-    record("threshold", new Integer(level), int.class);
+    record("threshold", Integer.valueOf(level), int.class);
     proc.threshold(level);
   }
 
   public FloatProcessor toFloat(int channelNumber, FloatProcessor fp) {
-    record("toFloat", new Object[] {new Integer(channelNumber), fp},
+    record("toFloat", new Object[] {Integer.valueOf(channelNumber), fp},
       new Class[] {int.class, FloatProcessor.class});
     return proc.toFloat(channelNumber, fp);
   }
@@ -1174,19 +1174,19 @@ public class RecordedImageProcessor extends ImageProcessor {
 
   public void translate(int xOffset, int yOffset) {
     record("translate",
-      new Object[] {new Integer(xOffset), new Integer(yOffset)},
+      new Object[] {Integer.valueOf(xOffset), Integer.valueOf(yOffset)},
       new Class[] {int.class, int.class});
     proc.translate(xOffset, yOffset);
   }
 
   public void updateComposite(int[] rgbPixels, int channel) {
-    record("updateComposite", new Object[] {rgbPixels, new Integer(channel)},
+    record("updateComposite", new Object[] {rgbPixels, Integer.valueOf(channel)},
       new Class[] {int[].class, int.class});
     proc.updateComposite(rgbPixels, channel);
   }
 
   public void xor(int value) {
-    record("xor", new Integer(value), int.class);
+    record("xor", Integer.valueOf(value), int.class);
     proc.xor(value);
   }
 


### PR DESCRIPTION
In the same spirit as #4177.

The `Class.newInstance()` changes are as recommended in https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance(). There should now be only 8 warnings in the bio-formats-plugins component.

Scheduling for 8.0.0 as discussed earlier today, so that we can sort out warnings right after 7.3.0.