### PR TITLE
ND2: swap channels when splitting RGB data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -295,7 +295,7 @@ public class ND2Reader extends SubResolutionFormatReader {
 
         if (split) {
           pix = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),
-            bpp, false, true);
+            bpp, true, true);
         }
         System.arraycopy(pix, 0, buf, 0, pix.length);
       }
@@ -334,9 +334,8 @@ public class ND2Reader extends SubResolutionFormatReader {
           LOGGER.warn("data line not fully read" + r + " of " + destLength);
         }
         byte[] p2 = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),
-                bpp, false, true);
+                bpp, true, true);
         System.arraycopy(p2, 0, buf, row*p2.length, p2.length);
-        
       }
 
     }
@@ -2628,7 +2627,7 @@ public class ND2Reader extends SubResolutionFormatReader {
   {
     if (split) {
       pix = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(), bpp,
-        false, true);
+        true, true);
     }
     RandomAccessInputStream s = new RandomAccessInputStream(pix);
     readPlane(s, x, y, w, h, scanlinePad, buf);


### PR DESCRIPTION
Fixes #3761.

See also notes in https://github.com/openmicroscopy/data_repo_config/pull/656.

Additional test data is https://zenodo.org/records/12734440 and https://zenodo.org/records/10277961. For all new datasets, comparing `showinf -merge ...` or similar option in ImageJ against screenshot of NIS Elements should show clearly incorrect colors without this change. With this change, `showinf -merge`/ImageJ should match Elements.

This is expected to cause some test failures, which will need to be carefully evaluated to determine if this PR needs to be refined or if configurations need to be updated.