### PR TITLE
Force isThisType check for .arf files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ARFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ARFReader.java
@@ -55,6 +55,7 @@ public class ARFReader extends FormatReader {
   public ARFReader() {
     super("ARF", "arf");
     domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+    suffixSufficient = false;
   }
 
   // -- IFormatReader API methods --


### PR DESCRIPTION
CV7000 datasets can contain an .arf file that is some sort of analysis results. `ARFReader` tried to read everything with an .arf extension, so directory imports of certain CV7000 plates may fail because the .arf files fail to be read.

Without this change, a simple test file:

```
$ cat test.arf
test
```

should throw this exception:

```
$ showinf -debug test.arf
...
loci.formats.FormatException: Undefined endianness
	at loci.formats.in.ARFReader.initFile(ARFReader.java:105)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.formats.ImageReader.setId(ImageReader.java:864)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:692)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1048)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1159)
```

With this change, `UnknownFormatException` should be thrown instead.