### PR TITLE
Make type cast explicit when calculating image count

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SpiderReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SpiderReader.java
@@ -246,7 +246,7 @@ public class SpiderReader extends FormatReader {
 
     m.imageCount = (int) Math.max(nSlice, 1);
     if (maxim > 0) {
-      m.imageCount *= maxim;
+      m.imageCount = (int) (maxim * m.imageCount);
     }
     m.sizeZ = getImageCount();
     m.sizeC = 1;


### PR DESCRIPTION
This is meant to test fixing an alert from CodeQL, and shouldn't otherwise impact builds.