### PR TITLE
Fix float casting when autoscaling int values to byte

### DIFF
--- a/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
@@ -1655,7 +1655,7 @@ public final class AWTImageTools {
           else if (ints[i][j] <= min) out[i][j] = 0;
           else {
             int diff = max - min;
-            float dist = (ints[i][j] - min) / diff;
+            float dist = (float) (ints[i][j] - min) / diff;
             out[i][j] = (byte) (dist * 256);
           }
         }


### PR DESCRIPTION
Fixes #4210.

Test code that uses the autoscale method:

```
$ cat AutoscaleTest.java 
import java.awt.image.BufferedImage;
import loci.formats.gui.AWTImageTools;

public class AutoscaleTest {
  public static void main(String[] args) throws Exception {
    int[] inputPixels = new int[] {40};
    BufferedImage input = AWTImageTools.makeImage(inputPixels, 1, 1, false);
    BufferedImage scaled = AWTImageTools.autoscale(input, 20, 120);
    byte[][] scaledPixels = (byte[][]) AWTImageTools.getPixels(scaled);
    System.out.println(scaledPixels[0][0]);
  }
}
```

Without this change, the value printed is 0. With this change, the value printed is 51.

The cast is the same strategy as used in the `short[]` case in line 1638.