### PR TITLE
FakeReader: link instrument to all images

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -71,6 +71,7 @@ import ome.specification.XMLMockObjects;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.MapPair;
 import ome.xml.model.OME;
+import ome.xml.model.Instrument;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.UnitsLength;
 import ome.xml.model.enums.handlers.UnitsLengthEnumHandler;
@@ -843,6 +844,7 @@ public class FakeReader extends FormatReader {
     }
 
     // populate SPW metadata
+    String instrumentID = null;
     MetadataStore store = makeFilterMetadata();
     boolean hasSPW = screens > 0 || plates > 0 || plateRows > 0 ||
       plateCols > 0 || fields > 0 || plateAcqs > 0;
@@ -856,10 +858,11 @@ public class FakeReader extends FormatReader {
       // generate SPW metadata and override series count to match
       int imageCount =
         populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs, withMicrobeam);
+      instrumentID = getOmeXmlMetadata().getInstrumentID​(0);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
     } else if (withInstrument) {
-      populateInstrument(store);
+      instrumentID = populateInstrument(store);
     }
 
     // populate core metadata
@@ -906,6 +909,9 @@ public class FakeReader extends FormatReader {
     fillPhysicalSizes(store);
     fillChannelWavelengths(store);
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
+      if (instrumentID != null) {
+        store.setImageInstrumentRef(instrumentID, currentImageIndex);
+      }
       if (currentImageIndex < seriesTables.size()) {
         parseSeriesTable(seriesTables.get(currentImageIndex), store, currentImageIndex);
       }
@@ -1428,13 +1434,15 @@ public class FakeReader extends FormatReader {
     return ome.sizeOfImageList();
   }
 
-  private void populateInstrument(MetadataStore store)
+  private String populateInstrument(MetadataStore store)
   {
     final XMLMockObjects xml = new XMLMockObjects();
     OME ome = xml.getRoot();
-    ome.addInstrument(xml.createInstrument(true));
+    Instrument instrument = xml.createInstrument(true);
+    ome.addInstrument(instrument);
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);
+    return instrument.getID();
   }
 
   /** Creates a mapping between indices and color values. */

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -71,7 +71,6 @@ import ome.specification.XMLMockObjects;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.MapPair;
 import ome.xml.model.OME;
-import ome.xml.model.Instrument;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.UnitsLength;
 import ome.xml.model.enums.handlers.UnitsLengthEnumHandler;
@@ -844,7 +843,6 @@ public class FakeReader extends FormatReader {
     }
 
     // populate SPW metadata
-    String instrumentID = null;
     MetadataStore store = makeFilterMetadata();
     boolean hasSPW = screens > 0 || plates > 0 || plateRows > 0 ||
       plateCols > 0 || fields > 0 || plateAcqs > 0;
@@ -858,11 +856,10 @@ public class FakeReader extends FormatReader {
       // generate SPW metadata and override series count to match
       int imageCount =
         populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs, withMicrobeam);
-      instrumentID = getOmeXmlMetadata().getInstrumentID​(0);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
     } else if (withInstrument) {
-      instrumentID = populateInstrument(store);
+      populateInstrument(store);
     }
 
     // populate core metadata
@@ -909,8 +906,8 @@ public class FakeReader extends FormatReader {
     fillPhysicalSizes(store);
     fillChannelWavelengths(store);
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
-      if (instrumentID != null) {
-        store.setImageInstrumentRef(instrumentID, currentImageIndex);
+      if (hasSPW || withInstrument) {
+        fillInstrumentRefs(store);
       }
       if (currentImageIndex < seriesTables.size()) {
         parseSeriesTable(seriesTables.get(currentImageIndex), store, currentImageIndex);
@@ -1121,6 +1118,35 @@ public class FakeReader extends FormatReader {
       annotationXmlCount++;
       annotationCount++;
       annotationRefCount++;
+    }
+  }
+
+  private void fillInstrumentRefs(MetadataStore store) {
+    for (int s=0; s<getSeriesCount(); s++) {
+      String detectorID = getOmeXmlMetadata().getDetectorID(0, 0);
+      String dichroicID = getOmeXmlMetadata().getDichroicID(0, 0);
+      String emissionFilterID = getOmeXmlMetadata().getFilterID​(0, 0);
+      String excitationFilterID = getOmeXmlMetadata().getFilterID​(0, 1);
+      String filterSetID = getOmeXmlMetadata().getFilterSetID​(0, 0);
+      String instrumentID = getOmeXmlMetadata().getInstrumentID​(0);
+      String[] lightSourcesID = {
+        getOmeXmlMetadata().getLaserID(0, 0),
+        getOmeXmlMetadata().getArcID(0, 1),
+        getOmeXmlMetadata().getFilamentID(0, 2),
+        getOmeXmlMetadata().getLightEmittingDiodeID(0, 3),
+        getOmeXmlMetadata().getLaserID(0, 4)
+      };
+      String objectiveID = getOmeXmlMetadata().getObjectiveID​(0, 0);
+      store.setImageInstrumentRef(instrumentID, s);
+      store.setObjectiveSettingsID(objectiveID, s);
+      for (int c=0; c<getEffectiveSizeC(); c++) {
+        store.setChannelFilterSetRef​(filterSetID, s, c);
+        store.setChannelLightSourceSettingsID​(lightSourcesID[c % 5], s, c);
+        store.setDetectorSettingsID(detectorID, s, c);
+        store.setLightPathDichroicRef​(dichroicID, s, c);
+        store.setLightPathEmissionFilterRef(emissionFilterID, s, c, 0);
+        store.setLightPathExcitationFilterRef​(excitationFilterID, s, c, 0);
+      }
     }
   }
 
@@ -1434,15 +1460,13 @@ public class FakeReader extends FormatReader {
     return ome.sizeOfImageList();
   }
 
-  private String populateInstrument(MetadataStore store)
+  private void populateInstrument(MetadataStore store)
   {
     final XMLMockObjects xml = new XMLMockObjects();
     OME ome = xml.getRoot();
-    Instrument instrument = xml.createInstrument(true);
-    ome.addInstrument(instrument);
+    ome.addInstrument(xml.createInstrument(true));
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);
-    return instrument.getID();
   }
 
   /** Creates a mapping between indices and color values. */

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -822,6 +822,28 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getInstrumentCount(), 1);
+    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
+    reader.close();
+
+    reader.setId("test&withInstrument=true&series=3.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getImageCount(), 3);
+    assertEquals(m.getInstrumentCount(), 1);
+    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
+    assertEquals(m.getImageInstrumentRef(1), m.getInstrumentID(0));
+    assertEquals(m.getImageInstrumentRef(2), m.getInstrumentID(0));
+    reader.close();
+
+    reader.setId("test&plates=1&plateRows=2&plateCols=2.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getImageCount(), 4);
+    assertEquals(m.getInstrumentCount(), 1);
+    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
+    assertEquals(m.getImageInstrumentRef(1), m.getInstrumentID(0));
+    assertEquals(m.getImageInstrumentRef(2), m.getInstrumentID(0));
+    assertEquals(m.getImageInstrumentRef(3), m.getInstrumentID(0));
     reader.close();
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -816,34 +816,59 @@ public class FakeReaderTest {
     assertEquals(m.getChannelEmissionWavelength(1, 1), new Length(580.0, UNITS.NANOMETER));
   }
 
-  @Test
-  public void testInstrument() throws Exception {
-    reader.setId("test&withInstrument=true.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getInstrumentCount(), 1);
-    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
-    reader.close();
+  @DataProvider(name = "instruments")
+  public Object[][] intruments() {
+    return new Object[][] {
+      {"test&withInstrument=true.fake", 1, 1},
+      {"test&withInstrument=true&series=3.fake", 3, 1},
+      {"test&sizeC=5&withInstrument=true.fake", 1, 5},
+      {"test&plates=1&plateRows=2&plateCols=2.fake", 4, 1},
+      {"test&plates=1&plateRows=2&plateCols=2&sizeC=4.fake", 4, 4}
+    };
+  }
 
-    reader.setId("test&withInstrument=true&series=3.fake");
+  @Test(dataProvider = "intruments")
+  public void testInstrument(String id, int imageCount, int channelCount) throws Exception {
+    reader.setId(id);
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getImageCount(), 3);
+    assertEquals(m.getDetectorCount(0), 1);
+    assertEquals(m.getDichroicCount(0), 1);
+    assertEquals(m.getFilterCount(0), 2);
+    assertEquals(m.getFilterSetCount(0), 1);
+    assertEquals(m.getImageCount(), imageCount);
     assertEquals(m.getInstrumentCount(), 1);
-    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
-    assertEquals(m.getImageInstrumentRef(1), m.getInstrumentID(0));
-    assertEquals(m.getImageInstrumentRef(2), m.getInstrumentID(0));
-    reader.close();
-
-    reader.setId("test&plates=1&plateRows=2&plateCols=2.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getImageCount(), 4);
-    assertEquals(m.getInstrumentCount(), 1);
-    assertEquals(m.getImageInstrumentRef(0), m.getInstrumentID(0));
-    assertEquals(m.getImageInstrumentRef(1), m.getInstrumentID(0));
-    assertEquals(m.getImageInstrumentRef(2), m.getInstrumentID(0));
-    assertEquals(m.getImageInstrumentRef(3), m.getInstrumentID(0));
-    reader.close();
+    assertEquals(m.getLightSourceCount​(0), 5);
+    assertEquals(m.getObjectiveCount(0), 1);
+    for (int i=0; i<imageCount; i++) {
+      assertEquals(m.getImageInstrumentRef(i), m.getInstrumentID(0));
+      assertEquals(m.getObjectiveSettingsID​(i), m.getObjectiveID(0, 0));
+      for (int c=0; c<channelCount; c++) {
+        assertEquals(m.getChannelCount(i), channelCount);
+        assertEquals(m.getChannelFilterSetRef​(i, c), m.getFilterSetID(0, 0));
+        switch (c % 5) {
+          case 0:
+            assertEquals(m.getChannelLightSourceSettingsID​(i, c), m.getLaserID(0, 0));
+            break;
+          case 1:
+            assertEquals(m.getChannelLightSourceSettingsID​(i, c), m.getArcID(0, 1));
+            break;
+          case 2:
+            assertEquals(m.getChannelLightSourceSettingsID​(i, c), m.getFilamentID(0, 2));
+            break;
+          case 3:
+            assertEquals(m.getChannelLightSourceSettingsID​(i, c), m.getLightEmittingDiodeID(0, 3));
+            break;
+          case 4:
+            assertEquals(m.getChannelLightSourceSettingsID​(i, c), m.getLaserID(0, 4));
+            break;
+        }
+        assertEquals(m.getLightPathDichroicRef​(i, c), m.getDichroicID(0, 0));
+        assertEquals(m.getLightPathEmissionFilterRefCount​​​(i, c), 1);
+        assertEquals(m.getLightPathEmissionFilterRef​​(i, c, 0), m.getFilterID(0, 0));
+        assertEquals(m.getLightPathExcitationFilterRefCount​​​(i, c), 1);
+        assertEquals(m.getLightPathExcitationFilterRef​​​(i, c, 0), m.getFilterID(0, 1));
+      }
+    }
   }
 }


### PR DESCRIPTION
Noticed during some internal testing, the mock instrument created in `FakeReader` either when using `plates=N` or when setting `withInstrument=true` is completely unreferenced in the OME metadata. This commit updates the metadata to create:
- Image.InstrumentRef and Image.ObjectiveSettings for each image
- Channel.DetectorSettings, Channel.FilterRefSet, Channel.LightSourceSettings for each channel of each image
- LightPath.DichroicRef, LightPath.EmissionFilterRef, LightPath.ExcitationFilterRef for the LightPath element of each channel of each image

The unit tests are updated to test existence of the various elements for all representations (single image, multi-image and SPW, single and multi-channel)

Functionally, this PR can be tested by running

```
showinf -nopix -omexml-only "test&series=2&withInstrument=true.fake"
showinf -nopix -omexml-only "test&series=2&sizeC=5&withInstrument=true.fake"
showinf -nopix -omexml-only "test&plates=1&plateRows=2&plateCols=2.fake"
showinf -nopix -omexml-only "test&plates=1&plateRows=2&plateCols=2&sizeC=3.fake"
```

Without this PR, the `Image` elements should have no reference to the `Instrument`, `Detector`... With this PR, all the elements under the `Instrument:0` should be linked in the relevant location.