### PR TITLE
Fix DCIMG indexing over multiple files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -123,9 +123,12 @@ public class DCIMGReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int zp = no % getSizeZ();
-    int tp = (no / getSizeZ()) % getSizeT();
+    int[] zct = getZCTCoords(no);
+    int zp = zct[0];
+    // int cp = zct[1];  
+    int tp = zct[2];
 
+  
     try (RandomAccessInputStream stream = new RandomAccessInputStream(uniqueFiles[zp])) {
       stream.order(IS_LITTLE);
 

--- a/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DCIMGReader.java
@@ -123,8 +123,8 @@ public class DCIMGReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int zp = no / getSizeT();
-    int tp = no % getSizeT();
+    int zp = no % getSizeZ();
+    int tp = (no / getSizeZ()) % getSizeT();
 
     try (RandomAccessInputStream stream = new RandomAccessInputStream(uniqueFiles[zp])) {
       stream.order(IS_LITTLE);


### PR DESCRIPTION
Selection of `z` and `t` was incorrect when multiple files were grouped as a virtual stack. Fixed here. While this is not a problem with the DCIMG reading, but with how I originally assumed `no` worked, I uploaded an example data set where there's drift, so it's easy to see the different between the correct (this PR) and incorrect (current code) indexing: https://zenodo.org/records/16875377. 