### PR TITLE
Metamorph TIFF: throw more explicit exceptions if parsing invalid TIFF

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -625,12 +625,18 @@ public class MetamorphTiffReader extends BaseTiffReader {
   }
 
   private void parseFile(String tiff, MetamorphHandler handler)
-    throws IOException
+    throws FormatException, IOException
   {
       try (RandomAccessInputStream s = new RandomAccessInputStream(tiff)) {
         TiffParser parser = new TiffParser(s);
         IFD firstIFD = parser.getFirstIFD();
+        if (firstIFD == null) {
+          throw new FormatException("Could not read IFD from " + tiff + "; possibly corrupt");
+        }
         String xml = XMLTools.sanitizeXML(firstIFD.getComment());
+        if (xml == null) {
+          throw new FormatException("No XML found in " + tiff + "; possibly corrupt");
+        }
         XMLTools.parseXML(xml, handler);
       }
   }


### PR DESCRIPTION
Fixes #3186.

If a TIFF without a valid IFD, or without the expected XML metadata, is encountered, this throws FormatException with the name of the affected file. That should be clearer than a NullPointerException with no indication of which file is causing the problem.

In this particular reader, each TIFF needs to have readable metadata in order to determine which specific plane (channel, Z section, etc.) the file refers to. Per-file metadata is also used to calculate the C, Z, and T sizes. That makes simply skipping problematic files tricky, as it can throw off the dimensions for the whole dataset.

To test, I used the dataset linked from #3186 (ten files named `23.001` to `23.010`), but removed `23.005` and replaced it with `touch 23.005`. `showinf 23.001` without this change should simply throw:

```
Exception in thread "main" java.lang.NullPointerException
	at loci.formats.in.MetamorphTiffReader.parseFile(MetamorphTiffReader.java:633)
	at loci.formats.in.MetamorphTiffReader.initFile(MetamorphTiffReader.java:218)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.formats.ImageReader.setId(ImageReader.java:864)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:692)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1054)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1165)
```

with no indication of which file is bad. With this change, the same test:

```
$ showinf -debug 23.001
...
loci.formats.FormatException: Could not read IFD from /home/melissa/data/test-series/23.005; possibly corrupt
	at loci.formats.in.MetamorphTiffReader.parseFile(MetamorphTiffReader.java:634)
	at loci.formats.in.MetamorphTiffReader.initFile(MetamorphTiffReader.java:218)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.formats.ImageReader.setId(ImageReader.java:864)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:692)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1054)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1165)
```