### PR TITLE
ImspectorReader: fix NumberFormatException on setId()

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -322,7 +322,6 @@ public class ImspectorReader extends FormatReader {
             break;
           case 2:
           case 3:
-          case 9:
           case 13:
           case 14:
           case 17:
@@ -335,6 +334,7 @@ public class ImspectorReader extends FormatReader {
           case 5:
           case 6:
           case 8:
+          case 9:
             key = value;
             value = String.valueOf(in.readInt());
             break;


### PR DESCRIPTION
Fixes #4139 

To reproduce this, use the sample file uploaded to https://zenodo.org/records/10476252. With Bio-Formats 8.1.0, `showinf` should fail with a `NumberFormatException`. With this PR, the command should read the file without issue