### PR TITLE
Check modulo values in repository tests

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -43,6 +43,7 @@ import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.MetadataTools;
+import loci.formats.Modulo;
 import loci.formats.ReaderWrapper;
 import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
@@ -132,6 +133,19 @@ public class Configuration {
   private static final String WELL_SAMPLE_POSITION_X_UNIT = "WellSamplePositionXUnit";
   private static final String WELL_SAMPLE_POSITION_Y = "WellSamplePositionY";
   private static final String WELL_SAMPLE_POSITION_Y_UNIT = "WellSamplePositionYUnit";
+
+  private static final String MODULO_Z_START = "ModuloZStart";
+  private static final String MODULO_Z_STEP = "ModuloZStep";
+  private static final String MODULO_Z_END = "ModuloZEnd";
+  private static final String MODULO_Z_TYPE = "ModuloZType";
+  private static final String MODULO_C_START = "ModuloCStart";
+  private static final String MODULO_C_STEP = "ModuloCStep";
+  private static final String MODULO_C_END = "ModuloCEnd";
+  private static final String MODULO_C_TYPE = "ModuloCType";
+  private static final String MODULO_T_START = "ModuloTStart";
+  private static final String MODULO_T_STEP = "ModuloTStep";
+  private static final String MODULO_T_END = "ModuloTEnd";
+  private static final String MODULO_T_TYPE = "ModuloTType";
 
   // -- Fields --
 
@@ -468,6 +482,63 @@ public class Configuration {
     return getPhysicalSize(WELL_SAMPLE_POSITION_Y, WELL_SAMPLE_POSITION_Y_UNIT);
   }
 
+  public Double getModuloZStart() {
+    String start = currentTable.get(MODULO_Z_START);
+    return start == null ? null : Double.parseDouble(start);
+  }
+
+  public Double getModuloZStep() {
+    String step = currentTable.get(MODULO_Z_STEP);
+    return step == null ? null : Double.parseDouble(step);
+  }
+
+  public Double getModuloZEnd() {
+    String end = currentTable.get(MODULO_Z_END);
+    return end == null ? null : Double.parseDouble(end);
+  }
+
+  public String getModuloZType() {
+    return currentTable.get(MODULO_Z_TYPE);
+  }
+
+  public Double getModuloCStart() {
+    String start = currentTable.get(MODULO_C_START);
+    return start == null ? null : Double.parseDouble(start);
+  }
+
+  public Double getModuloCStep() {
+    String step = currentTable.get(MODULO_C_STEP);
+    return step == null ? null : Double.parseDouble(step);
+  }
+
+  public Double getModuloCEnd() {
+    String end = currentTable.get(MODULO_C_END);
+    return end == null ? null : Double.parseDouble(end);
+  }
+
+  public String getModuloCType() {
+    return currentTable.get(MODULO_C_TYPE);
+  }
+
+  public Double getModuloTStart() {
+    String start = currentTable.get(MODULO_T_START);
+    return start == null ? null : Double.parseDouble(start);
+  }
+
+  public Double getModuloTStep() {
+    String step = currentTable.get(MODULO_T_STEP);
+    return step == null ? null : Double.parseDouble(step);
+  }
+
+  public Double getModuloTEnd() {
+    String end = currentTable.get(MODULO_T_END);
+    return end == null ? null : Double.parseDouble(end);
+  }
+
+  public String getModuloTType() {
+    return currentTable.get(MODULO_T_TYPE);
+  }
+
   public void setSeries(int series) throws IndexOutOfBoundsException {
     setSeries(series, true);
   }
@@ -630,6 +701,28 @@ public class Configuration {
 
         seriesTable.put(CHANNEL_COUNT,
           String.valueOf(retrieve.getChannelCount(index)));
+
+        Modulo moduloZ = reader.getModuloZ();
+        if (moduloZ.length() > 1) {
+          seriesTable.put(MODULO_Z_START, String.valueOf(moduloZ.start));
+          seriesTable.put(MODULO_Z_STEP, String.valueOf(moduloZ.step));
+          seriesTable.put(MODULO_Z_END, String.valueOf(moduloZ.end));
+          seriesTable.put(MODULO_Z_TYPE, moduloZ.type);
+        }
+        Modulo moduloC = reader.getModuloC();
+        if (moduloC.length() > 1) {
+          seriesTable.put(MODULO_C_START, String.valueOf(moduloC.start));
+          seriesTable.put(MODULO_C_STEP, String.valueOf(moduloC.step));
+          seriesTable.put(MODULO_C_END, String.valueOf(moduloC.end));
+          seriesTable.put(MODULO_C_TYPE, moduloC.type);
+        }
+        Modulo moduloT = reader.getModuloT();
+        if (moduloT.length() > 1) {
+          seriesTable.put(MODULO_T_START, String.valueOf(moduloT.start));
+          seriesTable.put(MODULO_T_STEP, String.valueOf(moduloT.step));
+          seriesTable.put(MODULO_T_END, String.valueOf(moduloT.end));
+          seriesTable.put(MODULO_T_TYPE, moduloT.type);
+        }
 
         if (canOpenImages(reader)) {
           try {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -53,6 +53,7 @@ import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.Memoizer;
+import loci.formats.Modulo;
 import loci.formats.ReaderWrapper;
 import loci.formats.gui.AWTImageTools;
 import loci.formats.gui.BufferedImageReader;
@@ -760,6 +761,28 @@ public class FormatReaderTest {
       if (reader.getSizeZ() != config.getSizeZ()) {
         result(testName, false, "Series " + i + " (expected " + config.getSizeZ() + ", actual " + reader.getSizeZ() + ")");
       }
+
+      Modulo moduloZ = reader.getModuloZ();
+      int moduloLength = moduloZ.length();
+      String type = config.getModuloZType();
+      Double start = config.getModuloZStart();
+      Double step = config.getModuloZStep();
+      Double end = config.getModuloZEnd();
+      if (!isEqual(type, moduloZ.type)) {
+        result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloZ.type + ")");
+      }
+      // start/stop/step values are 0/0/1 by default unless
+      // the reader set something else, which means a length of 1
+      // if corresponding config values are null, that's OK even though not strictly equal
+      if (!isAlmostEqual(start, moduloZ.start) && (moduloLength > 1 || start != null)) {
+        result(testName, false, "Series " + i + " (expected modulo start " + start + ", actual " + moduloZ.start + ")");
+      }
+      if (!isAlmostEqual(step, moduloZ.step) && (moduloLength > 1 || step != null)) {
+        result(testName, false, "Series " + i + " (expected modulo step " + step + ", actual " + moduloZ.step + ")");
+      }
+      if (!isAlmostEqual(end, moduloZ.end) && (moduloLength > 1 || end != null)) {
+        result(testName, false, "Series " + i + " (expected modulo end " + end + ", actual " + moduloZ.end + ")");
+      }
     }
     result(testName, true);
   }
@@ -777,6 +800,28 @@ public class FormatReaderTest {
       if (reader.getSizeC() != config.getSizeC()) {
         result(testName, false, "Series " + i + " (expected " + config.getSizeC() + ", actual " + reader.getSizeC() + ")");
       }
+
+      Modulo moduloC = reader.getModuloC();
+      int moduloLength = moduloC.length();
+      String type = config.getModuloCType();
+      Double start = config.getModuloCStart();
+      Double step = config.getModuloCStep();
+      Double end = config.getModuloCEnd();
+      if (!isEqual(type, moduloC.type)) {
+        result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloC.type + ")");
+      }
+      // start/stop/step values are 0/0/1 by default unless
+      // the reader set something else, which means a length of 1
+      // if corresponding config values are null, that's OK even though not strictly equal
+      if (!isAlmostEqual(start, moduloC.start) && (moduloLength > 1 || start != null)) {
+        result(testName, false, "Series " + i + " (expected modulo start " + start + ", actual " + moduloC.start + ")");
+      }
+      if (!isAlmostEqual(step, moduloC.step) && (moduloLength > 1 || step != null)) {
+        result(testName, false, "Series " + i + " (expected modulo step " + step + ", actual " + moduloC.step + ")");
+      }
+      if (!isAlmostEqual(end, moduloC.end) && (moduloLength > 1 || end != null)) {
+        result(testName, false, "Series " + i + " (expected modulo end " + end + ", actual " + moduloC.end + ")");
+      }
     }
     result(testName, true);
   }
@@ -793,6 +838,28 @@ public class FormatReaderTest {
 
       if (reader.getSizeT() != config.getSizeT()) {
         result(testName, false, "Series " + i + " (expected " + config.getSizeT() + ", actual " + reader.getSizeT() + ")");
+      }
+
+      Modulo moduloT = reader.getModuloT();
+      int moduloLength = moduloT.length();
+      String type = config.getModuloTType();
+      Double start = config.getModuloTStart();
+      Double step = config.getModuloTStep();
+      Double end = config.getModuloTEnd();
+      if (!isEqual(type, moduloT.type)) {
+        result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloT.type + ")");
+      }
+      // start/stop/step values are 0/0/1 by default unless
+      // the reader set something else, which means a length of 1
+      // if corresponding config values are null, that's OK even though not strictly equal
+      if (!isAlmostEqual(start, moduloT.start) && (moduloLength > 1 || start != null)) {
+        result(testName, false, "Series " + i + " (expected modulo start " + start + ", actual " + moduloT.start + ")");
+      }
+      if (!isAlmostEqual(step, moduloT.step) && (moduloLength > 1 || step != null)) {
+        result(testName, false, "Series " + i + " (expected modulo step " + step + ", actual " + moduloT.step + ")");
+      }
+      if (!isAlmostEqual(end, moduloT.end) && (moduloLength > 1 || end != null)) {
+        result(testName, false, "Series " + i + " (expected modulo end " + end + ", actual " + moduloT.end + ")");
       }
     }
     result(testName, true);
@@ -972,6 +1039,16 @@ public class FormatReaderTest {
     }
   }
 
+  private boolean isAlmostEqual(Double d1, Double d2) {
+    if (d1 == null && d2 == null) {
+      return true;
+    }
+    else if (d1 == null || d2 == null) {
+      return false;
+    }
+    return Math.abs(d1 - d2) < Constants.EPSILON;
+  }
+
   private boolean isAlmostEqual(Quantity q1, Quantity q2) {
     if (q1 == null && q2 == null) {
       return true;
@@ -979,12 +1056,8 @@ public class FormatReaderTest {
       return false;
     } else if (q1.unit() != q2.unit()) {
       return false;
-    } else if (Math.abs(q1.value().doubleValue() - q2.value().doubleValue()) > Constants.EPSILON) {
-
-      return false;
-    } else {
-      return true;
     }
+    return isAlmostEqual(q1.value().doubleValue(), q2.value().doubleValue());
   }
 
   @Test(groups = {"all", "fast", "automated"})

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -768,7 +768,7 @@ public class FormatReaderTest {
       Double start = config.getModuloZStart();
       Double step = config.getModuloZStep();
       Double end = config.getModuloZEnd();
-      if (!isEqual(type, moduloZ.type)) {
+      if (!isEqual(type, moduloZ.type) && moduloLength > 1) {
         result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloZ.type + ")");
       }
       // start/stop/step values are 0/0/1 by default unless
@@ -807,7 +807,7 @@ public class FormatReaderTest {
       Double start = config.getModuloCStart();
       Double step = config.getModuloCStep();
       Double end = config.getModuloCEnd();
-      if (!isEqual(type, moduloC.type)) {
+      if (!isEqual(type, moduloC.type) && moduloLength > 1) {
         result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloC.type + ")");
       }
       // start/stop/step values are 0/0/1 by default unless
@@ -846,7 +846,7 @@ public class FormatReaderTest {
       Double start = config.getModuloTStart();
       Double step = config.getModuloTStep();
       Double end = config.getModuloTEnd();
-      if (!isEqual(type, moduloT.type)) {
+      if (!isEqual(type, moduloT.type) && moduloLength > 1) {
         result(testName, false, "Series " + i + " (expected modulo type " + type + ", actual " + moduloT.type + ")");
       }
       // start/stop/step values are 0/0/1 by default unless

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1046,7 +1046,10 @@ public class FormatReaderTest {
     else if (d1 == null || d2 == null) {
       return false;
     }
-    return Math.abs(d1 - d2) < Constants.EPSILON;
+    else if (d1.isNaN() && d2.isNaN()) {
+      return true;
+    }
+    return Math.abs(d1 - d2) <= Constants.EPSILON;
   }
 
   private boolean isAlmostEqual(Quantity q1, Quantity q2) {


### PR DESCRIPTION
These are the tests I wish had already existed when reviewing #4326.

Generating test configuration should now include modulo type/start/step/end values for any dimension where the modulo length is greater than 1. A length of 1 is the default, so this prevents a bunch of unnecessary configuration from being added for datasets that don't use this feature.

Configuration for LI-FLIM data was generated with these commits and #4326, then tested with just these commits (to check for any changes introduced by #4326). There were no test failures. If I intentionally make the ModuloT calculations in `LiFlimReader` incorrect, then there are test failures as expected.

I would expect some test failures for the few other formats that support the modulo feature, but can regenerate relevant configuration tomorrow once the full list of affected data is available.