### PR TITLE
Fix Unidata repository URLs

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -32,7 +32,7 @@ Type "ant -p" for a list of targets.
   <resolver:pom file="pom.xml" id="pom"/>
 
   <resolver:remoterepo id="ome" url="https://artifacts.openmicroscopy.org/artifactory/maven/" type="default" releases="true" snapshots="false"/>
-  <resolver:remoterepo id="unidata" url="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases" type="default" releases="true"/>
+  <resolver:remoterepo id="unidata" url="https://artifacts.unidata.ucar.edu/repository/unidata-releases/" type="default" releases="true"/>
   <resolver:remoterepo id="jenkins" url="https://repo.jenkins-ci.org/releases/" type="default" releases="true"/>
   <resolver:remoterepos id="resolver.repositories">
     <resolver:remoterepo refid="central"/>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -369,7 +369,7 @@
     </repository>
     <repository>
       <id>unidata.releases</id>
-      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/repository/unidata-releases/</url>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>


### PR DESCRIPTION
This is consistent with https://docs.unidata.ucar.edu/netcdf-java/current/userguide/using_netcdf_java_artifacts.html. We have been seeing build errors with Gradle in other repositories that use `https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases`, so this is just a preventative measure.