### PR TITLE
Fix DICOM export in ImageJ

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -505,7 +505,7 @@ public class Exporter {
                     String lsid = MetadataTools.createLSID("Channel", 0, c);
                     store.setChannelID(lsid, 0, c);
                 }
-                store.setChannelSamplesPerPixel(new PositiveInteger(channels), 0, 0);
+                store.setChannelSamplesPerPixel(new PositiveInteger(channels), 0, c);
 
                 if (imp instanceof CompositeImage) {
                     luts[c] = ((CompositeImage) imp).getChannelLut(c + 1);

--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -2082,7 +2082,12 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
    * proper physical units (e.g. mm), so need to be handled specially.
    */
   private Length fixUnits(Length size) {
-    if (size == null || size.unit() == UNITS.PIXEL || size.unit() == UNITS.REFERENCEFRAME) {
+    if (size == null) {
+      return null;
+    }
+    if (size.unit() == UNITS.PIXEL || size.unit() == UNITS.REFERENCEFRAME) {
+      LOGGER.warn("Found physical length '{}' in relative units '{}'; this value will be lost",
+        size.value(), size.unit());
       return null;
     }
     return size;

--- a/components/formats-bsd/src/loci/formats/out/DicomWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/DicomWriter.java
@@ -1383,6 +1383,11 @@ public class DicomWriter extends FormatWriter implements IExtraMetadataWriter {
         for (int res=0; res<resolutionCount; res++) {
           resolution = res;
           openFile(pyramid, resolution);
+
+          if (out == null) {
+            // already closed
+            continue;
+          }
           int resolutionIndex = getIndex(pyramid, resolution);
 
           out.seek(out.length());


### PR DESCRIPTION
See https://forum.image.sc/t/exporting-a-dicom-stack/99400/6

I was able to reproduce the exception in that thread using ImageJ + Bio-Formats 7.3.1 by selecting `File > Open Samples > Organ of Corti...`, then `Plugins > Bio-Formats > Bio-Formats Exporter` and saving to a file with the `.dcm` extension.

With this change, the same test should result in a converted `.dcm` file (with no exception) that can be re-opened.