### PR TITLE
Don't use position metadata when distinguishing between T and series

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -1603,19 +1603,6 @@ public class ND2Reader extends SubResolutionFormatReader {
         }
       }
 
-      if (core.size() == 1 && ((uniqueX == getSizeT() &&
-        uniqueY == getSizeT()) || uniqueZ == getSizeT()))
-      {
-        int count = getSizeT();
-        core.get(0, 0).imageCount /= count;
-        core.get(0, 0).sizeT = 1;
-
-        for (int i=1; i<count; i++) {
-          core.add(core.get(0, 0));
-        }
-        numSeries = core.size();
-      }
-
       // reset the series count if we're confident that the image count
       // covers all of the offsets; this prevents too much memory being used
       // when the offsets array is allocated


### PR DESCRIPTION
One approach to #3313.

Opening to see which datasets are affected by removing this logic, and then can refine as needed. The .nd2 datasets I have locally were unaffected, but I don't have some of the larger files.