### PR TITLE
Operetta reader: don't add directories to the used files list

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -350,10 +350,16 @@ public class OperettaReader extends FormatReader {
           LOGGER.trace("Found folder {}", folder);
           if (!checkSuffix(folder, "tiff"))
           {
-            String metadataFile = new Location(path, folder).getAbsolutePath();
-            if (!metadataFile.equals(currentFile.getAbsolutePath())) {
-              metadataFiles.add(metadataFile);
-              LOGGER.trace("Adding metadata file {}", metadataFile);
+            Location metadataLocation = new Location(path, folder);
+            if (!metadataLocation.isDirectory()) {
+              String metadataFile = metadataLocation.getAbsolutePath();
+              if (!metadataFile.equals(currentFile.getAbsolutePath())) {
+                metadataFiles.add(metadataFile);
+                LOGGER.trace("Adding metadata file {}", metadataFile);
+              }
+            }
+            else {
+              LOGGER.debug("Skipping metadata folder {}", metadataLocation);
             }
           }
         }


### PR DESCRIPTION
Backported from a private PR.

Without this change, and with an extra directory in the Operetta/Phenix plates hierarchy like this:

```
/path/to/plate_name/images/index.xml
/path/to/plate_name/eval/ID/file.csv
```

`showinf` should report the directory `/path/to/plate_name/eval/ID` on the used files list, but not any of the files it contains.
Including directories on the used file list causes problems when importing to OMERO.

This change should remove any directories from the used files list, but will not recursively look for files in any unexpected directories - so `/path/to/plate_name/eval/ID/file.csv` would still not appear on the list.