### PR TITLE
ND2: preserve pixel type when a multi-position dataset is found

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -791,6 +791,7 @@ public class ND2Handler extends BaseHandler {
               int tSize = ms0.sizeT;
               int c = ms0.sizeC;
               String order = ms0.dimensionOrder;
+              int pixelType = ms0.pixelType;
               core = new CoreMetadataList();
               for (int i=0; i<numSeries; i++) {
                 CoreMetadata ms = new CoreMetadata();
@@ -801,6 +802,7 @@ public class ND2Handler extends BaseHandler {
                 ms.sizeC = c == 0 ? 1 : c;
                 ms.sizeT = tSize == 0 ? 1 : tSize;
                 ms.dimensionOrder = order;
+                ms.pixelType = pixelType;
               }
               ms0 = core.get(0, 0);
             }


### PR DESCRIPTION
See https://forum.image.sc/t/reconstructed-multiposition-files-from-nikon-sim-open-like-static-noise/108834 and data uploaded to https://zenodo.org/records/14893791.

`showinf` on that dataset with 8.1.0 shows that the pixel type is detected as `uint16`; NIS Elements Viewer confirms that the pixel type should be `float`.

With this change, `showinf -normalize` should also show a pixel type of `float`, and the image should correspond with the screenshot of NIS Elements in the forum thread. Omitting the `-normalize` option is expected not to work, but ImageJ can also be used to check that the image looks correct.