### PR TITLE
ScanR: populate exposure times even if field positions are missing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -611,8 +611,13 @@ public class ScanrReader extends FormatReader {
       ms.bitsPerPixel = 12;
     }
 
+    // only populate Plane.The* if at least one kind of additional
+    // plane metadata is available
+    boolean populatePlanes = deltaT != null || exposures.size() >= getSizeC() ||
+      fieldPositionX != null || fieldPositionY != null;
+
     MetadataStore store = makeFilterMetadata();
-    MetadataTools.populatePixels(store, this);
+    MetadataTools.populatePixels(store, this, populatePlanes);
 
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateColumns(new PositiveInteger(wellColumns), 0);
@@ -688,32 +693,35 @@ public class ScanrReader extends FormatReader {
           store.setPixelsPhysicalSizeY(y, i);
         }
 
+
+        int field = i % nFields;
+        int well = i / nFields;
         if (fieldPositionX != null && fieldPositionY != null) {
-          int field = i % nFields;
-          int well = i / nFields;
           final Length posX = fieldPositionX[field];
           final Length posY = fieldPositionY[field];
-          
+
           store.setWellSamplePositionX(posX, 0, well, field);
           store.setWellSamplePositionY(posY, 0, well, field);
-          for (int c=0; c<getSizeC(); c++) {
-            int image = getIndex(0, c, 0);
-            store.setPlaneTheZ(new NonNegativeInteger(0), i, image);
-            store.setPlaneTheC(new NonNegativeInteger(c), i, image);
-            store.setPlaneTheT(new NonNegativeInteger(0), i, image);
-            store.setPlanePositionX(fieldPositionX[field], i, image);
-            store.setPlanePositionY(fieldPositionY[field], i, image);
+        }
 
-            // exposure time is stored in milliseconds
-            // convert to seconds before populating MetadataStore
-            Double time = exposures.get(c);
-            if (time != null) {
-              time /= 1000;
-              store.setPlaneExposureTime(new Time(time, UNITS.SECOND), i, image);
-            }
-            if (deltaT != null) {
-              store.setPlaneDeltaT(new Time(deltaT, UNITS.SECOND), i, image);
-            }
+        for (int image=0; image<getImageCount(); image++) {
+          if (fieldPositionX != null) {
+            store.setPlanePositionX(fieldPositionX[field], i, image);
+          }
+          if (fieldPositionY != null) {
+            store.setPlanePositionY(fieldPositionY[field], i, image);
+          }
+
+          // exposure time is stored in milliseconds
+          // convert to seconds before populating MetadataStore
+          int[] coords = getZCTCoords(image);
+          Double time = exposures.get(coords[1]);
+          if (time != null) {
+            time /= 1000;
+            store.setPlaneExposureTime(new Time(time, UNITS.SECOND), i, image);
+          }
+          if (deltaT != null) {
+            store.setPlaneDeltaT(new Time(deltaT, UNITS.SECOND), i, image);
           }
         }
       }


### PR DESCRIPTION
Fixes #4231.

Compare `showinf -nopix -omexml experiment_descriptor.xml` in `curated/scanr/embl/Maik_001` with and without this PR. Without this PR, no exposure times should be present in the OME-XML. With this change, a `Plane` should be populated in OME-XML for every plane, and an exposure time should be set for all.

This particular plate (and a couple of others, see config PR) appears to legitimately not have physical XY field positions, so conditioning all `Plane` metadata population on field positions existing doesn't make sense.