### PR TITLE
OIRReader: Major performance improvement when reading a ROI within a plane

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -406,7 +406,7 @@ public class OIRReader extends FormatReader {
     // Get max number of blocks
     for (String uid: pixelBlocks.keySet()) {
       int b = getBlock(uid);
-      if (b>maxNumberOfBlocks) maxNumberOfBlocks = b+1;
+      if (b>=maxNumberOfBlocks) maxNumberOfBlocks = b+1;
     }
 
     for (String uid: pixelBlocks.keySet()) {

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -195,7 +195,7 @@ public class OIRReader extends FormatReader {
     lastChannel = zct[1];
 
     // Gets all the PixelBlock potentially contained within c, z and t
-    PixelBlock[] blocks = cztToPixelBlocks.get(new CZTKey(zct[1], zct[0], zct[2]));
+    PixelBlock[] blocks = cztToPixelBlocks.get(new CZTKey((zct[1] % channels.size()), zct[0], zct[2]));
 
     if ((blocks == null) || (blocks.length == 0)) {
       LOGGER.warn("No pixel blocks for plane #{}", no);

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -174,11 +174,13 @@ public class OIRReader extends FormatReader {
 
   @Override
   public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
     return Math.min(2048, optimalTileHeight);
   }
 
   @Override
   public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
     return Math.min(2048, getSizeX());
   }
 
@@ -211,6 +213,10 @@ public class OIRReader extends FormatReader {
     int yOffsetInBuffer = 0;                     // current y offset within the exported buffer
 
     for (PixelBlock block : blocks) { // This list is sorted along y
+      if (block == null) {
+        LOGGER.warn("Block not found.");
+        continue;
+      }
       // Skips blocks positioned fully outside [y, y+h[
       if (block.yEnd<y) continue;  // The pixel block is completely above the requested region - skip it
       if (block.yStart>y+h) break; // The pixel block is completely below the requested region - skip all remaining blocks
@@ -264,6 +270,7 @@ public class OIRReader extends FormatReader {
       defaultXMLSkip = 36;
       blocksPerPlane = 0;
       cztToPixelBlocks.clear();
+      optimalTileHeight = 0;
       baseName = null;
       lastChannel = -1;
       minZ = Integer.MAX_VALUE;

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -429,16 +429,18 @@ public class OIRReader extends FormatReader {
     for (PixelBlock[] blocks : cztToPixelBlocks.values()) {
       int yStart = 0;
       for (PixelBlock block: blocks) {
-        block.yStart = yStart;
-        if ((block.length % bytesPerLine)!=0) {
-          LOGGER.error("A pixel block contains a partial line.");
+        if (block != null) {
+          block.yStart = yStart;
+          if ((block.length % bytesPerLine)!=0) {
+            LOGGER.error("A pixel block contains a partial line.");
+          }
+          int nLines = block.length/bytesPerLine;
+          if (nLines > optimalTileHeight) {
+            optimalTileHeight = nLines;
+          }
+          yStart+=block.length/bytesPerLine;
+          block.yEnd = yStart; // start of the next block = end (excluded) of the previous block
         }
-        int nLines = block.length/bytesPerLine;
-        if (nLines > optimalTileHeight) {
-          optimalTileHeight = nLines;
-        }
-        yStart+=block.length/bytesPerLine;
-        block.yEnd = yStart; // start of the next block = end (excluded) of the previous block
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -195,7 +195,7 @@ public class OIRReader extends FormatReader {
     lastChannel = zct[1];
 
     // Gets all the PixelBlock potentially contained within c, z and t
-    PixelBlock[] blocks = cztToPixelBlocks.get(new CZTKey((zct[1] % channels.size()), zct[0], zct[2]));
+    PixelBlock[] blocks = cztToPixelBlocks.get(new CZTKey(zct[1], zct[0], zct[2]));
 
     if ((blocks == null) || (blocks.length == 0)) {
       LOGGER.warn("No pixel blocks for plane #{}", no);
@@ -412,8 +412,9 @@ public class OIRReader extends FormatReader {
     for (String uid: pixelBlocks.keySet()) {
       int z = getZ(uid)-minZ;
       int t = getT(uid)-minT;
-      int c = getC(uid);
+      int c = getC(uid) + getL(uid); // Channel index or lambda index (We suppose there's no multichannel + lambda);
       int b = getBlock(uid);
+
       CZTKey key = new CZTKey(c,z,t);
       if (!cztToPixelBlocks.containsKey(key)) cztToPixelBlocks.put(key, new PixelBlock[maxNumberOfBlocks]);
       PixelBlock pb = pixelBlocks.get(uid);
@@ -1534,6 +1535,14 @@ public class OIRReader extends FormatReader {
       return 0;
     }
     return Integer.parseInt(uid.substring(index + 1));
+  }
+
+  private int getL(String uid) {
+    // for example l001z001t001_0_1_93e4632f-0342-4d98-bdc1-4ce305b92525_46
+    // Assumes l is always first is the uid...
+    if (!uid.startsWith("l")) return 0;
+    // ... and has 3 digits
+    return Integer.parseInt(uid.substring(1, 4)) - 1;
   }
 
   private boolean isCurrentFile(String file) {


### PR DESCRIPTION
In the implementation before this PR each time a small ROI is read from an image, a full OIR Pixelblock was read. Combined with the fact that the Optimal Tile Size was not overriden and defaulted to a thin stripe in y (128 pixels), this could lead to a particularly bad scenario for big images:

- Imagine a 10000 by 10000 pixel plane read by tiles of 10000x128 pixels -> 79 tiles have to be read to read the full plane
- For big tiled OIR images, a PixelBlock typically spans the full plane
- This means that, to acquire all tiles of this plane, the full plane is actually read 97 times

The proposed new implementation of this PR:
- prevents reading fully all PixelBlocks when one needs to read a ROI within them
- overrides getOptimalTile size methods to match the underlying PixelBlock size (or crops at 2048 pixels)

When requesting a cropped region within big images, the speedup is massive.

Here's a real time display with big dataviewer with the current implementation:
![previousreader](https://github.com/ome/bioformats/assets/20223054/114ea211-b4ff-4eae-b4f7-de0c01ca71b2)

Here's a real time display with big dataviewer with the implementation in this PR:
![prreader](https://github.com/ome/bioformats/assets/20223054/0b262ec3-d309-4f11-8ed6-040437622fc6)


