### PR TITLE
xmlvalid: consume OMEXMLServiceImpl.SCHEMA_CLASSPATH_READER

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
@@ -45,6 +45,7 @@ import loci.common.RandomAccessInputStream;
 import loci.common.xml.XMLTools;
 import loci.formats.in.TiffReader;
 import loci.formats.tiff.TiffParser;
+import loci.formats.services.OMEXMLServiceImpl;
 
 /**
  * Attempts to validate the given XML files.
@@ -64,7 +65,7 @@ public class XMLValidate {
     } finally {
       in.close();
     }
-    return XMLTools.validateXML(sb.toString(), label);
+    return XMLTools.validateXML(sb.toString(), label, OMEXMLServiceImpl.SCHEMA_CLASSPATH_READER);
   }
 
   @Deprecated

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -165,7 +165,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   /**
    * Finds OME-XML schema definitions in specifications.jar.
    */
-  private static final XMLTools.SchemaReader SCHEMA_CLASSPATH_READER =
+  public static final XMLTools.SchemaReader SCHEMA_CLASSPATH_READER =
       new XMLTools.SchemaReader() {
         @Override
         public InputStream getSchemaAsStream(String url) {


### PR DESCRIPTION
Originally opened as a proposed remediation to #4313 

This allows to map the OME schemas from their URL to the corresponding XSD files available as resources from the specification JAR and perform the XML validation offline / without making HTTP requests.

With the batch improvements added in #4200, it should be possible to test this utility against all the sample OME-XML files from https://github.com/ome/ome-model/tree/master/specification/samples e.g

```
find /path/to/specification/samples -type f -exec ./tools/xmlvalid {} \;
```

Without this PR and with the current HTTP -> HTTPS redirect for the OME schemas URL, the command above should fail. With this PR included, it should work both online and offline