### PR TITLE
Override `getAvailableOptions()` in CV7000 and SVS readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -265,6 +265,14 @@ public class CV7000Reader extends FormatReader {
 
   // -- Internal FormatReader API methods --
 
+  /* @see loci.formats.FormatReader#getAvailableOptions() */
+  @Override
+  protected ArrayList<String> getAvailableOptions() {
+    ArrayList<String> optionsList = super.getAvailableOptions();
+    optionsList.add(DUPLICATE_PLANES_KEY);
+    return optionsList;
+  }
+
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -336,6 +336,16 @@ public class SVSReader extends BaseTiffReader {
     return options;
   }
 
+  // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#getAvailableOptions() */
+  @Override
+  protected ArrayList<String> getAvailableOptions() {
+    ArrayList<String> optionsList = super.getAvailableOptions();
+    optionsList.add(REMOVE_THUMBNAIL_KEY);
+    return optionsList;
+  }
+
   // -- Internal BaseTiffReader API methods --
 
   /* @see loci.formats.BaseTiffReader#initStandardMetadata() */


### PR DESCRIPTION
Noticed while adding an option in https://github.com/ome/bioformats/pull/4270.

This shouldn't impact builds, but just unifies option reporting across readers. I think this was just an oversight in #4085 and #4144.

Haven't assigned a milestone yet, as not sure whether this is best done in a minor release, or OK for a patch.