### PR TITLE
tiffcomment: fix `-version`, `-no-upgrade`, `-debug`, `-trace`

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -56,7 +56,7 @@ public class TiffComment {
     if (args.length == 0) {
       System.out.println("Usage:");
       System.out.println(
-        "tiffcomment [-set comment] [-edit] file1 [file2 ...]");
+        "tiffcomment [-version] [-debug] [-trace] [-no-upgrade] [-set comment] [-edit] file1 [file2 ...]");
       System.out.println();
 
       System.out.println("This tool requires an ImageDescription tag to be " +
@@ -71,6 +71,12 @@ public class TiffComment {
       System.out.println("  * '-', to enter the comment using stdin.  " +
         "Entering a blank line will");
       System.out.println("    terminate reading from stdin.");
+      System.out.println();
+      System.out.println("Additional options:");
+      System.out.println("    -version: print the library version");
+      System.out.println(" -no-upgrade: do not perform the upgrade check");
+      System.out.println("      -debug: enable DEBUG-level logging");
+      System.out.println("      -trace: enable TRACE-level logging");
       return;
     }
 

--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 
 import loci.common.Constants;
 import loci.common.DataTools;
+import loci.common.DebugTools;
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.formats.FormatException;
@@ -73,8 +74,6 @@ public class TiffComment {
       return;
     }
 
-    CommandLineTools.runUpgradeCheck(args);
-
     // parse flags
     boolean edit = false;
     String newComment = null;
@@ -106,8 +105,21 @@ public class TiffComment {
           }
         }
       }
-      else System.out.println("Warning: unknown flag: " + args[i]);
+      else if (args[i].equals(CommandLineTools.VERSION)) {
+        CommandLineTools.printVersion();
+      }
+      else if (args[i].equals("-debug")) {
+        DebugTools.setRootLevel("DEBUG");
+      }
+      else if (args[i].equals("-trace")) {
+        DebugTools.setRootLevel("TRACE");
+      }
+      else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
+        System.out.println("Warning: unknown flag: " + args[i]);
+      }
     }
+
+    CommandLineTools.runUpgradeCheck(args);
 
     // process files
     for (String file : files) {

--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -73,7 +73,7 @@ public class TiffComment {
       System.out.println("    terminate reading from stdin.");
       System.out.println();
       System.out.println("Additional options:");
-      System.out.println("    -version: print the library version");
+      System.out.println("    -version: print the library version and exit");
       System.out.println(" -no-upgrade: do not perform the upgrade check");
       System.out.println("      -debug: enable DEBUG-level logging");
       System.out.println("      -trace: enable TRACE-level logging");
@@ -113,6 +113,7 @@ public class TiffComment {
       }
       else if (args[i].equals(CommandLineTools.VERSION)) {
         CommandLineTools.printVersion();
+        return;
       }
       else if (args[i].equals("-debug")) {
         DebugTools.setRootLevel("DEBUG");


### PR DESCRIPTION
`tiffcomment` previously did not allow `-version`, `-debug` or `-trace`, and would incorrectly indicate that `-no-upgrade` was an unsupported option.

All 4 options should now behave as they do in `showinf` and `bfconvert`. In particular, `tiffcomment -debug ...` should indicate the upgrade check status and `tiffcomment -debug -no-upgrade ...` should indicate that the upgrade check is skipped.

I have not attempted to modernize option parsing here, as that's a bigger project, and likely something we'd want to do across all of the tools at once. This PR should hopefully help in the near term though.