### PR TITLE
Fix Metamorph .nd encoding

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -120,6 +120,8 @@ public class MetamorphReader extends BaseTiffReader {
   private static final String NDINFOFILE_VER1 = "Version 1.0";
   private static final String NDINFOFILE_VER2 = "Version 2.0";
 
+  private static final String ND_ENCODING = "windows-1252";
+
   // -- Fields --
 
   /** The TIFF's name */
@@ -484,7 +486,7 @@ public class MetamorphReader extends BaseTiffReader {
       boolean useWaveNames = true;
 
       ndFilename = ndfile.getAbsolutePath();
-      String[] lines = DataTools.readFile(ndFilename).split("\n");
+      String[] lines = DataTools.readFile(ndFilename, ND_ENCODING).split("\n");
 
       boolean globalDoZ = true;
       boolean doTimelapse = false;
@@ -2279,7 +2281,7 @@ public class MetamorphReader extends BaseTiffReader {
    */
   private String getNDVersionSuffix(Location ndfile) throws IOException {
     ndFilename = ndfile.getAbsolutePath();
-    String[] lines = DataTools.readFile(ndFilename).split("\n");
+    String[] lines = DataTools.readFile(ndFilename, ND_ENCODING).split("\n");
     boolean globalDoZ = true;
     String version = NDINFOFILE_VER1;
     StringBuilder currentValue = new StringBuilder();

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.0.26</ome-common.version>
+    <ome-common.version>6.1.0</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.5.0</ome-model.version>
     <ome-poi.version>5.3.10</ome-poi.version>


### PR DESCRIPTION
Fixes #4021.

See data in `curated/metamorph/gh-4021`. That is the `test.nd` file attached to #4021, with a single artificial .tif to allow for easier testing.

Without this change, `showinf -nopix test.nd` should show an incorrect stage name in the original metadata, as reported. With this change, the name should be fixed.