### PR TITLE
ImageInfo: only call System.exit in batch mode

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -1153,12 +1153,11 @@ public class ImageInfo {
         }
       }
       scanner.close();
+      System.exit(exitCode);
     }
     else {
       if (!new ImageInfo().testRead(args)) System.exit(1);
     }
-
-    System.exit(exitCode);
   }
 }
 


### PR DESCRIPTION
The ability to run showinf in batch mode introduced in Bio-Formats 8 has caused some regression with the interactivity of the utility when opening a single image without the -nopix option as the System.exit call immediately closes the viewer. This commit addresses the issue by only invoking it when multiple input are passed.

To test this PR run `showinf test.fake`. Without 8.0.0, the viewer should launch and terminate immediately. With this PR included the viewer should remain active until closed. The behavior of the utility when using the batch mode is unmodified.

As discussed with Melissa, given this is a regression, this might be a candidate for a 8.0.1 release in the upcoming weeks