### PR TITLE
ImageJ export plugin: add some checks to prevent file appending

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -302,6 +302,9 @@ public class Exporter {
             outfile = new File(dir, name).getAbsolutePath();
             if (outfile == null) return;
         }
+        else {
+          f = new File(outfile);
+        }
 
         if (windowless) {
             if (splitZ == null) splitZ = Boolean.FALSE;

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -686,6 +686,7 @@ public class Exporter {
             if (outputFiles.length > 1) {
                 for (int i = 0; i < outputFiles.length; i++) {
                     if (new File(outputFiles[i]).exists()) {
+                        IJ.error(outputFiles[i] + " already exists");
                         in = true;
                         break;
                     }

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -705,6 +705,10 @@ public class Exporter {
                     new File(outputFiles[i]).delete();
                 }
             }
+            else if (in) {
+              IJ.error("Some files already exist; delete them and try again.");
+              return;
+            }
             //We are now ready to write the image
             if (f != null) f.delete(); //delete the file.
             if (compression != null) {


### PR DESCRIPTION
This is one approach to fixing #4221.

I could reproduce the original issue when running a macro like:

```
run("Gel");
run("Bio-Formats Exporter", "save=test.ome.tif export compression=Uncompressed");
waitForUser("check file size", "check file size");
run("Gel");
run("Bio-Formats Exporter", "save=test.ome.tif export compression=Uncompressed");
```

When prompted to check the file size, it's ~132KB, at the end it's ~261 KB. With this change, the file size should be unchanged, as it's deleted due to 57ec2b6.

The last two commits add logging/erroring for multi-file datasets (e.g. one timepoint per file), so that files beyond the first are not appended to if the `windowless` flag is set to `true`.

This seemed like the least disruptive change, but other possible approaches include:

- add an `overwrite` option
  * only delete any file (including the first) if `overwrite` is `true` OR `windowless` is `false` and a prompt to delete files was accepted
 - only delete any file (including the first) if `windowless` is `false` and a prompt to delete files was accepted, otherwise stop the export
 - log but automatically delete files if `windowless` is `true` and this is a multi-file export (instead of stopping the export)