### PR TITLE
bfopen: fix array allocations

### DIFF
--- a/components/formats-bsd/matlab/bfopen.m
+++ b/components/formats-bsd/matlab/bfopen.m
@@ -133,7 +133,7 @@ if planeSize/(1024)^3 >= 2,
 end
 
 numSeries = r.getSeriesCount();
-result = cell(numSeries, 2);
+result = cell(numSeries, 4);
 
 globalMetadata = r.getGlobalMetadata();
 
@@ -146,7 +146,7 @@ for s = 1:numSeries
     bppMax = power(2, bpp * 8);
     numImages = r.getImageCount();
     imageList = cell(numImages, 2);
-    colorMaps = cell(numImages);
+    colorMaps = cell(numImages, 1);
     for i = 1:numImages
         if mod(i, 72) == 1
             fprintf('\n    ');
@@ -156,16 +156,16 @@ for s = 1:numSeries
 
         % retrieve color map data
         if bpp == 1
-            colorMaps{s, i} = r.get8BitLookupTable()';
+            colorMaps{i} = r.get8BitLookupTable();
         else
-            colorMaps{s, i} = r.get16BitLookupTable()';
+            colorMaps{i} = r.get16BitLookupTable();
         end
 
         warning_state = warning ('off');
-        if ~isempty(colorMaps{s, i})
-            newMap = single(colorMaps{s, i});
+        if ~isempty(colorMaps{i})
+            newMap = single(colorMaps{i});
             newMap(newMap < 0) = newMap(newMap < 0) + bppMax;
-            colorMaps{s, i} = newMap / (bppMax - 1);
+            colorMaps{i} = newMap / (bppMax - 1);
         end
         warning (warning_state);
 

--- a/components/formats-bsd/matlab/bfopen.m
+++ b/components/formats-bsd/matlab/bfopen.m
@@ -155,10 +155,11 @@ for s = 1:numSeries
         arr = bfGetPlane(r, i, varargin{:});
 
         % retrieve color map data
+        % transpose tables for compatibility with things like imshow
         if bpp == 1
-            colorMaps{i} = r.get8BitLookupTable();
+            colorMaps{i} = r.get8BitLookupTable()';
         else
-            colorMaps{i} = r.get16BitLookupTable();
+            colorMaps{i} = r.get16BitLookupTable()';
         end
 
         warning_state = warning ('off');


### PR DESCRIPTION
Fixes #3882.

Without this change, testing `bfopen` with any file that has multiple planes should confirm that `colorMaps` is an n x n array, not n x 1. https://www.mathworks.com/help/matlab/ref/cell.html also confirms that `cell(n)` produces a 2D array, not a 1D array.

This also exposes that the indexing of `colorMaps` is incorrect. `colorMaps` is allocated within the loop over series, so one `colorMaps` should be allocated per series (and assignment to `result` later on confirms this). That means that the only index into `colorMaps` should be `i` (the plane index), never `s` (the series index).

Looking more closely at `result` also exposed that the initial allocation can be 4 elements per series, rather than allocating 2 elements and later expanding to 4 to include metadata.

With this change, testing with any file that has multiple series and multiple planes should confirm that the `result` is now as expected, and in particular `result{*, 3}` which is the `colorMaps` for a particular series. Testing with a file that has a lookup table and `isFalseColor() == true` (e.g. `curated/tiff/wayne/Rockes-8bit-indexed.tif`) should show that a color map is still accessible without issue.