### PR TITLE
CellSensReader: set the VSI file as the first of getUsedFiles

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -770,7 +770,7 @@ public class CellSensReader extends FormatReader {
 
       if (s < files.size() - 1) {
         setCoreIndex(index);
-        String ff = files.get(s);
+        String ff = files.get(s + 1);
         /**
          * If there are more frame_*.ets files than there are metadata 'pyramids'
          * defined in the .vsi, then we have orphaned frame files.  In this case
@@ -787,8 +787,8 @@ public class CellSensReader extends FormatReader {
              */
              if (!validFrameFile) {
                 core.remove(core.size()-1);
-                extraFiles.add(files.get(s));
-                files.remove(s);
+                extraFiles.add(files.get(s + 1));
+                files.remove(s + 1);
                 usedFiles = files.toArray(new String[files.size()]);
                 s--;
                 seriesCount--;

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -692,6 +692,7 @@ public class CellSensReader extends FormatReader {
     String name = file.getName();
     name = name.substring(0, name.lastIndexOf("."));
 
+    files.add(file.getAbsolutePath());
     Location pixelsDir = new Location(dir, "_" + name + "_");
     String[] stackDirs = pixelsDir.list(true);
     if (stackDirs != null) {
@@ -712,7 +713,6 @@ public class CellSensReader extends FormatReader {
         }
       }
     }
-    files.add(file.getAbsolutePath());
     usedFiles = files.toArray(new String[files.size()]);
 
     if (expectETS && files.size() == 1) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -656,8 +656,6 @@ public class CellSensReader extends FormatReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-    super.initFile(id);
-
     if (!checkSuffix(id, "vsi")) {
       Location current = new Location(id).getAbsoluteFile();
       Location parent = current.getParentFile();
@@ -671,9 +669,11 @@ public class CellSensReader extends FormatReader {
         throw new FormatException("Could not find .vsi file.");
       }
       else {
-        id = vsiFile.getAbsolutePath();
+        initFile(vsiFile.getAbsolutePath());
+        return;
       }
     }
+    super.initFile(id);
 
     parser = new TiffParser(id);
     ifds = parser.getMainIFDs();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1869,7 +1869,6 @@ public class FormatReaderTest {
       if (!(reader.getFormat().equals("Bio-Rad PIC")) &&
           !(reader.getFormat().equals("Metamorph STK")) &&
           !(reader.getFormat().equals("Evotec Flex")) &&
-          !(reader.getFormat().equals("CellSens VSI")) &&
           !(reader.getFormat().equals("PerkinElmer")) &&
           !(reader.getFormat().equals("Fuji LAS 3000")) &&
           !(reader.getFormat().equals("Micro-Manager")) &&


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/4172 for more background

Also re-include the format in the `testSaneUsedFiles` tests checking that `getCurrentFile` matches the first element in `getUsedFiles`