### PR TITLE
Andor SIF: Support files larger than 4 GB and with non-fixed-size footers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SIFReader.java
@@ -79,7 +79,7 @@ public class SIFReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    in.seek(pixelOffset + no * FormatTools.getPlaneSize(this));
+    in.seek(pixelOffset + (long)no * (long)FormatTools.getPlaneSize(this));
     readPlane(in, x, y, w, h, buf);
     return buf;
   }
@@ -147,10 +147,10 @@ public class SIFReader extends FormatReader {
         int y2 = Integer.parseInt(tokens[4]);
         int x3 = Integer.parseInt(tokens[5]);
         int y3 = Integer.parseInt(tokens[6]);
-        m.sizeX = (int) (Math.abs(x1 - x2) + x3);
-        m.sizeY = (int) (Math.abs(y1 - y2) + y3);
+        m.sizeX = Math.abs(x1 - x2) + x3;
+        m.sizeY = Math.abs(y1 - y2) + y3;
         pixelOffset = in.length() - FOOTER_SIZE -
-          (getImageCount() * getSizeX() * getSizeY() * 4);
+          ((long)getImageCount() * (long)getSizeX() * (long)getSizeY() * 4L);
       }
     }
 


### PR DESCRIPTION
Hello! Our lab generates a large number of Andor SIF files which run into issues being loaded using bioformats (a IllegalArgumentException is thrown upon reading the first frame). As it turns out, this is the result of two issues:
- Our files contain more than 4 gb of pixel data, causing an integer overflow when calculating the offset in the file for pixel information (see commit 0f36dd6)
- Our files seem to have a section of XML appended to the end of them when exported from Andor Solis. See:

<details>
<summary>Output of tail for one of our Andor SIF files</summary>
<p>

```
D�D�D�CD�DD��C� D�C��C��C@      D�D��C�C��C�C@  DD@D@D��C��C��C�DD��C��C��C��C�C�D      DDD�C�C��C�CD�D��C�D@
                                                                                                             DD�D@D�D�D@D��CD�D��CD�D��C@D��C�C��C�D�C�D��C�D�C
                                                 D��CD�D�D@D�D�C��C�C��C�D�C�C�CD�D@D�D�C�C�C�D��C�C0
0
0
0
<?xml version="1.0" ?>
<Signals>
    <Signal>
        <TInstaImageData>
            <PreAmpGainText>Gain 1</PreAmpGainText>
            <SpectrographSerial></SpectrographSerial>
            <mSec>381</mSec>
            <DIRECT_IRIS_PRESENT>0</DIRECT_IRIS_PRESENT>
            <DIRECT_IRIS_POSITION>-1</DIRECT_IRIS_POSITION>
            <SIDE_IRIS_PRESENT>0</SIDE_IRIS_PRESENT>
            <SIDE_IRIS_POSITION>-1</SIDE_IRIS_POSITION>
            <FullSerialNumber>X-14188</FullSerialNumber>
            <DARKTHRESHOLD>-999</DARKTHRESHOLD>
            <FAST_KINETICS_OFFSET>0</FAST_KINETICS_OFFSET>
        </TInstaImageData>
        <TInstaImage>
            <IRIGAvailable>0</IRIGAvailable>
        </TInstaImage>
        <TCalibImage>
            <TCalibImageData />
            <TAndorImage>
                <TAndorImageData>
                    <ImageFormat>0</ImageFormat>
                    <ReadoutPort>-1</ReadoutPort>
                    <ExposureWindowHeight>0</ExposureWindowHeight>
                    <LineScanSpeed>0</LineScanSpeed>
                    <AlternatingReadoutDirection>0</AlternatingReadoutDirection>
                    <ScanSpeedControl>0</ScanSpeedControl>
                    <ReadoutDirection>-1</ReadoutDirection>
                    <FastKineticsStorageMode>0</FastKineticsStorageMode>
                    <FastKineticsTimeScanMode>-1</FastKineticsTimeScanMode>
                    <TickInterval>10</TickInterval>
                    <PIVMode>0</PIVMode>
                    <ExtendedDynamicRange>0</ExtendedDynamicRange>
                </TAndorImageData>
            </TAndorImage>
        </TCalibImage>
    </Signal>
</Signals>
<References />
<Backgrounds />
<Lives />
<Sources />
�SIFX%  
``` 
</p>
</details>

Both of these issues can be solved by parsing the entire SIF header, instead of relying on the positioning of the footer to determine where pixel data starts. I modified the header parsing based on @fujiisoup's sif_parser (https://github.com/fujiisoup/sif_parser/blob/a922fc299b749057f66bedaba3b6971e18f94c4e/sif_parser/_sif_open.py), which is able to open our files without issue.

Opening as a draft for now, because I am not sure if this works with all SIF file versions. Feedback and others testing their SIF files would be appreciated!

Specifically, on line 163, I believe parsing will fail when the first two bytes of image data are 0x300A. As far as I understand, this would only happen if the top-left pixel on frame 0 contains a value on the order of `5e-10`. I can't think of a scenario where you would have measurements that small, but I would be interested to see if others could come up with one!