### PR TITLE
InCell: only record per-timepoint channel counts if timelapse enabled

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -867,7 +867,7 @@ public class InCellReader extends FormatReader {
           }
         }
       }
-      else if (qName.equals("TimePoint")) {
+      else if (qName.equals("TimePoint") && doT) {
         channelsPerTimepoint.add(nChannels);
         nChannels = 0;
       }


### PR DESCRIPTION
Fixes #4271. See data in `curated/incell/public/zenodo-14769820/`, particularly `Dataset_Fail`.

In some cases, a complex timelapse with varying channel counts per timepoint will be defined but not actually used. Examining the `TimeSchedule` under `PlateMap` in `Dataset3_RedoAcq_1.xdce` will show that the timepoints defined do not match up with the .tif files (where only 1 timepoint is present), but the `TimeSchedule` has `enabled` set to `false` and so should be ignored.

Without this change, `showinf -omexml Dataset3_RedoAcq_1.xdce` should throw an exception. With this change, the same test should initialize without exception, and display OME-XML and the first well's images. The ZCT dimensions and plate metadata should match up with the .tif file names.