### PR TITLE
Fix incorrect logical operators in Zeiss LSM and OME-XML readers

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -290,7 +290,7 @@ public class OMEXMLReader extends FormatReader {
       Integer t = omexmlMeta.getPixelsSizeT(i).getValue();
       Integer z = omexmlMeta.getPixelsSizeZ(i).getValue();
       Integer c = omexmlMeta.getPixelsSizeC(i).getValue();
-      if (w == null || h == null || t == null || z == null | c == null) {
+      if (w == null || h == null || t == null || z == null || c == null) {
         throw new FormatException("Image dimensions not found");
       }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -1134,7 +1134,7 @@ public class ZeissLSMReader extends FormatReader {
             // if this is not the first channel, copy the color from the
             // previous channel (necessary for SIM data)
             // otherwise set the color to white, as this will display better
-            if (red == 0 && green == 0 & blue == 0) {
+            if (red == 0 && green == 0 && blue == 0) {
               if (i > 0 && isSIM) {
                 red = channelColor[i - 1].getRed();
                 green = channelColor[i - 1].getGreen();


### PR DESCRIPTION
Fixes #4209 
Fixes #4212