### PR TITLE
Fix a few string comparisons, fixes #4184

### DIFF
--- a/components/formats-bsd/src/loci/formats/gui/PreviewPane.java
+++ b/components/formats-bsd/src/loci/formats/gui/PreviewPane.java
@@ -215,7 +215,9 @@ public class PreviewPane extends JPanel
 
       try { // catch-all for unanticipated exceptions
         final String id = loadId;
-        if (id == lastId) continue;
+        if ((id == null && lastId == null) || (id != null && id.equals(lastId))) {
+          continue;
+        }
         if (id != null && lastId != null) {
           String[] files = reader.getUsedFiles();
           boolean found = false;
@@ -260,7 +262,7 @@ public class PreviewPane extends JPanel
           lastId = null;
           continue;
         }
-        if (id != loadId) {
+        if (!id.equals(loadId)) {
           SwingUtilities.invokeLater(refresher);
           continue;
         }


### PR DESCRIPTION
I don't think we have relevant automated tests, so it's probably a good idea to check `File > Open` in the image window shown by

* double-clicking on `bioformats_package.jar`
* running `showinf` on anything (even `test.fake`)
 
to make sure that a thumbnail is displayed in the file chooser and there isn't anything obviously broken. I wouldn't expect an actual change in behavior with this PR.