### PR TITLE
fix for garbled images with CZIs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -4241,7 +4241,7 @@ public class ZeissCZIReader extends FormatReader {
         }
       }
 
-      throw new FormatException("DimensionEntry for 'X' not found");
+      throw new FormatException("DimensionEntry for 'Y' not found");
     }
 
     // -- Helper methods --

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -405,8 +405,12 @@ public class ZeissCZIReader extends FormatReader {
         {
           int res = (int) Math.pow(scaleFactor, plane.resolutionIndex);
 
-          int realX = plane.x / res;
-          int realY = plane.y / res;
+          // The physical extent (i.e. the number of pixels) for the respective sub-block is unambiguously given
+          //  by the "storedSize" of the respective dimension-entry. Note that this may differ from dividing the
+          //  logical extent by the scale-factor, e.g. due to rounding errors (since we are dealing here with integers
+          //  only).
+          int realX = plane.getPhysicalWidth();
+          int realY = plane.getPhysicalHeight();
 
           if ((prestitched != null && prestitched) || validScanDim) {
             Region tile = new Region(plane.col, plane.row, realX, realY);
@@ -4218,6 +4222,26 @@ public class ZeissCZIReader extends FormatReader {
         return buf;
       }
       return data;
+    }
+
+    public int getPhysicalWidth() throws FormatException {
+      for (DimensionEntry entry : this.directoryEntry.dimensionEntries) {
+        if ("X".equals(entry.dimension)) {
+          return entry.storedSize;
+        }
+      }
+
+      throw new FormatException("DimensionEntry for 'X' not found");
+    }
+
+    public int getPhysicalHeight() throws FormatException {
+      for (DimensionEntry entry : this.directoryEntry.dimensionEntries) {
+        if ("Y".equals(entry.dimension)) {
+          return entry.storedSize;
+        }
+      }
+
+      throw new FormatException("DimensionEntry for 'X' not found");
     }
 
     // -- Helper methods --


### PR DESCRIPTION
This is trying to address an issue which was seen with CZIs from e. g. AxioScan. Those CZIs contain pyramids, and under certain situations the resulting images are garbled like this:
![image](https://github.com/user-attachments/assets/060b12d8-f86b-45c8-8747-d5e581936ca6)

It was found that the code seems to determine the extent of the sub-blocks by dividing the logical size by a scale-factor (corresponding to the pyramid-layer), which seems highly questionable, or this assumption of equality seems unjustified. For the very least, it may give inaccurate results. The patched version is using information for the sub-block's dimension-entry array, which unambiguously gives the pixel-size (or: physical size) of the sub-block instead. For the cases investigated, this gives the correct result:
![image](https://github.com/user-attachments/assets/c1f43e4a-189f-49be-8ddd-5623bbf1b7ad)
