### PR TITLE
ND2: add TextInfoItems to original metadata before parsing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -2135,6 +2135,7 @@ public class ND2Reader extends SubResolutionFormatReader {
             value = resultString.toString();
 
             if (name.startsWith("TextInfoItem")) {
+              addGlobalMeta(name, value);
               textInfos.add((String) value);
             }
             break;


### PR DESCRIPTION
Fixes #3991.

This shouldn't affect parsing of individual key/value pairs, but makes it easier to get each `TextInfoItem` as it is stored in the file (and as it is presented in Elements). For `TextInfoItem`s that are just a value with no key (e.g. the timestamp in #3991), this makes sure that the value is preserved when a valid key/value pair cannot be parsed.

Without this change, `showinf -nopix` on `curated/nd2/imagesc-80198` should not include the timestamp (`03.04.2023  16:51:32`) anywhere in original metadata. With this change, it should appear under the key `TextInfoItem_9`. While intuitively that's a timestamp, I don't know of a great way to automatically detect this value as a date/timestamp other than assuming a particular order to the `TextInfoItem`s.