### PR TITLE
Fix tag encoding for LEO files

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -98,6 +98,8 @@ public class TiffParser implements Closeable {
 
   private boolean canClose = false;
 
+  private String tagEncoding = null;
+
   // -- Constructors --
 
   /** Constructs a new TIFF parser from the given file name. */
@@ -172,6 +174,14 @@ public class TiffParser implements Closeable {
   /** Sets whether or not YCbCr color correction is allowed. */
   public void setYCbCrCorrection(boolean correctionAllowed) {
     ycbcrCorrection = correctionAllowed;
+  }
+
+  /**
+   * Sets the encoding to use for tags with ASCII values.
+   * Defaults to UTF-8 if unset.
+   */
+  public void setEncoding(String encoding) {
+    tagEncoding = encoding;
   }
 
   /** Gets the stream from which TIFF data is being parsed. */
@@ -578,14 +588,15 @@ public class TiffParser implements Closeable {
       String[] strings = nullCount == 1 ? null : new String[nullCount];
       String s = null;
       int c = 0, ndx = -1;
+      String encoding = tagEncoding == null ? Constants.ENCODING : tagEncoding;
       for (int j=0; j<count; j++) {
         if (ascii[j] == 0) {
-          s = new String(ascii, ndx + 1, j - ndx - 1, Constants.ENCODING);
+          s = new String(ascii, ndx + 1, j - ndx - 1, encoding);
           ndx = j;
         }
         else if (j == count - 1) {
           // handle non-null-terminated strings
-          s = new String(ascii, ndx + 1, j - ndx, Constants.ENCODING);
+          s = new String(ascii, ndx + 1, j - ndx, encoding);
         }
         else s = null;
         if (strings != null && s != null) strings[c++] = s;

--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -53,6 +53,7 @@ public class LEOReader extends BaseTiffReader {
   public static final int LEO_TAG = 34118;
   private static final String[] DATE_FORMATS = new String[] {
       "HH:mm dd-MMM-yyyy", "HH:mm:ss dd MMM yyyy"};
+  private static final String TAG_ENCODING = "iso-8859-1";
 
   // -- Fields --
 
@@ -83,6 +84,13 @@ public class LEOReader extends BaseTiffReader {
   }
 
   // -- Internal BaseTiffReader API methods --
+
+  /* @see BaseTiffReader#initTiffParser() */
+  @Override
+  protected void initTiffParser() {
+    super.initTiffParser();
+    tiffParser.setEncoding(TAG_ENCODING);
+  }
 
   /* @see BaseTiffReader#initStandardMetadata() */
   @Override


### PR DESCRIPTION
Fixes #4352.

4a7ea54 allows the tag encoding to be configured on a `TiffParser`, and 9a8f661 makes use of that in the `LEOReader` specifically. This does mean one new public method in `TiffParser` (so requires minor release), but that seemed like the most straightforward way to fix, and makes it easier if other readers have similar problems in the future.

With data provided in https://zenodo.org/records/16760282, `showinf -nopix -omexml 'AWM2-HCF-7021-04_06 - Correct_Scale_Bar.tif'` should show the same physical pixel sizes with and without this change. `showinf -nopix -omexml 'AWM2-HCF-7021-04_01 - Wrong_Scale_Bar.tif'` without this change should show physical pixel sizes of 3.19 µm, and with this change should show 1.595 µm as indicated in https://forum.image.sc/t/wrong-scale-bar-after-importing-images/114991/12.

It looks like data in this format more commonly has physical pixel sizes in nm, not µm, which is why this hasn't come up before.