### PR TITLE
ICS: Fix NPE when image name is empty

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -1478,10 +1478,12 @@ public class ICSReader extends FormatReader {
     MetadataTools.populatePixels(store, this, true);
 
     // populate Image data
-    imageName = imageName.replace('/', File.separatorChar);
-    imageName = imageName.replace('\\', File.separatorChar);
-    imageName = imageName.substring(imageName.lastIndexOf(File.separator) + 1);
-    store.setImageName(imageName, 0);
+    if (imageName != null) {
+      imageName = imageName.replace('/', File.separatorChar);
+      imageName = imageName.replace('\\', File.separatorChar);
+      imageName = imageName.substring(imageName.lastIndexOf(File.separator) + 1);
+      store.setImageName(imageName, 0);
+    }
 
     if (date != null) store.setImageAcquisitionDate(new Timestamp(date), 0);
 


### PR DESCRIPTION
Issue was raised on forum thread https://forum.image.sc/t/issues-with-ics-ids-files/97696

A sample file reproducing the issue with Bio-Formats 7.3.0 is available at https://zenodo.org/records/11637422

**To test:**
Without this PR, opening the file results in an NPE:
```
java.lang.NullPointerException
	at loci.formats.in.ICSReader.initFile(ICSReader.java:1481)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.plugins.in.ImportProcess.initializeFile(ImportProcess.java:498)
	at loci.plugins.in.ImportProcess.execute(ImportProcess.java:141)
	at loci.plugins.in.Importer.showDialogs(Importer.java:156)
	at loci.plugins.in.Importer.run(Importer.java:77)
	at loci.plugins.LociImporter.run(LociImporter.java:78)
	at ij.IJ.runUserPlugIn(IJ.java:244)
	at ij.IJ.runPlugIn(IJ.java:210)
	at ij.Executer.runCommand(Executer.java:152)
	at ij.Executer.run(Executer.java:70)
	at ij.IJ.run(IJ.java:326)
	at ij.IJ.run(IJ.java:337)
	at ij.macro.Functions.doRun(Functions.java:703)
	at ij.macro.Functions.doFunction(Functions.java:99)
	at ij.macro.Interpreter.doStatement(Interpreter.java:281)
	at ij.macro.Interpreter.doStatements(Interpreter.java:267)
	at ij.macro.Interpreter.run(Interpreter.java:163)
	at ij.macro.Interpreter.run(Interpreter.java:93)
	at ij.macro.MacroRunner.run(MacroRunner.java:146)
	at java.lang.Thread.run(Thread.java:750)
```

With the PR included, the file should open without an exception and the images display as expected