### PR TITLE
SDT: fix NegativeArraySizeException when reading files recorded by SPCM64 9.90

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTInfo.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTInfo.java
@@ -106,7 +106,7 @@ public class SDTInfo {
   public int setupOffs;
 
   /** Length of the setup data. */
-  public short setupLength;
+  public int setupLength;
 
   /** Offset of the first data block. */
   public int dataBlockOffs;
@@ -443,7 +443,7 @@ public class SDTInfo {
     infoOffs = in.readInt();
     infoLength = in.readShort();
     setupOffs = in.readInt();
-    setupLength = in.readShort();
+    setupLength = in.readUnsignedShort();
     dataBlockOffs = in.readInt();
     noOfDataBlocks = in.readShort();
     dataBlockLength = in.readInt();


### PR DESCRIPTION
I encountered a java.lang.NegativeArraySizeException when reading files recorded by the latest version (9.90) of Becker Hickl's SPCM64 software. Files recorded with older versions don't seem to have this issue.

On further investigation, it seems to be related to a value setupLength. This should be an unsigned short, but was read as a signed short previously. In the SDT files recorded by the latest SPCM64, this seems to have exceeded the range of a signed short but is still within range of an unsigned short.

This PR fixes the error by changing readShort to readUnsignedShort and the type of setupLength to int.

Test data here: https://doi.org/10.5281/zenodo.12094862