### PR TITLE
Review declaration of Maven Scijava as a repository

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -33,9 +33,11 @@ Type "ant -p" for a list of targets.
 
   <resolver:remoterepo id="ome" url="https://artifacts.openmicroscopy.org/artifactory/maven/" type="default" releases="true" snapshots="false"/>
   <resolver:remoterepo id="unidata" url="https://artifacts.unidata.ucar.edu/repository/unidata-releases/" type="default" releases="true"/>
+  <resolver:remoterepo id="scijava" url="https://maven.scijava.org/content/groups/public/" type="default" releases="true"/>
   <resolver:remoterepo id="jenkins" url="https://repo.jenkins-ci.org/releases/" type="default" releases="true"/>
   <resolver:remoterepos id="resolver.repositories">
     <resolver:remoterepo refid="central"/>
+    <resolver:remoterepo refid="scijava"/>
     <resolver:remoterepo refid="ome"/>
     <resolver:remoterepo refid="unidata"/>
     <resolver:remoterepo refid="jenkins"/>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -378,9 +378,9 @@
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
     <repository>
-      <id>imagej.public</id>
-      <name>ImageJ Maven repositrory</name>
-      <url>https://maven.imagej.net/content/groups/public</url>
+      <id>scijava</id>
+      <name>SciJava</name>
+      <url>https://maven.scijava.org/content/groups/public/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,11 @@
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
+      <id>scijava</id>
+      <name>SciJava</name>
+      <url>https://maven.scijava.org/content/groups/public/</url>
+    </repository>
+    <repository>
       <id>ome</id>
       <name>OME Artifactory</name>
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>


### PR DESCRIPTION
- Update places pointing to the legacy maven.imagej.net
- Add maven.scijava.org in pom.xml and ant/java.xml

This should mitigate recent issues fetching JHDF5 dependency from the OME artifactory. See also https://github.com/ome/omero-model/pull/113