### PR TITLE
Upgrade from commons-lang:commons-lang to org.apache.commons:commons-lang3

### DIFF
--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -58,7 +58,7 @@ import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
 import loci.formats.tiff.TiffParser;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -74,9 +74,9 @@
      <version>${kryo.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.perf4j</groupId>

--- a/components/formats-bsd/src/loci/formats/in/BDVReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BDVReader.java
@@ -41,7 +41,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 

--- a/components/formats-bsd/src/loci/formats/in/KLBReader.java
+++ b/components/formats-bsd/src/loci/formats/in/KLBReader.java
@@ -46,7 +46,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import loci.common.CBZip2InputStream;
 import loci.common.DataTools;

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -70,7 +70,7 @@ import ome.units.quantity.Time;
 import ome.units.UNITS;
 
 import org.xml.sax.SAXException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;

--- a/components/formats-gpl/src/loci/formats/in/LeicaMicrosystemsMetadata/LMSMetadataExtractor.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaMicrosystemsMetadata/LMSMetadataExtractor.java
@@ -36,7 +36,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Node;

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import loci.common.DataTools;
 import loci.common.DateTools;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -81,7 +81,7 @@ import ome.units.quantity.Temperature;
 import ome.units.quantity.Time;
 import ome.units.UNITS;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Reader is the file format reader for Metamorph STK files.

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -55,7 +55,7 @@ import ome.units.quantity.Temperature;
 import ome.units.quantity.Time;
 import ome.units.UNITS;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * MetamorphTiffReader is the file format reader for TIFF files produced by


### PR DESCRIPTION
The latest release of commons-lang 2.6 is now over a decade old and is affected by the recent https://nvd.nist.gov/vuln/detail/CVE-2025-48924. As a mitigation, this upgrades the dependency to the latest release of org.apache.commons:commons-lang3.

Testing wise, there are no functional change, this should be a straightforward replacement and the nightly CI builds should keep passing