### PR TITLE
Fix Java 9+ deprecation warnings in smaller components

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -367,7 +367,7 @@ public class ImageInfo {
       // create reader of a specific format type
       try {
         Class<?> c = Class.forName("loci.formats.in." + format + "Reader");
-        reader = (IFormatReader) c.newInstance();
+        reader = (IFormatReader) c.getDeclaredConstructor().newInstance();
       }
       catch (ClassNotFoundException exc) {
         LOGGER.warn("Unknown reader: {}", format);
@@ -377,7 +377,7 @@ public class ImageInfo {
         LOGGER.warn("Cannot instantiate reader: {}", format);
         LOGGER.debug("", exc);
       }
-      catch (IllegalAccessException exc) {
+      catch (ReflectiveOperationException exc) {
         LOGGER.warn("Cannot access reader: {}", format);
         LOGGER.debug("", exc);
       }

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -134,11 +134,10 @@ public class ImageReader implements IFormatReader {
     for (int i=0; i<c.length; i++) {
       IFormatReader reader = null;
       try {
-        reader = c[i].newInstance();
+        reader = c[i].getDeclaredConstructor().newInstance();
         reader.setMetadataOptions(opt);
       }
-      catch (IllegalAccessException exc) { }
-      catch (InstantiationException exc) { }
+      catch (ReflectiveOperationException exc) { }
       if (reader == null) {
         LOGGER.error("{} cannot be instantiated.", c[i].getName());
         continue;

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -121,10 +121,9 @@ public class ImageWriter implements IFormatWriter {
     for (int i=0; i<c.length; i++) {
       IFormatWriter writer = null;
       try {
-        writer = c[i].newInstance();
+        writer = c[i].getDeclaredConstructor().newInstance();
       }
-      catch (IllegalAccessException exc) { }
-      catch (InstantiationException exc) { }
+      catch (ReflectiveOperationException exc) { }
       if (writer == null) {
         LOGGER.error("{} cannot be instantiated.", c[i].getName());
         continue;

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -723,10 +723,9 @@ public abstract class ReaderWrapper implements IFormatReader {
         c = reader.getClass();
       }
       try {
-        childCopy = c.newInstance();
+        childCopy = c.getDeclaredConstructor().newInstance();
       }
-      catch (IllegalAccessException exc) { throw new FormatException(exc); }
-      catch (InstantiationException exc) { throw new FormatException(exc); }
+      catch (ReflectiveOperationException exc) { throw new FormatException(exc); }
 
       // preserve reader-specific configuration with original reader
       if (reader instanceof DelegateReader) {

--- a/components/formats-api/src/loci/formats/WriterWrapper.java
+++ b/components/formats-api/src/loci/formats/WriterWrapper.java
@@ -451,10 +451,9 @@ public abstract class WriterWrapper implements IFormatWriter {
         c = writer.getClass();
       }
       try {
-        childCopy = (IFormatWriter) c.newInstance();
+        childCopy = (IFormatWriter) c.getDeclaredConstructor().newInstance();
       }
-      catch (IllegalAccessException exc) { throw new FormatException(exc); }
-      catch (InstantiationException exc) { throw new FormatException(exc); }
+      catch (ReflectiveOperationException exc) { throw new FormatException(exc); }
     }
 
     // use crazy reflection to instantiate a writer of the proper type

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -202,12 +202,12 @@ public class Configuration {
     if (delim >= 0) {
       test = test.substring(0, delim);
     }
-    return new Boolean(test.trim()).booleanValue();
+    return Boolean.parseBoolean(test.trim());
   }
 
   public boolean hasValidXML() {
     if (globalTable.get(HAS_VALID_XML) == null) return true;
-    return new Boolean(globalTable.get(HAS_VALID_XML)).booleanValue();
+    return Boolean.parseBoolean(globalTable.get(HAS_VALID_XML));
   }
 
   public String getReader() {
@@ -261,19 +261,19 @@ public class Configuration {
   }
 
   public boolean isInterleaved() {
-    return new Boolean(currentTable.get(IS_INTERLEAVED)).booleanValue();
+    return Boolean.parseBoolean(currentTable.get(IS_INTERLEAVED));
   }
 
   public boolean isIndexed() {
-    return new Boolean(currentTable.get(IS_INDEXED)).booleanValue();
+    return Boolean.parseBoolean(currentTable.get(IS_INDEXED));
   }
 
   public boolean isFalseColor() {
-    return new Boolean(currentTable.get(IS_FALSE_COLOR)).booleanValue();
+    return Boolean.parseBoolean(currentTable.get(IS_FALSE_COLOR));
   }
 
   public boolean isRGB() {
-    return new Boolean(currentTable.get(IS_RGB)).booleanValue();
+    return Boolean.parseBoolean(currentTable.get(IS_RGB));
   }
 
   public int getThumbSizeX() {
@@ -289,7 +289,7 @@ public class Configuration {
   }
 
   public boolean isLittleEndian() {
-    return new Boolean(currentTable.get(IS_LITTLE_ENDIAN)).booleanValue();
+    return Boolean.parseBoolean(currentTable.get(IS_LITTLE_ENDIAN));
   }
 
   public String getMD5() {
@@ -324,7 +324,7 @@ public class Configuration {
     String timeIncrement = currentTable.get(TIME_INCREMENT);
     String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNIT);
     try {
-      return timeIncrement == null ? null : FormatTools.getTime(new Double(timeIncrement), timeIncrementUnits);
+      return timeIncrement == null ? null : FormatTools.getTime(DataTools.parseDouble(timeIncrement), timeIncrementUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -351,7 +351,7 @@ public class Configuration {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
     String exposureUnits = currentTable.get(EXPOSURE_TIME_UNIT + channel);
     try {
-      return exposure == null ? null : FormatTools.getTime(new Double(exposure), exposureUnits);
+      return exposure == null ? null : FormatTools.getTime(DataTools.parseDouble(exposure), exposureUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -360,12 +360,12 @@ public class Configuration {
 
   public Double getDeltaT(int plane) {
     String deltaT = currentTable.get(DELTA_T + plane);
-    return deltaT == null ? null : new Double(deltaT);
+    return deltaT == null ? null : DataTools.parseDouble(deltaT);
   }
 
   public Double getPositionX(int plane) {
     String pos = currentTable.get(X_POSITION + plane);
-    return pos == null ? null : new Double(pos);
+    return pos == null ? null : DataTools.parseDouble(pos);
   }
   
   public String getPositionXUnit(int plane) {
@@ -374,7 +374,7 @@ public class Configuration {
 
   public Double getPositionY(int plane) {
     String pos = currentTable.get(Y_POSITION + plane);
-    return pos == null ? null : new Double(pos);
+    return pos == null ? null : DataTools.parseDouble(pos);
   }
   
   public String getPositionYUnit(int plane) {
@@ -383,7 +383,7 @@ public class Configuration {
 
   public Double getPositionZ(int plane) {
     String pos = currentTable.get(Z_POSITION + plane);
-    return pos == null ? null : new Double(pos);
+    return pos == null ? null : DataTools.parseDouble(pos);
   }
 
   public String getPositionZUnit(int plane) {
@@ -394,7 +394,7 @@ public class Configuration {
     String wavelength = currentTable.get(EMISSION_WAVELENGTH + channel);
     String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNIT + channel);
     try {
-      return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), emissionUnits);
+      return wavelength == null ? null : FormatTools.getWavelength(DataTools.parseDouble(wavelength), emissionUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -405,7 +405,7 @@ public class Configuration {
     String wavelength = currentTable.get(EXCITATION_WAVELENGTH + channel);
     String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNIT + channel);
     try {
-      return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), excitationUnits);
+      return wavelength == null ? null : FormatTools.getWavelength(DataTools.parseDouble(wavelength), excitationUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -828,7 +828,7 @@ public class Configuration {
     String units = currentTable.get(unitKey);
     try {
       UnitsLength unit = units == null ? UnitsLength.MICROMETER : UnitsLength.fromString(units);
-      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), unit);
+      return physicalSize == null ? null : UnitsLength.create(DataTools.parseDouble(physicalSize), unit);
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -324,8 +324,7 @@ public class Configuration {
     String timeIncrement = currentTable.get(TIME_INCREMENT);
     String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNIT);
     try {
-      Double time = DataTools.parseDouble(timeIncrement);
-      return time == null ? null : FormatTools.getTime(time, timeIncrementUnits);
+      return timeIncrement == null ? null : FormatTools.getTime(Double.parseDouble(timeIncrement), timeIncrementUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -352,8 +351,7 @@ public class Configuration {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
     String exposureUnits = currentTable.get(EXPOSURE_TIME_UNIT + channel);
     try {
-      Double exp = DataTools.parseDouble(exposure);
-      return exp == null ? null : FormatTools.getTime(exp, exposureUnits);
+      return exposure == null ? null : FormatTools.getTime(Double.parseDouble(exposure), exposureUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -362,12 +360,12 @@ public class Configuration {
 
   public Double getDeltaT(int plane) {
     String deltaT = currentTable.get(DELTA_T + plane);
-    return deltaT == null ? null : DataTools.parseDouble(deltaT);
+    return deltaT == null ? null : Double.parseDouble(deltaT);
   }
 
   public Double getPositionX(int plane) {
     String pos = currentTable.get(X_POSITION + plane);
-    return pos == null ? null : DataTools.parseDouble(pos);
+    return pos == null ? null : Double.parseDouble(pos);
   }
   
   public String getPositionXUnit(int plane) {
@@ -376,7 +374,7 @@ public class Configuration {
 
   public Double getPositionY(int plane) {
     String pos = currentTable.get(Y_POSITION + plane);
-    return pos == null ? null : DataTools.parseDouble(pos);
+    return pos == null ? null : Double.parseDouble(pos);
   }
   
   public String getPositionYUnit(int plane) {
@@ -385,7 +383,7 @@ public class Configuration {
 
   public Double getPositionZ(int plane) {
     String pos = currentTable.get(Z_POSITION + plane);
-    return pos == null ? null : DataTools.parseDouble(pos);
+    return pos == null ? null : Double.parseDouble(pos);
   }
 
   public String getPositionZUnit(int plane) {
@@ -396,8 +394,7 @@ public class Configuration {
     String wavelength = currentTable.get(EMISSION_WAVELENGTH + channel);
     String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNIT + channel);
     try {
-      Double wave = DataTools.parseDouble(wavelength);
-      return wave == null ? null : FormatTools.getWavelength(wave, emissionUnits);
+      return wavelength == null ? null : FormatTools.getWavelength(Double.parseDouble(wavelength), emissionUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -408,8 +405,7 @@ public class Configuration {
     String wavelength = currentTable.get(EXCITATION_WAVELENGTH + channel);
     String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNIT + channel);
     try {
-      Double wave = DataTools.parseDouble(wavelength);
-      return wave == null ? null : FormatTools.getWavelength(wave, excitationUnits);
+      return wavelength == null ? null : FormatTools.getWavelength(Double.parseDouble(wavelength), excitationUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -832,8 +828,7 @@ public class Configuration {
     String units = currentTable.get(unitKey);
     try {
       UnitsLength unit = units == null ? UnitsLength.MICROMETER : UnitsLength.fromString(units);
-      Double size = DataTools.parseDouble(physicalSize);
-      return size == null ? null : UnitsLength.create(size, unit);
+      return physicalSize == null ? null : UnitsLength.create(Double.parseDouble(physicalSize), unit);
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -324,7 +324,8 @@ public class Configuration {
     String timeIncrement = currentTable.get(TIME_INCREMENT);
     String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNIT);
     try {
-      return timeIncrement == null ? null : FormatTools.getTime(DataTools.parseDouble(timeIncrement), timeIncrementUnits);
+      Double time = DataTools.parseDouble(timeIncrement);
+      return time == null ? null : FormatTools.getTime(time, timeIncrementUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -351,7 +352,8 @@ public class Configuration {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
     String exposureUnits = currentTable.get(EXPOSURE_TIME_UNIT + channel);
     try {
-      return exposure == null ? null : FormatTools.getTime(DataTools.parseDouble(exposure), exposureUnits);
+      Double exp = DataTools.parseDouble(exposure);
+      return exp == null ? null : FormatTools.getTime(exp, exposureUnits);
     }
     catch (NumberFormatException e) { 
       return null; 
@@ -394,7 +396,8 @@ public class Configuration {
     String wavelength = currentTable.get(EMISSION_WAVELENGTH + channel);
     String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNIT + channel);
     try {
-      return wavelength == null ? null : FormatTools.getWavelength(DataTools.parseDouble(wavelength), emissionUnits);
+      Double wave = DataTools.parseDouble(wavelength);
+      return wave == null ? null : FormatTools.getWavelength(wave, emissionUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -405,7 +408,8 @@ public class Configuration {
     String wavelength = currentTable.get(EXCITATION_WAVELENGTH + channel);
     String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNIT + channel);
     try {
-      return wavelength == null ? null : FormatTools.getWavelength(DataTools.parseDouble(wavelength), excitationUnits);
+      Double wave = DataTools.parseDouble(wavelength);
+      return wave == null ? null : FormatTools.getWavelength(wave, excitationUnits);
     }
     catch (NumberFormatException e) { 
       return null;
@@ -828,7 +832,8 @@ public class Configuration {
     String units = currentTable.get(unitKey);
     try {
       UnitsLength unit = units == null ? UnitsLength.MICROMETER : UnitsLength.fromString(units);
-      return physicalSize == null ? null : UnitsLength.create(DataTools.parseDouble(physicalSize), unit);
+      Double size = DataTools.parseDouble(physicalSize);
+      return size == null ? null : UnitsLength.create(size, unit);
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }

--- a/components/test-suite/src/loci/tests/testng/FormatWriterTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatWriterTest.java
@@ -110,16 +110,15 @@ public class FormatWriterTest {
       String[] compressionTypes = writers[i].getCompressionTypes();
       if (compressionTypes == null) {
         try {
-          IFormatWriter w = (IFormatWriter) writers[i].getClass().newInstance();
+          IFormatWriter w = (IFormatWriter) writers[i].getClass().getDeclaredConstructor().newInstance();
           tmp.add(w);
         }
-        catch (InstantiationException ie) { }
-        catch (IllegalAccessException iae) { }
+        catch (ReflectiveOperationException roe) { }
         continue;
       }
       for (int q=0; q<compressionTypes.length; q++) {
         try {
-          IFormatWriter w = (IFormatWriter) writers[i].getClass().newInstance();
+          IFormatWriter w = (IFormatWriter) writers[i].getClass().getDeclaredConstructor().newInstance();
           if (DataTools.containsValue(w.getPixelTypes(compressionTypes[q]),
             reader.getPixelType()))
           {
@@ -128,8 +127,7 @@ public class FormatWriterTest {
           }
         }
         catch (FormatException fe) { }
-        catch (InstantiationException ie) { }
-        catch (IllegalAccessException iae) { }
+        catch (ReflectiveOperationException roe) { }
       }
     }
     IFormatWriter[][] writersToUse = new IFormatWriter[tmp.size()][1];


### PR DESCRIPTION
In particular, `bio-formats-tools`, `formats-api`, and `test-suite`. This is similar to #4177 and #4178; only the `formats-gpl` component still requires work.