### PR TITLE
Zeiss CZI: use millisecond units for exposure times attached to channels

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1652,7 +1652,7 @@ public class ZeissCZIReader extends FormatReader {
             channels.get(channel).exposure != null)
           {
             store.setPlaneExposureTime(
-              new Time(channels.get(channel).exposure, UNITS.SECOND), i, plane);
+              new Time(channels.get(channel).exposure, UNITS.MILLISECOND), i, plane);
           }
         }
       }


### PR DESCRIPTION
Backported from a private PR, this is likely to fix #3648.

Expecting test failures, but want to let tests run at least once with this change and no configuration updates so that we can see exactly what needs to be evaluated.

This and #4306 likely need configuration changes in a similar scope, so will try to do the re-configuration once for both PRs.