### PR TITLE
RCPNL: add data for objective ID 18112

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
@@ -99,6 +99,16 @@ public class RCPNLReader extends DeltavisionReader {
           MetadataTools.getCorrection("PlanApo"), 0, 0);
         store.setObjectiveManufacturer("Nikon", 0, 0);
         break;
+      case 18112:
+        store.setObjectiveNominalMagnification(20.0, 0, 0);
+        store.setObjectiveLensNA(0.8, 0, 0);
+        store.setObjectiveWorkingDistance(
+          new Length(0.8, UNITS.MILLIMETER), 0, 0);
+        store.setObjectiveImmersion(MetadataTools.getImmersion("Air"), 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanApo"), 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
     }
   }
 


### PR DESCRIPTION
Backported from a private PR.

See test file in `curated/deltavision/samples/lens-id-18112`. Without this change, `showinf -nopix -omexml` is expected to report incorrect objective metadata. With this change, the same test should show objective metadata that matches the changes here.

This shouldn't impact existing test data, and should be safe for a patch release.