### PR TITLE
Some improvements to OME-TIFF write performance

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -131,7 +131,6 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
       }
 
       int mainIFDIndex = 0;
-      int currentFullResolution = 0;
       for (int i=0; i<r.getImageCount(); i++) {
         setSeries(i);
         int resCount = resCounts[i];
@@ -159,7 +158,6 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
           }
 
           mainIFDIndex++;
-          currentFullResolution++;
         }
         mainIFDIndex += (planeCounts[i] * (resCount - 1));
       }

--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -155,7 +155,7 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
             long nextPointer = index < allOffsets.length ? allOffsets[index] : 0;
 
             saver.overwriteIFDOffset(in, allOffsets[mainIFDIndex], nextPointer);
-            saver.overwriteIFDValue(in, currentFullResolution, IFD.SUB_IFD, subIFDOffsets);
+            saver.overwriteIFDValue(in, allOffsets[mainIFDIndex], IFD.SUB_IFD, subIFDOffsets, true);
           }
 
           mainIFDIndex++;


### PR DESCRIPTION
88b846d is primarily meant to address #4204, while 0b42e1b is expected to provide some help for #4204, #3983, and #3480.

If the use of `ByteArrayOutputStream` in 0b42e1b is too concerning, I can rework that change to just reduce the seeks in that were removed at line 1181 - that alone would give some measurable benefit.

Using the same test as https://github.com/ome/bioformats/issues/4204#issuecomment-2339470615, I now see:

```
$ for i in `cat timepoint-counts.txt` ; do java SmallPyramidWriter $i.ome.tiff $i; done
Populating metadata...
Writing image to '1.ome.tiff'...
init: 32 ms
image writing: 347 ms
close: 214 ms
Done.
Populating metadata...
Writing image to '8.ome.tiff'...
init: 36 ms
image writing: 699 ms
close: 250 ms
Done.
Populating metadata...
Writing image to '64.ome.tiff'...
init: 31 ms
image writing: 3409 ms
close: 955 ms
Done.
Populating metadata...
Writing image to '128.ome.tiff'...
init: 35 ms
image writing: 7984 ms
close: 1009 ms
Done.
Populating metadata...
Writing image to '512.ome.tiff'...
init: 41 ms
image writing: 68755 ms
close: 2649 ms
Done.
Populating metadata...
Writing image to '1024.ome.tiff'...
init: 26 ms
image writing: 257061 ms
close: 5343 ms
Done.
Populating metadata...
Writing image to '2048.ome.tiff'...
Switching to BigTIFF (by file size)
init: 41 ms
image writing: 1002326 ms
close: 10170 ms
Done.
```

Comparing `bfconvert` performance on `gh-3983&sizeX=512&sizeY=1024&pixelType=uint16&series=27&sizeT=55.fake` (which matches the dimensions in #3983), I see total conversion times:

|    | Local disk | Network disk |
|---|------------|----------------|
| develop | 58s | 351s |
| this PR | 22s | 91s |

To check that this did not impact working with slides, I also tried `bfconvert -noflat CMU-1.svs CMU-1.ome.tiff` with and without this change. As expected, I did not see any change in conversion performance; both output OME-TIFF files behaved identically when opened in QuPath.

All together, that looks like it might be enough of an improvement to justify closing #4204 / #3983 / #3480, but is only one set of tests - confirmation with other test data and on other systems would definitely be appreciated. In particular, if any of the original issue reporters (@NicoKiaru / @anntzer / @ebremer / @tischi) have time and interest to try this, comments would be welcome.