### PR TITLE
Metamorph: prevent NumberFormatException when trying to read wavelength in nm

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -34,6 +34,9 @@ import loci.common.xml.BaseHandler;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.xml.sax.Attributes;
 
 /**
@@ -44,6 +47,9 @@ import org.xml.sax.Attributes;
  * @author Thomas Caswell tcaswell at uchicago.edu
  */
 public class MetamorphHandler extends BaseHandler {
+
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(MetamorphHandler.class);
 
   // -- Fields --
 
@@ -256,7 +262,15 @@ public class MetamorphHandler extends BaseHandler {
       }
     }
     if (key.equals("wavelength")) {
-      wavelengths.add(Integer.parseInt(value));
+      // usually this key represents an integer wavelength in nm
+      // sometimes it can be a more descriptive string with no
+      // usable value in nm
+      try {
+        wavelengths.add(Integer.parseInt(value));
+      }
+      catch (NumberFormatException e) {
+        LOGGER.debug("Could not parse wavelength value from {}", value);
+      }
     }
     else if (key.equals("acquisition-time-local")) {
       date = value;


### PR DESCRIPTION
Fixes #4273.

Without this change, `showinf` on any of the files referenced in #4273 should throw a `NumberFormatException`, as indicated in the issue description. With this change, `showinf` on any of the files should display images as expected.

Checking a few of the files, there doesn't appear to be a valid wavelength in nm, e.g.:

```
$ pwd
/home/melissa/data/inbox/ssbd-232/FigureS2/TIFF/20211203_Vec_ISOto5HT_35mm
$ tiffinfo Dish2_w1FRET_t1.TIF | grep wavelength
<prop id="Description" type="string" value="Exposure: 100 ms&#13;&#10;Binning: 4 x 4&#13;&#10;Region: 2048 x 2048, offset at (0, 0)&#13;&#10;Subtract: Off&#13;&#10;Shading: Off&#13;&#10;Digitizer: 10 MHz&#13;&#10;Gain: 1&#13;&#10;Offset: 1&#13;&#10;Cooler On: 1&#13;&#10;Frames to Average: 1&#13;&#10;Trigger Mode: Normal (Internal)&#13;&#10;&#13;&#10;Illumination: FRET&#13;&#10;&#13;&#10;40xOil, bins4&#13;&#10;timelapse: 31 points / 30 min / 1 min&#13;&#10;(0-5 min: No stimuli, 6-15 min: 1st stimuli, 16-30 min: 2nd stimuli by recollecting media)&#13;&#10;wavelength: (1) FRET, 005(255), 100 ms (2) CFP, 005(255), 100 ms&#13;&#10;4 position: ISO 100 nM =&#62; HCl (vehicle)&#13;&#10;starvation: 22 hours&#13;&#10;cell line:  HRE191120F2&#13;&#10;expression: pCAGGS-MCS&#13;&#10;Dish: 35 mm, glass bottom&#13;&#10;&#13;&#10;"/>
<prop id="look-up-table-type" type="string" value="by-wavelength"/>
<prop id="wavelength" type="float" value="0"/>
```