### PR TITLE
Address CVE-2023-32697

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-codecs.version>1.1.0</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.3</xalan.version>
-    <sqlite.version>3.28.0</sqlite.version>
+    <sqlite.version>3.49.1.0</sqlite.version>
 
     <!-- Maven plugin versions -->
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>


### PR DESCRIPTION
It [came up on the Image.sc Forum](https://forum.image.sc/t/security-risks-in-fiji/110630) that sqlite-jdbc 3.28.0 suffers from CVE-2023-32697. This PR updates the version of sqlite-jdbc to 3.49.1.0 (latest version as of this writing), which resolves the issue.
