### PR TITLE
org.openmicroscopy component updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,42 +413,24 @@
 
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
 
+  <scm>
+    <connection>scm:git:https://github.com/ome/bioformats</connection>
+    <developerConnection>scm:git:git@github.com:ome/bioformats</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/ome/bioformats</url>
+  </scm>
   <issueManagement>
-    <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/bioformats/issues</url>
   </issueManagement>
-
   <ciManagement>
-    <system>Jenkins</system>
-    <url>https://ci.openmicroscopy.org/</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/bioformats/actions</url>
   </ciManagement>
 
-  <mailingLists>
-    <mailingList>
-      <name>OME-users</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
-      <post>ome-users@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
-    </mailingList>
-    <mailingList>
-      <name>OME-devel</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
-      <post>ome-devel@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
-    </mailingList>
-  </mailingLists>
-
-  <scm>
-    <connection>scm:git:https://github.com/openmicroscopy/bioformats</connection>
-    <developerConnection>scm:git:git@github.com:openmicroscopy/bioformats</developerConnection>
-    <tag>HEAD</tag>
-    <url>http://github.com/openmicroscopy/bioformats</url>
-  </scm>
 
   <!-- NB: for parent project -->
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -41,20 +41,20 @@
     <imagej1.version>1.54c</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <logback.version>1.3.15</logback.version>
-    <ome-stubs.version>6.0.2</ome-stubs.version>
+    <ome-stubs.version>6.0.3</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.8</ome-metakit.version>
+    <ome-metakit.version>5.3.9</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.25</ome-common.version>
+    <ome-common.version>6.0.26</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.4.0</ome-model.version>
-    <ome-poi.version>5.3.9</ome-poi.version>
-    <ome-mdbtools.version>5.3.3</ome-mdbtools.version>
-    <ome-jai.version>0.1.4</ome-jai.version>
-    <ome-codecs.version>1.1.0</ome-codecs.version>
+    <ome-model.version>6.5.0</ome-model.version>
+    <ome-poi.version>5.3.10</ome-poi.version>
+    <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
+    <ome-jai.version>0.1.5</ome-jai.version>
+    <ome-codecs.version>1.1.1</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.3</xalan.version>
     <sqlite.version>3.49.1.0</sqlite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,11 +210,12 @@
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.14.0</version>
           <!-- Require the Java 8 platform. -->
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>8</source>
+            <target>8</target>
+            <release>8</release>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
This bumps the version of all low-level OME components which have been released to https://central.sonatype.com/namespace/org.openmicroscopy using the new [release process](https://ome-contributing.readthedocs.io/en/latest/java-development.html#release-process)

- bump `org.openmicroscopy:metakit` from 5.3.8 to 5.3.9 - see https://github.com/ome/ome-common-java/releases/tag/v5.3.9
- bump `org.openmicroscopy:ome-codecs` from 1.1.0 to 1.1.1 - see https://github.com/ome/ome-common-java/releases/tag/v1.1.1
- bump `org.openmicroscopy:ome-common` from 6.0.25 to 6.0.26 - see https://github.com/ome/ome-common-java/releases/tag/v6.0.26
- bump `org.openmicroscopy:ome-jai` from 0.1.4 to 0.1.5 - see https://github.com/ome/ome-common-java/releases/tag/v0.1.5
- bump `org.openmicroscopy:ome-mdbtools` from 5.3.3 to 5.3.4 - see https://github.com/ome/ome-common-java/releases/tag/v5.3.4
- bump `org.openmicroscopy:ome-model` from 6.4.0 to 6.5.0 - see https://github.com/ome/ome-common-java/releases/tag/v6.5.0
- bump `org.openmicroscopy:ome-poi` from 5.3.9 to 5.3.10 - see https://github.com/ome/ome-common-java/releases/tag/v5.3.10
- bump `org.openmicroscopy:ome-stubs` from 6.0.2 to 6.0.3 - see https://github.com/ome/ome-stubs/releases/tag/v6.0.3

This also bumps `maven-compiler-plugin` to version 3.14.0 and set the `release` option to 8 to ensure that the binaries are always compatible with Java 8 independently of the compiler version and updates some outdated metadata from the POM.