### PR TITLE
bfsave: use the metadata endianness to create the byte array

### DIFF
--- a/components/formats-bsd/matlab/bfsave.m
+++ b/components/formats-bsd/matlab/bfsave.m
@@ -109,17 +109,18 @@ end
 writer.setId(ip.Results.outputPath);
 
 % Load conversion tools for saving planes
+isLittleEndian = ~metadata.getPixelsBigEndian(0).booleanValue;
 switch class(ip.Results.I)
     case {'int8', 'uint8'}
         getBytes = @(x) x(:);
     case {'uint16','int16'}
-        getBytes = @(x) javaMethod('shortsToBytes', 'loci.common.DataTools', x(:), 0);
+        getBytes = @(x) javaMethod('shortsToBytes', 'loci.common.DataTools', x(:), isLittleEndian);
     case {'uint32','int32'}
-        getBytes = @(x) javaMethod('intsToBytes', 'loci.common.DataTools', x(:), 0);
+        getBytes = @(x) javaMethod('intsToBytes', 'loci.common.DataTools', x(:), isLittleEndian);
     case {'single'}
-        getBytes = @(x) javaMethod('floatsToBytes', 'loci.common.DataTools', x(:), 0);
+        getBytes = @(x) javaMethod('floatsToBytes', 'loci.common.DataTools', x(:), isLittleEndian);
     case 'double'
-        getBytes = @(x) javaMethod('doublesToBytes', 'loci.common.DataTools', x(:), 0);
+        getBytes = @(x) javaMethod('doublesToBytes', 'loci.common.DataTools', x(:), isLittleEndian);
 end
 
 % Save planes to the writer


### PR DESCRIPTION
See https://forum.image.sc/t/issues-with-bfsave-and-native-ome-metadata/106195

The existing code assumes the data are ordered using big-endian as in the default minimal OME-XML metadata.
This adjusts the code to handle OME metadata specifying little-endian ordering

Testing can be done by downloading the LSM file uploaded https://zenodo.org/records/14510432 at running the minimal code (https://matlab.mathworks.com/ might be 

```
data=bfopen('10-01.lsm');
bfsave(cat(3,data{1}{:,1}),'10-01.ome.tiff','metadata',data{4});
```

Without this PR, the OME-TIFF should appear corrupted. With this PR included, the array ordering should match the metadata and the output of `showinf 10-01.lsm` should match `showinf 10-01.ome.tiff`.

Additional tests should probably be performed e.g. using synthetic sample files with different endianness  and pixel types to ensure that the logic works in all scenarios.

