### PR TITLE
Build report workflow: fix failure when no tests failed

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -21,9 +21,11 @@ jobs:
           start=$(grep -c "Batch .* started" ./build-status.log)
           end=$(grep -c "Batch .* finished" ./build-status.log)
           if [ "$start" != "$end" ]; then
+              echo "$start batches started but $end finished"
               exit 1
           fi 
-          output=$(grep "Tests failed in" ./build-status.log)
+          output=$(grep "Tests failed in" ./build-status.log || true)
           if [ -n "$output" ]; then
+            echo "Found failures in the build status"
             exit 1
           fi


### PR DESCRIPTION
Fixes #4346

grep returns a non-zero exit status is the pattern is not found. To be able to perform the second test of the workflow, this ensures that a successful exit code is returned before testing the emptiness of the output