### PR TITLE
Bump ome-common, ome-model and ome-metakit to their latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,14 @@
     <logback.version>1.3.15</logback.version>
     <ome-stubs.version>6.0.2</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.7</ome-metakit.version>
+    <ome-metakit.version>5.3.8</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.24</ome-common.version>
+    <ome-common.version>6.0.25</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.3.6</ome-model.version>
+    <ome-model.version>6.4.0</ome-model.version>
     <ome-poi.version>5.3.9</ome-poi.version>
     <ome-mdbtools.version>5.3.3</ome-mdbtools.version>
     <ome-jai.version>0.1.4</ome-jai.version>


### PR DESCRIPTION
See https://github.com/ome/ome-model/releases/tag/v6.4.0, https://github.com/ome/ome-common-java/releases/tag/v6.0.25 and https://github.com/ome/ome-metakit/releases/tag/v5.3.8 for more details