### PR TITLE
CV7000: handle NullPointerException when resetting allFiles in close()

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -223,7 +223,11 @@ public class CV7000Reader extends FormatReader {
       reversePlaneLookup = null;
       extraFiles = null;
       acquiredWells.clear();
-      allFiles.clear();
+      if (allFiles != null) {
+          allFiles.clear();
+      } else {
+          allFiles = new ArrayList<String>();
+      }
     }
   }
 


### PR DESCRIPTION
While the reader should initialize this field as an empty ArrayList, there are scenarios where allFiles will be null when calling `close()`. A use case would be a reader initialized from a memo file created with a previous release of Bio-Formats since this field was formerly a string array set to null by default.

A minimal reproducible scenario can be created by creating a TIFF file and reading using Bio-Formats 7.3.1 command-line tools with `-cache`

```bash
sbesson@Sebastiens-MacBook-Pro-3 Downloads % ./bftools-7.3.1/bfconvert test.fake test.tif
test.fake
FakeReader initializing test.fake
[Simulated data] -> test.tif [Tagged Image File Format]
	Converted 1/1 planes (100%)
[done]
0.717s elapsed (9.0+103.0ms per plane, 586ms overhead)
sbesson@Sebastiens-MacBook-Pro-3 Downloads % ./bftools-7.3.1/showinf -nopix -cache test.tif
Checking file format [Tagged Image File Format]
Initializing reader
TiffDelegateReader initializing test.tif
Reading IFDs
Populating metadata
Checking comment style
Populating OME metadata
Parsing schema path
http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd
Validating OME-XML
No validation errors found.
Initialization took 0.426s

Reading core metadata
filename = test.tif
Series count = 1
Series #0 -- test.tif:
	Image count = 1
	RGB = false (1) 
	Interleaved = false
	Indexed = false (false color)
	Width = 512
	Height = 512
	SizeZ = 1
	SizeT = 1
	SizeC = 1
	Tile size = 512 x 512
	Thumbnail size = 128 x 128
	Endianness = intel (little)
	Dimension order = XYCZT (certain)
	Pixel type = uint8
	Valid bits per pixel = 8
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0


Reading global metadata
BitsPerSample: 8
Compression: Uncompressed
ImageLength: 512
ImageWidth: 512
MetaDataPhotometricInterpretation: Monochrome
MetaMorph: no
NumberOfChannels: 1
PhotometricInterpretation: BlackIsZero
PlanarConfiguration: Chunky
ResolutionUnit: Centimeter
SampleFormat: unsigned integer
SamplesPerPixel: 1
Software: OME Bio-Formats 7.3.1
XResolution: 0.0
YResolution: 0.0
hyperstack: true

Reading metadata
```

Using a command-line tools build from the current HEAD of develop ([e4ffbe8](https://github.com/ome/bioformats/commit/e4ffbe89ba6cb9fd44f92fb4dfa4cc64f3918ba5)), reopening this file should fail with a NullPointerException

```bash
sbesson@Sebastiens-MacBook-Pro-3 Downloads % ./bftools/showinf -nopix -cache test.tif 
Checking file format [Tagged Image File Format]
Initializing reader
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.esotericsoftware.reflectasm.AccessClassLoader (file:/Users/sbesson/Downloads/bftools/bioformats_package.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.esotericsoftware.reflectasm.AccessClassLoader
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Initialization took 0.232s

Reading core metadata
filename = test.tif
Series count = 1
Series #0 -- test.tif:
	Image count = 1
	RGB = false (1) 
	Interleaved = false
	Indexed = false (false color)
	Width = 512
	Height = 512
	SizeZ = 1
	SizeT = 1
	SizeC = 1
	Tile size = 512 x 512
	Thumbnail size = 128 x 128
	Endianness = intel (little)
	Dimension order = XYCZT (certain)
	Pixel type = uint8
	Valid bits per pixel = 8
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0


Reading global metadata
BitsPerSample: 8
Compression: Uncompressed
ImageLength: 512
ImageWidth: 512
MetaDataPhotometricInterpretation: Monochrome
MetaMorph: no
NumberOfChannels: 1
PhotometricInterpretation: BlackIsZero
PlanarConfiguration: Chunky
ResolutionUnit: Centimeter
SampleFormat: unsigned integer
SamplesPerPixel: 1
Software: OME Bio-Formats 7.3.1
XResolution: 0.0
YResolution: 0.0
hyperstack: true

Reading metadata
Exception in thread "main" java.lang.NullPointerException
	at loci.formats.in.CV7000Reader.close(CV7000Reader.java:226)
	at loci.formats.ImageReader.close(ImageReader.java:594)
	at loci.formats.ReaderWrapper.close(ReaderWrapper.java:397)
	at loci.formats.ReaderWrapper.close(ReaderWrapper.java:397)
	at loci.formats.FileStitcher.close(FileStitcher.java:544)
	at loci.formats.WrappedReader.close(WrappedReader.java:266)
	at loci.formats.ImageReader.close(ImageReader.java:594)
	at loci.formats.ImageReader.close(ImageReader.java:875)
	at loci.formats.ReaderWrapper.close(ReaderWrapper.java:702)
	at loci.formats.Memoizer.close(Memoizer.java:671)
	at loci.formats.ReaderWrapper.close(ReaderWrapper.java:702)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1080)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1150)
``` 

With this PR included, the same command should succeed.
