### PR TITLE
CV7000/8000: fix used files list when TIFFs are in a subdirectory

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -81,7 +81,7 @@ public class CV7000Reader extends FormatReader {
 
   // -- Fields --
 
-  private String[] allFiles;
+  private List<String> allFiles = new ArrayList<String>();
   private MinimalTiffReader reader;
   private String wppPath;
   private String detailPath;
@@ -223,6 +223,7 @@ public class CV7000Reader extends FormatReader {
       reversePlaneLookup = null;
       extraFiles = null;
       acquiredWells.clear();
+      allFiles.clear();
     }
   }
 
@@ -269,15 +270,12 @@ public class CV7000Reader extends FormatReader {
     XMLTools.parseXML(wpiXML, plate);
 
     Location parent = new Location(id).getAbsoluteFile().getParentFile();
-    allFiles = parent.list(true);
-    Arrays.sort(allFiles);
-    for (int i=0; i<allFiles.length; i++) {
-      Location file = new Location(parent, allFiles[i]);
+    String[] listedFiles = parent.list(true);
+    Arrays.sort(listedFiles);
+    for (int i=0; i<listedFiles.length; i++) {
+      Location file = new Location(parent, listedFiles[i]);
       if (!file.isDirectory() && file.canRead()) {
-        allFiles[i] = file.getAbsolutePath();
-      }
-      else {
-        allFiles[i] = null;
+        allFiles.add(file.getAbsolutePath());
       }
     }
     Location measurementData = new Location(parent, MEASUREMENT_FILE);
@@ -345,6 +343,9 @@ public class CV7000Reader extends FormatReader {
       if (p != null) {
         if (!isWellAcquired(p.field.row, p.field.column)) {
           continue;
+        }
+        if (!allFiles.contains(p.file)) {
+          allFiles.add(p.file);
         }
 
         p.channelIndex = getChannelIndex(p);


### PR DESCRIPTION
Some CV7000/8000 plates store image data in a separate `Image` subdirectory. This fixes the used file list calculation to correctly include image files that are in a subdirectory.

`curated/cv7000/samples/separate-image-directory` is an artificial plate that can be used to test. Without this PR, `showinf` on the .wpi file should successfully initialize the plate and display a not-blank image, but the list of used files will not include anything in the `Image` subdirectory. For OMERO imports in particular, this would mean that none of the image files would be transferred.

With this PR, the same test should initialize/display images as before, but the used file list should include everything in the `Image` subdirectory as well.

This may not be completely safe for a patch release, as `allFiles` is changed from a `String[]` to a `List<String>`, which may affect memo files.