### PR TITLE
Update SlideBook7Reader.java to fix handling of negative Interplane Spacing

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/SlideBook7Reader.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.List;
 import static java.lang.Integer.max;
+import java.lang.Math;
 
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -1669,7 +1670,7 @@ public class SlideBook7Reader  extends FormatReader {
         
         public float GetInterplaneSpacing()
         {
-            return mChannelRecordList.get(0).mExposureRecord.mInterplaneSpacing;
+            return Math.abs(mChannelRecordList.get(0).mExposureRecord.mInterplaneSpacing);
         }
 
         public int GetExposureTime(int inChannel)


### PR DESCRIPTION
There was a problem setting PhysicalSizeZ if the value was negative. Changed to use the absolute value of Interplane Spacing Uploaded a test file to Zenodo:
https://zenodo.org/records/16355849
Old version will not display PhysicalSizeZ  in the OME Metadata window. New version will show it with a value of 100 for this test case.