### PR TITLE
Memoizer: ask any ImageReader instances to remove all but the current reader

### DIFF
--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -151,6 +151,24 @@ public class ImageReader implements IFormatReader {
   // -- ImageReader API methods --
 
   /**
+   * Intended for use prior to caching an initialized reader.
+   * This removes everything except the current reader from the
+   * list of possible readers to use. Be very careful, and do
+   * not call this method on an ImageReader that may be reused
+   * for multiple different files.
+   *
+   * If the current reader index is less than 0 (i.e. not initialized),
+   * this does nothing.
+   */
+  protected void cleanupReaderList() {
+    if (current >= 0) {
+      IFormatReader currentReader = readers[current];
+      current = 0;
+      readers = new IFormatReader[] {currentReader};
+    }
+  }
+
+  /**
    * Toggles whether or not file system access is allowed when doing type
    * detection.  By default, file system access is allowed.
    */

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -208,6 +208,17 @@ public class Memoizer extends ReaderWrapper {
 
     @Override
     public void saveReader(IFormatReader reader) {
+      // clean up reader list in any instances of ImageReader
+      IFormatReader r = reader;
+      while (r instanceof ReaderWrapper || r instanceof ImageReader) {
+        if (r instanceof ImageReader) {
+          ImageReader ir = (ImageReader) r;
+          ir.cleanupReaderList();
+          r = ir.getReader();
+        }
+        else r = ((ReaderWrapper) r).getReader();
+      }
+
       kryo.writeObject(output, reader.getClass());
       kryo.writeObject(output, reader);
     }


### PR DESCRIPTION
Ported from a private draft, for wider discussion (cc @joshmoore). https://github.com/glencoesoftware/omero-ms-image-region/issues/148 provides some additional context for where this idea is coming from.

To minimally demonstrate the difference, run something like `showinf -cache -minmax -expand -separate` without this change, and note size of memo file (in same directory as data). Run the same thing twice with this change - once to generate the new memo file (note the size again), and once after a minute or so to verify that the new memo file is used and not overwritten. Note `-minmax -expand -separate` mimics the reader stack used in OMERO.

However, this has the potential to impact anything that uses `Memoizer`, including but not limited to OMERO. So ideas of what might break, why this change might be bad in general, or other approaches to consider would all be welcome.

One potential problem identified is what happens when there is an existing memo file generated by this change, but new reader (or better type detection) is introduced such that the underlying reader that should be used for the file changes.