### PR TITLE
Bump ome-poi to 5.3.9 and ome-metakit to 5.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <logback.version>1.3.14</logback.version>
     <ome-stubs.version>6.0.2</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.6</ome-metakit.version>
+    <ome-metakit.version>5.3.7</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
@@ -51,7 +51,7 @@
     <ome-common.version>6.0.22</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.3.6</ome-model.version>
-    <ome-poi.version>5.3.8</ome-poi.version>
+    <ome-poi.version>5.3.9</ome-poi.version>
     <ome-mdbtools.version>5.3.3</ome-mdbtools.version>
     <ome-jai.version>0.1.4</ome-jai.version>
     <ome-codecs.version>1.0.3</ome-codecs.version>


### PR DESCRIPTION
Bumping these components to the latest versions.

This is a follow up to https://github.com/ome/bioformats/pull/4183 which initially bumped the version of these components but not to the latest versions as discovered in review of the docs PR