### PR TITLE
Operetta/Harmony: fix case where index XML is in the parent of the image directory

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -79,6 +79,8 @@ public class OperettaReader extends FormatReader {
   private MinimalTiffReader reader;
   private ArrayList<String> metadataFiles = new ArrayList<String>();
 
+  private transient Location imagesDir;
+
   // -- Constructor --
 
   /** Constructs a new Operetta reader. */
@@ -211,6 +213,7 @@ public class OperettaReader extends FormatReader {
       reader = null;
       planes = null;
       metadataFiles.clear();
+      imagesDir = null;
     }
   }
 
@@ -1005,7 +1008,34 @@ public class OperettaReader extends FormatReader {
             else {
               Location parent =
                 new Location(currentId).getAbsoluteFile().getParentFile();
-              activePlane.filename = new Location(parent, value).getAbsolutePath();
+              Location planeFile = new Location(parent, value);
+              if (planeFile.exists()) {
+                activePlane.filename = planeFile.getAbsolutePath();
+              }
+              else {
+                // "Images" or "images" directory may be missing from path
+                if (!parent.getName().equalsIgnoreCase("images") &&
+                  !value.toLowerCase().startsWith("images"))
+                {
+                  // only get the images directory once per initialization
+                  // to minimize impact on initialization time
+                  if (imagesDir == null) {
+                    String[] parentList = parent.list(true);
+                    for (String s : parentList) {
+                      if (s.equalsIgnoreCase("images")) {
+                        imagesDir = new Location(parent, s);
+                        break;
+                      }
+                    }
+                    if (imagesDir == null) {
+                      LOGGER.warn("Cannot locate image directory in {}", parent);
+                    }
+                  }
+                  if (imagesDir != null) {
+                    activePlane.filename = new Location(imagesDir, value).getAbsolutePath();
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Backported from a private PR.

Operetta/Harmony v7 supposedly can place the `index.idx.xml` file in a directory above the image data. `curated/perkinelmer-operetta/samples/artificial-v7-layout` is an artificial example of the file structure that we have seen with some private data.

Using the example plate, `showinf index.idx.xml` without this change will run without an exception, but the used files list will not contain any TIFFs, the images will be entirely blank, and the pixel types will be `int8`. With this change, all TIFF files in each subdirectory should be on the used files list, there should be no warnings about missing files, and the image data/pixel type should be sensible.