### PR TITLE
InCell: allow mix of 2D and 3D channels to be treated as a Z stack

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -464,7 +464,8 @@ public class InCellReader extends FormatReader {
       }
       int expectedSeries = totalImages / (getSizeZ() * getSizeC() * getSizeT());
       if (expectedSeries > 0) {
-        seriesCount = (int) Math.min(seriesCount, expectedSeries);
+        LOGGER.warn("Using series count {} but plane count indicates {}",
+          seriesCount, expectedSeries);
       }
     }
     else seriesCount = totalImages / (getSizeZ() * getSizeC() * getSizeT());
@@ -791,7 +792,7 @@ public class InCellReader extends FormatReader {
     private int wellRow, wellCol;
     private int nChannels = 0;
     private boolean doT = true;
-    private boolean doZ = true;
+    private Boolean doZ = null;
     private Image lastImage = null;
 
     @Override
@@ -908,7 +909,11 @@ public class InCellReader extends FormatReader {
         String fusion = attributes.getValue("fusion_wave");
         if (fusion.equals("false")) ms0.sizeC++;
         String mode = attributes.getValue("imaging_mode");
-        if (mode != null) {
+
+        // different wavelengths (channels) may have different imaging modes
+        // we want to allow a Z stack if one or more "3-D" imaging modes
+        // are encountered, even if some are variations on "2-D"
+        if (mode != null && (doZ == null || !doZ)) {
           doZ = mode.equals("3-D");
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -67,6 +67,9 @@ public class InCellReader extends FormatReader {
 
   // -- Constants --
 
+  public static final String DUPLICATE_PLANES_KEY = "incell.duplicate_missing_planes";
+  public static final boolean DUPLICATE_PLANES_DEFAULT = true;
+
   public static final String INCELL_MAGIC_STRING = "IN Cell Analyzer";
   public static final String CYTELL_MAGIC_STRING = "Cytell";
 
@@ -125,6 +128,17 @@ public class InCellReader extends FormatReader {
     hasCompanionFiles = true;
     datasetDescription = "One .xdce file with at least one .tif/.tiff or " +
       ".im file";
+  }
+
+  // -- InCellReader API methods --
+
+  public boolean duplicatePlanes() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       DUPLICATE_PLANES_KEY, DUPLICATE_PLANES_DEFAULT);
+    }
+    return DUPLICATE_PLANES_DEFAULT;
   }
 
   // -- IFormatReader API methods --
@@ -191,9 +205,18 @@ public class InCellReader extends FormatReader {
       getSeries() % channelsPerTimepoint.size() : coordinates[2];
     int image = getIndex(coordinates[0], coordinates[1], 0);
 
-    if (imageFiles[well][field][timepoint][image] == null) return buf;
+    if (imageFiles[well][field][timepoint][image] == null) {
+      // unless otherwise configured, copy the first Z section
+      // to any other planes in the Z stack that are missing
+      if (duplicatePlanes() && coordinates[0] > 0) {
+        return openBytes(getIndex(0, coordinates[1], coordinates[2]), buf, x, y, w, h);
+      }
+      return buf;
+    }
     String filename = imageFiles[well][field][timepoint][image].filename;
-    if (filename == null || !(new Location(filename).exists())) return buf;
+    if (filename == null || !(new Location(filename).exists())) {
+      return buf;
+    }
 
     if (imageFiles[well][field][timepoint][image].isTiff) {
       try {
@@ -329,6 +352,14 @@ public class InCellReader extends FormatReader {
   }
 
   // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#getAvailableOptions() */
+  @Override
+  protected ArrayList<String> getAvailableOptions() {
+    ArrayList<String> optionsList = super.getAvailableOptions();
+    optionsList.add(DUPLICATE_PLANES_KEY);
+    return optionsList;
+  }
 
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -112,6 +112,8 @@ public class InCellReader extends FormatReader {
   private List<String> exFilters = new ArrayList<String>();
   private List<String> emFilters = new ArrayList<String>();
 
+  private transient boolean variableZ = false;
+
   // -- Constructor --
 
   /** Constructs a new InCell 1000/2000 reader. */
@@ -280,6 +282,7 @@ public class InCellReader extends FormatReader {
       refractive = null;
       emFilters.clear();
       exFilters.clear();
+      variableZ = false;
     }
   }
 
@@ -464,8 +467,18 @@ public class InCellReader extends FormatReader {
       }
       int expectedSeries = totalImages / (getSizeZ() * getSizeC() * getSizeT());
       if (expectedSeries > 0) {
-        LOGGER.warn("Using series count {} but plane count indicates {}",
-          seriesCount, expectedSeries);
+        if (variableZ) {
+          // we know that different channels may have different Z sizes,
+          // so don't try to recalculate the series count based on
+          // SizeZ * SizeC
+          LOGGER.warn("Using series count {} but plane count indicates {}",
+            seriesCount, expectedSeries);
+        }
+        else {
+          // we expect all channels to have the same Z size,
+          // so recalculate the series count based on the expected number of planes
+          seriesCount = (int) Math.min(seriesCount, expectedSeries);
+        }
       }
     }
     else seriesCount = totalImages / (getSizeZ() * getSizeC() * getSizeT());
@@ -792,7 +805,7 @@ public class InCellReader extends FormatReader {
     private int wellRow, wellCol;
     private int nChannels = 0;
     private boolean doT = true;
-    private Boolean doZ = null;
+    private boolean doZ = true;
     private Image lastImage = null;
 
     @Override
@@ -913,8 +926,15 @@ public class InCellReader extends FormatReader {
         // different wavelengths (channels) may have different imaging modes
         // we want to allow a Z stack if one or more "3-D" imaging modes
         // are encountered, even if some are variations on "2-D"
-        if (mode != null && (doZ == null || !doZ)) {
-          doZ = mode.equals("3-D");
+        if (mode != null) {
+          boolean is3D = mode.equals("3-D");
+          // record if there were different imaging modes found
+          if (!variableZ && is3D != doZ && ms0.sizeC > 1) {
+            variableZ = true;
+          }
+          if (ms0.sizeC == 1 || !doZ) {
+            doZ = is3D;
+          }
         }
       }
       else if (qName.equals("AcqWave")) {


### PR DESCRIPTION
See https://forum.image.sc/t/incell-plates-with-z-stacks-cannot-be-imported-on-omero/107802 and data copied to `inbox/imagesc-107802`.

As indicated in the forum post, one channel in the plate has a Z stack (16 slices), while the remaining channels have a single Z slice. The changes in lines 795 and later are to pick up the dimensions of each field as 16 Z x 4 C, with most planes blank.

The changes in lines 467-468 are necessary because the total image count is 152, and the number of planes per field is 64 - so the `expectedSeries` calculation results in 2, when there are actually 8 series (4 fields x 2 wells). This change in particular might break some older data, so we'll see what the test results are, and may need to exclude/rework this a bit.

Adding to 8.1.1 milestone instead of 8.1.0, anticipating that some extra work will be needed.