### PR TITLE
Add Hamamatsu DCIMG Reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tools/*.jar
 *.iml
 .*.swp
 *.clean
+.vscode

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -107,6 +107,7 @@ loci.formats.in.MicroCTReader         # vff
 loci.formats.in.LOFReader	            # lof
 loci.formats.in.XLEFReader            # xlef
 loci.formats.in.OlympusTileReader     # omp2info
+loci.formats.in.DCIMGReader           # dcimg
 
 # multi-extension messes
 loci.formats.in.JEOLReader            # dat, img, par

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.sun.media.jfxmedia.logging.Logger;
-
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
@@ -101,6 +99,7 @@ public class DCIMGReader extends FormatReader {
       stream.skipBytes(byteFactor*(getSizeX() - w - x));
     }
 
+    stream.close();
     return buf;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -17,7 +17,7 @@ import loci.formats.meta.MetadataStore;
 /**
  * DCIMGReader reads Hamamatsu DCIMG files.
  * 
- * Follows spec at https://github.com/python-microscopy/python-microscopy/blob/master/PYME/IO/dcimg.py
+ * Follows spec/code at https://github.com/python-microscopy/python-microscopy/blob/master/PYME/IO/dcimg.py
  * and https://github.com/lens-biophotonics/dcimg/blob/master/dcimg.py.
  * 
  */
@@ -204,6 +204,8 @@ public class DCIMGReader extends FormatReader {
       byteFactor = 2;
     }
 
+    // DCIMG sometimes stores the first 4 pixels of one of its lines somewhere separate
+    // from the rest of the data.
     fourPixelCorrectionLine = getFourPixelCorrectionLine();
     fourPixelCorrectionOffset = getFourPixelCorrectionOffset();
 
@@ -233,7 +235,7 @@ public class DCIMGReader extends FormatReader {
 
   }
 
-  /* Logic copied from DicomReader */
+  // Logic copied from DicomReader 
   private void scanDirectory(Location dir)
     throws FormatException, IOException 
   {
@@ -247,6 +249,7 @@ public class DCIMGReader extends FormatReader {
     }
   }
 
+  // Logic copied from DicomReader 
   private void addFileToList(String file)
     throws FormatException, IOException
   {
@@ -262,11 +265,12 @@ public class DCIMGReader extends FormatReader {
       return;
     }
     // stream.order(IS_LITTLE);
-    // now check width/height
+    // TODO: now check width/height
     companionFiles.add(file);
     stream.close();
   }
 
+  // TODO: Surely this exists somewhere else?
   private String getExtension(String file)
   {
     String ext = "";
@@ -277,6 +281,7 @@ public class DCIMGReader extends FormatReader {
     return ext;
   }
 
+  // The header and footer code feature many commented out properties "for later"
   private void parseDCAMVersion0Header(RandomAccessInputStream stream)
     throws IOException 
   {
@@ -365,6 +370,7 @@ public class DCIMGReader extends FormatReader {
     }
   }
 
+  // Get the correct line and offset for the 4 pixel correction
   private int getFourPixelCorrectionLine() 
   {
     if (version == DCIMG_VERSION_0) {
@@ -390,4 +396,5 @@ public class DCIMGReader extends FormatReader {
     }
     return headerSize + dataOffset + bytesPerImage + 12;
   }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -1,7 +1,13 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import com.sun.media.jfxmedia.logging.Logger;
+
+import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -17,145 +23,262 @@ import loci.formats.meta.MetadataStore;
  */
 public class DCIMGReader extends FormatReader {
 
-    // -- Constants --
+  // -- Constants --
 
-    private static final boolean IS_LITTLE = true;
+  private static final boolean IS_LITTLE = true;
 
-    private static final long DCAM_VERSION_0 = 0x7;
-    private static final long DCAM_VERSION_1 = 0x1000000;
+  private static final long DCAM_VERSION_0 = 0x7;
+  private static final long DCAM_VERSION_1 = 0x1000000;
 
-    private static final long DCIMG_PIXELTYPE_NONE = 0x00000000; // defined, but I don't know what to do with this
-    private static final long DCIMG_PIXELTYPE_MONO8 = 0x00000001;
-    private static final long DCIMG_PIXELTYPE_MONO16 = 0x00000002;
+  private static final long DCIMG_PIXELTYPE_NONE = 0x00000000; // defined, but I don't know what to do with this
+  private static final long DCIMG_PIXELTYPE_MONO8 = 0x00000001;
+  private static final long DCIMG_PIXELTYPE_MONO16 = 0x00000002;
 
-    // -- Fields --
+  // -- Fields --
 
-    private long sessionOffset;
-    private long dataOffset;
-    private long pixelType;
-    private int byteFactor;
+  private long sessionOffset;
+  private long dataOffset;
+  private long pixelType;
+  private int byteFactor;
 
-    public DCIMGReader() {
-        super("Hamamatsu DCIMG", "dcimg");
-        suffixSufficient = false;
-        domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+  private List<String> companionFiles = new ArrayList<String>();
+  private String[] uniqueFiles;
+
+  public DCIMGReader() 
+  {
+    super("Hamamatsu DCIMG", "dcimg");
+    suffixSufficient = false;
+    domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+  }
+
+  @Override
+  public boolean isSingleFile(String id) 
+    throws FormatException, IOException 
+  {
+    return false;
+  }
+
+  @Override
+  public int fileGroupOption(String id) 
+    throws FormatException, IOException 
+  {
+    return FormatTools.CAN_GROUP;
+  }
+
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) 
+  {
+    FormatTools.assertId(currentId, true, 1);
+
+    if (!isGroupFiles() || noPixels) return null;
+
+    return uniqueFiles;
+
+  }
+
+  @Override
+  public boolean isThisType(RandomAccessInputStream stream) 
+    throws IOException 
+  {
+    String desc = stream.readString(5);
+    if (!desc.equals("DCIMG")) return false;
+    return true;
+  }
+  
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h) 
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+    RandomAccessInputStream stream = new RandomAccessInputStream(uniqueFiles[no]);
+
+    // DCIMG is stored column major
+    stream.seek(sessionOffset + dataOffset + byteFactor*y*getSizeX());
+    for (int row=h-1; row>=0; row--) {
+      stream.skipBytes(byteFactor*x);
+      stream.read(buf, byteFactor*row*w, byteFactor*w);
+      stream.skipBytes(byteFactor*(getSizeX() - w - x));
     }
 
-    @Override
-    public boolean isThisType(RandomAccessInputStream stream) throws IOException {
-        String desc = stream.readString(5);
-        if (!desc.equals("DCIMG")) return false;
-        return true;
-    }
-    
-    @Override
-    public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h) 
-        throws FormatException, IOException
-    {
-        FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    return buf;
+  }
 
-        // DCIMG is stored column major
-        in.seek(sessionOffset + dataOffset + byteFactor*y*getSizeX());
-        for (int row=h-1; row>=0; row--) {
-            in.skipBytes(byteFactor*x);
-            in.read(buf, byteFactor*row*w, byteFactor*w);
-            in.skipBytes(byteFactor*(getSizeX() - w - x));
-        }
+  @Override
+  protected void initFile(String id)
+    throws FormatException, IOException
+  {
+    super.initFile(id);
+    in = new RandomAccessInputStream(id);
 
-        return buf;
+    in.order(IS_LITTLE);  // little endian 
+
+    // confirm this is DCIMG
+    if (!isThisType(in)) throw new FormatException("Not a valid DCIMG file.");
+
+    in.seek(8);
+
+    long version = in.readUnsignedInt();  // DCIMG version number
+    if ((!(version == DCAM_VERSION_0)) && (!(version >= DCAM_VERSION_1))) {
+      throw new FormatException(String.format("Unknown DCIMG version number %d.", version));
     }
 
-    @Override
-    protected void initFile(String id) throws FormatException, IOException {
-        super.initFile(id);
-        in = new RandomAccessInputStream(id);
-
-        in.order(IS_LITTLE);  // big endian 
-
-        // confirm this is DCIMG
-        String desc = in.readString(5);
-        if (!desc.equals("DCIMG")) throw new FormatException("Not a valid DCIMG file.");
-
-        in.skipBytes(3);
-
-        long version = in.readUnsignedInt();  // DCIMG version number
-        if ((!(version == DCAM_VERSION_0)) && (!(version == DCAM_VERSION_1))) {
-            throw new FormatException(String.format("Unknown DCIMG version number %d.", version));
-        }
-
-        in.skipBytes(20);
-
-        long numSessions = in.readUnsignedInt();
-        long numFrames = in.readUnsignedInt();
-        sessionOffset = in.readUnsignedInt();
-        in.skipBytes(4);
-        long fileSize = in.readUnsignedInt();
-        in.skipBytes(12);
-        long fileSize2 = in.readUnsignedInt();
-        if (fileSize != fileSize2) throw new FormatException("Improper header. File sizes do not match.");
-        in.skipBytes(16);
-        long mystery1 = in.readUnsignedInt();  // 1024 in all examples
-
-        CoreMetadata m = core.get(0);
-
-        m.dimensionOrder = "XYZCT";
-        m.rgb = false;
-        m.interleaved = false;
-        m.littleEndian = IS_LITTLE;
-        m.indexed = false;
-        m.falseColor = false;
-        m.metadataComplete = true;
-        m.thumbnail = false;
-        m.sizeC = 1;
-        m.sizeZ = 1;
-        m.imageCount = getSizeZ() * getSizeC();
-
-        if (version == DCAM_VERSION_0) {
-            parseDCAMVersion0Header();
-        } else if (version == DCAM_VERSION_1) {
-            parseDCAMVersion1Header();
-        }
-
-        if (pixelType == DCIMG_PIXELTYPE_MONO8) {
-            m.pixelType = FormatTools.UINT8;
-            byteFactor = 1;
-        } else if (pixelType == DCIMG_PIXELTYPE_MONO16) {
-            m.pixelType = FormatTools.UINT16;
-            byteFactor = 2;
-        }
-
-        addGlobalMeta("Version", version);
-
-        // The metadata store we're working with.
-        MetadataStore store = makeFilterMetadata();
-        MetadataTools.populatePixels(store, this);
-
+    if (version > DCAM_VERSION_1) {
+      LOGGER.warn(String.format("Your file is DCAM version %d, but only %d is guaranteed to work.", version, DCAM_VERSION_1));
     }
 
-    private void parseDCAMVersion0Header() throws IOException {
-        
+    in.skipBytes(20);
+
+    long numSessions = in.readUnsignedInt();
+    long numFrames = in.readUnsignedInt();
+    sessionOffset = in.readUnsignedInt();
+    in.skipBytes(4);
+    long fileSize = in.readUnsignedInt();
+    in.skipBytes(12);
+    long fileSize2 = in.readUnsignedInt();
+    if (fileSize != fileSize2) throw new FormatException("Improper header. File sizes do not match.");
+    in.skipBytes(16);
+    long mystery1 = in.readUnsignedInt();  // 1024 in all examples
+
+    CoreMetadata m = core.get(0);
+
+    m.dimensionOrder = "XYZCT";
+    m.rgb = false;
+    m.interleaved = false;
+    m.littleEndian = IS_LITTLE;
+    m.indexed = false;
+    m.falseColor = false;
+    m.metadataComplete = true;
+    m.thumbnail = false;
+    m.sizeC = 1;
+
+    if (version == DCAM_VERSION_0) {
+      parseDCAMVersion0Header(in);
+    } else if (version == DCAM_VERSION_1) {
+      parseDCAMVersion1Header(in);
     }
 
-    private void parseDCAMVersion1Header() throws IOException {
-        CoreMetadata m = core.get(0);
-
-        in.seek(sessionOffset);
-        long sessionLength = in.readUnsignedInt();
-        in.skipBytes(20);
-        long pseudoOffset = in.readUnsignedInt(); 
-        in.skipBytes(32);  // unknown numbers 1, 144, 65537
-        m.sizeT = (int) in.readUnsignedInt();
-        pixelType = in.readUnsignedInt();
-        long mystery1 = in.readUnsignedInt();
-        // TODO: Is this casting always legal? I think not...
-        m.sizeX = (int) in.readUnsignedInt();  // num columns (this is a column-major format)
-        m.sizeY = (int) in.readUnsignedInt();  // num rows
-        long bytesPerRow = in.readUnsignedInt();
-        long bytesPerImage = in.readUnsignedInt();
-        in.skipBytes(8);
-        dataOffset = in.readUnsignedInt();
-        in.skipBytes(16);
-        long bytesPerFrame = in.readUnsignedInt();
-
+    if (pixelType == DCIMG_PIXELTYPE_MONO8) {
+      m.pixelType = FormatTools.UINT8;
+      byteFactor = 1;
+    } else if (pixelType == DCIMG_PIXELTYPE_MONO16) {
+      m.pixelType = FormatTools.UINT16;
+      byteFactor = 2;
     }
+
+    if (isGroupFiles()) {
+      Location currentFile = new Location(id).getAbsoluteFile();
+      Location directory = currentFile.getParentFile();
+      scanDirectory(directory);
+    } else {
+      String file = new Location(id).getAbsolutePath();
+      companionFiles.add(file);
+    }
+
+    uniqueFiles = companionFiles.toArray(new String[companionFiles.size()]);
+    m.sizeZ = uniqueFiles.length;
+    m.imageCount = getSizeZ() * getSizeC();
+
+    LOGGER.debug("sizeX: {} sizeY: {} sizeZ: {} sizeC: {} sizeT: {}", m.sizeX, m.sizeY, m.sizeZ, m.sizeC, m.sizeT);
+
+    addGlobalMeta("Version", version);
+
+    // The metadata store we're working with.
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this);
+
+    in.close();
+
+  }
+
+  /* Logic copied from DicomReader */
+  private void scanDirectory(Location dir)
+    throws FormatException, IOException 
+  {
+    String[] files = dir.list(true);
+    if (files == null) return;
+    Arrays.sort(files);
+    for (String f : files) {
+      String file = new Location(dir, f).getAbsolutePath();
+      LOGGER.debug("Checking file {}", file);
+      addFileToList(file);
+    }
+  }
+
+  private void addFileToList(String file)
+    throws FormatException, IOException
+  {
+    String ext = getExtension(file);
+    if (!ext.equals("dcimg")) {
+      LOGGER.debug("File {} with extension {} failed extension check", file, ext);
+      return;
+    }
+    RandomAccessInputStream stream = new RandomAccessInputStream(file);
+    if (!isThisType(stream)) {
+      LOGGER.debug("File {} is not DCIMG", file);
+      stream.close();
+      return;
+    }
+    // stream.order(IS_LITTLE);
+    // now check width/height
+    companionFiles.add(file);
+    stream.close();
+  }
+
+  private String getExtension(String file)
+  {
+    String ext = "";
+    int i = file.lastIndexOf(".");
+    if (i > 0) {
+      ext = file.substring(i+1);
+    }
+    return ext;
+  }
+
+  private void parseDCAMVersion0Header(RandomAccessInputStream stream)
+    throws IOException 
+  {
+    CoreMetadata m = core.get(0);
+
+    stream.seek(sessionOffset);
+    long sessionLength = stream.readUnsignedInt();
+    stream.skipBytes(4);
+    long pseudoOffset = stream.readUnsignedInt(); 
+    stream.skipBytes(20);  
+    m.sizeT = (int) stream.readUnsignedInt();
+    pixelType = stream.readUnsignedInt();
+    long mystery1 = stream.readUnsignedInt();
+    // TODO: This will fail for large numbers
+    m.sizeX = (int) stream.readUnsignedInt();  // num columns (this is a column-major format)
+    long bytesPerRow = stream.readUnsignedInt();
+    m.sizeY = (int) stream.readUnsignedInt();  // num rows
+    long bytesPerImage = stream.readUnsignedInt();
+    stream.skipBytes(8);
+    dataOffset = stream.readUnsignedInt();
+    long offsetToFooter = stream.readUnsignedInt();  /// TODO: Deal with footer
+  }
+
+  private void parseDCAMVersion1Header(RandomAccessInputStream stream)
+    throws IOException 
+  {
+    CoreMetadata m = core.get(0);
+
+    stream.seek(sessionOffset);
+    long sessionLength = stream.readUnsignedInt();
+    stream.skipBytes(20);
+    long pseudoOffset = stream.readUnsignedInt(); 
+    stream.skipBytes(32);  // unknown numbers 1, 144, 65537
+    m.sizeT = (int) stream.readUnsignedInt();
+    pixelType = stream.readUnsignedInt();
+    long mystery1 = stream.readUnsignedInt();
+    // TODO: This will fail for large numbers
+    m.sizeX = (int) stream.readUnsignedInt();  // num columns (this is a column-major format)
+    m.sizeY = (int) stream.readUnsignedInt();  // num rows
+    long bytesPerRow = stream.readUnsignedInt();
+    long bytesPerImage = stream.readUnsignedInt();
+    stream.skipBytes(8);
+    dataOffset = stream.readUnsignedInt();
+    stream.skipBytes(16);
+    long bytesPerFrame = stream.readUnsignedInt();
+  }
 }

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -13,7 +13,6 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
-import ucar.nc2.util.IO;
 
 /**
  * DCIMGReader reads Hamamatsu DCIMG files.
@@ -373,7 +372,6 @@ public class DCIMGReader extends FormatReader {
 
   // Get the correct line and offset for the 4 pixel correction
   private int getFourPixelCorrectionLine() 
-    throws IOException
   {
     if (version == DCIMG_VERSION_0) {
       if (fourPixelCorrectionInFooter) {

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -1,0 +1,161 @@
+package loci.formats.in;
+
+import java.io.IOException;
+
+import loci.common.RandomAccessInputStream;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataStore;
+
+/**
+ * DCIMGReader reads Hamamatsu DCIMG files.
+ * 
+ * Follows spec in https://github.com/python-microscopy/python-microscopy/blob/master/PYME/IO/dcimg.py.
+ */
+public class DCIMGReader extends FormatReader {
+
+    // -- Constants --
+
+    private static final boolean IS_LITTLE = true;
+
+    private static final long DCAM_VERSION_0 = 0x7;
+    private static final long DCAM_VERSION_1 = 0x1000000;
+
+    private static final long DCIMG_PIXELTYPE_NONE = 0x00000000; // defined, but I don't know what to do with this
+    private static final long DCIMG_PIXELTYPE_MONO8 = 0x00000001;
+    private static final long DCIMG_PIXELTYPE_MONO16 = 0x00000002;
+
+    // -- Fields --
+
+    private long sessionOffset;
+    private long dataOffset;
+    private long pixelType;
+    private int byteFactor;
+
+    public DCIMGReader() {
+        super("Hamamatsu DCIMG", "dcimg");
+        suffixSufficient = false;
+        domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+    }
+
+    @Override
+    public boolean isThisType(RandomAccessInputStream stream) throws IOException {
+        String desc = stream.readString(5);
+        if (!desc.equals("DCIMG")) return false;
+        return true;
+    }
+    
+    @Override
+    public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h) 
+        throws FormatException, IOException
+    {
+        FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+        // DCIMG is stored column major
+        in.seek(sessionOffset + dataOffset + byteFactor*y*getSizeX());
+        for (int row=h-1; row>=0; row--) {
+            in.skipBytes(byteFactor*x);
+            in.read(buf, byteFactor*row*w, byteFactor*w);
+            in.skipBytes(byteFactor*(getSizeX() - w - x));
+        }
+
+        return buf;
+    }
+
+    @Override
+    protected void initFile(String id) throws FormatException, IOException {
+        super.initFile(id);
+        in = new RandomAccessInputStream(id);
+
+        in.order(IS_LITTLE);  // big endian 
+
+        // confirm this is DCIMG
+        String desc = in.readString(5);
+        if (!desc.equals("DCIMG")) throw new FormatException("Not a valid DCIMG file.");
+
+        in.skipBytes(3);
+
+        long version = in.readUnsignedInt();  // DCIMG version number
+        if ((!(version == DCAM_VERSION_0)) && (!(version == DCAM_VERSION_1))) {
+            throw new FormatException(String.format("Unknown DCIMG version number %d.", version));
+        }
+
+        in.skipBytes(20);
+
+        long numSessions = in.readUnsignedInt();
+        long numFrames = in.readUnsignedInt();
+        sessionOffset = in.readUnsignedInt();
+        in.skipBytes(4);
+        long fileSize = in.readUnsignedInt();
+        in.skipBytes(12);
+        long fileSize2 = in.readUnsignedInt();
+        if (fileSize != fileSize2) throw new FormatException("Improper header. File sizes do not match.");
+        in.skipBytes(16);
+        long mystery1 = in.readUnsignedInt();  // 1024 in all examples
+
+        CoreMetadata m = core.get(0);
+
+        m.dimensionOrder = "XYZCT";
+        m.rgb = false;
+        m.interleaved = false;
+        m.littleEndian = IS_LITTLE;
+        m.indexed = false;
+        m.falseColor = false;
+        m.metadataComplete = true;
+        m.thumbnail = false;
+        m.sizeC = 1;
+        m.sizeZ = 1;
+        m.imageCount = getSizeZ() * getSizeC();
+
+        if (version == DCAM_VERSION_0) {
+            parseDCAMVersion0Header();
+        } else if (version == DCAM_VERSION_1) {
+            parseDCAMVersion1Header();
+        }
+
+        if (pixelType == DCIMG_PIXELTYPE_MONO8) {
+            m.pixelType = FormatTools.UINT8;
+            byteFactor = 1;
+        } else if (pixelType == DCIMG_PIXELTYPE_MONO16) {
+            m.pixelType = FormatTools.UINT16;
+            byteFactor = 2;
+        }
+
+        addGlobalMeta("Version", version);
+
+        // The metadata store we're working with.
+        MetadataStore store = makeFilterMetadata();
+        MetadataTools.populatePixels(store, this);
+
+    }
+
+    private void parseDCAMVersion0Header() throws IOException {
+        
+    }
+
+    private void parseDCAMVersion1Header() throws IOException {
+        CoreMetadata m = core.get(0);
+
+        in.seek(sessionOffset);
+        long sessionLength = in.readUnsignedInt();
+        in.skipBytes(20);
+        long pseudoOffset = in.readUnsignedInt(); 
+        in.skipBytes(32);  // unknown numbers 1, 144, 65537
+        m.sizeT = (int) in.readUnsignedInt();
+        pixelType = in.readUnsignedInt();
+        long mystery1 = in.readUnsignedInt();
+        // TODO: Is this casting always legal? I think not...
+        m.sizeX = (int) in.readUnsignedInt();  // num columns (this is a column-major format)
+        m.sizeY = (int) in.readUnsignedInt();  // num rows
+        long bytesPerRow = in.readUnsignedInt();
+        long bytesPerImage = in.readUnsignedInt();
+        in.skipBytes(8);
+        dataOffset = in.readUnsignedInt();
+        in.skipBytes(16);
+        long bytesPerFrame = in.readUnsignedInt();
+
+    }
+}


### PR DESCRIPTION
I found myself in the fortunate position of regularly needing to investigate bead stacks acquired as `.dcimg` files. My goal was to load them and reslice in xz. This seemed easiest to do in ImageJ, so I ported a merge of some existing DCIMG readers to Java for use as a local tool. The result is presented here, in case there is broader interest in the reader.

There are a few things to note:

1. On a Mac (works fine on Windows), while the stacks load fine, reslicing does not work on the loaded stack. I receive the error

```
java.lang.IllegalArgumentException: Invalid bitDepth: 0
  at ij.gui.NewImage.createImage(NewImage.java:397)
  at ij.plugin.Slicer.createOutputStack(Slicer.java:462)
  at ij.plugin.Slicer.resliceRectOrLine(Slicer.java:442)
  at ij.plugin.Slicer.reslice(Slicer.java:115)
  at ij.plugin.Slicer.run(Slicer.java:80)
  at ij.IJ.runPlugIn(IJ.java:216)
  at ij.Executer.runCommand(Executer.java:152)
  at ij.Executer.run(Executer.java:70)
  at java.lang.Thread.run(Thread.java:750)
```

If I duplicate the stack, reslicing works fine. Does anyone know what is likely to cause such an error just on a Mac?

2. I’ve made a design choice, where multiple frames within a single DCIMG file are loaded in `T` and multiple DCIMG files are loaded along `Z`. 

3. I’ve done the bare minimum on loading metadata.

4. I have only tested the 4 pixel correction on older DCIMG 0x7. I don’t have any examples of DCIMG 0x1000000 or 0x2000000 that need the 4 pixel correction, though I would be happy to take a look at one.
