### PR TITLE
ChannelMerger: correct number of Channels in MetadataStore

### DIFF
--- a/components/formats-bsd/src/loci/formats/ChannelMerger.java
+++ b/components/formats-bsd/src/loci/formats/ChannelMerger.java
@@ -35,13 +35,26 @@ package loci.formats;
 import java.io.IOException;
 
 import loci.common.DataTools;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
 import loci.formats.codec.Codec;
 import loci.formats.codec.CodecOptions;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.meta.MetadataStore;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Logic to automatically merge channels in a file.
  */
 public class ChannelMerger extends ReaderWrapper {
+
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(ChannelMerger.class);
 
   // -- Utility methods --
 
@@ -225,6 +238,34 @@ public class ChannelMerger extends ReaderWrapper {
   @Override
   public Class<?> getNativeDataType() {
     return byte[].class;
+  }
+
+  /* @see IFormatHandler#setId(String) */
+  @Override
+  public void setId(String id) throws FormatException, IOException {
+    super.setId(id);
+
+    MetadataStore store = getMetadataStore();
+    try {
+      OMEXMLService service =
+          new ServiceFactory().getInstance(OMEXMLService.class);
+
+      if (service.isOMEXMLMetadata(store)) {
+        OMEXMLMetadata omexml = service.getOMEMetadata((MetadataRetrieve) store);
+        for (int s=0; s<getSeriesCount(); s++) {
+          setSeries(s);
+          if (canMerge()) {
+            service.removeChannels(omexml, s, getEffectiveSizeC());
+          }
+        }
+      }
+    }
+    catch (DependencyException | ServiceException e) {
+      LOGGER.debug("Could not check for OMEXMLMetadata", e);
+    }
+    finally {
+      setSeries(0);
+    }
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/ChannelMerger.java
+++ b/components/formats-bsd/src/loci/formats/ChannelMerger.java
@@ -45,6 +45,8 @@ import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 
+import ome.xml.model.primitives.PositiveInteger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -256,6 +258,8 @@ public class ChannelMerger extends ReaderWrapper {
           setSeries(s);
           if (canMerge()) {
             service.removeChannels(omexml, s, getEffectiveSizeC());
+            omexml.setChannelSamplesPerPixel(
+              new PositiveInteger(getRGBChannelCount()), s, 0);
           }
         }
       }


### PR DESCRIPTION
Fixes #4342.

I initially thought this would be a problem specific to `loci.formats.tools.ImageConverter`, but further investigation showed that `ChannelMerger` did not have any logic corresponding to what is in `ChannelSeparator` already for ensuring that the `MetadataStore` matches the adjusted channel representation.

Without this change, try the test in #4342 and/or the use case mentioned in https://forum.image.sc/t/rgb-and-ome-xml/39240/4. With this change, the same test should remove extra `Channel` elements, such that `SizeC` is the sum of `SamplesPerPixel` on every `Channel`.

I wouldn't expect this to impact tests or anything in OMERO.