### PR TITLE
ImageJ exporter: save original metadata

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -52,6 +52,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
 
@@ -60,6 +61,7 @@ import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 
 import loci.common.DataTools;
+import loci.common.DebugTools;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
@@ -538,6 +540,7 @@ public class Exporter {
             }
 
             Object info = imp.getProperty("Info");
+            Hashtable<String, Object> originalMetadata = new Hashtable<String, Object>();
             if (info != null) {
                 String imageInfo = info.toString();
                 if (imageInfo != null) {
@@ -548,13 +551,21 @@ public class Exporter {
                             String key = line.substring(0, eq).trim();
                             String value = line.substring(eq + 1).trim();
 
+                            originalMetadata.put(key, value);
+
                             if (key.endsWith("BitsPerPixel")) {
                                 w.setValidBitsPerPixel(Integer.parseInt(value));
-                                break;
                             }
                         }
                     }
                 }
+            }
+            try {
+              service.populateOriginalMetadata(service.getOMEMetadata(store), originalMetadata);
+            }
+            catch (ServiceException e) {
+              IJ.log("Could not populate original metadata");
+              IJ.log(DebugTools.getStackTrace(e));
             }
 
             // NB: Animation rate code copied from ij.plugin.Animator#doOptions().


### PR DESCRIPTION
Fixes #4201.

I tested with https://downloads.openmicroscopy.org/images/ND2/karl/sample_image.nd2 since it has lots of original metadata, but pretty much any other test data would work as well.

Without this change, open in ImageJ with `Plugins > Bio-Formats > Bio-Formats Importer` and the `Display metadata` box checked. Export to OME-TIFF with `Plugins > Bio-Formats > Bio-Formats Exporter`, and default options (no boxes checked). Open the exported OME-TIFF as with the original file, and note that most of the original metadata is no longer available.

With this change, the same test should show that the original metadata window is more or less the same for the original file and the exported OME-TIFF.

cc @joshmoore, @tischi