### PR TITLE
GH release workflow: add flag to automatically generate notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
           sha256sum ./*.xz >> SHASUMS
           sha256sum ./*.gz >> SHASUMS
           tag_name="${GITHUB_REF##*/}"
-          gh release create "$tag_name" ./*.zip ./*.jar ./*.xz ./*.gz SHASUMS
+          gh release create --generate-notes "$tag_name" ./*.zip ./*.jar ./*.xz ./*.gz SHASUMS
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This tries to take advantage of  the `gh release create` options to automatically populate the release created on tags with notes as per  https://ome-contributing.readthedocs.io/en/latest/bioformats-release-process.html#source-code-release