### PR TITLE
showinf: configure logging for `-omexml-only` after all arguments parsed

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -230,7 +230,6 @@ public class ImageInfo {
         else if (args[i].equals("-omexml-only")) {
           omexmlOnly = true;
           omexml = true;
-          DebugTools.setRootLevel("OFF");
         }
         else if (args[i].equals("-preload")) preload = true;
         else if (args[i].equals("-ascii")) ascii = true;
@@ -296,6 +295,13 @@ public class ImageInfo {
           return false;
         }
       }
+    }
+
+    // if the -omexml-only flag was used, only print OME-XML, no other logging
+    // the log level is set at the end of argument parsing, so that unknown
+    // any unknown arguments are still logged correctly
+    if (omexmlOnly) {
+      DebugTools.setRootLevel("OFF");
     }
     return true;
   }


### PR DESCRIPTION
Fixes #4310.

As noted in the issue, compare `showinf -omexml-only -no-pix test.fake` against `showinf -no-pix -omexml-only test.fake` and note the difference in behavior without this change. Similarly for `showinf -omexml-only -debug test.fake` and `showinf -debug -omexml-only test.fake`.

With this change, the same sets of options should behave the same, independent of the order in which they are specified. `-debug`, `-trace`, and `-omexml-only` are the only options that change the log level from the default `INFO`.