### PR TITLE
Document time parsing and warn if time in milliseconds is out of range

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2046,8 +2046,20 @@ public class MetamorphReader extends BaseTiffReader {
     return intFormat(day, 2) + "/" + intFormat(month, 2) + "/" + year;
   }
 
-  /** Converts a time value in milliseconds into a human-readable string. */
+  /**
+   * Converts a time value in milliseconds into a human-readable string.
+   * Note that the date and time are handled separately, so this method
+   * is only concerned with the time of day. The time of day in milliseconds
+   * is stored as a 32-bit int in Metamorph files, but is expected to be
+   * a positive integer less than the number of milliseconds in one day.
+   *
+   * @param millis milliseconds elapsed in the relevant day
+   * @see decodeDate(int)
+   */
   public static String decodeTime(int millis) {
+    if (millis < 0 || millis > 1000 * 60 * 60 * 24) {
+      LOGGER.warn("Unexpected milliseconds when parsing relative time: {}", millis);
+    }
     DateTime tm = new DateTime(millis, DateTimeZone.UTC);
     String hours = intFormat(tm.getHourOfDay(), 2);
     String minutes = intFormat(tm.getMinuteOfHour(), 2);


### PR DESCRIPTION
Fixes #4142.

This is mainly meant to clarify the expectations of `decodeTime(int)`, namely that it takes the 32-bit int stored in a Metamorph file for the time of day in milliseconds, and converts to a human-readable string timestamp. The actual date is stored separately, so the number of milliseconds should represent less than 24 hours.

The only change in behavior should be that there is a warning if the number of milliseconds is outside the bounds of the number of milliseconds in a day (which is much narrower than int32 range). That shouldn't happen in practice with Metamorph data, but is included because this is a public method. I could see a case here for throwing `IllegalArgumentException` instead.