### PR TITLE
Add reader for Molecular Devices JDCE

### DIFF
--- a/components/formats-api/src/loci/formats/WellContainer.java
+++ b/components/formats-api/src/loci/formats/WellContainer.java
@@ -1,0 +1,158 @@
+/*
+ * #%L
+ * Top-level reader and writer APIs
+ * %%
+ * Copyright (C) 2020 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import loci.formats.meta.MetadataStore;
+import ome.xml.model.primitives.NonNegativeInteger;
+
+/**
+ * Represents a well in a plate.
+ */
+public abstract class WellContainer implements Comparable<WellContainer> {
+
+  private int plateAcquisitionIndex;
+  private int rowIndex;
+  private int columnIndex;
+  private transient int wellIndex;
+  private int fieldCount;
+
+  private List<String> files = new ArrayList<String>();
+
+  public WellContainer() {
+  }
+
+  public WellContainer(int pa, int row, int col, int fields) {
+    plateAcquisitionIndex = pa;
+    rowIndex = row;
+    columnIndex = col;
+    fieldCount = fields;
+  }
+
+  public String getFile(int fieldIndex, int planeIndex) {
+    String[] fieldFiles = getFiles(fieldIndex);
+    if (fieldFiles != null && planeIndex < fieldFiles.length) {
+      return fieldFiles[planeIndex];
+    }
+    return null;
+  }
+
+  public abstract String[] getFiles(int fieldIndex);
+
+  public List<String> getAllFiles() {
+    return files;
+  }
+
+  public void addFile(String file) {
+    files.add(file);
+  }
+
+  public int getPlateAcquisition() {
+    return plateAcquisitionIndex;
+  }
+
+  public void setPlateAcquisition(int pa) {
+    plateAcquisitionIndex = pa;
+  }
+
+  public int getRowIndex() {
+    return rowIndex;
+  }
+
+  public void setRowIndex(int newRow) {
+    rowIndex = newRow;
+  }
+
+  public int getColumnIndex() {
+    return columnIndex;
+  }
+
+  public void setColumnIndex(int newColumn) {
+    columnIndex = newColumn;
+  }
+
+  public int getFieldCount() {
+    return fieldCount;
+  }
+
+  public void setFieldCount(int fields) {
+    fieldCount = fields;
+  }
+
+  public int getWellIndex() {
+    return wellIndex;
+  }
+
+  public void setWellIndex(int index) {
+    wellIndex = index;
+  }
+
+  public void fillMetadataStore(MetadataStore store, int plate, int plateAcq, int wellSampleStart, int nextImage) {
+    fillMetadataStore(store, plate, plateAcq, wellIndex, wellSampleStart, nextImage);
+  }
+
+  public void fillMetadataStore(MetadataStore store, int plate, int plateAcq, int well, int wellSampleStart, int nextImage) {
+    store.setWellID(MetadataTools.createLSID("Well", plate, well), plate, well);
+    store.setWellRow(new NonNegativeInteger(getRowIndex()), plate, well);
+    store.setWellColumn(new NonNegativeInteger(getColumnIndex()), plate, well);
+
+    for (int field=0; field<getFieldCount(); field++) {
+      int wellSampleIndex = field + wellSampleStart;
+      String wellSample = MetadataTools.createLSID("WellSample", plate, well, wellSampleIndex);
+      store.setWellSampleID(wellSample, plate, well, wellSampleIndex);
+
+      int imageIndex = nextImage + field;
+      store.setWellSampleIndex(new NonNegativeInteger(imageIndex), plate, well, wellSampleIndex);
+      String imageID = MetadataTools.createLSID("Image", imageIndex);
+      store.setImageID(imageID, imageIndex);
+      store.setWellSampleImageRef(imageID, plate, well, wellSampleIndex);
+      store.setPlateAcquisitionWellSampleRef(wellSample, plate, plateAcq, imageIndex);
+    }
+  }
+
+  @Override
+  public int compareTo(WellContainer w) {
+    int paDiff = getPlateAcquisition() - w.getPlateAcquisition();
+    if (paDiff != 0) {
+      return paDiff;
+    }
+    int rowDiff = getRowIndex() - w.getRowIndex();
+    if (rowDiff != 0) {
+      return rowDiff;
+    }
+    return getColumnIndex() - w.getColumnIndex();
+  }
+
+}

--- a/components/formats-api/src/loci/formats/internal/WellContainer.java
+++ b/components/formats-api/src/loci/formats/internal/WellContainer.java
@@ -30,11 +30,12 @@
  * #L%
  */
 
-package loci.formats;
+package loci.formats.internal;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import ome.xml.model.primitives.NonNegativeInteger;
 

--- a/components/formats-api/src/loci/formats/internal/package.html
+++ b/components/formats-api/src/loci/formats/internal/package.html
@@ -1,0 +1,37 @@
+<!--
+  #%L
+  Top-level reader and writer APIs
+  %%
+  Copyright (C) 2005 - 2025 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<html><body>
+Package containing common classes for internal use by Bio-Formats readers/writers.
+These classes are meant for internal use only, and not intended to be used by
+consumers of reader/writer API.
+</body></html>

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -108,6 +108,7 @@ loci.formats.in.LOFReader	            # lof
 loci.formats.in.XLEFReader            # xlef
 loci.formats.in.OlympusTileReader     # omp2info
 loci.formats.in.DCIMGReader           # dcimg
+loci.formats.in.JDCEReader            # jdce
 
 # multi-extension messes
 loci.formats.in.JEOLReader            # dat, img, par

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -104,6 +104,9 @@ public class JDCEReader extends FormatReader {
     String file = getFile(no);
     if (file != null) {
       try {
+        if (helper == null) {
+          helper = new MinimalTiffReader();
+        }
         helper.setId(file);
         return helper.openBytes(0, buf, x, y, w, h);
       }
@@ -162,8 +165,13 @@ public class JDCEReader extends FormatReader {
 
     try {
       String file = getFile(0);
-      helper.setId(file);
-      return helper.getOptimalTileWidth();
+      if (file != null) {
+        if (helper == null) {
+          helper = new MinimalTiffReader();
+        }
+        helper.setId(file);
+        return helper.getOptimalTileWidth();
+      }
     }
     catch (FormatException | IOException e) {
       LOGGER.debug("Could not get optimal tile width", e);
@@ -178,8 +186,13 @@ public class JDCEReader extends FormatReader {
 
     try {
       String file = getFile(0);
-      helper.setId(file);
-      return helper.getOptimalTileHeight();
+      if (file != null) {
+        if (helper == null) {
+          helper = new MinimalTiffReader();
+        }
+        helper.setId(file);
+        return helper.getOptimalTileHeight();
+      }
     }
     catch (FormatException | IOException e) {
       LOGGER.debug("Could not get optimal tile height", e);
@@ -362,9 +375,9 @@ public class JDCEReader extends FormatReader {
       if (currentWell == null || currentWell.getRowIndex() != wellRow ||
         currentWell.getColumnIndex() != wellCol)
       {
-        currentWell = lookupWell(wellRow, wellCol);
+        currentWell = lookupWell(wellRow, wellCol, ms0.imageCount);
       }
-      currentWell.addFile(imagePath, position);
+      currentWell.addFile(imagePath, position[0], getIndex(position[1], position[2], position[3]));
       currentWell.setFieldCount((int) Math.max(currentWell.getFieldCount(), position[0] + 1));
 
       PlaneMetadata p = new PlaneMetadata();
@@ -383,6 +396,9 @@ public class JDCEReader extends FormatReader {
 
       if (firstFile) {
         try {
+          if (helper == null) {
+            helper = new MinimalTiffReader();
+          }
           helper.setId(imagePath);
           CoreMetadata m = helper.getCoreMetadataList().get(0);
           ms0.sizeX = m.sizeX;
@@ -452,13 +468,13 @@ public class JDCEReader extends FormatReader {
     }
   }
 
-  private JDCEWell lookupWell(int row, int col) {
+  private JDCEWell lookupWell(int row, int col, int planeCount) {
     for (JDCEWell well : wells) {
       if (well.getRowIndex() == row && well.getColumnIndex() == col) {
         return well;
       }
     }
-    JDCEWell well = new JDCEWell(row, col);
+    JDCEWell well = new JDCEWell(row, col, planeCount);
     wells.add(well);
     return well;
   }
@@ -475,27 +491,39 @@ public class JDCEReader extends FormatReader {
   }
 
   class JDCEWell extends WellContainer {
-    HashMap<int[], Integer> posMap = new HashMap<int[], Integer>();
+    HashMap<String, Integer> posMap = new HashMap<String, Integer>();
     HashMap<String, PlaneMetadata> metadataMap = new HashMap<String, PlaneMetadata>();
+    int planeCount = 0;
 
-    public JDCEWell(int row, int col) {
+    public JDCEWell(int row, int col, int planeCount) {
       super(0, row, col, 1);
+      this.planeCount = planeCount;
     }
 
     /**
-     * Add file at position [field, z, c, t].
+     * Add file for the given field and plane indexes.
      */
-    public void addFile(String file, int[] position) {
+    public void addFile(String file, int fieldIndex, int planeIndex) {
       super.addFile(file);
-      posMap.put(position, getAllFiles().size() - 1);
+      posMap.put(fieldIndex + "-" + planeIndex, getAllFiles().size() - 1);
+    }
+
+    private int[] getIndex(String key) {
+      String[] k = key.split("-");
+      int[] v = new int[k.length];
+      for (int i=0; i<v.length; i++) {
+        v[i] = Integer.parseInt(k[i]);
+      }
+      return v;
     }
 
     public String[] getFiles(int fieldIndex) {
       List<String> allFiles = getAllFiles();
-      String[] fieldFiles = new String[getImageCount()];
-      for (int[] key : posMap.keySet()) {
-        if (key[0] == fieldIndex) {
-          fieldFiles[getIndex(key[1], key[2], key[3])] = allFiles.get(posMap.get(key));
+      String[] fieldFiles = new String[planeCount];
+      for (String key : posMap.keySet()) {
+        int[] keyIndex = getIndex(key);
+        if (keyIndex[0] == fieldIndex) {
+          fieldFiles[keyIndex[1]] = allFiles.get(posMap.get(key));
         }
       }
       return fieldFiles;

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -1,0 +1,209 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2024 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import loci.common.DataTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.WellContainer;
+import loci.formats.meta.MetadataStore;
+
+import org.json.JSONException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * JDCEReader is the file format reader for Molecular Devices JDCE plates.
+ */
+public class JDCEReader extends FormatReader {
+
+  // -- Constants --
+
+  // -- Fields --
+
+  private List<WellContainer> wells = new ArrayList<WellContainer>();
+  private String imageFileCSV = null;
+
+  // -- Constructor --
+
+  /** Constructs a new JDCE reader. */
+  public JDCEReader() {
+    super("Molecular Devices JDCE", new String[] {"jdce"});
+    suffixSufficient = true;
+    domains = new String[] {FormatTools.HCS_DOMAIN};
+    hasCompanionFiles = true;
+    datasetDescription = "One .jdce (JSON) file with at least one .tif/.tiff file";
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#isSingleFile(String) */
+  @Override
+  public boolean isSingleFile(String id) throws FormatException, IOException {
+    return false;
+  }
+
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    Arrays.fill(buf, getFillColor());
+
+    return buf;
+  }
+
+  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+    // TODO
+    return new String[] {currentId, imageFileCSV};
+  }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      imageFileCSV = null;
+      if (wells != null) {
+        wells.clear();
+      }
+    }
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    // TODO
+    return super.getOptimalTileWidth();
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    // TODO
+    return super.getOptimalTileHeight();
+  }
+
+  // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
+
+    CoreMetadata ms0 = core.get(0);
+    try {
+      JSONObject root = new JSONObject(DataTools.readFile(id));
+
+      JSONObject imageStack = root.getJSONObject("ImageStack");
+      if (imageStack == null) {
+        throw new FormatException("Could not find image stack definition");
+      }
+
+      String imageFormat = imageStack.getString("ImageFormat");
+      if (!"TIFF".equalsIgnoreCase(imageFormat)) {
+        throw new FormatException("Unsupported image format " + imageFormat);
+      }
+
+      JSONObject acquisition = imageStack.getJSONObject("AutoLeadAcquisitionProtocol");
+      if (acquisition == null) {
+        throw new FormatException("Could not find acquisition definition");
+      }
+
+      JSONObject objective = acquisition.getJSONObject("ObjectiveCalibration");
+      // TODO: parse objective
+
+      JSONObject plate = acquisition.getJSONObject("Plate");
+      // TODO: parse plate
+
+      JSONObject plateMap = acquisition.getJSONObject("PlateMap");
+      if (plateMap == null) {
+        throw new FormatException("Could not find plate map, cannot determine dimensions");
+      }
+      JSONObject timeSchedule = plateMap.getJSONObject("TimeSchedule");
+      if (timeSchedule == null) {
+        throw new FormatException("Could not find time schedule, cannot determine SizeT");
+      }
+      ms0.sizeT = timeSchedule.getInt("NumberOfTimepoints");
+
+      JSONObject zDimension = plateMap.getJSONObject("ZDimensionParameters");
+      if (zDimension == null) {
+        throw new FormatException("Could not find Z dimension parameters, cannot determine SizeZ");
+      }
+      ms0.sizeZ = zDimension.getInt("NumberOfSlices");
+
+      JSONArray wavelengths = acquisition.getJSONArray("Wavelengths");
+      if (wavelengths == null) {
+        throw new FormatException("Could not find wavelength array, cannot determine SizeC");
+      }
+      ms0.sizeC = wavelengths.length();
+
+      JSONArray metadataFiles = imageStack.getJSONArray("ImageMetadataFiles");
+      if (metadataFiles == null || metadataFiles.length() == 0) {
+        throw new FormatException("Could not find image metadata CSV, cannot get list of TIFF files");
+      }
+      imageFileCSV = metadataFiles.getString(0);
+    }
+    catch (JSONException e) {
+      throw new FormatException("Could not parse .jdce file", e);
+    }
+
+    if (imageFileCSV == null) {
+      throw new FormatException("Image metadata CSV not found, cannot get list of TIFF files");
+    }
+
+    String[] csvLines = DataTools.readFile(imageFileCSV).split("\r\n");
+    String[] columns = csvLines[0].split(",");
+    for (int i=1; i<csvLines.length; i++) {
+      String[] line = csvLines[i].split(",");
+    }
+
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this, true);
+  }
+}

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -489,12 +489,19 @@ public class JDCEReader extends FormatReader {
           store.setChannelExcitationWavelength(excitationWavelengths[c], imageIndex, c);
         }
 
+        boolean firstPlane = true;
         for (int plane=0; plane<getImageCount(); plane++) {
           PlaneMetadata p = well.getPlaneMetadata(f, getZCTCoords(plane));
           if (p != null) {
             store.setPlanePositionX(p.positionX, imageIndex, plane);
             store.setPlanePositionY(p.positionY, imageIndex, plane);
             store.setPlanePositionZ(p.positionZ, imageIndex, plane);
+
+            if (firstPlane) {
+              firstPlane = false;
+              store.setWellSamplePositionX(p.positionX, 0, w, f);
+              store.setWellSamplePositionY(p.positionY, 0, w, f);
+            }
 
             if (p.timestamp != null && smallestTimestamp != null) {
               Time stamp = FormatTools.createTime(p.timestamp - smallestTimestamp, UNITS.SECOND);

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -424,6 +424,14 @@ public class JDCEReader extends FormatReader {
           }
           helper.setId(imagePath);
           CoreMetadata m = helper.getCoreMetadataList().get(0);
+          if (p.sizeX == 0) {
+            ms0.sizeX = m.sizeX;
+            LOGGER.warn("Found image width 0 in CSV; using {} from TIFF", ms0.sizeX);
+          }
+          if (p.sizeY == 0) {
+            ms0.sizeY = m.sizeY;
+            LOGGER.warn("Found image height 0 in CSV; using {} from TIFF", ms0.sizeY);
+          }
           ms0.pixelType = m.pixelType;
           ms0.littleEndian = m.littleEndian;
           ms0.sizeC *= m.sizeC;

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -326,7 +326,7 @@ public class JDCEReader extends FormatReader {
         // if all of the imaging modes are "Max Intensity Projection",
         // the Z size will be reset to 1 since only one Z slice is present
         imagingMode[c] = wavelength.getString("ImagingMode");
-        if (imagingMode[c] == null || (c >= 1 && (!imagingMode[c].equals("Max Intensity Projection") || !imagingMode[c].equals(imagingMode[0])))) {
+        if (imagingMode[c] == null || !imagingMode[c].equals("Max Intensity Projection") || !imagingMode[c].equals(imagingMode[0])) {
           singleZ = false;
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -30,8 +30,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.StringJoiner;
 
 import loci.common.DataTools;
+import loci.common.DateTools;
 import loci.common.Location;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -40,6 +42,12 @@ import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.WellContainer;
 import loci.formats.meta.MetadataStore;
+
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.xml.model.enums.NamingConvention;
+import ome.xml.model.primitives.PositiveInteger;
 
 import org.json.JSONException;
 import org.json.JSONArray;
@@ -102,8 +110,26 @@ public class JDCEReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    // TODO
-    return new String[] {currentId, imageFileCSV};
+    String[] imageFiles = null;
+    if (!noPixels) {
+      int index = 0;
+      for (JDCEWell well : wells) {
+        if (well.getFieldCount() + index > getSeries()) {
+          imageFiles = well.getFiles(getSeries() - index);
+          break;
+        }
+        index += well.getFieldCount();
+      }
+    }
+    int totalFileCount = imageFiles == null ? 2 : imageFiles.length + 2;
+    String[] rtn = new String[totalFileCount];
+    rtn[0] = currentId;
+    rtn[1] = imageFileCSV;
+    if (imageFiles != null) {
+      System.arraycopy(imageFiles, 0, rtn, 2, imageFiles.length);
+    }
+
+    return rtn;
   }
 
   /* @see loci.formats.IFormatReader#close(boolean) */
@@ -125,7 +151,15 @@ public class JDCEReader extends FormatReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
-    // TODO
+
+    try {
+      String file = getFile(0);
+      helper.setId(file);
+      return helper.getOptimalTileWidth();
+    }
+    catch (FormatException | IOException e) {
+      LOGGER.debug("Could not get optimal tile width", e);
+    }
     return super.getOptimalTileWidth();
   }
 
@@ -133,7 +167,15 @@ public class JDCEReader extends FormatReader {
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
-    // TODO
+
+    try {
+      String file = getFile(0);
+      helper.setId(file);
+      return helper.getOptimalTileHeight();
+    }
+    catch (FormatException | IOException e) {
+      LOGGER.debug("Could not get optimal tile height", e);
+    }
     return super.getOptimalTileHeight();
   }
 
@@ -143,6 +185,17 @@ public class JDCEReader extends FormatReader {
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
+
+    String plateName = null;
+    Length physicalSizeX = null;
+    Length physicalSizeY = null;
+    String[] channelNames = null;
+    Length[] emissionWavelengths = null;
+    Length[] excitationWavelengths = null;
+
+    int plateRows = 0;
+    int plateColumns = 0;
+    double creationTimestamp = 0;
 
     CoreMetadata ms0 = core.get(0);
     try {
@@ -158,16 +211,41 @@ public class JDCEReader extends FormatReader {
         throw new FormatException("Unsupported image format " + imageFormat);
       }
 
+      JSONObject creation = imageStack.getJSONObject("Creation");
+      if (creation != null) {
+        String date = creation.getString("Date");
+        String time = creation.getString("Time");
+        String timezone = creation.getString("TimeZoneOffset");
+
+        if (timezone == null || timezone.isEmpty()) {
+          LOGGER.warn("Timezone not defined; plane timestamps may be wrong");
+        }
+        else {
+          // store creation timestamp in seconds, as plane timestamps are in seconds
+          // TODO: not sure if timezone is right here
+          creationTimestamp = DateTools.getTime(date + " " + time + " " + timezone, "yyy-MM-dd HH:mm:ss X") / 1000.0;
+        }
+      }
+      else {
+        LOGGER.debug("Could not find plate creation time; plane timestamps may be wrong");
+      }
+
       JSONObject acquisition = imageStack.getJSONObject("AutoLeadAcquisitionProtocol");
       if (acquisition == null) {
         throw new FormatException("Could not find acquisition definition");
       }
 
       JSONObject objective = acquisition.getJSONObject("ObjectiveCalibration");
-      // TODO: parse objective
+      String unit = objective.getString("Unit");
+      double pixelWidth = objective.getDouble("PixelWidth");
+      double pixelHeight = objective.getDouble("PixelHeight");
+      physicalSizeX = FormatTools.getPhysicalSize(pixelWidth, unit);
+      physicalSizeY = FormatTools.getPhysicalSize(pixelHeight, unit);
 
       JSONObject plate = acquisition.getJSONObject("Plate");
-      // TODO: parse plate
+      plateName = plate.getString("Name");
+      plateRows = plate.getInt("Rows");
+      plateColumns = plate.getInt("Columns");
 
       JSONObject plateMap = acquisition.getJSONObject("PlateMap");
       if (plateMap == null) {
@@ -190,6 +268,25 @@ public class JDCEReader extends FormatReader {
         throw new FormatException("Could not find wavelength array, cannot determine SizeC");
       }
       ms0.sizeC = wavelengths.length();
+      channelNames = new String[ms0.sizeC];
+      emissionWavelengths = new Length[ms0.sizeC];
+      excitationWavelengths = new Length[ms0.sizeC];
+      for (int c=0; c<ms0.sizeC; c++) {
+        JSONObject wavelength = wavelengths.getJSONObject(c);
+        int channelIndex = wavelength.getInt("Index");
+
+        JSONObject emission = wavelength.getJSONObject("EmissionFilter");
+        JSONObject excitation = wavelength.getJSONObject("ExcitationFilter");
+
+        channelNames[channelIndex] = emission.getString("Name");
+        String emUnit = emission.getString("Unit");
+        double emWave = emission.getDouble("Wavelength");
+        emissionWavelengths[channelIndex] = FormatTools.getWavelength(emWave, emUnit);
+
+        String exUnit = excitation.getString("Unit");
+        double exWave = excitation.getDouble("Wavelength");
+        excitationWavelengths[channelIndex] = FormatTools.getWavelength(exWave, exUnit);
+      }
 
       JSONArray metadataFiles = imageStack.getJSONArray("ImageMetadataFiles");
       if (metadataFiles == null || metadataFiles.length() == 0) {
@@ -218,6 +315,12 @@ public class JDCEReader extends FormatReader {
     int subfolderIndex = columns.indexOf("ImageSubFolderPath");
     int fileNameIndex = columns.indexOf("ImageFileName");
 
+    int timestampIndex = columns.indexOf("TimeStampSec");
+    int exposureTimeIndex = columns.indexOf("ExposureTimeMs");
+    int positionXIndex = columns.indexOf("PositionXUm");
+    int positionYIndex = columns.indexOf("PositionYUm");
+    int positionZIndex = columns.indexOf("PositionZUm");
+
     Location parentDir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
     JDCEWell currentWell = null;
     boolean firstFile = true;
@@ -244,6 +347,20 @@ public class JDCEReader extends FormatReader {
       }
       currentWell.addFile(imagePath, position);
       currentWell.setFieldCount((int) Math.max(currentWell.getFieldCount(), position[0] + 1));
+
+      PlaneMetadata p = new PlaneMetadata();
+
+      // plane times are stored in seconds since Jan. 1 1970
+      // subtracting the plate creation time gives relative timestamps
+      Double planeTime = DataTools.parseDouble(line[timestampIndex]);
+      planeTime -= creationTimestamp;
+      p.timestamp = FormatTools.createTime(planeTime, UNITS.SECOND);
+
+      p.exposureTime = FormatTools.createTime(DataTools.parseDouble(line[exposureTimeIndex]), UNITS.MILLISECOND);
+      p.positionX = FormatTools.getStagePosition(DataTools.parseDouble(line[positionXIndex]), UNITS.MICROMETER);
+      p.positionY = FormatTools.getStagePosition(DataTools.parseDouble(line[positionYIndex]), UNITS.MICROMETER);
+      p.positionZ = FormatTools.getStagePosition(DataTools.parseDouble(line[positionZIndex]), UNITS.MICROMETER);
+      currentWell.addPlaneMetadata(p, position);
 
       if (firstFile) {
         try {
@@ -273,12 +390,46 @@ public class JDCEReader extends FormatReader {
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 
+    store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+    store.setPlateName(plateName, 0);
+    store.setPlateRows(new PositiveInteger(plateRows), 0);
+    store.setPlateColumns(new PositiveInteger(plateColumns), 0);
+    store.setPlateRowNamingConvention(NamingConvention.LETTER, 0);
+    store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
+
+    store.setPlateAcquisitionID(MetadataTools.createLSID("PlateAcquisition", 0, 0), 0, 0);
+
     wells.sort(null);
 
     int imageIndex = 0;
     for (int w=0; w<wells.size(); w++) {
-      wells.get(w).fillMetadataStore(store, 0, 0, w, 0, imageIndex);
-      imageIndex += wells.get(w).getFieldCount();
+      JDCEWell well = wells.get(w);
+      well.fillMetadataStore(store, 0, 0, w, 0, imageIndex);
+
+      int fieldCount = well.getFieldCount();
+      String wellName = FormatTools.getWellName(well.getRowIndex(), well.getColumnIndex());
+      for (int f=0; f<fieldCount; f++, imageIndex++) {
+        store.setImageName(wellName + ", Field #" + (f + 1), imageIndex);
+        store.setPixelsPhysicalSizeX(physicalSizeX, imageIndex);
+        store.setPixelsPhysicalSizeY(physicalSizeY, imageIndex);
+
+        for (int c=0; c<channelNames.length; c++) {
+          store.setChannelName(channelNames[c], imageIndex, c);
+          store.setChannelEmissionWavelength(emissionWavelengths[c], imageIndex, c);
+          store.setChannelExcitationWavelength(excitationWavelengths[c], imageIndex, c);
+        }
+
+        for (int plane=0; plane<getImageCount(); plane++) {
+          PlaneMetadata p = well.getPlaneMetadata(f, getZCTCoords(plane));
+          if (p != null) {
+            store.setPlanePositionX(p.positionX, imageIndex, plane);
+            store.setPlanePositionY(p.positionY, imageIndex, plane);
+            store.setPlanePositionZ(p.positionZ, imageIndex, plane);
+            store.setPlaneDeltaT(p.timestamp, imageIndex, plane);
+            store.setPlaneExposureTime(p.exposureTime, imageIndex, plane);
+          }
+        }
+      }
     }
   }
 
@@ -306,6 +457,7 @@ public class JDCEReader extends FormatReader {
 
   class JDCEWell extends WellContainer {
     HashMap<int[], Integer> posMap = new HashMap<int[], Integer>();
+    HashMap<String, PlaneMetadata> metadataMap = new HashMap<String, PlaneMetadata>();
 
     public JDCEWell(int row, int col) {
       super(0, row, col, 1);
@@ -329,5 +481,30 @@ public class JDCEReader extends FormatReader {
       }
       return fieldFiles;
     }
+
+    public void addPlaneMetadata(PlaneMetadata p, int[] position) {
+      StringJoiner joiner = new StringJoiner("-");
+      for (int pos : position) {
+        joiner.add(String.valueOf(pos));
+      }
+      metadataMap.put(joiner.toString(), p);
+    }
+
+    public PlaneMetadata getPlaneMetadata(int field, int[] position) {
+      StringJoiner joiner = new StringJoiner("-");
+      joiner.add(String.valueOf(field));
+      for (int pos : position) {
+        joiner.add(String.valueOf(pos));
+      }
+      return metadataMap.get(joiner.toString());
+    }
+  }
+
+  class PlaneMetadata {
+    public Time timestamp;
+    public Time exposureTime;
+    public Length positionX;
+    public Length positionY;
+    public Length positionZ;
   }
 }

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -368,6 +368,9 @@ public class JDCEReader extends FormatReader {
     int positionYIndex = columns.indexOf("PositionYUm");
     int positionZIndex = columns.indexOf("PositionZUm");
 
+    int imageWidthIndex = columns.indexOf("ImageSizeXPx");
+    int imageHeightIndex = columns.indexOf("ImageSizeYPx");
+
     Double smallestTimestamp = null;
 
     JDCEWell currentWell = null;
@@ -410,6 +413,8 @@ public class JDCEReader extends FormatReader {
       p.positionX = FormatTools.getStagePosition(DataTools.parseDouble(line[positionXIndex]), UNITS.MICROMETER);
       p.positionY = FormatTools.getStagePosition(DataTools.parseDouble(line[positionYIndex]), UNITS.MICROMETER);
       p.positionZ = FormatTools.getStagePosition(DataTools.parseDouble(line[positionZIndex]), UNITS.MICROMETER);
+      p.sizeX = Integer.parseInt(line[imageWidthIndex]);
+      p.sizeY = Integer.parseInt(line[imageHeightIndex]);
       currentWell.addPlaneMetadata(p, position);
 
       if (firstFile) {
@@ -419,8 +424,6 @@ public class JDCEReader extends FormatReader {
           }
           helper.setId(imagePath);
           CoreMetadata m = helper.getCoreMetadataList().get(0);
-          ms0.sizeX = m.sizeX;
-          ms0.sizeY = m.sizeY;
           ms0.pixelType = m.pixelType;
           ms0.littleEndian = m.littleEndian;
           ms0.sizeC *= m.sizeC;
@@ -435,7 +438,18 @@ public class JDCEReader extends FormatReader {
     }
     for (JDCEWell well : wells) {
       for (int f=0; f<well.getFieldCount(); f++) {
-        core.add(new CoreMetadata(ms0));
+        CoreMetadata m = new CoreMetadata(ms0);
+        // an XY size is stored for every plane
+        // different wells/fields in particular may have different sizes
+        // for each field, the largest plane dimension is selected
+        for (int plane=0; plane<m.imageCount; plane++) {
+          PlaneMetadata p = well.getPlaneMetadata(f, getZCTCoords(plane));
+          if (p != null) {
+            m.sizeX = (int) Math.max(m.sizeX, p.sizeX);
+            m.sizeY = (int) Math.max(m.sizeY, p.sizeY);
+          }
+        }
+        core.add(m);
       }
     }
     core.remove(0);
@@ -579,5 +593,8 @@ public class JDCEReader extends FormatReader {
     public Length positionX;
     public Length positionY;
     public Length positionZ;
+
+    public int sizeX;
+    public int sizeY;
   }
 }

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -40,7 +40,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
-import loci.formats.WellContainer;
+import loci.formats.internal.WellContainer;
 import loci.formats.meta.MetadataStore;
 
 import ome.units.UNITS;

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -28,9 +28,11 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import loci.common.DataTools;
+import loci.common.Location;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
@@ -52,8 +54,9 @@ public class JDCEReader extends FormatReader {
 
   // -- Fields --
 
-  private List<WellContainer> wells = new ArrayList<WellContainer>();
+  private List<JDCEWell> wells = new ArrayList<JDCEWell>();
   private String imageFileCSV = null;
+  private transient MinimalTiffReader helper = new MinimalTiffReader();
 
   // -- Constructor --
 
@@ -90,7 +93,9 @@ public class JDCEReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
     Arrays.fill(buf, getFillColor());
 
-    return buf;
+    String file = getFile(no);
+    helper.setId(file);
+    return helper.openBytes(0, buf, x, y, w, h);
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -105,6 +110,9 @@ public class JDCEReader extends FormatReader {
   @Override
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
+    if (helper != null) {
+      helper.close(fileOnly);
+    }
     if (!fileOnly) {
       imageFileCSV = null;
       if (wells != null) {
@@ -192,18 +200,134 @@ public class JDCEReader extends FormatReader {
     catch (JSONException e) {
       throw new FormatException("Could not parse .jdce file", e);
     }
+    ms0.imageCount = getSizeZ() * getSizeC() * getSizeT();
+    ms0.dimensionOrder = "XYCZT";
 
     if (imageFileCSV == null) {
       throw new FormatException("Image metadata CSV not found, cannot get list of TIFF files");
     }
 
     String[] csvLines = DataTools.readFile(imageFileCSV).split("\r\n");
-    String[] columns = csvLines[0].split(",");
+    List<String> columns = Arrays.asList(csvLines[0].split(","));
+    int wellRowIndex = columns.indexOf("Row");
+    int wellColIndex = columns.indexOf("Column");
+    int fieldIndex = columns.indexOf("Field");
+    int wavelengthIndex = columns.indexOf("Wavelength");
+    int timepointIndex = columns.indexOf("Timepoint");
+    int zIndex = columns.indexOf("ZIndex");
+    int subfolderIndex = columns.indexOf("ImageSubFolderPath");
+    int fileNameIndex = columns.indexOf("ImageFileName");
+
+    Location parentDir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
+    JDCEWell currentWell = null;
+    boolean firstFile = true;
     for (int i=1; i<csvLines.length; i++) {
       String[] line = csvLines[i].split(",");
+
+      int[] position = new int[4];
+      position[0] = Integer.parseInt(line[fieldIndex]);
+      position[1] = Integer.parseInt(line[zIndex]);
+      position[2] = Integer.parseInt(line[wavelengthIndex]);
+      position[3] = Integer.parseInt(line[timepointIndex]);
+
+      String subfolder = line[subfolderIndex];
+      String filename = line[fileNameIndex];
+      Location subfolderFile = new Location(parentDir, subfolder);
+      String imagePath = new Location(subfolderFile, filename).getAbsolutePath();
+
+      int wellRow = Integer.parseInt(line[wellRowIndex]) - 1;
+      int wellCol = Integer.parseInt(line[wellColIndex]) - 1;
+      if (currentWell == null || currentWell.getRowIndex() != wellRow ||
+        currentWell.getColumnIndex() != wellCol)
+      {
+        currentWell = lookupWell(wellRow, wellCol);
+      }
+      currentWell.addFile(imagePath, position);
+      currentWell.setFieldCount((int) Math.max(currentWell.getFieldCount(), position[0] + 1));
+
+      if (firstFile) {
+        try {
+          helper.setId(imagePath);
+          CoreMetadata m = helper.getCoreMetadataList().get(0);
+          ms0.sizeX = m.sizeX;
+          ms0.sizeY = m.sizeY;
+          ms0.pixelType = m.pixelType;
+          ms0.littleEndian = m.littleEndian;
+          ms0.sizeC *= m.sizeC;
+          ms0.rgb = m.rgb;
+
+          firstFile = false;
+        }
+        catch (FormatException | IOException e) {
+          LOGGER.debug("Could not read " + imagePath, e);
+        }
+      }
     }
+    for (JDCEWell well : wells) {
+      for (int f=0; f<well.getFieldCount(); f++) {
+        core.add(new CoreMetadata(ms0));
+      }
+    }
+    core.remove(0);
 
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
+
+    wells.sort(null);
+
+    int imageIndex = 0;
+    for (int w=0; w<wells.size(); w++) {
+      wells.get(w).fillMetadataStore(store, 0, 0, w, 0, imageIndex);
+      imageIndex += wells.get(w).getFieldCount();
+    }
+  }
+
+  private JDCEWell lookupWell(int row, int col) {
+    for (JDCEWell well : wells) {
+      if (well.getRowIndex() == row && well.getColumnIndex() == col) {
+        return well;
+      }
+    }
+    JDCEWell well = new JDCEWell(row, col);
+    wells.add(well);
+    return well;
+  }
+
+  private String getFile(int no) {
+    int index = 0;
+    for (JDCEWell well : wells) {
+      if (well.getFieldCount() + index > getSeries()) {
+        return well.getFile(getSeries() - index, no);
+      }
+      index += well.getFieldCount();
+    }
+    return null;
+  }
+
+  class JDCEWell extends WellContainer {
+    HashMap<int[], Integer> posMap = new HashMap<int[], Integer>();
+
+    public JDCEWell(int row, int col) {
+      super(0, row, col, 1);
+    }
+
+    /**
+     * Add file at position [field, z, c, t].
+     */
+    public void addFile(String file, int[] position) {
+      super.addFile(file);
+      posMap.put(position, getAllFiles().size() - 1);
+    }
+
+    public String[] getFiles(int fieldIndex) {
+      List<String> allFiles = getAllFiles();
+      String[] fieldFiles = new String[getImageCount()];
+      for (int[] key : posMap.keySet()) {
+        if (key[0] == fieldIndex) {
+          fieldFiles[getIndex(key[1], key[2], key[3])] = allFiles.get(posMap.get(key));
+        }
+      }
+      return fieldFiles;
+    }
   }
 }

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -304,6 +304,9 @@ public class JDCEReader extends FormatReader {
       channelNames = new String[ms0.sizeC];
       emissionWavelengths = new Length[ms0.sizeC];
       excitationWavelengths = new Length[ms0.sizeC];
+      String[] imagingMode = new String[ms0.sizeC];
+
+      boolean singleZ = true;
       for (int c=0; c<ms0.sizeC; c++) {
         JSONObject wavelength = wavelengths.getJSONObject(c);
         int channelIndex = wavelength.getInt("Index");
@@ -319,6 +322,17 @@ public class JDCEReader extends FormatReader {
         String exUnit = excitation.getString("Unit");
         double exWave = excitation.getDouble("Wavelength");
         excitationWavelengths[channelIndex] = FormatTools.getWavelength(exWave, exUnit);
+
+        // if all of the imaging modes are "Max Intensity Projection",
+        // the Z size will be reset to 1 since only one Z slice is present
+        imagingMode[c] = wavelength.getString("ImagingMode");
+        if (imagingMode[c] == null || (c >= 1 && (!imagingMode[c].equals("Max Intensity Projection") || !imagingMode[c].equals(imagingMode[0])))) {
+          singleZ = false;
+        }
+      }
+      if (singleZ) {
+        LOGGER.debug("Ignoring Z stack size {} based on wavelength definition", ms0.sizeZ);
+        ms0.sizeZ = 1;
       }
 
       JSONArray metadataFiles = imageStack.getJSONArray("ImageMetadataFiles");

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -48,6 +48,7 @@ import ome.units.quantity.Length;
 import ome.units.quantity.Time;
 import ome.xml.model.enums.NamingConvention;
 import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
 
 import org.json.JSONException;
 import org.json.JSONArray;
@@ -218,7 +219,7 @@ public class JDCEReader extends FormatReader {
 
     int plateRows = 0;
     int plateColumns = 0;
-    double creationTimestamp = 0;
+    String creationTimestamp = null;
 
     CoreMetadata ms0 = core.get(0);
     try {
@@ -245,16 +246,15 @@ public class JDCEReader extends FormatReader {
         String timezone = creation.getString("TimeZoneOffset");
 
         if (timezone == null || timezone.isEmpty()) {
-          LOGGER.warn("Timezone not defined; plane timestamps may be wrong");
+          LOGGER.warn("Timezone not defined; plate acquisition time may be wrong");
+          creationTimestamp = DateTools.formatDate(date + " " + time, "yyyy-MM-dd HH:mm:ss");
         }
         else {
-          // store creation timestamp in seconds, as plane timestamps are in seconds
-          // TODO: not sure if timezone is right here
-          creationTimestamp = DateTools.getTime(date + " " + time + " " + timezone, "yyy-MM-dd HH:mm:ss Z") / 1000.0;
+          creationTimestamp = DateTools.formatDate(date + " " + time + " " + timezone, "yyyy-MM-dd HH:mm:ss Z");
         }
       }
       else {
-        LOGGER.debug("Could not find plate creation time; plane timestamps may be wrong");
+        LOGGER.debug("Could not find plate creation time");
       }
 
       JSONObject acquisition = imageStack.getJSONObject("AutoLeadAcquisitionProtocol");
@@ -354,6 +354,8 @@ public class JDCEReader extends FormatReader {
     int positionYIndex = columns.indexOf("PositionYUm");
     int positionZIndex = columns.indexOf("PositionZUm");
 
+    Double smallestTimestamp = null;
+
     JDCEWell currentWell = null;
     boolean firstFile = true;
     for (int i=1; i<csvLines.length; i++) {
@@ -383,10 +385,12 @@ public class JDCEReader extends FormatReader {
       PlaneMetadata p = new PlaneMetadata();
 
       // plane times are stored in seconds since Jan. 1 1970
-      // subtracting the plate creation time gives relative timestamps
-      Double planeTime = DataTools.parseDouble(line[timestampIndex]);
-      planeTime -= creationTimestamp;
-      p.timestamp = FormatTools.createTime(planeTime, UNITS.SECOND);
+      // the smallest absolute timestamp will be subtracted later to get
+      // a readable relative timestamp
+      p.timestamp = DataTools.parseDouble(line[timestampIndex]);
+      if (p.timestamp != null && (smallestTimestamp == null || p.timestamp < smallestTimestamp)) {
+        smallestTimestamp = p.timestamp;
+      }
 
       p.exposureTime = FormatTools.createTime(DataTools.parseDouble(line[exposureTimeIndex]), UNITS.MILLISECOND);
       p.positionX = FormatTools.getStagePosition(DataTools.parseDouble(line[positionXIndex]), UNITS.MICROMETER);
@@ -433,6 +437,9 @@ public class JDCEReader extends FormatReader {
     store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
 
     store.setPlateAcquisitionID(MetadataTools.createLSID("PlateAcquisition", 0, 0), 0, 0);
+    if (creationTimestamp != null) {
+      store.setPlateAcquisitionStartTime(new Timestamp(creationTimestamp), 0, 0);
+    }
 
     wells.sort(null);
 
@@ -460,7 +467,12 @@ public class JDCEReader extends FormatReader {
             store.setPlanePositionX(p.positionX, imageIndex, plane);
             store.setPlanePositionY(p.positionY, imageIndex, plane);
             store.setPlanePositionZ(p.positionZ, imageIndex, plane);
-            store.setPlaneDeltaT(p.timestamp, imageIndex, plane);
+
+            if (p.timestamp != null && smallestTimestamp != null) {
+              Time stamp = FormatTools.createTime(p.timestamp - smallestTimestamp, UNITS.SECOND);
+              store.setPlaneDeltaT(stamp, imageIndex, plane);
+            }
+
             store.setPlaneExposureTime(p.exposureTime, imageIndex, plane);
           }
         }
@@ -548,7 +560,7 @@ public class JDCEReader extends FormatReader {
   }
 
   class PlaneMetadata {
-    public Time timestamp;
+    public Double timestamp;
     public Time exposureTime;
     public Length positionX;
     public Length positionY;

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -102,34 +102,42 @@ public class JDCEReader extends FormatReader {
     Arrays.fill(buf, getFillColor());
 
     String file = getFile(no);
-    helper.setId(file);
-    return helper.openBytes(0, buf, x, y, w, h);
+    if (file != null) {
+      try {
+        helper.setId(file);
+        return helper.openBytes(0, buf, x, y, w, h);
+      }
+      catch (FormatException | IOException e) {
+        LOGGER.error("Invalid file " + file, e);
+      }
+    }
+    return buf;
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    String[] imageFiles = null;
+    ArrayList<String> imageFiles = new ArrayList<String>();
+    imageFiles.add(currentId);
+    imageFiles.add(imageFileCSV);
     if (!noPixels) {
       int index = 0;
       for (JDCEWell well : wells) {
         if (well.getFieldCount() + index > getSeries()) {
-          imageFiles = well.getFiles(getSeries() - index);
+          String[] f = well.getFiles(getSeries() - index);
+          for (String file : f) {
+            if (file != null && !imageFiles.contains(file)) {
+              imageFiles.add(file);
+            }
+          }
           break;
         }
         index += well.getFieldCount();
       }
     }
-    int totalFileCount = imageFiles == null ? 2 : imageFiles.length + 2;
-    String[] rtn = new String[totalFileCount];
-    rtn[0] = currentId;
-    rtn[1] = imageFileCSV;
-    if (imageFiles != null) {
-      System.arraycopy(imageFiles, 0, rtn, 2, imageFiles.length);
-    }
 
-    return rtn;
+    return imageFiles.toArray(new String[imageFiles.size()]);
   }
 
   /* @see loci.formats.IFormatReader#close(boolean) */
@@ -199,7 +207,11 @@ public class JDCEReader extends FormatReader {
 
     CoreMetadata ms0 = core.get(0);
     try {
-      JSONObject root = new JSONObject(DataTools.readFile(id));
+      String jsonText = DataTools.readFile(id);
+      if (!jsonText.startsWith("{")) {
+        jsonText = jsonText.substring(jsonText.indexOf("{"));
+      }
+      JSONObject root = new JSONObject(jsonText);
 
       JSONObject imageStack = root.getJSONObject("ImageStack");
       if (imageStack == null) {
@@ -223,7 +235,7 @@ public class JDCEReader extends FormatReader {
         else {
           // store creation timestamp in seconds, as plane timestamps are in seconds
           // TODO: not sure if timezone is right here
-          creationTimestamp = DateTools.getTime(date + " " + time + " " + timezone, "yyy-MM-dd HH:mm:ss X") / 1000.0;
+          creationTimestamp = DateTools.getTime(date + " " + time + " " + timezone, "yyy-MM-dd HH:mm:ss Z") / 1000.0;
         }
       }
       else {
@@ -255,7 +267,13 @@ public class JDCEReader extends FormatReader {
       if (timeSchedule == null) {
         throw new FormatException("Could not find time schedule, cannot determine SizeT");
       }
-      ms0.sizeT = timeSchedule.getInt("NumberOfTimepoints");
+      JSONArray timepoints = timeSchedule.getJSONArray("Times");
+      int timepointCount = timeSchedule.getInt("NumberOfTimepoints");
+      if (timepoints.length() != timepointCount) {
+        LOGGER.warn("Mismatched timepoint count; using {}, also found {}",
+          timepoints.length(), timepointCount);
+      }
+      ms0.sizeT = timepoints.length();
 
       JSONObject zDimension = plateMap.getJSONObject("ZDimensionParameters");
       if (zDimension == null) {

--- a/components/formats-gpl/src/loci/formats/in/JDCEReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JDCEReader.java
@@ -194,6 +194,8 @@ public class JDCEReader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
+    Location parentDir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
+
     String plateName = null;
     Length physicalSizeX = null;
     Length physicalSizeY = null;
@@ -310,7 +312,7 @@ public class JDCEReader extends FormatReader {
       if (metadataFiles == null || metadataFiles.length() == 0) {
         throw new FormatException("Could not find image metadata CSV, cannot get list of TIFF files");
       }
-      imageFileCSV = metadataFiles.getString(0);
+      imageFileCSV = new Location(parentDir, metadataFiles.getString(0)).getAbsolutePath();
     }
     catch (JSONException e) {
       throw new FormatException("Could not parse .jdce file", e);
@@ -339,7 +341,6 @@ public class JDCEReader extends FormatReader {
     int positionYIndex = columns.indexOf("PositionYUm");
     int positionZIndex = columns.indexOf("PositionZUm");
 
-    Location parentDir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
     JDCEWell currentWell = null;
     boolean firstFile = true;
     for (int i=1; i<csvLines.length; i++) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1909,6 +1909,13 @@ public class FormatReaderTest {
             continue;
           }
 
+          // only .jdce file in MD JDCE data can be used
+          if (reader.getFormat().equals("Molecular Devices JDCE") &&
+            !base[i].toLowerCase().endsWith(".jdce"))
+          {
+            continue;
+          }
+
           // extra metadata files in Harmony/Operetta datasets
           // cannot be used for type detection
           if (reader.getFormat().equals("PerkinElmer Operetta")) {
@@ -2893,6 +2900,18 @@ public class FormatReaderTest {
             if (!result && r instanceof CellSensReader &&
               ((!used[i].endsWith(".vsi") && !used[i].endsWith(".ets")) ||
               (used[i].endsWith(".ets") && !used[i].startsWith("frame"))))
+            {
+              continue;
+            }
+
+            // .jdce data can only be detected from .jdce file
+            if (!result && r instanceof JDCEReader &&
+              !used[i].endsWith(".jdce"))
+            {
+              continue;
+            }
+            if (result && r instanceof JDCEReader &&
+              readers[j] instanceof MetamorphTiffReader)
             {
               continue;
             }


### PR DESCRIPTION
Backported from private PRs. 

Test plates are in `curated/jdce/`. The `*.jdce` file is the target for `showinf` or import.

Note the `WellContainer` class is new; if adding that as public API (or adding in a minor release) isn't comfortable, I am OK with reworking. The intent of that class was to be able to reduce some of the duplicated well handling across multiple HCS readers, but obviously none of the other readers in this repository use it.