### PR TITLE
CZI: LightSource fixes, set LightSourceSettings.Attenuation

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -162,6 +162,7 @@ public class ZeissCZIReader extends FormatReader {
   private ArrayList<String> detectorRefs = new ArrayList<String>();
   private ArrayList<Double> timestamps = new ArrayList<Double>();
   private transient ArrayList<String> gains = new ArrayList<String>();
+  private transient HashMap<String, String> lightSourceIDs = new HashMap<String, String>();
 
   private Length[] positionsX;
   private Length[] positionsY;
@@ -559,6 +560,7 @@ public class ZeissCZIReader extends FormatReader {
       detectorRefs.clear();
       timestamps.clear();
       gains.clear();
+      lightSourceIDs.clear();
 
       previousChannel = 0;
       prestitched = null;
@@ -1715,8 +1717,10 @@ public class ZeissCZIReader extends FormatReader {
           if (thisChannel.acquisitionMode != null) {
             store.setChannelAcquisitionMode(thisChannel.acquisitionMode, i, c);
           }
-          if (thisChannel.lightSourceRef != null) {
-            store.setChannelLightSourceSettingsID(thisChannel.lightSourceRef, i, c);
+          if (thisChannel.lightSourceRef != null &&
+            lightSourceIDs.containsKey(thisChannel.lightSourceRef))
+          {
+            store.setChannelLightSourceSettingsID(lightSourceIDs.get(thisChannel.lightSourceRef), i, c);
             if (thisChannel.intensity != null) {
               // value is stored as a percentage, e.g. "50 %"
               // needs to be converted to a percent fraction, e.g. 0.5
@@ -2563,13 +2567,14 @@ public class ZeissCZIReader extends FormatReader {
           }
 
           String lightSourceID = lightSource.getAttribute("Id");
-          if (lightSourceID == null) {
-            lightSourceID = MetadataTools.createLSID(type, 0, i);
+          String realID = MetadataTools.createLSID("LightSource", 0, i);
+          if (lightSourceID != null) {
+            lightSourceIDs.put(lightSourceID, realID);
           }
 
           String power = getFirstNodeValue(lightSource, "Power");
           if ("Laser".equals(type)) {
-            store.setLaserID(lightSourceID, 0, i);
+            store.setLaserID(realID, 0, i);
             if (power != null) {
               store.setLaserPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2579,7 +2584,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setLaserSerialNumber(serialNumber, 0, i);
           }
           else if ("Arc".equals(type)) {
-            store.setArcID(lightSourceID, 0, i);
+            store.setArcID(realID, 0, i);
             if (power != null) {
               store.setArcPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2589,7 +2594,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setArcSerialNumber(serialNumber, 0, i);
           }
           else if ("LightEmittingDiode".equals(type)) {
-            store.setLightEmittingDiodeID(lightSourceID, 0, i);
+            store.setLightEmittingDiodeID(realID, 0, i);
             if (power != null) {
               store.setLightEmittingDiodePower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2599,7 +2604,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setLightEmittingDiodeSerialNumber(serialNumber, 0, i);
           }
           else if ("Filament".equals(type)) {
-            store.setFilamentID(lightSourceID, 0, i);
+            store.setFilamentID(realID, 0, i);
             if (power != null) {
               store.setFilamentPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2607,6 +2612,11 @@ public class ZeissCZIReader extends FormatReader {
             store.setFilamentManufacturer(manufacturer, 0, i);
             store.setFilamentModel(model, 0, i);
             store.setFilamentSerialNumber(serialNumber, 0, i);
+          }
+          else {
+            // if the type is missing or unsupported,
+            // don't record that the ID was used
+            lightSourceIDs.remove(lightSourceID);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1661,18 +1661,19 @@ public class ZeissCZIReader extends FormatReader {
 
       for (int c=0; c<getEffectiveSizeC(); c++) {
         if (c < channels.size()) {
+          Channel thisChannel = channels.get(c);
           if (isPALM && i < channels.size()) {
             store.setChannelName(channels.get(i).name, i, c);
           }
           else {
-            store.setChannelName(channels.get(c).name, i, c);
+            store.setChannelName(thisChannel.name, i, c);
           }
-          store.setChannelFluor(channels.get(c).fluor, i, c);
-          if (channels.get(c).filterSetRef != null) {
-            store.setChannelFilterSetRef(channels.get(c).filterSetRef, i, c);
+          store.setChannelFluor(thisChannel.fluor, i, c);
+          if (thisChannel.filterSetRef != null) {
+            store.setChannelFilterSetRef(thisChannel.filterSetRef, i, c);
           }
 
-          String color = channels.get(c).color;
+          String color = thisChannel.color;
           if (color != null && !isRGB()) {
             color = normalizeColor(color);
             try {
@@ -1685,7 +1686,7 @@ public class ZeissCZIReader extends FormatReader {
             }
           }
 
-          String emWave = channels.get(c).emission;
+          String emWave = thisChannel.emission;
           if (emWave != null) {
             Double wave = Double.parseDouble(emWave);
             Length em = FormatTools.getEmissionWavelength(wave);
@@ -1693,7 +1694,7 @@ public class ZeissCZIReader extends FormatReader {
               store.setChannelEmissionWavelength(em, i, c);
             }
           }
-          String exWave = channels.get(c).excitation;
+          String exWave = thisChannel.excitation;
           if (exWave != null) {
             Double wave = Double.parseDouble(exWave);
             Length ex = FormatTools.getExcitationWavelength(wave);
@@ -1702,19 +1703,27 @@ public class ZeissCZIReader extends FormatReader {
             }
           }
 
-          if (channels.get(c).illumination != null) {
-            store.setChannelIlluminationType(
-              channels.get(c).illumination, i, c);
+          if (thisChannel.illumination != null) {
+            store.setChannelIlluminationType(thisChannel.illumination, i, c);
           }
 
-          if (channels.get(c).pinhole != null) {
+          if (thisChannel.pinhole != null) {
             store.setChannelPinholeSize(
-              new Length(Double.parseDouble(channels.get(c).pinhole), UNITS.MICROMETER), i, c);
+              new Length(Double.parseDouble(thisChannel.pinhole), UNITS.MICROMETER), i, c);
           }
 
-          if (channels.get(c).acquisitionMode != null) {
-            store.setChannelAcquisitionMode(
-              channels.get(c).acquisitionMode, i, c);
+          if (thisChannel.acquisitionMode != null) {
+            store.setChannelAcquisitionMode(thisChannel.acquisitionMode, i, c);
+          }
+          if (thisChannel.lightSourceRef != null) {
+            store.setChannelLightSourceSettingsID(thisChannel.lightSourceRef, i, c);
+            if (thisChannel.intensity != null) {
+              // value is stored as a percentage, e.g. "50 %"
+              // needs to be converted to a percent fraction, e.g. 0.5
+              Double attenuation = DataTools.parseDouble(thisChannel.intensity.replaceAll("[ %]", ""));
+              attenuation /= 100.0;
+              store.setChannelLightSourceSettingsAttenuation(new PercentFraction(attenuation.floatValue()), i, c);
+            }
           }
         }
 
@@ -2407,6 +2416,7 @@ public class ZeissCZIReader extends FormatReader {
           channels.get(i).pinhole = getFirstNodeValue(channel, "PinholeSize");
 
           channels.get(i).name = channel.getAttribute("Name");
+          channels.get(i).intensity = getFirstNodeValue(channel, "Intensity");
 
           String illumination = getFirstNodeValue(channel, "IlluminationType");
           if (illumination != null) {
@@ -2445,6 +2455,11 @@ public class ZeissCZIReader extends FormatReader {
           Element filterSet = getFirstNode(channel, "FilterSetRef");
           if (filterSet != null) {
             channels.get(i).filterSetRef = filterSet.getAttribute("Id");
+          }
+
+          Element lightSource = getFirstNode(channel, "LightSource");
+          if (lightSource != null) {
+            channels.get(i).lightSourceRef = lightSource.getAttribute("Id");
           }
         }
       }
@@ -2505,9 +2520,45 @@ public class ZeissCZIReader extends FormatReader {
             getFirstNodeValue(manufacturerNode, "SerialNumber");
           String lotNumber = getFirstNodeValue(manufacturerNode, "LotNumber");
 
-          String type = getFirstNodeValue(lightSource, "LightSourceType");
+          Element typeNode = getFirstNode(lightSource, "LightSourceType");
+          String type = null;
+          if (typeNode.hasChildNodes()) {
+            NodeList typeChildren = typeNode.getChildNodes();
+            for (int tc=0; tc<typeChildren.getLength(); tc++) {
+              Node n = typeChildren.item(tc);
+              if (n.getNodeType() != Node.TEXT_NODE) {
+                type = n.getNodeName();
+                break;
+              }
+            }
+          }
+          else {
+            type = typeNode.getTextContent();
+          }
+          String name = lightSource.getAttribute("Name");
+
+          // this should at least set a light source with an ID and Model
+          // even if no other information is present
+          // this matters for being able to link to a Channel
+          if (type == null && model == null) {
+            model = name;
+            if (model.startsWith("LED")) {
+              type = "LightEmittingDiode";
+            }
+            else {
+              type = "Laser";
+              LOGGER.warn("Unknown light source name '{}'; assuming Laser", model);
+            }
+          }
+
+          String lightSourceID = lightSource.getAttribute("Id");
+          if (lightSourceID == null) {
+            lightSourceID = MetadataTools.createLSID(type, 0, i);
+          }
+
           String power = getFirstNodeValue(lightSource, "Power");
           if ("Laser".equals(type)) {
+            store.setLaserID(lightSourceID, 0, i);
             if (power != null) {
               store.setLaserPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2517,6 +2568,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setLaserSerialNumber(serialNumber, 0, i);
           }
           else if ("Arc".equals(type)) {
+            store.setArcID(lightSourceID, 0, i);
             if (power != null) {
               store.setArcPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2526,6 +2578,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setArcSerialNumber(serialNumber, 0, i);
           }
           else if ("LightEmittingDiode".equals(type)) {
+            store.setLightEmittingDiodeID(lightSourceID, 0, i);
             if (power != null) {
               store.setLightEmittingDiodePower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -2535,6 +2588,7 @@ public class ZeissCZIReader extends FormatReader {
             store.setLightEmittingDiodeSerialNumber(serialNumber, 0, i);
           }
           else if ("Filament".equals(type)) {
+            store.setFilamentID(lightSourceID, 0, i);
             if (power != null) {
               store.setFilamentPower(new Power(Double.parseDouble(power), UNITS.MILLIWATT), 0, i);
             }
@@ -4605,6 +4659,8 @@ public class ZeissCZIReader extends FormatReader {
     public Double gain;
     public String fluor;
     public String filterSetRef;
+    public String intensity;
+    public String lightSourceRef;
   }
 
   static class Coordinate {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2529,18 +2529,20 @@ public class ZeissCZIReader extends FormatReader {
 
           Element typeNode = getFirstNode(lightSource, "LightSourceType");
           String type = null;
-          if (typeNode.hasChildNodes()) {
-            NodeList typeChildren = typeNode.getChildNodes();
-            for (int tc=0; tc<typeChildren.getLength(); tc++) {
-              Node n = typeChildren.item(tc);
-              if (n.getNodeType() != Node.TEXT_NODE) {
-                type = n.getNodeName();
-                break;
+          if (typeNode != null) {
+            if (typeNode.hasChildNodes()) {
+              NodeList typeChildren = typeNode.getChildNodes();
+              for (int tc=0; tc<typeChildren.getLength(); tc++) {
+                Node n = typeChildren.item(tc);
+                if (n.getNodeType() != Node.TEXT_NODE) {
+                  type = n.getNodeName();
+                  break;
+                }
               }
             }
-          }
-          else {
-            type = typeNode.getTextContent();
+            else {
+              type = typeNode.getTextContent();
+            }
           }
           String name = lightSource.getAttribute("Name");
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1722,7 +1722,14 @@ public class ZeissCZIReader extends FormatReader {
               // needs to be converted to a percent fraction, e.g. 0.5
               Double attenuation = DataTools.parseDouble(thisChannel.intensity.replaceAll("[ %]", ""));
               attenuation /= 100.0;
-              store.setChannelLightSourceSettingsAttenuation(new PercentFraction(attenuation.floatValue()), i, c);
+              attenuation = 1 - attenuation;
+              if (attenuation - 0 > Constants.EPSILON && 1 - attenuation > Constants.EPSILON) {
+                store.setChannelLightSourceSettingsAttenuation(new PercentFraction(attenuation.floatValue()), i, c);
+              }
+              else {
+                LOGGER.warn("Could not store intensity '{}' in LightSourceSettings.Attenuation",
+                  thisChannel.intensity);
+              }
             }
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1721,14 +1721,16 @@ public class ZeissCZIReader extends FormatReader {
               // value is stored as a percentage, e.g. "50 %"
               // needs to be converted to a percent fraction, e.g. 0.5
               Double attenuation = DataTools.parseDouble(thisChannel.intensity.replaceAll("[ %]", ""));
-              attenuation /= 100.0;
-              attenuation = 1 - attenuation;
-              if (attenuation - 0 > Constants.EPSILON && 1 - attenuation > Constants.EPSILON) {
-                store.setChannelLightSourceSettingsAttenuation(new PercentFraction(attenuation.floatValue()), i, c);
-              }
-              else {
-                LOGGER.warn("Could not store intensity '{}' in LightSourceSettings.Attenuation",
-                  thisChannel.intensity);
+              if (attenuation != null) {
+                attenuation /= 100.0;
+                attenuation = 1 - attenuation;
+                if (attenuation - 0 > Constants.EPSILON && 1 - attenuation > Constants.EPSILON) {
+                  store.setChannelLightSourceSettingsAttenuation(new PercentFraction(attenuation.floatValue()), i, c);
+                }
+                else {
+                  LOGGER.warn("Could not store intensity '{}' in LightSourceSettings.Attenuation",
+                    thisChannel.intensity);
+                }
               }
             }
           }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1720,8 +1720,9 @@ public class ZeissCZIReader extends FormatReader {
           if (thisChannel.lightSourceRef != null &&
             lightSourceIDs.containsKey(thisChannel.lightSourceRef))
           {
-            store.setChannelLightSourceSettingsID(lightSourceIDs.get(thisChannel.lightSourceRef), i, c);
             if (thisChannel.intensity != null) {
+              store.setChannelLightSourceSettingsID(lightSourceIDs.get(thisChannel.lightSourceRef), i, c);
+
               // value is stored as a percentage, e.g. "50 %"
               // needs to be converted to a percent fraction, e.g. 0.5
               Double attenuation = DataTools.parseDouble(thisChannel.intensity.replaceAll("[ %]", ""));

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1087,10 +1087,12 @@ public class FormatReaderTest {
         }
         catch (NullPointerException e) { }
 
-        if (!(expectedLightSource == null && realLightSource == null) &&
-          !expectedLightSource.equals(realLightSource))
-        {
-          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedLightSource + ", actual " + realLightSource + ")");
+        if (expectedLightSource != null || realLightSource != null) {
+          if ((expectedLightSource != null && !expectedLightSource.equals(realLightSource)) ||
+            (realLightSource != null && !realLightSource.equals(expectedLightSource)))
+          {
+            result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedLightSource + ", actual " + realLightSource + ")");
+          }
         }
       }
     }


### PR DESCRIPTION
Backported from a private PR.

This fixes LightSource population to include IDs, which then allows LightSources to be linked to Channels. If an `Intensity` value is present on a Channel (and is in the range 0-100%), then the inverse will be set as the `Attenuation` on `LightSourceSettings`.

Not scheduling for 8.2.0 as this might need additional work, and appropriate test data still needs to be identified. Just opening this now to check for build failures, and then can exclude or update as needed.