### PR TITLE
Fix OME-TIFF optimal tile size if an IFD is not linked to an Image

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1110,8 +1110,16 @@ public class OMETiffReader extends SubResolutionFormatReader {
           if (info[s][0].id != null && failOnMissingTIFF()) {
             throw new FormatException("Invalid file (may be corrupted): " + info[s][0].id);
           }
-          LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
-          info[s][0].id = currentId;
+          // warning if the id is null (usually no linked data in Image)
+          // isn't helpful, and potentially confusing
+          if (info[s][0].id != null) {
+            LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
+          }
+          // only reset the id if the current file is a TIFF,
+          // not just a companion OME-XML
+          if (info[s][0].reader.isThisType(currentId)) {
+            info[s][0].id = currentId;
+          }
           info[s][0].exists = false;
           if (info[s][0].ifd < 0) {
             info[s][0].ifd = 0;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -467,14 +467,18 @@ public class OMETiffReader extends SubResolutionFormatReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
-    return ((OMETiffCoreMetadata) getCurrentCore()).tileWidth;
+    // tile width might be 0 if an Image was defined with no linked IFDs
+    int tw = ((OMETiffCoreMetadata) getCurrentCore()).tileWidth;
+    return tw > 0 ? tw : super.getOptimalTileWidth();
   }
 
   /* @see loci.formats.SubResolutionFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
-    return ((OMETiffCoreMetadata) getCurrentCore()).tileHeight;
+    // tile height might be 0 if an Image was defined with no linked IFDs
+    int th = ((OMETiffCoreMetadata) getCurrentCore()).tileHeight;
+    return th > 0 ? th : super.getOptimalTileHeight();
   }
 
   // -- Internal FormatReader API methods --

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -657,8 +657,10 @@ public class Configuration {
         String flattenedName = retrieve.getImageName(index);
         seriesTable.put(NAME, flattenedName);
         String unflattenedName = unflattenedRetrieve.getImageName(series);
-        if ((flattenedName == null && unflattenedName != null) || !flattenedName.equals(unflattenedName)) {
-          seriesTable.put(UNFLATTENED_NAME, unflattenedName);
+        if (unflattenedName != null) {
+          if ((flattenedName == null) || !flattenedName.equals(unflattenedName)) {
+            seriesTable.put(UNFLATTENED_NAME, unflattenedName);
+          }
         }
         seriesTable.put(DESCRIPTION, retrieve.getImageDescription(index));
 


### PR DESCRIPTION
22b58ea is backported from a private PR; 464755c was needed to get the test data to configure correctly.

Sample data is `curated/ome-tiff/samples/image-with-no-data/`. Without this change, and simple test:

```
$ cat Test.java 
import loci.common.DebugTools;
import loci.formats.ImageReader;

public class Test {
  public static void main(String[] args) throws Exception {
    DebugTools.enableLogging("INFO");
    try (ImageReader reader = new ImageReader()) {
      reader.setId(args[0]);
      for (int s=0; s<reader.getSeriesCount(); s++) {
        reader.setSeries(s);
        System.out.println("series #" + s + " tile size: " +
          reader.getOptimalTileWidth() + " x " +
          reader.getOptimalTileHeight());
      }
    }
  }
}
$ java Test hcs.companion.ome
```

should print that the last series has an optimal tile size of 0x0. That will cause OMERO imports to fail, in particular see https://github.com/ome/omero-blitz/blob/master/src/main/java/ome/services/blitz/repo/ManagedImportRequestI.java#L840. Note that `showinf hcs.companion.ome` will fail.

With this change, the same test should show optimal tile dimensions greater than 0.

