### PR TITLE
OIR: parse time step from TIMELAPSE axis when possible

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.xml.parsers.ParserConfigurationException;
 
+import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
@@ -1198,8 +1199,8 @@ public class OIRReader extends FormatReader {
               // prefer setting tStep from the TIMELAPSE axis,
               // but fall back to this if needed
               if (seriesInterval != null && tStep == null) {
-                // units are seconds, so multiply to get milliseconds
-                tStep = DataTools.parseDouble(seriesInterval.getTextContent()) * 1000;
+                // units are expected to be milliseconds
+                tStep = DataTools.parseDouble(seriesInterval.getTextContent());
               }
             }
           }
@@ -1367,8 +1368,12 @@ public class OIRReader extends FormatReader {
       else if (name.equals("TIMELAPSE")) {
         if (m.sizeT <= 1) {
           m.sizeT = Integer.parseInt(size.getTextContent());
-          tStart = DataTools.parseDouble(start.getTextContent());
-          tStep = DataTools.parseDouble(step.getTextContent());
+          // units are expected to be seconds, multiply to get milliseconds
+          tStart = DataTools.parseDouble(start.getTextContent()) * 1000;
+          double stepValue = DataTools.parseDouble(step.getTextContent());
+          if (stepValue > Constants.EPSILON) {
+            tStep = stepValue * 1000;
+          }
         }
       }
       else if (name.equals("LAMBDA")) {

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -92,6 +92,7 @@ public class OIRReader extends FormatReader {
 
   private transient Double zStart;
   private transient Double zStep;
+  private transient Double tStart;
   private transient Double tStep;
   private transient HashMap<Integer, Double> timestampAdjustments = new HashMap<Integer, Double>();
 
@@ -277,6 +278,7 @@ public class OIRReader extends FormatReader {
       minT = Integer.MAX_VALUE;
       zStart = null;
       zStep = null;
+      tStart = null;
       tStep = null;
     }
   }
@@ -603,6 +605,9 @@ public class OIRReader extends FormatReader {
       for (int i=0; i<getImageCount(); i++) {
         int t = getZCTCoords(i)[2];
         double deltaT = t * tStep;
+        if (tStart != null) {
+          deltaT += tStart;
+        }
         for (Integer frame : timestampAdjustments.keySet()) {
           if (t >= frame) {
             deltaT += (timestampAdjustments.get(frame) - tStep);
@@ -1189,8 +1194,12 @@ public class OIRReader extends FormatReader {
               Element speed = getFirstChild(getFirstChild(scanner, "lsmimage:param"), "lsmparam:speed");
               speed = getFirstChild(speed, "commonparam:speedInformation");
               Element seriesInterval = getFirstChild(speed, "commonparam:seriesInterval");
-              if (seriesInterval != null) {
-                tStep = DataTools.parseDouble(seriesInterval.getTextContent());
+
+              // prefer setting tStep from the TIMELAPSE axis,
+              // but fall back to this if needed
+              if (seriesInterval != null && tStep == null) {
+                // units are seconds, so multiply to get milliseconds
+                tStep = DataTools.parseDouble(seriesInterval.getTextContent()) * 1000;
               }
             }
           }
@@ -1358,6 +1367,8 @@ public class OIRReader extends FormatReader {
       else if (name.equals("TIMELAPSE")) {
         if (m.sizeT <= 1) {
           m.sizeT = Integer.parseInt(size.getTextContent());
+          tStart = DataTools.parseDouble(start.getTextContent());
+          tStep = DataTools.parseDouble(step.getTextContent());
         }
       }
       else if (name.equals("LAMBDA")) {


### PR DESCRIPTION
See https://forum.image.sc/t/bio-formats-reads-wrong-time-interval-from-oir-time-lapse-images/105684/

Without this change, `showinf -nopix -omexml` on the provided file (in `curated/olympus-oir/imagesc-105684/`) should show `Plane.DeltaT` values spaced ~2.17 seconds apart. With this change, `Plane.DeltaT` values should be spaced 30 seconds apart.

The time step is now being parsed the same way that the Z step is parsed, so I think this makes sense. I would expect some test failures overnight in the `DeltaT` test for existing .oir data; I can update configs as needed later in the week, or we can exclude temporarily.