### PR TITLE
Metamorph: don't reset dimensions if the well count and series count match

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -831,7 +831,9 @@ public class MetamorphReader extends BaseTiffReader {
       } else {
         rows = Collections.max(rowMap.values()) + 1;
         cols = Collections.max(colMap.values()) + 1;
-        if (rows > 0 && cols > 0) {
+        if (rows > 0 && cols > 0 &&
+          core.size() != uniqueWells.size())
+        {
           CoreMetadata c = core.get(0, 0);
           core.clear();
           c.sizeZ = 1;


### PR DESCRIPTION
Fixes #4226.

With the .nd file in `curated/metamorph/gh-4226/`, `showinf -nopix -omexml` without this change should show 6 series each with a single plane. The contents of the .nd file and the .TIF file names clearly indicate that there should be 6 series (== 6 wells), each with 13 timepoints.

With this change, the same test should show 6 series still identified as wells, but now with 13 timepoints each.

Not sure what, if any, tests will be impacted, so it's possible this will need a little more work tomorrow.