### PR TITLE
SVS: update isThisType to reject files with a single IFD

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -174,7 +174,9 @@ public class SVSReader extends BaseTiffReader {
           }
           if (imageDescription != null
               && imageDescription.startsWith(APERIO_IMAGE_DESCRIPTION_PREFIX)) {
-            return true;
+            // reject anything with just one IFD, as that indicates there is
+            // no pyramid, thumbnail, label, or macro
+            return tiffParser.getIFDOffsets().length > 1;
           }
         }
         return false;


### PR DESCRIPTION
See https://github.com/IDR/idr-metadata/issues/699.

With this change, I would expect the files from idr0008 to be detected as "plain" TIFF; `showinf` or similar should initialize and show the image without error. I tested with an artificial file created by:

```
$ bfconvert "test&sizeX=1000&sizeY=1000.fake" svs-test.tif
$ cat comment.txt 
Aperio Image Library v8.2.43
81713x37331 [70791,733 2942x2942] (0x0) RAW;Scan
{composite image: 41 files}|AppMag = 20
|StripeWidth = 2032
|ScanScope ID = SS1644
|Filename = 156866
|Title = 
|Date = 10/10/13
|Time = 09:14:17
|User = 85966804-1588-42c3-bd9e-88ca3cfca814
|Acquisition Bit Depth = 8
|MPP = 0.4970
|OriginalWidth = 81713|Originalheight = 37331
$ tiffcomment -set comment.txt svs-test.tif
```

which was enough to demonstrate the original exception, but we may want one of the idr0008 files in the test repo to be safe.

As discussed separately with @sbesson, this is probably the least disruptive way to solve the problem, as it does not require modifying any of the extra image detection logic in `SVSReader`. I would not expect this to introduce any test failures, and it should be safe for a patch release.