### PR TITLE
ND2Reader Changed the padding for a specific condition to pad to 4 byte boundaries.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -25,6 +25,7 @@
 
 package loci.formats.in;
 
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -310,25 +311,34 @@ public class ND2Reader extends SubResolutionFormatReader {
       pix = null;
     }
     else if (split) {
-      // one padding pixel per row total, instead of one padding pixel
-      // per channel per row
-      int rowLength = getSizeX() * pixel + scanlinePad * bpp;
+      //pad to 4 byte boundaries.
+      long rowLength = getSizeX() * (long)pixel;
+      long mod = rowLength%4;
+      long pad = mod == 0 ? mod : 4 - mod;
+      long scanline = rowLength + pad;
+
       int destLength = w * pixel;
 
-      long skip = (long) rowLength * y;
-      in.seek(in.getFilePointer() + skip);
-      byte[] pix = new byte[destLength * h];
-      long pre = (long) x * pixel;
-      long post = (long) pixel * (getSizeX() - w - x) + (scanlinePad * bpp);
-      for (int row=0; row<h; row++) {
-        in.seek(in.getFilePointer() + pre);
-        in.read(pix, row * destLength, destLength);
-        in.seek(in.getFilePointer() + post);
-      }
 
+      long base = in.getFilePointer();
+
+      byte[] pix = new byte[destLength * h];
+
+      long pre = (long) x * pixel;
+
+      //scanlines
+      for (int row=0; row<h; row++) {
+        in.seek(base + (row + y)*scanline + pre);
+        long r = in.read(pix, row * destLength, destLength);
+        if(r != destLength){
+          LOGGER.warn("data line not fully read" + r + " of " + destLength);
+        }
+
+      }
       pix = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),
         bpp, false, true);
-      System.arraycopy(pix, 0, buf, 0, pix.length);
+
+      System.arraycopy(pix, 0, buf, 0, buf.length);
     }
     else {
       // plane is not compressed
@@ -2837,5 +2847,4 @@ public class ND2Reader extends SubResolutionFormatReader {
     in = new RandomAccessInputStream(file);
     offsets = newOffsets;
   }
-
 }

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -322,23 +322,23 @@ public class ND2Reader extends SubResolutionFormatReader {
 
       long base = in.getFilePointer();
 
-      byte[] pix = new byte[destLength * h];
+      byte[] pix = new byte[destLength];
 
       long pre = (long) x * pixel;
 
       //scanlines
       for (int row=0; row<h; row++) {
         in.seek(base + (row + y)*scanline + pre);
-        long r = in.read(pix, row * destLength, destLength);
+        long r = in.read(pix, 0, destLength);
         if(r != destLength){
           LOGGER.warn("data line not fully read" + r + " of " + destLength);
         }
-
+        byte[] p2 = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),
+                bpp, false, true);
+        System.arraycopy(p2, 0, buf, row*p2.length, p2.length);
+        
       }
-      pix = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),
-        bpp, false, true);
 
-      System.arraycopy(pix, 0, buf, 0, buf.length);
     }
     else {
       // plane is not compressed


### PR DESCRIPTION
This relates to issue https://github.com/ome/bioformats/issues/3661 The problem appears to be caused by a padding at the end of each scanline. The padding is incorrectly calculated so the bytes shift across the image.

This fix calculates the scanline padding to achieve 4 bytes aligned scanlines. 

The scanline padding is used at one other place in the code. I haven't checked that but it could probably use the same calculation.