### PR TITLE
Allow processing multiple files sequentially in a single run, with file names read from stdin.

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -37,6 +37,9 @@ import java.io.IOException;
 import java.io.File;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
+import java.util.Scanner;
+import java.util.Arrays;
+import java.util.List;
 
 import loci.common.ByteArrayHandle;
 import loci.common.DataTools;
@@ -1126,7 +1129,23 @@ public class ImageInfo {
 
   public static void main(String[] args) throws Exception {
     DebugTools.enableLogging("INFO");
-    if (!new ImageInfo().testRead(args)) System.exit(1);
+
+    List<String> argsList = Arrays.asList(args);
+    int idx = argsList.indexOf("--");
+
+    if (idx >= 0) {
+      Scanner scanner = new Scanner(System.in);
+      String[] newArgs = argsList.toArray(new String[0]);
+
+      while (scanner.hasNext()) {
+        newArgs[idx] = scanner.nextLine();
+        if (!new ImageInfo().testRead(newArgs)) System.exit(1);
+      }
+      scanner.close();
+    }
+    else {
+      if (!new ImageInfo().testRead(args)) System.exit(1);
+   }
   }
 
 }

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -314,6 +314,7 @@ public class ImageInfo {
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
+      "              reads file names line-wise from stdin if -- is passed",
       "      -nopix: read metadata only, not pixels",
       "     -nocore: do not output core metadata",
       "     -nometa: do not parse format-specific metadata table",

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -314,7 +314,8 @@ public class ImageInfo {
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
-      "              reads file names line-wise from stdin if -- is passed",
+      "              if - is passed, process multiple files",
+      "              with file names read line-wise from stdin",
       "      -nopix: read metadata only, not pixels",
       "     -nocore: do not output core metadata",
       "     -nometa: do not parse format-specific metadata table",
@@ -1132,7 +1133,7 @@ public class ImageInfo {
     DebugTools.enableLogging("INFO");
 
     List<String> argsList = Arrays.asList(args);
-    int idx = argsList.indexOf("--");
+    int idx = argsList.indexOf("-");
 
     if (idx >= 0) {
       Scanner scanner = new Scanner(System.in);
@@ -1140,6 +1141,7 @@ public class ImageInfo {
 
       while (scanner.hasNext()) {
         newArgs[idx] = scanner.nextLine();
+	System.out.println("====% " + newArgs[idx]);
         if (!new ImageInfo().testRead(newArgs)) System.exit(1);
       }
       scanner.close();
@@ -1150,3 +1152,4 @@ public class ImageInfo {
   }
 
 }
+


### PR DESCRIPTION
This reduces JVM startup overhead when processing thousands of files. If -- is passed as file argument then file names are read line by line from stdin and processed sequentially. Usage information for reading file names from stdin are added with the second commit.

Code compiles with `ant clean jars tools`, compilation with Maven not tested.
All tests using `ant test` have passed.