### PR TITLE
Added Multi-Page TIFF Support for Prairie Technologies TIFFs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
@@ -46,6 +46,7 @@ import org.w3c.dom.NodeList;
  * Metadata structure for Prairie Technologies' TIFF-based format.
  * 
  * @author Curtis Rueden
+ * @author Michael Fox
  */
 public class PrairieMetadata {
 
@@ -932,6 +933,9 @@ public class PrairieMetadata {
 
     /** {@code filename} attribute of this {@code <File>}. */
     private String filename;
+    
+    /** {@code page} attribute of this {@code <File>}. */
+    private Integer page;
 
     /** {@code wavelengthMin} attribute of this {@code <File>}. */
     private Double waveMin;
@@ -964,6 +968,14 @@ public class PrairieMetadata {
 
       channelName = attr(fileElement, "channelName");
       filename = attr(fileElement, "filename");
+      page = i(attr(fileElement, "page"));
+      if (page == null) {
+    	  page = 0;
+      } else {
+    	  page -= 1;
+      }
+    	  
+    	  
 
       waveMin = d(attr(fileElement, "wavelengthMin"));
       waveMax = d(attr(fileElement, "wavelengthMax"));
@@ -982,6 +994,11 @@ public class PrairieMetadata {
     /** Gets the {@code filename} associated with this {@code File}. */
     public String getFilename() {
       return filename;
+    }
+    
+    /** Gets the {@code page} associated with this {@code File}. */
+    public Integer getPage() {
+      return page;
     }
 
     /** Gets the {@code wavelengthMin} associated with this {@code File}. */

--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -65,6 +65,7 @@ import org.xml.sax.SAXException;
  *
  * @author Curtis Rueden
  * @author Melissa Linkert
+ * @author Michael Fox
  */
 public class PrairieReader extends FormatReader {
 
@@ -292,7 +293,7 @@ public class PrairieReader extends FormatReader {
     }
 
     tiff.setId(getPath(file));
-    return tiff.openBytes(0, buf, x, y, w, h);
+    return tiff.openBytes(file.getPage(), buf, x, y, w, h);
   }
 
   @Override


### PR DESCRIPTION
The existing FormatReader for Prairie Technologies TIFFs was hardcoded to only consider the first page in a multi-page TIFF.  I've added support to read the page number from the XML metadata and use that when loading images.