### PR TITLE
Add support for reading compressed NDPI tiles

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1228,6 +1228,14 @@ public final class ImageConverter {
     if (writer instanceof DicomWriter ||
       (writer instanceof ImageWriter && ((ImageWriter) writer).getWriter(outputFile) instanceof DicomWriter))
     {
+      // if we asked to try a precompressed conversion,
+      // then the writer's tile sizes will have been set automatically
+      // according to the input data
+      // the conversion must then be performed tile-wise to match the tile sizes,
+      // even if precompression doesn't end up being possible
+      if (precompressed) {
+        return true;
+      }
       MetadataStore r = reader.getMetadataStore();
       return !(r instanceof IPyramidStore) || ((IPyramidStore) r).getResolutionCount(reader.getSeries()) > 1;
     }

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -705,4 +705,73 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
     tiffParser.setUse64BitOffsets(use64Bit);
   }
 
+  /**
+   * Get the index of the tile corresponding to given IFD (plane)
+   * and tile XY indexes.
+   *
+   * @param ifd IFD for the requested tile's plane
+   * @param x tile X index
+   * @param y tile Y index
+   * @return corresponding tile index
+   */
+  protected int getTileIndex(IFD ifd, int x, int y) throws FormatException {
+    int rows = (int) ifd.getTilesPerColumn();
+    int cols = (int) ifd.getTilesPerRow();
+
+    if (x < 0 || x >= cols) {
+      throw new IllegalArgumentException("X index " + x + " not in range [0, " + cols + ")");
+    }
+    if (y < 0 || y >= rows) {
+      throw new IllegalArgumentException("Y index " + y + " not in range [0, " + rows + ")");
+    }
+
+    return (cols * y) + x;
+  }
+
+  protected long getCompressedByteCount(IFD ifd, int x, int y) throws FormatException, IOException {
+    long[] byteCounts = ifd.getStripByteCounts();
+    int tileIndex = getTileIndex(ifd, x, y);
+    byte[] jpegTable = (byte[]) ifd.getIFDValue(IFD.JPEG_TABLES);
+    int jpegTableBytes = jpegTable == null ? 0 : jpegTable.length - 2;
+    long expectedBytes = byteCounts[tileIndex];
+    if (expectedBytes > 0) {
+      expectedBytes += jpegTableBytes;
+    }
+    if (expectedBytes < 0 || expectedBytes > Integer.MAX_VALUE) {
+      throw new IOException("Invalid compressed tile size: " + expectedBytes);
+    }
+    return expectedBytes;
+  }
+
+  protected byte[] copyTile(IFD ifd, byte[] buf, int x, int y) throws FormatException, IOException {
+    long[] offsets = ifd.getStripOffsets();
+    long[] byteCounts = ifd.getStripByteCounts();
+
+    int tileIndex = getTileIndex(ifd, x, y);
+
+    byte[] jpegTable = (byte[]) ifd.getIFDValue(IFD.JPEG_TABLES);
+    int jpegTableBytes = jpegTable == null ? 0 : jpegTable.length - 2;
+    long expectedBytes = getCompressedByteCount(ifd, x, y);
+
+    if (buf.length < expectedBytes) {
+      throw new IllegalArgumentException("Tile buffer too small: expected >=" +
+        expectedBytes + ", got " + buf.length);
+    }
+    else if (expectedBytes < 0 || expectedBytes > Integer.MAX_VALUE) {
+      throw new IOException("Invalid compressed tile size: " + expectedBytes);
+    }
+
+    if (jpegTable != null && expectedBytes > 0) {
+      System.arraycopy(jpegTable, 0, buf, 0, jpegTable.length - 2);
+      // skip over the duplicate SOI marker
+      tiffParser.getStream().seek(offsets[tileIndex] + 2);
+      tiffParser.getStream().readFully(buf, jpegTable.length - 2, (int) byteCounts[tileIndex]);
+    }
+    else if (byteCounts[tileIndex] > 0) {
+      tiffParser.getStream().seek(offsets[tileIndex]);
+      tiffParser.getStream().readFully(buf, 0, (int) byteCounts[tileIndex]);
+    }
+    return buf;
+  }
+
 }

--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -235,14 +235,7 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     LOGGER.debug("savePrecompressedBytes(series={}, resolution={}, no={}, x={}, y={})",
       series, resolution, no, x, y);
 
-    // TODO: may want better handling of non-tiled "extra" images (e.g. label, macro)
     MetadataRetrieve r = getMetadataRetrieve();
-    if ((!(r instanceof IPyramidStore) ||
-      ((IPyramidStore) r).getResolutionCount(series) == 1) &&
-      !isFullPlane(x, y, w, h))
-    {
-      throw new FormatException("DicomWriter does not allow tiles for non-pyramid images");
-    }
 
     int bytesPerPixel = FormatTools.getBytesPerPixel(
       FormatTools.pixelTypeFromString(
@@ -397,13 +390,7 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     int thisTileHeight = tileHeight[resolutionIndex];
 
     MetadataRetrieve r = getMetadataRetrieve();
-    if ((!(r instanceof IPyramidStore) ||
-      ((IPyramidStore) r).getResolutionCount(series) == 1) &&
-      !isFullPlane(x, y, w, h))
-    {
-      throw new FormatException("DicomWriter does not allow tiles for non-pyramid images");
-    }
-    else if (x % thisTileWidth != 0 || y % thisTileHeight != 0 ||
+    if (x % thisTileWidth != 0 || y % thisTileHeight != 0 ||
       (w != thisTileWidth && x + w != getSizeX()) ||
       (h != thisTileHeight && y + h != getSizeY()))
     {

--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -113,6 +113,9 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
   private int baseTileHeight = 256;
   private int[] tileWidth;
   private int[] tileHeight;
+  private long[] tileWidthPointer;
+  private long[] tileHeightPointer;
+  private long[] tileCountPointer;
   private PlaneOffset[][] planeOffsets;
   private Integer currentPlane = null;
   private UIDCreator uids;
@@ -279,6 +282,13 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     boolean first = x == 0 && y == 0;
     boolean last = x + w == getSizeX() && y + h == getSizeY();
 
+    int width = getSizeX();
+    int height = getSizeY();
+    int sizeZ = r.getPixelsSizeZ(series).getValue().intValue();
+
+    int tileCountX = (int) Math.ceil((double) width / tileWidth[resolutionIndex]);
+    int tileCountY = (int) Math.ceil((double) height / tileHeight[resolutionIndex]);
+
     // the compression type isn't supplied to the writer until
     // after setId is called, so metadata that indicates or
     // depends on the compression type needs to be set in
@@ -296,6 +306,15 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
       if (getTIFFCompression() == TiffCompression.JPEG) {
         ifds[resolutionIndex][no].put(IFD.PHOTOMETRIC_INTERPRETATION, PhotoInterp.Y_CB_CR.getCode());
       }
+
+      out.seek(tileWidthPointer[resolutionIndex]);
+      out.writeShort((short) getTileSizeX());
+      out.seek(tileHeightPointer[resolutionIndex]);
+      out.writeShort((short) getTileSizeY());
+      out.seek(tileCountPointer[resolutionIndex]);
+
+      out.writeBytes(padString(String.valueOf(
+          tileCountX * tileCountY * sizeZ * r.getChannelCount(series))));
     }
 
     out.seek(out.length());
@@ -334,6 +353,17 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     if (ifds[resolutionIndex][no] != null) {
       tileByteCounts = (long[]) ifds[resolutionIndex][no].getIFDValue(IFD.TILE_BYTE_COUNTS);
       tileOffsets = (long[]) ifds[resolutionIndex][no].getIFDValue(IFD.TILE_OFFSETS);
+
+      if (tileByteCounts.length < tileCountX * tileCountY) {
+        long[] newTileByteCounts = new long[tileCountX * tileCountY];
+        long[] newTileOffsets = new long[tileCountX * tileCountY];
+        System.arraycopy(tileByteCounts, 0, newTileByteCounts, 0, tileByteCounts.length);
+        System.arraycopy(tileOffsets, 0, newTileOffsets, 0, tileOffsets.length);
+        tileByteCounts = newTileByteCounts;
+        tileOffsets = newTileOffsets;
+        ifds[resolutionIndex][no].put(IFD.TILE_BYTE_COUNTS, tileByteCounts);
+        ifds[resolutionIndex][no].put(IFD.TILE_OFFSETS, tileOffsets);
+      }
     }
 
     if (tileByteCounts != null) {
@@ -640,6 +670,9 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     planeOffsets = new PlaneOffset[totalFiles][];
     tileWidth = new int[totalFiles];
     tileHeight = new int[totalFiles];
+    tileWidthPointer = new long[totalFiles];
+    tileHeightPointer = new long[totalFiles];
+    tileCountPointer = new long[totalFiles];
 
     // create UIDs that must be consistent across all files in the dataset
     String specimenUIDValue = uids.getUID();
@@ -739,8 +772,9 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
         int tileCountX = (int) Math.ceil((double) width / tileWidth[resolutionIndex]);
         int tileCountY = (int) Math.ceil((double) height / tileHeight[resolutionIndex]);
         DicomTag numberOfFrames = new DicomTag(NUMBER_OF_FRAMES, IS);
+        // save space for up to 10 digits
         numberOfFrames.value = padString(String.valueOf(
-          tileCountX * tileCountY * sizeZ * r.getChannelCount(pyramid)));
+          tileCountX * tileCountY * sizeZ * r.getChannelCount(pyramid)), " ", 10);
         tags.add(numberOfFrames);
 
         DicomTag matrixFrames = new DicomTag(TOTAL_PIXEL_MATRIX_FOCAL_PLANES, UL);
@@ -1374,6 +1408,9 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     ifds = null;
     tiffSaver = null;
     validPixelCount = null;
+    tileWidthPointer = null;
+    tileHeightPointer = null;
+    tileCountPointer = null;
 
     tagProviders.clear();
 
@@ -1382,33 +1419,46 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
 
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
-    // TODO: this currently enforces the same tile size across all resolutions
-    // since the tile size is written during setId
-    // the tile size should probably be configurable per resolution,
-    // for better pre-compressed tile support
     if (currentId == null) {
       baseTileWidth = tileSize;
+      return baseTileWidth;
     }
-    return baseTileWidth;
+
+    int resolutionIndex = getIndex(series, resolution);
+    tileWidth[resolutionIndex] = tileSize;
+    return tileWidth[resolutionIndex];
   }
 
   @Override
   public int getTileSizeX() {
-    return baseTileWidth;
+    if (currentId == null) {
+      return baseTileWidth;
+    }
+
+    int resolutionIndex = getIndex(series, resolution);
+    return tileWidth[resolutionIndex];
   }
 
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
-    // TODO: see note in setTileSizeX above
     if (currentId == null) {
       baseTileHeight = tileSize;
+      return baseTileHeight;
     }
-    return baseTileHeight;
+
+    int resolutionIndex = getIndex(series, resolution);
+    tileHeight[resolutionIndex] = tileSize;
+    return tileHeight[resolutionIndex];
   }
 
   @Override
   public int getTileSizeY() {
-    return baseTileHeight;
+    if (currentId == null) {
+      return baseTileHeight;
+    }
+
+    int resolutionIndex = getIndex(series, resolution);
+    return tileHeight[resolutionIndex];
   }
 
   // -- DicomWriter-specific methods --
@@ -1468,14 +1518,24 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
         out.writeShort((short) getStoredLength(tag));
       }
 
+      int resolutionIndex = getIndex(series, resolution);
       if (tag.attribute == TRANSFER_SYNTAX_UID) {
-        transferSyntaxPointer[getIndex(series, resolution)] = out.getFilePointer();
+        transferSyntaxPointer[resolutionIndex] = out.getFilePointer();
       }
       else if (tag.attribute == LOSSY_IMAGE_COMPRESSION_METHOD) {
-        compressionMethodPointer[getIndex(series, resolution)] = out.getFilePointer();
+        compressionMethodPointer[resolutionIndex] = out.getFilePointer();
       }
       else if (tag.attribute == FILE_META_INFO_GROUP_LENGTH) {
         fileMetaLengthPointer = out.getFilePointer();
+      }
+      else if (tag.attribute == ROWS) {
+        tileHeightPointer[resolutionIndex] = out.getFilePointer();
+      }
+      else if (tag.attribute == COLUMNS) {
+        tileWidthPointer[resolutionIndex] = out.getFilePointer();
+      }
+      else if (tag.attribute == NUMBER_OF_FRAMES) {
+        tileCountPointer[resolutionIndex] = out.getFilePointer();
       }
 
       // sequences with no items still need to write a SequenceDelimitationItem below
@@ -1663,6 +1723,17 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
       return value;
     }
     return value + append;
+  }
+
+  private String padString(String value, String append, int length) {
+    String rtn = "";
+    if (value != null) {
+      rtn += value;
+    }
+    while (rtn.length() < length) {
+      rtn += append;
+    }
+    return rtn;
   }
 
   /**
@@ -1918,6 +1989,9 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
     out.seek(ifdStart);
 
     for (int no=0; no<ifds[resIndex].length; no++) {
+      ifds[resIndex][no].put(IFD.TILE_WIDTH, tileWidth[resIndex]);
+      ifds[resIndex][no].put(IFD.TILE_LENGTH, tileHeight[resIndex]);
+
       try {
         tiffSaver.writeIFD(ifds[resIndex][no], 0, no < ifds[resIndex].length - 1);
       }

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
@@ -44,21 +44,90 @@ import loci.common.services.ServiceException;
  */
 public interface JPEGTurboService extends Service {
 
+  /**
+   * @return the restart markers associated with the current JPEG stream
+   */
   long[] getRestartMarkers();
 
+  /**
+   * @param markers precalculated restart markers associated with
+   *                the current JPEG stream
+   */
   void setRestartMarkers(long[] markers);
 
+  /**
+   * Initialize the given stream, which represents an image of the given
+   * width and height. This service is primarily intended for very large
+   * JPEG images whose width and/or height exceed 65535 (the maximum
+   * that can be recorded in a JPEG stream).
+   *
+   * @param jpeg open stream containing JPEG data
+   * @param width total image width
+   * @param height total image height
+   */
   void initialize(RandomAccessInputStream jpeg, int width, int height)
     throws ServiceException, IOException;
 
+  /**
+   * @return the width (in pixels) of a tile
+   */
+  int getTileWidth();
+
+  /**
+   * @return the height (in pixels) of a tile
+   */
+  int getTileHeight();
+
+  /**
+   * @return the number of rows of tiles
+   */
+  int getTileRows();
+
+  /**
+   * @return the number of columns of tiles
+   */
+  int getTileColumns();
+
+  /**
+   * Get the uncompressed bytes representing the given bounding box.
+   *
+   * @param buf array in which to store uncompressed bytes
+   * @param xCoordinate upper-left X coordinate of bounding box
+   * @param yCoordinate upper-left Y coordinate of bounding box
+   * @param width width of bounding box
+   * @param height height of bounding box
+   * @return uncompressed bytes
+   */
   byte[] getTile(byte[] buf, int xCoordinate, int yCoordinate, int width,
     int height)
     throws IOException;
 
+  /**
+   * Get the uncompressed bytes representing the given tile index.
+   *
+   * @param xTile column index of the tile
+   * @param yTile row index of the tile
+   * @return uncompressed bytes
+   */
   byte[] getTile(int xTile, int yTile) throws IOException;
 
+  /**
+   * Similar to getTile(int, int), but returns the JPEG-compressed bytes.
+   *
+   * @param xTile column index of the tile
+   * @param yTile row index of the tile
+   * @return JPEG-compressed bytes
+   */
+  byte[] getCompressedTile(int xTile, int yTile) throws IOException;
+
+  /**
+   * Free resources associated with the initialized stream.
+   */
   void close() throws IOException;
-  
+
+  /**
+   * @return true if the underlying native library was successfully loaded
+   */
   boolean isLibraryLoaded();
 
 }

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
@@ -121,6 +121,16 @@ public interface JPEGTurboService extends Service {
   byte[] getCompressedTile(int xTile, int yTile) throws IOException;
 
   /**
+   * Similar to getTile(int, int), but returns the JPEG-compressed bytes.
+   *
+   * @param data preallocated array for storing tile
+   * @param xTile column index of the tile
+   * @param yTile row index of the tile
+   * @return JPEG-compressed bytes
+   */
+  byte[] getCompressedTile(byte[] data, int xTile, int yTile) throws IOException;
+
+  /**
    * Free resources associated with the initialized stream.
    */
   void close() throws IOException;

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -356,12 +356,21 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
     }
 
     byte[] data = new byte[(int) dataLength];
+    return getCompressedTile(data, tileX, tileY);
+  }
+
+  @Override
+  public byte[] getCompressedTile(byte[] data, int tileX, int tileY) throws IOException {
+    if (header == null) {
+      header = getFixedHeader();
+    }
 
     int offset = 0;
     System.arraycopy(header, 0, data, offset, header.length);
     offset += header.length;
 
-    start = tileX + (tileY * xTiles * mult);
+    int mult = tileHeight / mcuHeight; // was restartInterval
+    int start = tileX + (tileY * xTiles * mult);
     for (int row=0; row<tileHeight/mcuHeight; row++) {
       int end = start + 1;
 

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -35,6 +35,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
+import loci.formats.codec.Codec;
+import loci.formats.codec.CodecOptions;
 import loci.formats.meta.MetadataStore;
 import loci.formats.services.JPEGTurboService;
 import loci.formats.services.JPEGTurboServiceImpl;
@@ -119,6 +121,106 @@ public class NDPIReader extends BaseTiffReader {
     canSeparateSeries = false;
   }
 
+  // -- ICompressedTileReader API methods --
+
+  @Override
+  public int getTileRows(int no) {
+    FormatTools.assertId(currentId, true, 1);
+
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    //service.initialize();
+    return service.getTileRows();
+  }
+
+  @Override
+  public int getTileColumns(int no) {
+    FormatTools.assertId(currentId, true, 1);
+
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    //service.initialize();
+    return service.getTileColumns();
+  }
+
+  @Override
+  public byte[] openCompressedBytes(int no, int x, int y) throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+
+    if (useTiffParser(ifd)) {
+      // TODO
+      return null;
+    }
+
+    if (initializedSeries != getCoreIndex() || initializedPlane != no) {
+      resetStream(ifd);
+      initializedSeries = getCoreIndex();
+      initializedPlane = no;
+    }
+    if ((x % service.getTileWidth()) != 0) {
+      throw new FormatException("Invalid x: " + x + " must be multiple of " +
+        service.getTileWidth());
+    }
+    if ((y % service.getTileHeight()) != 0) {
+      throw new FormatException("Invalid y: " + y + " must be multiple of " +
+        service.getTileHeight());
+    }
+    int tileRow = y / service.getTileHeight();
+    int tileColumn = x / service.getTileWidth();
+    return service.getCompressedTile(tileColumn, tileRow);
+  }
+
+  @Override
+  public byte[] openCompressedBytes(int no, byte[] buf, int x, int y) throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+
+    if (useTiffParser(ifd)) {
+      // TODO
+      return buf;
+    }
+
+    if (initializedSeries != getCoreIndex() || initializedPlane != no) {
+      resetStream(ifd);
+      initializedSeries = getCoreIndex();
+      initializedPlane = no;
+    }
+    if ((x % service.getTileWidth()) != 0) {
+      throw new FormatException("Invalid x: " + x + " must be multiple of " +
+        service.getTileWidth());
+    }
+    if ((y % service.getTileHeight()) != 0) {
+      throw new FormatException("Invalid y: " + y + " must be multiple of " +
+        service.getTileHeight());
+    }
+    int tileRow = y / service.getTileHeight();
+    int tileColumn = x / service.getTileWidth();
+    service.getCompressedTile(buf, tileColumn, tileRow);
+    return buf;
+  }
+
+  @Override
+  public Codec getTileCodec(int no) throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+    return ifd.getCompression().getCodec();
+  }
+
+  @Override
+  public CodecOptions getTileCodecOptions(int no, int x, int y) throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+    CodecOptions options = ifd.getCompression().getCompressionCodecOptions(ifd);
+    options.width = getOptimalTileWidth();
+    options.height = getOptimalTileHeight();
+    return options;
+  }
+
   // -- IFormatReader API methods --
 
   /* (non-Javadoc)
@@ -185,56 +287,7 @@ public class NDPIReader extends BaseTiffReader {
 
     if (initializedSeries != getCoreIndex() || initializedPlane != no) {
       IFD ifd = ifds.get(ifdIndex);
-
-      long offset = ifd.getStripOffsets()[0];
-      long byteCount = ifd.getStripByteCounts()[0];
-      if (in != null) {
-        in.close();
-      }
-      in = new RandomAccessInputStream(currentId);
-      in.seek(offset);
-      in.setLength(offset + byteCount);
-
-      try {
-        service.close();
-        long[] markers = ifd.getIFDLongArray(MARKER_TAG);
-        long[] markerHighBytes = ifd.getIFDLongArray(MARKER_TAG_HIGH_BYTES);
-        if (!use64Bit) {
-          for (int i=0; i<markers.length; i++) {
-            markers[i] = markers[i] & 0xffffffffL;
-          }
-        }
-        else if (markerHighBytes != null) {
-          // 64-bit offsets expected
-          // markers need to be reconstructed from MARKER_TAG (lower 32 bits)
-          // and MARKER_TAG_HIGH_BYTES (upper 32 bits)
-          for (int i=0; i<markers.length; i++) {
-            if (i < markerHighBytes.length) {
-              markers[i] = markers[i] & 0xffffffffL;
-              markers[i] += (markerHighBytes[i] << 32);
-            }
-          }
-        }
-        else {
-          // 64-bit offsets expected, but upper 32 bits not found
-          // this can happen in sub-resolution IFDs
-          // try to correct for offset overflow by adding 4GB to offsets, if appropriate
-          LOGGER.debug("Optional tag {} missing or unreadable", MARKER_TAG_HIGH_BYTES);
-          for (int i=1; i<markers.length; i++) {
-            if (markers[i] < markers[i - 1]) {
-              markers[i] += (long) Math.pow(2, 32);
-            }
-          }
-        }
-        if (markers != null) {
-          service.setRestartMarkers(markers);
-        }
-        service.initialize(in, getSizeX(), getSizeY());
-      }
-      catch (ServiceException e) {
-        throw new FormatException(e);
-      }
-
+      resetStream(ifd);
       initializedSeries = getCoreIndex();
       initializedPlane = no;
     }
@@ -314,14 +367,54 @@ public class NDPIReader extends BaseTiffReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
-    return 1024;
+
+    int no = 0;
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+    try {
+      if (useTiffParser(ifd)) {
+        // TODO:
+        return 1024;
+      }
+
+      if (initializedSeries != getCoreIndex() || initializedPlane != no) {
+        resetStream(ifd);
+        initializedSeries = getCoreIndex();
+        initializedPlane = no;
+      }
+    }
+    catch (FormatException|IOException e) {
+      return 1024;
+    }
+
+    return service.getTileWidth();
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
-    return 1024;
+
+    int no = 0;
+    int ifdIndex = getIFDIndex(getCoreIndex(), no);
+    IFD ifd = ifds.get(ifdIndex);
+    try {
+      if (useTiffParser(ifd)) {
+        // TODO:
+        return 1024;
+      }
+
+      if (initializedSeries != getCoreIndex() || initializedPlane != no) {
+        resetStream(ifd);
+        initializedSeries = getCoreIndex();
+        initializedPlane = no;
+      }
+    }
+    catch (FormatException|IOException e) {
+      return 1024;
+    }
+
+    return service.getTileHeight();
   }
 
   // -- Internal FormatReader API methods --
@@ -792,6 +885,73 @@ public class NDPIReader extends BaseTiffReader {
         return 16;
     }
     return -1;
+  }
+
+  /**
+   * Get the array of restart markers (offsets) for the given IFD.
+   *
+   * Reads both the marker tag and marker high bytes tag (if present)
+   * to build the array of 64-bit offsets.
+   */
+  private long[] getMarkers(IFD ifd) throws FormatException {
+    long[] markers = ifd.getIFDLongArray(MARKER_TAG);
+    long[] markerHighBytes = ifd.getIFDLongArray(MARKER_TAG_HIGH_BYTES);
+    if (!use64Bit) {
+      for (int i=0; i<markers.length; i++) {
+        markers[i] = markers[i] & 0xffffffffL;
+      }
+    }
+    else if (markerHighBytes != null) {
+      // 64-bit offsets expected
+      // markers need to be reconstructed from MARKER_TAG (lower 32 bits)
+      // and MARKER_TAG_HIGH_BYTES (upper 32 bits)
+      for (int i=0; i<markers.length; i++) {
+        if (i < markerHighBytes.length) {
+          markers[i] = markers[i] & 0xffffffffL;
+          markers[i] += (markerHighBytes[i] << 32);
+        }
+      }
+    }
+    else {
+      // 64-bit offsets expected, but upper 32 bits not found
+      // this can happen in sub-resolution IFDs
+      // try to correct for offset overflow by adding 4GB to offsets, if appropriate
+      LOGGER.debug("Optional tag {} missing or unreadable", MARKER_TAG_HIGH_BYTES);
+      for (int i=1; i<markers.length; i++) {
+        if (markers[i] < markers[i - 1]) {
+          markers[i] += (long) Math.pow(2, 32);
+        }
+      }
+    }
+    return markers;
+  }
+
+  private void resetStream(IFD ifd) throws IOException, FormatException {
+    // get the size and location of the single tile
+    long offset = ifd.getStripOffsets()[0];
+    long byteCount = ifd.getStripByteCounts()[0];
+
+    // reopen the stream
+    if (in != null) {
+      in.close();
+    }
+    in = new RandomAccessInputStream(currentId);
+    in.seek(offset);
+    // don't allow seeking past the end of the tile
+    in.setLength(offset + byteCount);
+
+    // initialize stream for the current plane
+    try {
+      service.close();
+      long[] markers = getMarkers(ifd);
+      if (markers != null) {
+        service.setRestartMarkers(markers);
+      }
+      service.initialize(in, getSizeX(), getSizeY());
+    }
+    catch (ServiceException e) {
+      throw new FormatException(e);
+    }
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -149,8 +149,8 @@ public class NDPIReader extends BaseTiffReader {
     IFD ifd = ifds.get(ifdIndex);
 
     if (useTiffParser(ifd)) {
-      // TODO
-      return null;
+      byte[] buf = new byte[(int) getCompressedByteCount(ifd, x, y)];
+      return openCompressedBytes(no, buf, x, y);
     }
 
     if (initializedSeries != getCoreIndex() || initializedPlane != no) {
@@ -169,8 +169,7 @@ public class NDPIReader extends BaseTiffReader {
     IFD ifd = ifds.get(ifdIndex);
 
     if (useTiffParser(ifd)) {
-      // TODO
-      return buf;
+      return copyTile(ifd, buf, x, y);
     }
 
     if (initializedSeries != getCoreIndex() || initializedPlane != no) {

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -158,17 +158,7 @@ public class NDPIReader extends BaseTiffReader {
       initializedSeries = getCoreIndex();
       initializedPlane = no;
     }
-    if ((x % service.getTileWidth()) != 0) {
-      throw new FormatException("Invalid x: " + x + " must be multiple of " +
-        service.getTileWidth());
-    }
-    if ((y % service.getTileHeight()) != 0) {
-      throw new FormatException("Invalid y: " + y + " must be multiple of " +
-        service.getTileHeight());
-    }
-    int tileRow = y / service.getTileHeight();
-    int tileColumn = x / service.getTileWidth();
-    return service.getCompressedTile(tileColumn, tileRow);
+    return service.getCompressedTile(x, y);
   }
 
   @Override
@@ -188,17 +178,7 @@ public class NDPIReader extends BaseTiffReader {
       initializedSeries = getCoreIndex();
       initializedPlane = no;
     }
-    if ((x % service.getTileWidth()) != 0) {
-      throw new FormatException("Invalid x: " + x + " must be multiple of " +
-        service.getTileWidth());
-    }
-    if ((y % service.getTileHeight()) != 0) {
-      throw new FormatException("Invalid y: " + y + " must be multiple of " +
-        service.getTileHeight());
-    }
-    int tileRow = y / service.getTileHeight();
-    int tileColumn = x / service.getTileWidth();
-    service.getCompressedTile(buf, tileColumn, tileRow);
+    service.getCompressedTile(buf, x, y);
     return buf;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -169,7 +169,14 @@ public class NDPIReader extends BaseTiffReader {
     IFD ifd = ifds.get(ifdIndex);
 
     if (useTiffParser(ifd)) {
-      return copyTile(ifd, buf, x, y);
+      try (RandomAccessInputStream s = new RandomAccessInputStream(currentId)) {
+        tiffParser = new TiffParser(s);
+        tiffParser.setUse64BitOffsets(true);
+        return copyTile(ifd, buf, x, y);
+      }
+      finally {
+        tiffParser.getStream().close();
+      }
     }
 
     if (initializedSeries != getCoreIndex() || initializedPlane != no) {
@@ -352,8 +359,7 @@ public class NDPIReader extends BaseTiffReader {
     IFD ifd = ifds.get(ifdIndex);
     try {
       if (useTiffParser(ifd)) {
-        // TODO:
-        return 1024;
+        return (int) ifd.getTileWidth();
       }
 
       if (initializedSeries != getCoreIndex() || initializedPlane != no) {
@@ -379,8 +385,7 @@ public class NDPIReader extends BaseTiffReader {
     IFD ifd = ifds.get(ifdIndex);
     try {
       if (useTiffParser(ifd)) {
-        // TODO:
-        return 1024;
+        return (int) ifd.getTileLength();
       }
 
       if (initializedSeries != getCoreIndex() || initializedPlane != no) {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -306,21 +306,7 @@ public class SVSReader extends BaseTiffReader {
   public byte[] openCompressedBytes(int no, int x, int y) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     IFD ifd = getIFD(no);
-    long[] byteCounts = ifd.getStripByteCounts();
-    int tileIndex = getTileIndex(ifd, x, y);
-
-    byte[] jpegTable = (byte[]) ifd.getIFDValue(IFD.JPEG_TABLES);
-    int jpegTableBytes = jpegTable == null ? 0 : jpegTable.length - 2;
-    long expectedBytes = byteCounts[tileIndex];
-    if (expectedBytes > 0) {
-      expectedBytes += jpegTableBytes;
-    }
-
-    if (expectedBytes < 0 || expectedBytes > Integer.MAX_VALUE) {
-      throw new IOException("Invalid compressed tile size: " + expectedBytes);
-    }
-
-    byte[] buf = new byte[(int) expectedBytes];
+    byte[] buf = new byte[(int) getCompressedByteCount(ifd, x, y)];
     return openCompressedBytes(no, buf, x, y);
   }
 
@@ -328,38 +314,7 @@ public class SVSReader extends BaseTiffReader {
   public byte[] openCompressedBytes(int no, byte[] buf, int x, int y) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     IFD ifd = getIFD(no);
-    long[] offsets = ifd.getStripOffsets();
-    long[] byteCounts = ifd.getStripByteCounts();
-
-    int tileIndex = getTileIndex(ifd, x, y);
-
-    byte[] jpegTable = (byte[]) ifd.getIFDValue(IFD.JPEG_TABLES);
-    int jpegTableBytes = jpegTable == null ? 0 : jpegTable.length - 2;
-    long expectedBytes = byteCounts[tileIndex];
-    if (expectedBytes > 0) {
-      expectedBytes += jpegTableBytes;
-    }
-
-    if (buf.length < expectedBytes) {
-      throw new IllegalArgumentException("Tile buffer too small: expected >=" +
-        expectedBytes + ", got " + buf.length);
-    }
-    else if (expectedBytes < 0 || expectedBytes > Integer.MAX_VALUE) {
-      throw new IOException("Invalid compressed tile size: " + expectedBytes);
-    }
-
-    if (jpegTable != null && expectedBytes > 0) {
-      System.arraycopy(jpegTable, 0, buf, 0, jpegTable.length - 2);
-      // skip over the duplicate SOI marker
-      tiffParser.getStream().seek(offsets[tileIndex] + 2);
-      tiffParser.getStream().readFully(buf, jpegTable.length - 2, (int) byteCounts[tileIndex]);
-    }
-    else if (byteCounts[tileIndex] > 0) {
-      tiffParser.getStream().seek(offsets[tileIndex]);
-      tiffParser.getStream().readFully(buf, 0, (int) byteCounts[tileIndex]);
-    }
-
-    return buf;
+    return copyTile(ifd, buf, x, y);
   }
 
   @Override
@@ -871,29 +826,6 @@ public class SVSReader extends BaseTiffReader {
     }
     int ifd = ((SVSCoreMetadata) getCurrentCore()).ifdIndex[no];
     return ifds.get(ifd);
-  }
-
-  /**
-   * Get the index of the tile corresponding to given IFD (plane)
-   * and tile XY indexes.
-   *
-   * @param ifd IFD for the requested tile's plane
-   * @param x tile X index
-   * @param y tile Y index
-   * @return corresponding tile index
-   */
-  protected int getTileIndex(IFD ifd, int x, int y) throws FormatException {
-    int rows = (int) ifd.getTilesPerColumn();
-    int cols = (int) ifd.getTilesPerRow();
-
-    if (x < 0 || x >= cols) {
-      throw new IllegalArgumentException("X index " + x + " not in range [0, " + cols + ")");
-    }
-    if (y < 0 || y >= rows) {
-      throw new IllegalArgumentException("Y index " + y + " not in range [0, " + rows + ")");
-    }
-
-    return (cols * y) + x;
   }
 
 }


### PR DESCRIPTION
This expands on the "precompressed" features added in #3992.

The main goal was to just add compressed tile reading to the NDPI reader, so that conversion from NDPI to DICOM wouldn't require much if any recompression. This required a variety of changes not limited to NDPI though:

- update `JPEGTurboService` so that the repackaged compressed tiles can be retrieved, as well as the tile size and counts
- move general TIFF tile copying logic out of `SVSReader`, and into `MinimalTiffReader` (to prevent duplicate logic in `NDPIReader`)
  - this should also make it easier to support precompressed tiles in other TIFF-based formats later on
- update `NDPIReader` to report optimal sizes based on actual IFD/JPEG stream, instead of constant 1024x1024
- update `DicomWriter` to allow different tile sizes in each resolution, since NDPI reports different sizes per resolution
- update `NDPIReader` to use the `saveCompressedBytes` API

The end result is that something like this should now work:

```bfconvert -noflat -precompressed -compression JPEG CMU-1.ndpi cmu.dcm```

and should complete within a few seconds as all tiles can be copied without any recompression.

I would not expect SVS -> DICOM support to change, but it probably makes sense to double-check just in case the refactoring caused any problems.

I don't expect this to fail tests, but excluding for now so this doesn't distract from 7.3.0. Given the API changes in `JPEGTurboService`, this probably does require a major version.

cc @dclunie, @fedorov