### PR TITLE
Leica TCS: make sure XML file is on used files list

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -202,8 +202,10 @@ public class LeicaHandler extends BaseHandler {
       if (level != MetadataLevel.MINIMUM) {
         int nChannels = coreMeta.rgb ? 0 : numChannels;
 
-        for (int c=0; c<nChannels; c++) {
-          store.setChannelPinholeSize(new Length(pinhole, UNITS.MICROMETER), numDatasets, c);
+        if (pinhole != null) {
+          for (int c=0; c<nChannels; c++) {
+            store.setChannelPinholeSize(new Length(pinhole, UNITS.MICROMETER), numDatasets, c);
+          }
         }
 
         for (int i=0; i<xPos.size(); i++) {
@@ -256,8 +258,10 @@ public class LeicaHandler extends BaseHandler {
           String id = MetadataTools.createLSID("Detector", numDatasets, index);
           store.setDetectorSettingsID(id, numDatasets, index);
         }
-        for (int c=0; c<nChannels; c++) {
-          store.setChannelPinholeSize(new Length(pinhole, UNITS.MICROMETER), numDatasets, c);
+        if (pinhole != null) {
+          for (int c=0; c<nChannels; c++) {
+            store.setChannelPinholeSize(new Length(pinhole, UNITS.MICROMETER), numDatasets, c);
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -120,6 +120,9 @@ public class LeicaHandler extends BaseHandler {
   private MetadataLevel level;
   private int laserCount = 0;
 
+  private Map<String, Time> exposureTimes = new HashMap<String, Time>();
+  private Map<String, Time> deltaT = new HashMap<String, Time>();
+
   // -- Constructor --
 
   public LeicaHandler(MetadataStore store, MetadataLevel level) {
@@ -143,6 +146,10 @@ public class LeicaHandler extends BaseHandler {
   public Hashtable getGlobalMetadata() { return globalMetadata; }
 
   public Vector<String> getLutNames() { return lutNames; }
+
+  public Map<String, Time> getExposureTimes() { return exposureTimes; }
+
+  public Map<String, Time> getDeltaT() { return deltaT; }
 
   // -- DefaultHandler API methods --
 
@@ -549,7 +556,7 @@ public class LeicaHandler extends BaseHandler {
           try {
             Double exposureTime = DataTools.parseDouble(value);
             if (exposureTime != null) {
-              store.setPlaneExposureTime(new Time(exposureTime, UNITS.SECOND), numDatasets, c);
+              exposureTimes.put(numDatasets + "-" + c, new Time(exposureTime, UNITS.SECOND));
             }
           }
           catch (IndexOutOfBoundsException e) { }
@@ -878,14 +885,14 @@ public class LeicaHandler extends BaseHandler {
           store.setImageAcquisitionDate(new Timestamp(date), numDatasets);
         }
         firstStamp = ms;
-        store.setPlaneDeltaT(new Time(0.0, UNITS.SECOND), numDatasets, count);
+        deltaT.put(numDatasets + "-" + count, new Time(0.0, UNITS.SECOND));
       }
       else if (level != MetadataLevel.MINIMUM) {
         CoreMetadata coreMeta = core.get(numDatasets);
         int nImages = coreMeta.sizeZ * coreMeta.sizeT * coreMeta.sizeC;
         if (count < nImages) {
           ms -= firstStamp;
-          store.setPlaneDeltaT(new Time(ms / 1000.0, UNITS.SECOND), numDatasets, count);
+          deltaT.put(numDatasets + "-" + count, new Time(ms / 1000.0, UNITS.SECOND));
         }
       }
 
@@ -897,7 +904,8 @@ public class LeicaHandler extends BaseHandler {
       if (count < nImages) {
         Double time = DataTools.parseDouble(attributes.getValue("Time"));
         if (time != null) {
-          store.setPlaneDeltaT(new Time(time, UNITS.SECOND), numDatasets, count++);
+          deltaT.put(numDatasets + "-" + count, new Time(time, UNITS.SECOND));
+          count++;
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -247,6 +247,7 @@ public class TCSReader extends FormatReader {
     Arrays.sort(list);
 
     boolean isXML = checkSuffix(id, XML_SUFFIX);
+    if (isXML) xmlFile = l.getAbsolutePath();
 
     if (list != null) {
       for (String file : list) {
@@ -255,13 +256,16 @@ public class TCSReader extends FormatReader {
           break;
         }
         else if (checkSuffix(file, TiffReader.TIFF_SUFFIXES) && isXML) {
+          // this will result in a call to super.initFile(...),
+          // which calls close and resets xmlFile
+          // so xmlFile must be reset here before returning,
+          // otherwise the XML file will not appear on the used files list
           initFile(new Location(parent, file).getAbsolutePath());
+          xmlFile = l.getAbsolutePath();
           return;
         }
       }
     }
-
-    if (isXML) xmlFile = l.getAbsolutePath();
 
     super.initFile(id);
 

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -476,7 +476,7 @@ public class TCSReader extends FormatReader {
       xml = XMLTools.sanitizeXML(PREFIX + xml + SUFFIX);
 
       LeicaHandler handler =
-        new LeicaHandler(store, getMetadataOptions().getMetadataLevel());
+        new LeicaHandler(store, getMetadataOptions().getMetadataLevel(), false);
       XMLTools.parseXML(xml, handler);
       exposureTime = handler.getExposureTimes();
       deltaT = handler.getDeltaT();

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -246,28 +246,29 @@ public class TCSReader extends FormatReader {
     String[] list = parent.list();
     Arrays.sort(list);
 
+    String currentXMLFile = null;
+
     boolean isXML = checkSuffix(id, XML_SUFFIX);
-    if (isXML) xmlFile = l.getAbsolutePath();
+    if (isXML) currentXMLFile = l.getAbsolutePath();
 
     if (list != null) {
       for (String file : list) {
         if (checkSuffix(file, XML_SUFFIX) && !isXML && isGroupFiles()) {
-          xmlFile = new Location(parent, file).getAbsolutePath();
+          currentXMLFile = new Location(parent, file).getAbsolutePath();
           break;
         }
         else if (checkSuffix(file, TiffReader.TIFF_SUFFIXES) && isXML) {
-          // this will result in a call to super.initFile(...),
-          // which calls close and resets xmlFile
-          // so xmlFile must be reset here before returning,
-          // otherwise the XML file will not appear on the used files list
           initFile(new Location(parent, file).getAbsolutePath());
-          xmlFile = l.getAbsolutePath();
           return;
         }
       }
     }
 
+    // super.initFile(...) calls close, which resets xmlFile
+    // so xmlFile must be set after super.initFile(...) returns,
+    // otherwise the XML file will not appear on the used files list
     super.initFile(id);
+    xmlFile = currentXMLFile;
 
     MetadataStore store = makeFilterMetadata();
 


### PR DESCRIPTION
Fixes #4229 (cc @mabruce).

As indicated in the original issue, `showinf curated/leica-tcs/brian/Series002.xml` without this change will not include `Series002.xml` on the used file list. With this change, it should be included on the used file list.

Note `Series002.xml` will appear at the end of the list, which at first glance looks like it should cause test failures due to the changes in #4172. However, the use of `initFile(...)` on the first TIFF file found in line 263 means that the initialized file in the end is *not* `Series002.xml`.

Adding to 8.0.1 since this should be safe for a patch release, but this could easily be moved to a later milestone.