### PR TITLE
Extend precompressed support to read DICOM and write TIFF/OME-TIFF

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1260,11 +1260,9 @@ public final class ImageConverter {
   private boolean doTileConversion(IFormatWriter writer, String outputFile)
     throws FormatException
   {
-    if (writer instanceof DicomWriter ||
-      (writer instanceof ImageWriter && ((ImageWriter) writer).getWriter(outputFile) instanceof DicomWriter))
-    {
-      MetadataStore r = reader.getMetadataStore();
-      return !(r instanceof IPyramidStore) || ((IPyramidStore) r).getResolutionCount(reader.getSeries()) > 1;
+    MetadataStore r = reader.getMetadataStore();
+    if ((r instanceof IPyramidStore) && ((IPyramidStore) r).getResolutionCount(reader.getSeries()) > 1) {
+      return true;
     }
     return DataTools.safeMultiply64(width, height) >= DataTools.safeMultiply64(4096, 4096) ||
       saveTileWidth > 0 || saveTileHeight > 0;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1268,16 +1268,13 @@ public final class ImageConverter {
   private boolean doTileConversion(IFormatWriter writer, String outputFile)
     throws FormatException
   {
-    MetadataStore r = reader.getMetadataStore();
-    if ((r instanceof IPyramidStore) && ((IPyramidStore) r).getResolutionCount(reader.getSeries()) > 1) {
-      // if we asked to try a precompressed conversion,
-      // then the writer's tile sizes will have been set automatically
-      // according to the input data
-      // the conversion must then be performed tile-wise to match the tile sizes,
-      // even if precompression doesn't end up being possible
-      if (precompressed) {
-        return true;
-      }
+    // if we asked to try a precompressed conversion,
+    // then the writer's tile sizes will have been set automatically
+    // according to the input data
+    // the conversion must then be performed tile-wise to match the tile sizes,
+    // even if precompression doesn't end up being possible
+    if (precompressed) {
+      return true;
     }
     return DataTools.safeMultiply64(width, height) >= DataTools.safeMultiply64(4096, 4096) ||
       saveTileWidth > 0 || saveTileHeight > 0;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -767,7 +767,9 @@ public final class ImageConverter {
         int writerSeries = series == -1 ? q : 0;
         writer.setSeries(writerSeries);
         writer.setResolution(res);
+
         writer.setInterleaved(reader.isInterleaved() && !autoscale);
+
         writer.setValidBitsPerPixel(reader.getBitsPerPixel());
         int numImages = writer.canDoStacks() ? reader.getImageCount() : 1;
 
@@ -837,6 +839,12 @@ public final class ImageConverter {
               setCodecOptions(writer);
               writer.setId(tileName);
               if (compression != null) writer.setCompression(compression);
+            }
+          }
+
+          if (precompressed && FormatTools.canUsePrecompressedTiles(reader, writer, writer.getSeries(), writer.getResolution())) {
+            if (getReaderCodecName().startsWith("JPEG")) {
+              writer.setInterleaved(true);
             }
           }
 

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1284,6 +1284,14 @@ public final class ImageConverter {
     if (precompressed) {
       return true;
     }
+    // tile size has already been set in the writer,
+    // so tile-wise conversion should be performed
+    // independent of image size
+    if ((writer.getTileSizeX() > 0 && writer.getTileSizeX() < width) ||
+      (writer.getTileSizeY() > 0 && writer.getTileSizeY() < height))
+    {
+      return true;
+    }
     return DataTools.safeMultiply64(width, height) >= DataTools.safeMultiply64(4096, 4096) ||
       saveTileWidth > 0 || saveTileHeight > 0;
   }

--- a/components/formats-api/src/loci/formats/ICompressedTileReader.java
+++ b/components/formats-api/src/loci/formats/ICompressedTileReader.java
@@ -66,7 +66,7 @@ public interface ICompressedTileReader {
    *
    * @param no plane index
    * @param x tile X index (indexed from 0, @see getTileColumns(int))
-   * @param y tile Y index (indexed frmo 0, @see getTileRows(int))
+   * @param y tile Y index (indexed from 0, @see getTileRows(int))
    * @return compressed tile bytes
    */
   default byte[] openCompressedBytes(int no, int x, int y) throws FormatException, IOException {
@@ -79,7 +79,7 @@ public interface ICompressedTileReader {
    * @param no plane index
    * @param buf pre-allocated buffer in which to store compressed bytes
    * @param x tile X index (indexed from 0, @see getTileColumns(int))
-   * @param y tile Y index (indexed frmo 0, @see getTileRows(int))
+   * @param y tile Y index (indexed from 0, @see getTileRows(int))
    * @return compressed tile bytes
    */
   default byte[] openCompressedBytes(int no, byte[] buf, int x, int y) throws FormatException, IOException {
@@ -102,7 +102,7 @@ public interface ICompressedTileReader {
    *
    * @param no plane index
    * @param x tile X index (indexed from 0, @see getTileColumns(int))
-   * @param y tile Y index (indexed frmo 0, @see getTileRows(int))
+   * @param y tile Y index (indexed from 0, @see getTileRows(int))
    * @return codec options
    * @see getTileCodec(int)
    */

--- a/components/formats-bsd/src/loci/formats/codec/CompressionType.java
+++ b/components/formats-bsd/src/loci/formats/codec/CompressionType.java
@@ -115,5 +115,27 @@ public enum CompressionType implements CodedEnum {
   public String getCompression() {
     return compression;
   }
-  
+
+  /**
+   * Look up the compression type by Codec instance.
+   */
+  public static CompressionType get(Codec c) {
+    if (c instanceof ZlibCodec) {
+      return ZLIB;
+    }
+    if (c instanceof LZWCodec) {
+      return LZW;
+    }
+    if (c instanceof JPEGCodec) {
+      return JPEG;
+    }
+    if (c instanceof JPEG2000Codec) {
+      return J2K;
+    }
+    if (c instanceof PassthroughCodec) {
+      return UNCOMPRESSED;
+    }
+    return null;
+  }
+
 }

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -199,6 +199,24 @@ public class OMETiffWriter extends TiffWriter {
 
   // -- IFormatWriter API methods --
 
+  @Override
+  public void saveCompressedBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    super.saveCompressedBytes(no, buf, x, y, w, h);
+
+    int index = no;
+    while (imageLocations[series][index] != null) {
+      if (index < imageLocations[series].length - 1) {
+        index++;
+      }
+      else {
+        break;
+      }
+    }
+    imageLocations[series][index] = currentId;
+  }
+
   /**
    * @see loci.formats.IFormatWriter#saveBytes(int, byte[], int, int, int, int)
    */

--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -70,6 +70,19 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
 
   // -- IFormatWriter API methods --
 
+  protected IFD makeIFD() throws FormatException, IOException {
+    IFD ifd = super.makeIFD();
+    if (getResolution() > 0) {
+      ifd.put(IFD.NEW_SUBFILE_TYPE, 1);
+    }
+    else {
+      if (!ifd.containsKey(IFD.SUB_IFD)) {
+        ifd.put(IFD.SUB_IFD, (long) 0);
+      }
+    }
+    return ifd;
+  }
+
   @Override
   public void saveBytes(int no, byte[] buf, IFD ifd, int x, int y, int w, int h)
     throws FormatException, IOException

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -176,7 +176,7 @@ public class TiffWriter extends FormatWriter {
         "Sequential tile writing must be enabled to write precompressed tiles");
     }
 
-    LOGGER.warn("saveCompressedBytes(series={}, resolution={}, no={}, x={}, y={})",
+    LOGGER.debug("saveCompressedBytes(series={}, resolution={}, no={}, x={}, y={})",
       series, resolution, no, x, y);
 
     IFD ifd = makeIFD();

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -178,7 +178,7 @@ public class TiffWriter extends FormatWriter {
     LOGGER.warn("saveCompressedBytes(series={}, resolution={}, no={}, x={}, y={})",
       series, resolution, no, x, y);
 
-    IFD ifd = new IFD();
+    IFD ifd = makeIFD();
     MetadataRetrieve retrieve = getMetadataRetrieve();
     int type = FormatTools.pixelTypeFromString(
         retrieve.getPixelsType(series).toString());
@@ -191,12 +191,6 @@ public class TiffWriter extends FormatWriter {
       (currentTileSizeY != h && y + h != getSizeY()))
     {
       throw new IllegalArgumentException("Compressed tile dimensions must match tile size");
-    }
-
-    boolean usingTiling = currentTileSizeX > 0 && currentTileSizeY > 0;
-    if (usingTiling) {
-      ifd.put(new Integer(IFD.TILE_WIDTH), new Long(currentTileSizeX));
-      ifd.put(new Integer(IFD.TILE_LENGTH), new Long(currentTileSizeY));
     }
 
     // This operation is synchronized
@@ -219,6 +213,16 @@ public class TiffWriter extends FormatWriter {
     tiffSaver.makeValidIFD(ifd, type, nChannels);
     tiffSaver.writeImageIFD(ifd, index, new byte[][] {buf},
       nChannels, lastPlane && lastSeries && lastResolution, x, y);
+  }
+
+  protected IFD makeIFD() throws FormatException, IOException {
+    IFD ifd = new IFD();
+    boolean usingTiling = getTileSizeX() > 0 && getTileSizeY() > 0;
+    if (usingTiling) {
+      ifd.put(new Integer(IFD.TILE_WIDTH), new Long(getTileSizeX()));
+      ifd.put(new Integer(IFD.TILE_LENGTH), new Long(getTileSizeY()));
+    }
+    return ifd;
   }
 
   // -- FormatWriter API methods --

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -450,7 +450,7 @@ public class TiffSaver implements Closeable {
    * @throws FormatException
    * @throws IOException
    */
-  private void writeImageIFD(IFD ifd, int no, byte[][] strips,
+  public void writeImageIFD(IFD ifd, int no, byte[][] strips,
       int nChannels, boolean last, int x, int y)
   throws FormatException, IOException {
     LOGGER.debug("Attempting to write image IFD.");
@@ -1003,7 +1003,7 @@ public class TiffSaver implements Closeable {
    * @param pixelType The pixel type.
    * @param nChannels The number of channels.
    */
-  private void makeValidIFD(IFD ifd, int pixelType, int nChannels) {
+  public void makeValidIFD(IFD ifd, int pixelType, int nChannels) {
     int bytesPerPixel = FormatTools.getBytesPerPixel(pixelType);
     int bps = 8 * bytesPerPixel;
     int[] bpsArray = new int[nChannels];


### PR DESCRIPTION
Opening as a draft for now, as #4181 is higher priority. This may need some updates once #4181 is merged.

I would expect basic conversions such as `bfconvert -noflat -precompressed -compression JPEG input.dcm output.ome.tiff` to work, where the input DICOM is part of a whole slide dataset. Tile sizes should be correctly picked up without being specified in the `bfconvert` options.

A few outstanding things related to this PR and #4181:

- `-precompressed` does still require the `-compression` option to be set correctly; removing that requirement could be done here
- documentation started in https://github.com/ome/bio-formats-documentation/pull/349 should be updated to include additions here and in #4181 - we may want a separate page just for this feature

/cc @fedorov, @dclunie