### PR TITLE
Update IExtraMetadataWriter.setExtraMetadata(...) to accept an Object

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/IExtraMetadataWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/IExtraMetadataWriter.java
@@ -48,6 +48,6 @@ public interface IExtraMetadataWriter {
    *
    * All calls to this method must occur before setId is called.
    */
-  void setExtraMetadata(String metadataSource);
+  void setExtraMetadata(Object metadataSource);
 
 }


### PR DESCRIPTION
If an ITagProvider is passed to this method when called on DicomWriter, the ITagProvider is directly added to the tag provider list. If a String is passed instead, then it is assumed to be a path to a file that can be parsed by DicomJSONProvider (as before).

Drafting for consideration in 8.0.0. @ebremer, is this sufficient to cover what you had in mind for #4169? If not, concrete suggestions and/or a more complete description of the use case that needs to be considered would be very helpful.

Any writers that implement `IExtraMetadataWriter` in the future then have flexibility in what they accept in `setExtraMetadata(...)`. I don't know if this ends up being too flexible though.

I did test briefly with this and still got the expected output file contents:

```
$ cat hierarchy-test.json 
{
   "BodyPartExamined": {
     "Value": "BRAIN",
     "VR": "CS",
     "Tag": "(0018,0015)"
   },
   "SpecimenLabelInImage": {
      "Value": "NO",
      "VR": "CS",
      "Tag": "(0048,0010)",
      "ReplacementStrategy": "IGNORE"
   },
   "ContributingEquipmentSequence": {
     "VR": "SQ",
     "Tag": "(0018,a001)",
     "Sequence": {
       "Manufacturer": {
         "Value": "PixelMed",
         "VR": "LO",
         "Tag": "(0008,0070)"
       },
       "ContributionDateTime": {
         "Value": "20210710234601.105+0000",
         "VR": "DT",
         "Tag": "(0018,a002)"
       }
     }
   },
   "OpticalPathSequence": {
    "VR": "SQ",
    "Tag": "(0048,0105)",
    "Sequence": {
      "IlluminationTypeCodeSequence": {
        "VR": "SQ",
        "Tag": "(0022,0016)",
        "Sequence": {
          "CodeValue": {
            "VR": "SH",
            "Tag": "(0008,0100)",
            "Value": "111743"
          },
          "CodingSchemeDesignator": {
            "VR": "SH",
            "Tag": "(0008,0102)",
            "Value": "DCM"
          },
          "CodeMeaning": {
            "VR": "LO",
            "Tag": "(0008,0104)",
            "Value": "Epifluorescence illumination"
          }
        }
      },
      "IlluminationWaveLength": {
        "VR": "FL",
        "Tag": "(0022,0055)",
        "Value": "488.0"
      },
      "OpticalPathIdentifier": {
        "VR": "SH",
        "Tag": "(0048,0106)",
        "Value": "1"
      },
      "OpticalPathDescription": {
        "VR": "ST",
        "Tag": "(0048,0107)",
        "Value": "replacement channel"
      }
    },
    "ResolutionStrategy": "REPLACE"
   }
}
$ bfconvert -no-upgrade test.fake wednesday-test.dcm -extra-metadata hierarchy-test.json
```