### PR TITLE
FakeReader: add support for populating channel wavelengths and instrument

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -609,6 +609,7 @@ public class FakeReader extends FormatReader {
     boolean metadataComplete = true;
     boolean thumbnail = false;
     boolean withMicrobeam = false;
+    boolean withInstrument = false;
 
     int seriesCount = 1;
     int resolutionCount = 1;
@@ -720,6 +721,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("fields")) fields = intValue;
       else if (key.equals("plateAcqs")) plateAcqs = intValue;
       else if (key.equals("withMicrobeam")) withMicrobeam = boolValue;
+      else if (key.equals("withInstrument")) withInstrument = boolValue;
       else if (key.equals("annLong")) annLong = intValue;
       else if (key.equals("annDouble")) annDouble = intValue;
       else if (key.equals("annMap")) annMap = intValue;
@@ -852,6 +854,8 @@ public class FakeReader extends FormatReader {
         populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs, withMicrobeam);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
+    } else if (withInstrument) {
+      populateInstrument(store);
     }
 
     // populate core metadata
@@ -1398,6 +1402,15 @@ public class FakeReader extends FormatReader {
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);
     domains = new String[] {FormatTools.HCS_DOMAIN};
     return ome.sizeOfImageList();
+  }
+
+  private void populateInstrument(MetadataStore store)
+  {
+    final XMLMockObjects xml = new XMLMockObjects();
+    OME ome = xml.getRoot();
+    ome.addInstrument(xml.createInstrument(true));
+    getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
+    getOmeXmlService().convertMetadata(omeXmlMetadata, store);
   }
 
   /** Creates a mapping between indices and color values. */

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -153,8 +153,8 @@ public class FakeReader extends FormatReader {
   private Length physicalSizeX, physicalSizeY, physicalSizeZ;
 
   /* channel wavelengths */
-  ArrayList<Length> excitationWavelengths = new ArrayList<Length>();
-  ArrayList<Length> emissionWavelengths = new ArrayList<Length>();
+  private transient ArrayList<Length> excitationWavelengths = new ArrayList<Length>();
+  private transient ArrayList<Length> emissionWavelengths = new ArrayList<Length>();
 
   /* annotation counts per file */
   private int annBool = 0;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -152,6 +152,10 @@ public class FakeReader extends FormatReader {
   /* physical sizes */
   private Length physicalSizeX, physicalSizeY, physicalSizeZ;
 
+  /* channel wavelengths */
+  ArrayList<Length> excitationWavelengths = new ArrayList<Length>();
+  ArrayList<Length> emissionWavelengths = new ArrayList<Length>();
+
   /* annotation counts per file */
   private int annBool = 0;
   private int annComment = 0;
@@ -511,6 +515,8 @@ public class FakeReader extends FormatReader {
     plateCols = 0;
     fields = 0;
     plateAcqs = 0;
+    excitationWavelengths.clear();
+    emissionWavelengths.clear();
     super.close(fileOnly);
   }
 
@@ -620,8 +626,6 @@ public class FakeReader extends FormatReader {
 
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
-    ArrayList<Length> excitationWavelengths = new ArrayList<Length>();
-    ArrayList<Length> emissionWavelengths = new ArrayList<Length>();
 
     ArrayList<IniTable> seriesTables = new ArrayList<IniTable>();
 
@@ -900,6 +904,7 @@ public class FakeReader extends FormatReader {
     MetadataTools.populatePixels(store, this, planeInfo);
     fillExposureTime(store);
     fillPhysicalSizes(store);
+    fillChannelWavelengths(store);
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
       if (currentImageIndex < seriesTables.size()) {
         parseSeriesTable(seriesTables.get(currentImageIndex), store, currentImageIndex);
@@ -916,12 +921,6 @@ public class FakeReader extends FormatReader {
         }
         if (channel != null) {
           store.setChannelColor(channel, currentImageIndex, c);
-        }
-        if (c < emissionWavelengths.size() && emissionWavelengths.get(c) != null) {
-          store.setChannelEmissionWavelength(emissionWavelengths.get(c), currentImageIndex, c);
-        }
-        if (c < excitationWavelengths.size() && excitationWavelengths.get(c) != null) {
-          store.setChannelExcitationWavelength(excitationWavelengths.get(c), currentImageIndex, c);
         }
       }
       fillAnnotations(store, currentImageIndex);
@@ -986,6 +985,19 @@ public class FakeReader extends FormatReader {
       }
     }
     setSeries(oldSeries);
+  }
+
+  private void fillChannelWavelengths(MetadataStore store) {
+    for (int s=0; s<getSeriesCount(); s++) {
+      for (int c=0; c<getEffectiveSizeC(); c++) {
+        if (c < emissionWavelengths.size() && emissionWavelengths.get(c) != null) {
+          store.setChannelEmissionWavelength(emissionWavelengths.get(c), s, c);
+        }
+        if (c < excitationWavelengths.size() && excitationWavelengths.get(c) != null) {
+          store.setChannelExcitationWavelength(excitationWavelengths.get(c), s, c);
+        }
+      }
+    }
   }
 
   private void fillAcquisitionDate(MetadataStore store, String date, int imageIndex) {

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -32,6 +32,8 @@
 
 package loci.formats.in;
 
+import static ome.xml.model.Channel.getEmissionWavelengthUnitXsdDefault;
+import static ome.xml.model.Channel.getExcitationWavelengthUnitXsdDefault;
 import static ome.xml.model.Pixels.getPhysicalSizeXUnitXsdDefault;
 import static ome.xml.model.Pixels.getPhysicalSizeYUnitXsdDefault;
 import static ome.xml.model.Pixels.getPhysicalSizeZUnitXsdDefault;
@@ -617,6 +619,8 @@ public class FakeReader extends FormatReader {
 
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
+    ArrayList<Length> excitationWavelengths = new ArrayList<Length>();
+    ArrayList<Length> emissionWavelengths = new ArrayList<Length>();
 
     ArrayList<IniTable> seriesTables = new ArrayList<IniTable>();
 
@@ -755,6 +759,20 @@ public class FakeReader extends FormatReader {
           color.add(null);
         }
         color.set(index, parseColor(value));
+      } else if (key.startsWith("emission_")) {
+        int index = Integer.parseInt(key.substring(key.indexOf('_') + 1));
+        while (index >= emissionWavelengths.size()) {
+          emissionWavelengths.add(null);
+        }
+        emissionWavelengths.set(index, parseWavelength(
+          value, getEmissionWavelengthUnitXsdDefault()));
+      } else if (key.startsWith("excitation_")) {
+        int index = Integer.parseInt(key.substring(key.indexOf('_') + 1));
+        while (index >= excitationWavelengths.size()) {
+          excitationWavelengths.add(null);
+        }
+        excitationWavelengths.set(index, parseWavelength(
+          value, getExcitationWavelengthUnitXsdDefault()));
       } else if (key.equals("sleepOpenBytes")) {
         sleepOpenBytes = intValue;
       } else if (key.equals("sleepInitFile")) {
@@ -894,6 +912,12 @@ public class FakeReader extends FormatReader {
         }
         if (channel != null) {
           store.setChannelColor(channel, currentImageIndex, c);
+        }
+        if (c < emissionWavelengths.size() && emissionWavelengths.get(c) != null) {
+          store.setChannelEmissionWavelength(emissionWavelengths.get(c), currentImageIndex, c);
+        }
+        if (c < excitationWavelengths.size() && excitationWavelengths.get(c) != null) {
+          store.setChannelExcitationWavelength(excitationWavelengths.get(c), currentImageIndex, c);
         }
       }
       fillAnnotations(store, currentImageIndex);
@@ -1482,6 +1506,18 @@ public class FakeReader extends FormatReader {
       return null;
     }
     return physicalSize;
+  }
+
+  private Length parseWavelength(String s, String defaultUnit) {
+    Length wavelength = FormatTools.parseLength(s, defaultUnit);
+    if (wavelength == null) {
+      throw new RuntimeException("Invalid wavelength: " + s);
+    }
+    if (!FormatTools.isPositiveValue(wavelength.value().doubleValue())) {
+      LOGGER.warn("Invalid wavelength value: {}", wavelength.value());
+      return null;
+    }
+    return wavelength;
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1244,6 +1244,18 @@ public class FakeReader extends FormatReader {
     for (int c=0; c<getEffectiveSizeC(); c++) {
       String channelName = table.get("ChannelName_" + c);
       store.setChannelName(channelName, newSeries, c);
+      String emissionWavelength = table.get("ChannelEmissionWavelength_" + c);
+      if (emissionWavelength != null) {
+        store.setChannelEmissionWavelength(
+          parseWavelength(emissionWavelength, getEmissionWavelengthUnitXsdDefault()),
+          newSeries, c);
+      }
+      String excitationWavelength = table.get("ChannelExcitationWavelength_" + c);
+      if (excitationWavelength != null) {
+        store.setChannelExcitationWavelength(
+          parseWavelength(excitationWavelength, getExcitationWavelengthUnitXsdDefault()),
+          newSeries, c);
+      }
     }
 
     for (int i=0; i<getImageCount(); i++) {

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -722,4 +722,43 @@ public class FakeReaderTest {
     reader.setId("test&dimOrder=CXYZT.fake");
   }
 
+  @Test
+  public void testExcitationWavelengths() throws Exception {
+    File fakeIni = mkIni("excitationWavelengths.fake.ini",
+      "sizeC=5",
+      "excitation_0 = 502nm",
+      "excitation_1 = 502.0nm",
+      "excitation_2 = 502",
+      "excitation_4 = 5020Å");
+    reader.setId(wd.resolve("excitationWavelengths.fake").toString());
+    assertEquals(reader.getSizeC(), 5);
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getChannelExcitationWavelength(0, 0), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(0, 1), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(0, 2), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(0, 3), null);
+    assertEquals(m.getChannelExcitationWavelength(0, 4), new Length(5020.0, UNITS.ANGSTROM));
+    reader.close();
+  }
+
+  @Test
+  public void testEmissionWavelengths() throws Exception {
+    File fakeIni = mkIni("emissionWavelengths.fake.ini",
+      "sizeC=5",
+      "emission_0 = 502nm",
+      "emission_1 = 502.0nm",
+      "emission_2 = 502",
+      "emission_4 = 5020Å");
+    reader.setId(wd.resolve("emissionWavelengths.fake").toString());
+    assertEquals(reader.getSizeC(), 5);
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getChannelEmissionWavelength(0, 0), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 1), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 2), new Length(502.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 3), null);
+    assertEquals(m.getChannelEmissionWavelength(0, 4), new Length(5020.0, UNITS.ANGSTROM));
+    reader.close();
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -761,4 +761,13 @@ public class FakeReaderTest {
     assertEquals(m.getChannelEmissionWavelength(0, 4), new Length(5020.0, UNITS.ANGSTROM));
     reader.close();
   }
+
+  @Test
+  public void testInstrument() throws Exception {
+    reader.setId("test&withInstrument=true.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getInstrumentCount(), 1);
+    reader.close();
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -790,6 +790,33 @@ public class FakeReaderTest {
   }
 
   @Test
+  public void testWavelengthSeriesOverride() throws Exception {
+    File fakeIni = mkIni("multiseries_wavelengths.fake.ini",
+      "series=2",
+      "sizeC=2",
+      "excitation_0=340nm",
+      "emission_0=450nm",
+      "excitation_1=470nm",
+      "emission_1=512nm",
+      "[series_0]",
+      "[series_1]",
+      "ChannelExcitationWavelength_0=350.0nm",
+      "ChannelEmissionWavelength_0=425.0nm",
+      "ChannelExcitationWavelength_1=500.0nm",
+      "ChannelEmissionWavelength_1=580.0nm");
+    reader.setId(fakeIni.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getChannelExcitationWavelength(0, 0), new Length(340.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 0), new Length(450.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(0, 1), new Length(470.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 1), new Length(512.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(1, 0), new Length(350.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(1, 0), new Length(425.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(1, 1), new Length(500.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(1, 1), new Length(580.0, UNITS.NANOMETER));
+  }
+
+  @Test
   public void testInstrument() throws Exception {
     reader.setId("test&withInstrument=true.fake");
     m = service.asRetrieve(reader.getMetadataStore());

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -763,6 +763,33 @@ public class FakeReaderTest {
   }
 
   @Test
+  public void testWavelengthSeries() throws Exception {
+    File fakeIni = mkIni("multiseries_wavelengths.fake.ini",
+      "series=2",
+      "sizeC=2",
+      "[series_0]",
+      "ChannelExcitationWavelength_0=340.0nm",
+      "ChannelEmissionWavelength_0=450.0nm",
+      "ChannelExcitationWavelength_1=470.0nm",
+      "ChannelEmissionWavelength_1=512.0nm",
+      "[series_1]",
+      "ChannelExcitationWavelength_0=350.0nm",
+      "ChannelEmissionWavelength_0=425.0nm",
+      "ChannelExcitationWavelength_1=500.0nm",
+      "ChannelEmissionWavelength_1=580.0nm");
+    reader.setId(fakeIni.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getChannelExcitationWavelength(0, 0), new Length(340.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 0), new Length(450.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(0, 1), new Length(470.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(0, 1), new Length(512.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(1, 0), new Length(350.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(1, 0), new Length(425.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelExcitationWavelength(1, 1), new Length(500.0, UNITS.NANOMETER));
+    assertEquals(m.getChannelEmissionWavelength(1, 1), new Length(580.0, UNITS.NANOMETER));
+  }
+
+  @Test
   public void testInstrument() throws Exception {
     reader.setId("test&withInstrument=true.fake");
     m = service.asRetrieve(reader.getMetadataStore());


### PR DESCRIPTION
See discussion at https://github.com/ome/omero-py/pull/443

This extends the FakeReader logic to be able to populate additional metadata:
- channel wavelengths (both emission & excitation): using a set of channel specific keys similar to how channel colors and channel names are set
- instrument: using a single boolean `withInstrument` key

With these changes, the following fake file should include channel wavelengths and an instrument

```
showinf "test&sizeC=3&emission_0=457nm&emission_1=528nm&excitation_0=360nm&excitation_1=490nm&withInstrument=true.fake" -omexml-only -nopix 
```

Up for discussion is the naming of the wavelength key as we have a mixture of supported styles - see https://bio-formats.readthedocs.io/en/latest/developers/generating-test-images.html#key-value-pairs. I started with a minimal version, alternatives would be:

- `emissionWavelength_x` / `excitationWavelength_x` (like `physicalSizeX`)
- `EmissionWavelength_x` / `ExcitationWavelength_x` (like `PositionX_x`)
- `ChannelEmissionWavelength_x` / `ChannelExcitationWavelength_x` (like `ChannelName_x`)