### PR TITLE
Imaris: Remove empty color entries for non 0 indexed colors

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -408,6 +408,7 @@ public class ImarisHDFReader extends SubResolutionFormatReader {
           catch (NumberFormatException e) { }
         }
 
+        colors.remove(null);
         if (i < colors.size()) {
           double[] color = colors.get(i);
           Color realColor = new Color(

--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -130,7 +130,7 @@ public class ImarisHDFReader extends SubResolutionFormatReader {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.UINT16 || !isIndexed()) return null;
 
-    if (lastChannel < 0 || lastChannel >= colors.size()) {
+    if (lastChannel < 0 || lastChannel >= colors.size() || colors.get(lastChannel) == null) {
       return null;
     }
 
@@ -408,8 +408,7 @@ public class ImarisHDFReader extends SubResolutionFormatReader {
           catch (NumberFormatException e) { }
         }
 
-        colors.remove(null);
-        if (i < colors.size()) {
+        if (i < colors.size() && colors.get(i) != null) {
           double[] color = colors.get(i);
           Color realColor = new Color(
             (int) (color[0] * 255), (int) (color[1] * 255),


### PR DESCRIPTION
Issue was raised on forum thread https://forum.image.sc/t/how-to-open-ims-files-with-fiji/29907/12
A sample file was provided on https://zenodo.org/records/11203497 and can be used for testing

The problem appears to be due to the colors in the file being indexed from 1 rather than 0, this lead to a null entry in the arraylist. Removing the empty entry allows for the file to read without exception.

To test, use the sample file in the Zenodo link
- Without this PR attampting to initiate the file should result in an exception as below
- With the PR the file should be read without the exception and the images display as expected

```java.lang.NullPointerException
	at loci.formats.in.ImarisHDFReader.initFile(ImarisHDFReader.java:413)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.plugins.in.ImportProcess.initializeFile(ImportProcess.java:498)
	at loci.plugins.in.ImportProcess.execute(ImportProcess.java:141)
	at loci.plugins.in.Importer.showDialogs(Importer.java:156)
	at loci.plugins.in.Importer.run(Importer.java:77)
	at loci.plugins.LociImporter.run(LociImporter.java:78)
	at ij.IJ.runUserPlugIn(IJ.java:244)
	at ij.IJ.runPlugIn(IJ.java:210)
	at ij.Executer.runCommand(Executer.java:152)
	at ij.Executer.run(Executer.java:70)
	at java.lang.Thread.run(Thread.java:748)
```