### PR TITLE
Operetta/Phenix: calculate physical Z size in micrometers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -729,11 +729,10 @@ public class OperettaReader extends FormatReader {
             FormatTools.getPhysicalSizeY(first.resolutionY), i);
 
           if (getSizeZ() > 1 && last != null) {
-            Unit<Length> firstZUnit = first.positionZ.unit();
-            double firstZ = first.positionZ.value().doubleValue();
-            double lastZ = last.positionZ.value(firstZUnit).doubleValue();
+            double firstZ = first.positionZ.value(UNITS.MICROMETER).doubleValue();
+            double lastZ = last.positionZ.value(UNITS.MICROMETER).doubleValue();
             double averageStep = (lastZ - firstZ) / (getSizeZ() - 1);
-            store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(averageStep, firstZUnit), i);
+            store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(averageStep, UNITS.MICROMETER), i);
           }
         }
       }


### PR DESCRIPTION
Fixes #4240 (cc @mabruce).

`showinf -nopix -omexml` on `curated/perkinelmer-operetta/public/omer/` without this change should show a `PhysicalSizeZ` that is very small, and in `dm` units. With this change, the `PhysicalSizeZ` should be in `µm` units, and large enough to not round to 0.

This does require a configuration update, which does flag that two sample plates now have a `PhysicalSizeZ` of `1µm`. See forthcoming configuration PR.

Adding to 8.0.1 for initial evaluation, but this can easily be moved to a later milestone.