### PR TITLE
Add reader for TissueFAXS (.tfcyto) data

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -109,7 +109,7 @@ loci.formats.in.XLEFReader            # xlef
 loci.formats.in.OlympusTileReader     # omp2info
 loci.formats.in.DCIMGReader           # dcimg
 loci.formats.in.JDCEReader            # jdce
-loci.formats.in.TissuegnosticsReader  # tfcyto
+loci.formats.in.TissueFAXSReader      # aqproj
 loci.formats.in.ZeissXRMReader        # txm, txrm
 
 # multi-extension messes

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -109,7 +109,7 @@ loci.formats.in.XLEFReader            # xlef
 loci.formats.in.OlympusTileReader     # omp2info
 loci.formats.in.DCIMGReader           # dcimg
 loci.formats.in.JDCEReader            # jdce
-loci.formats.in.TissueFAXSReader      # aqproj
+loci.formats.in.TissueFAXSReader      # aqproj, tfcyto
 loci.formats.in.ZeissXRMReader        # txm, txrm
 
 # multi-extension messes

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -109,6 +109,7 @@ loci.formats.in.XLEFReader            # xlef
 loci.formats.in.OlympusTileReader     # omp2info
 loci.formats.in.DCIMGReader           # dcimg
 loci.formats.in.JDCEReader            # jdce
+loci.formats.in.TissuegnosticsReader  # tfcyto
 loci.formats.in.ZeissXRMReader        # txm, txrm
 
 # multi-extension messes

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -594,11 +594,13 @@ public class TissueFAXSReader extends FormatReader {
       // if the region has TMA XY coordinates,
       // then the row/column values in the images table for this region ID
       // will be relative to this specific TMA block, not the overall image
+      // if we're somewhere within this TMA block, consider all FOVs for
+      // this TMA block
       if (region.tmaX != null) {
         int regionCol = region.tmaX * region.scaleFactor;
         startCol -= regionCol;
         endCol -= regionCol;
-        if (endCol >= 0) {
+        if (endCol >= 0 && startCol <= region.scaleFactor - 1) {
           startCol = 0;
           endCol = region.scaleFactor - 1;
         }
@@ -607,7 +609,7 @@ public class TissueFAXSReader extends FormatReader {
         int regionRow = region.tmaY * region.scaleFactor;
         startRow -= regionRow;
         endRow -= regionRow;
-        if (endRow >= 0) {
+        if (endRow >= 0 && startRow <= region.scaleFactor - 1) {
           startRow = 0;
           endRow = region.scaleFactor - 1;
         }

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -508,7 +508,7 @@ public class TissueFAXSReader extends FormatReader {
       }
 
       if (region.correctionImageCoreIndex != null) {
-        int corrImage = nextImage;
+        int corrImage = hasFlattenedResolutions() ? region.correctionImageCoreIndex : nextImage;
         nextImage++;
 
         store.setImageName(region.regionMetadata.getString("Name") + " Correction Image", corrImage);

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -58,6 +58,7 @@ import loci.formats.meta.MetadataStore;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
+import ome.xml.model.enums.AcquisitionMode;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
@@ -426,9 +427,16 @@ public class TissueFAXSReader extends FormatReader {
       store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(physicalX), imageIndex);
       store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(physicalY), imageIndex);
 
+      String acquisitionMode = region.regionMetadata.getString("AcquisitionMode");
+      AcquisitionMode mode = getAcquisitionMode(acquisitionMode);
+
       for (int c=0; c<region.channels.size(); c++) {
         Channel ch = region.channels.get(c);
         store.setChannelName(ch.name, imageIndex, c);
+
+        if (mode != null) {
+          store.setChannelAcquisitionMode(mode, imageIndex, c);
+        }
 
         if (ch.emWave >= WAVE_MIN && ch.emWave <= WAVE_MAX) {
           store.setChannelEmissionWavelength(FormatTools.getWavelength((double) ch.emWave), imageIndex, c);

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -430,10 +430,9 @@ public class TissueFAXSReader extends FormatReader {
         CoreMetadata correction = new CoreMetadata(m);
         correction.sizeX = start.tileSizeX;
         correction.sizeY = start.tileSizeY;
-        correction.sizeC = m.rgb ? 4 : m.sizeC;
         correction.pixelType = FormatTools.FLOAT;
         correction.resolutionCount = 1;
-        correction.littleEndian = false;
+        correction.littleEndian = true;
 
         core.add(correction);
       }
@@ -628,6 +627,7 @@ public class TissueFAXSReader extends FormatReader {
     options.width = region.tileSizeX;
     options.height = region.tileSizeY;
     options.interleaved = isInterleaved();
+    options.littleEndian = isLittleEndian();
     return options;
   }
 
@@ -869,6 +869,24 @@ public class TissueFAXSReader extends FormatReader {
         CodecOptions options = getCodecOptions(region);
 
         data = getCodec(compression).decompress(data, options);
+        int bpp = FormatTools.getBytesPerPixel(getPixelType());
+
+        // found 4 channels, need to remove extras to match channel count
+        if (data.length == options.width * options.height * bpp * 4) {
+          int srcStride = bpp * 4;
+          int destStride = bpp * getRGBChannelCount();
+          byte[] tmp = new byte[options.width * options.height * destStride];
+
+          if (isInterleaved()) {
+            for (int pix=0; pix<options.width*options.height; pix++) {
+              System.arraycopy(data, pix * srcStride, tmp, pix * destStride, destStride);
+            }
+          }
+          else {
+            System.arraycopy(data, 0, tmp, 0, tmp.length);
+          }
+          data = tmp;
+        }
 
         Region correction = new Region(0, 0, options.width, options.height);
 

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -166,133 +166,15 @@ public class TissueFAXSReader extends FormatReader {
     Arrays.fill(buf, getFillColor());
 
     int[] zct = getZCTCoords(no);
-    ScanRegion region = getRegion(zct[2]);
-    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    List<ScanRegion> planeRegions = getAllRegions(zct[2]);
     int level = getLevel();
-    int scale = (int) Math.pow(region.scaleFactor, level);
-
-    int scaledOverlapX = region.overlapX / scale;
-    int scaledOverlapY = region.overlapY / scale;
 
     Region dest = new Region(x, y, w, h);
-    Connection conn = openConnection(region.file);
-    try {
-      PreparedStatement tiles = conn.prepareStatement(
-        "SELECT data, compression, row, column FROM images WHERE region=? AND level=? AND " +
-        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column"
-      );
 
-      int rowOffset = (int) Math.floor((double) region.tileRangeY[0] / scale);
-      int colOffset = (int) Math.floor((double) region.tileRangeX[0] / scale);
-
-      int startRow = (int) Math.floor((double) y / region.tileSizeY) + rowOffset;
-      int startCol = (int) Math.floor((double) x / region.tileSizeX) + colOffset;
-      int endRow = (int) Math.ceil((double) (y + h) / region.tileSizeY) + rowOffset;
-      int endCol = (int) Math.ceil((double) (x + w) / region.tileSizeX) + colOffset;
-
-      tiles.setInt(1, region.id);
-      tiles.setInt(2, level);
-      tiles.setInt(3, startRow);
-      tiles.setInt(4, endRow);
-      tiles.setInt(5, startCol);
-      tiles.setInt(6, endCol);
-
-      tiles.setInt(7, zct[1] + 1);
-      tiles.setInt(8, zct[0] > 0 ? 1 : 0);
-      tiles.setInt(9, region.zSteps[zct[0]]);
-
-      ResultSet subsetTiles = tiles.executeQuery();
-      while (subsetTiles.next()) {
-        byte[] data = subsetTiles.getBytes(1);
-        int compression = subsetTiles.getInt(2);
-        int row = subsetTiles.getInt(3);
-        int column = subsetTiles.getInt(4);
-
-        LOGGER.debug("found {} bytes for row={}, column={}",
-          data.length, row, column);
-
-        CodecOptions options = new CodecOptions();
-        options.bitsPerSample = bpp * 8;
-        options.width = region.tileSizeX;
-        options.height = region.tileSizeY;
-
-        Codec codec = getCodec(compression);
-        byte[] tile = codec.decompress(data, options);
-
-        int relativeColumn = column - (int) Math.floor((double) region.tileRangeX[0] / scale);
-        int relativeRow = row - (int) Math.floor((double) region.tileRangeY[0] / scale);
-
-        int pixelColumn = relativeColumn * options.width;
-        int pixelRow = relativeRow * options.height;
-
-        // overlap handling
-        byte[][] fovs = null;
-        Region[] fovPositions = new Region[scale * scale];
-        if (level == 0) {
-          Region fov = region.fovs.get(row + "-" + column);
-          pixelRow -= fov.y;
-          pixelColumn -= fov.x;
-
-          pixelRow -= (relativeRow * region.overlapY);
-          pixelColumn -= (relativeColumn * region.overlapX);
-
-          fovPositions[0] = new Region(pixelColumn, pixelRow, options.width, options.height);
-          fovs = new byte[1][];
-          fovs[0] = tile;
-        }
-        else {
-          fovs = splitFOVs(region, tile, scale);
-
-          for (int f=0; f<fovs.length; f++) {
-            int fovRow = row*scale + (f / scale);
-            int fovColumn = column*scale + (f % scale);
-            Region fov = region.fovs.get(fovRow + "-" + fovColumn);
-            if (fov != null) {
-              int xx = (fovColumn * options.width / scale) - (fov.x / scale) - (fovColumn * scaledOverlapX);
-              int yy = (fovRow * options.height / scale) - (fov.y / scale) - (fovRow * scaledOverlapY);
-              fovPositions[f] = new Region(xx, yy, options.width / scale, options.height / scale);
-            }
-          }
-        }
-
-        for (int f=0; f<fovs.length; f++) {
-          if (fovPositions[f] == null) {
-            continue;
-          }
-          Region intersection = fovPositions[f].intersection(dest);
-
-          if (intersection.width > 0 && intersection.height > 0) {
-            int outputRowLen = w * bpp;
-            int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
-            int rowLen = bpp * (int) Math.min(intersection.width, fovPositions[f].width);
-
-            int outputRow = intersection.y - y;
-            int outputCol = intersection.x - x;
-            int outputOffset = outputRow * outputRowLen + outputCol * bpp;
-            for (int c=0; c<getRGBChannelCount(); c++) {
-              int srcChannelOffset = c * (fovs[f].length / getRGBChannelCount());
-              int destChannelOffset = c * w * h * bpp;
-              for (int copyRow=0; copyRow<intersection.height; copyRow++) {
-                int realRow = copyRow + intersection.y - fovPositions[f].y;
-                int inputOffset = bpp * (realRow * (region.tileSizeX / scale) + intersectionX);
-                System.arraycopy(fovs[f], srcChannelOffset + inputOffset,
-                  buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
-              }
-            }
-          }
-        }
-      }
-    }
-    catch (SQLException e) {
-      LOGGER.warn("Failed to query tiles", e);
-    }
-    finally {
-      try {
-        conn.close();
-      }
-      catch (SQLException e) {
-        LOGGER.warn("Failed to close connection", e);
-      }
+    // most datasets will have a single region per plane/resolution
+    // TMA data will have multiple regions for each full resolution plane
+    for (ScanRegion region : planeRegions) {
+      copyRegionToBuffer(region, level, dest, zct, buf);
     }
 
     return buf;
@@ -348,13 +230,15 @@ public class TissueFAXSReader extends FormatReader {
           }
 
           region.parseJSON();
-          region.timepoint = regions.size() - startRegionIndex;
-
-          // TODO: this means TMA regions are parsed, but not recorded separately
-          // that might be OK, but needs to be double-checked
-          if (isTimelapse || regions.size() == startRegionIndex) {
-            regions.add(region);
+          if (isTimelapse) {
+            region.timepoint = regions.size() - startRegionIndex;
           }
+          else if (regions.size() != startRegionIndex) {
+            // found region that represents part of the full resolution in a TMA
+            region.resolutions.add(0);
+          }
+
+          regions.add(region);
         }
         int timepoints = regions.size() - startRegionIndex;
 
@@ -382,20 +266,6 @@ public class TissueFAXSReader extends FormatReader {
             Region fov = new Region((int) x, (int) y, (int) w, (int) h);
             currentRegion.fovs.put(row + "-" + col, fov);
           }
-          int xTiles = currentRegion.tileRangeX[1] - currentRegion.tileRangeX[0] + 1;
-          int yTiles = currentRegion.tileRangeY[1] - currentRegion.tileRangeY[0] + 1;
-          m.sizeX = xTiles * (currentRegion.tileSizeX - currentRegion.overlapX);
-          m.sizeY = yTiles * (currentRegion.tileSizeY - currentRegion.overlapY);
-
-          PreparedStatement maxLevelQuery = conn.prepareStatement(
-            "SELECT level FROM images WHERE region=? ORDER BY level DESC"
-          );
-          maxLevelQuery.setInt(1, currentRegion.id);
-          ResultSet maxLevel = maxLevelQuery.executeQuery();
-          if (maxLevel.next()) {
-            int resolutionCount = maxLevel.getInt(1);
-            m.resolutionCount = resolutionCount + 1;
-          }
 
           PreparedStatement zQuery = conn.prepareStatement(
             "SELECT DISTINCT is_zstack,z_position FROM images WHERE region=? ORDER BY is_zstack,z_position"
@@ -412,6 +282,36 @@ public class TissueFAXSReader extends FormatReader {
           }
           currentRegion.zSteps = tmpZ.toArray(new Integer[tmpZ.size()]);
           currentRegion.fullResolutionCoreIndex = core.size();
+
+          if (currentRegion.resolutions.size() > 0) {
+            continue;
+          }
+
+          int xTiles = currentRegion.tileRangeX[1] - currentRegion.tileRangeX[0] + 1;
+          int yTiles = currentRegion.tileRangeY[1] - currentRegion.tileRangeY[0] + 1;
+          m.sizeX = xTiles * (currentRegion.tileSizeX - currentRegion.overlapX);
+          m.sizeY = yTiles * (currentRegion.tileSizeY - currentRegion.overlapY);
+
+          PreparedStatement maxLevelQuery = conn.prepareStatement(
+            "SELECT level FROM images WHERE region=? ORDER BY level DESC"
+          );
+          maxLevelQuery.setInt(1, currentRegion.id);
+          ResultSet maxLevel = maxLevelQuery.executeQuery();
+          int max = 0;
+          int min = Integer.MAX_VALUE;
+          while (maxLevel.next()) {
+            int level = maxLevel.getInt(1);
+            if (max == 0) {
+              max = level;
+            }
+            if (level >= m.resolutionCount) {
+              m.resolutionCount = level + 1;
+            }
+            min = level;
+          }
+          for (int r=min; r<=max; r++) {
+            currentRegion.resolutions.add(r);
+          }
         }
 
         PreparedStatement channelQuery = conn.prepareStatement(
@@ -450,7 +350,11 @@ public class TissueFAXSReader extends FormatReader {
       }
 
       m.sizeZ = regions.get(startRegionIndex).zSteps.length;
-      m.sizeT = regions.size() - startRegionIndex;
+
+      for (int r=startRegionIndex; r<regions.size(); r++) {
+        m.sizeT = (int) Math.max(m.sizeT, regions.get(r).timepoint + 1);
+      }
+
       m.imageCount = m.sizeZ * m.sizeC * m.sizeT;
 
       // TODO: bad assumption in general?
@@ -481,8 +385,17 @@ public class TissueFAXSReader extends FormatReader {
     String instrument = MetadataTools.createLSID("Instrument", 0);
     store.setInstrumentID(instrument, 0);
 
+    ArrayList<Integer> populatedCoreIndexes = new ArrayList<Integer>();
     for (int i=0, index=0; i<regions.size(); index++) {
       ScanRegion region = regions.get(i);
+
+      // skip over remaining TMA regions
+      if (populatedCoreIndexes.contains(region.fullResolutionCoreIndex)) {
+        i++;
+        index--;
+        continue;
+      }
+      populatedCoreIndexes.add(region.fullResolutionCoreIndex);
       int imageIndex = hasFlattenedResolutions() ? region.fullResolutionCoreIndex : index;
 
       String objectiveID = MetadataTools.createLSID("Objective", 0, index);
@@ -550,6 +463,21 @@ public class TissueFAXSReader extends FormatReader {
     }
   }
 
+  private List<ScanRegion> getAllRegions(int t) throws FormatException {
+    ArrayList<ScanRegion> planeRegions = new ArrayList<ScanRegion>();
+    int index = getCoreIndex();
+    for (int i=regions.size()-1; i>=0; i--) {
+      ScanRegion r = regions.get(i);
+      if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
+        int res = index - r.fullResolutionCoreIndex;
+        if (r.resolutions.contains(res)) {
+          planeRegions.add(r);
+        }
+      }
+    }
+    return planeRegions;
+  }
+
   private ScanRegion getRegion() throws FormatException {
     return getRegion(0);
   }
@@ -559,7 +487,10 @@ public class TissueFAXSReader extends FormatReader {
     for (int i=regions.size()-1; i>=0; i--) {
       ScanRegion r = regions.get(i);
       if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
-        return r;
+        int res = index - r.fullResolutionCoreIndex;
+        if (r.resolutions.contains(res)) {
+          return r;
+        }
       }
     }
     throw new FormatException("Could not find ScanRegion (core index " + index + ", t=" + t + ")");
@@ -636,6 +567,173 @@ public class TissueFAXSReader extends FormatReader {
     return fovs;
   }
 
+  private void copyRegionToBuffer(ScanRegion region, int level, Region dest, int[] zct, byte[] buf)
+    throws FormatException, IOException
+  {
+    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    int scale = (int) Math.pow(region.scaleFactor, level);
+
+    int scaledOverlapX = region.overlapX / scale;
+    int scaledOverlapY = region.overlapY / scale;
+
+    Connection conn = openConnection(region.file);
+    try {
+      PreparedStatement tiles = conn.prepareStatement(
+        "SELECT data, compression, row, column FROM images WHERE region=? AND level=? AND " +
+        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column"
+      );
+
+      int rowOffset = (int) Math.floor((double) region.tileRangeY[0] / scale);
+      int colOffset = (int) Math.floor((double) region.tileRangeX[0] / scale);
+
+      int startRow = (int) Math.floor((double) dest.y / region.tileSizeY) + rowOffset;
+      int startCol = (int) Math.floor((double) dest.x / region.tileSizeX) + colOffset;
+      int endRow = (int) Math.ceil((double) (dest.y + dest.height) / region.tileSizeY) + rowOffset;
+      int endCol = (int) Math.ceil((double) (dest.x + dest.width) / region.tileSizeX) + colOffset;
+
+      // if the region has TMA XY coordinates,
+      // then the row/column values in the images table for this region ID
+      // will be relative to this specific TMA block, not the overall image
+      if (region.tmaX != null) {
+        int regionCol = region.tmaX * region.scaleFactor;
+        startCol -= regionCol;
+        endCol -= regionCol;
+        if (endCol >= 0) {
+          startCol = 0;
+          endCol = region.scaleFactor - 1;
+        }
+      }
+      if (region.tmaY != null) {
+        int regionRow = region.tmaY * region.scaleFactor;
+        startRow -= regionRow;
+        endRow -= regionRow;
+        if (endRow >= 0) {
+          startRow = 0;
+          endRow = region.scaleFactor - 1;
+        }
+      }
+
+      tiles.setInt(1, region.id);
+      tiles.setInt(2, level);
+      tiles.setInt(3, startRow);
+      tiles.setInt(4, endRow);
+      tiles.setInt(5, startCol);
+      tiles.setInt(6, endCol);
+
+      tiles.setInt(7, zct[1] + 1);
+      tiles.setInt(8, zct[0] > 0 ? 1 : 0);
+      tiles.setInt(9, region.zSteps[zct[0]]);
+
+      ResultSet subsetTiles = tiles.executeQuery();
+      while (subsetTiles.next()) {
+        byte[] data = subsetTiles.getBytes(1);
+        int compression = subsetTiles.getInt(2);
+        int row = subsetTiles.getInt(3);
+        int column = subsetTiles.getInt(4);
+
+        LOGGER.debug("found {} bytes for row={}, column={}",
+          data.length, row, column);
+
+        CodecOptions options = new CodecOptions();
+        options.bitsPerSample = bpp * 8;
+        options.width = region.tileSizeX;
+        options.height = region.tileSizeY;
+
+        Codec codec = getCodec(compression);
+        byte[] tile = codec.decompress(data, options);
+
+        int regionRow = row;
+        int regionColumn = column;
+        if (region.tmaX != null) {
+          regionColumn += (region.tmaX * region.scaleFactor);
+        }
+        if (region.tmaY != null) {
+          regionRow += (region.tmaY * region.scaleFactor);
+        }
+
+        int relativeColumn = regionColumn - (int) Math.floor((double) region.tileRangeX[0] / scale);
+        int relativeRow = regionRow - (int) Math.floor((double) region.tileRangeY[0] / scale);
+
+        int pixelColumn = relativeColumn * options.width;
+        int pixelRow = relativeRow * options.height;
+
+        // overlap handling
+        byte[][] fovs = null;
+        Region[] fovPositions = new Region[scale * scale];
+        if (level == 0) {
+          Region fov = region.fovs.get(row + "-" + column);
+          pixelRow -= fov.y;
+          pixelColumn -= fov.x;
+
+          if (region.tmaX == null || region.tmaY == null) {
+            pixelRow -= (relativeRow * region.overlapY);
+            pixelColumn -= (relativeColumn * region.overlapX);
+          }
+          else {
+            pixelRow -= (regionRow * region.overlapY);
+            pixelColumn -= (regionColumn * region.overlapX);
+          }
+
+          fovPositions[0] = new Region(pixelColumn, pixelRow, options.width, options.height);
+          fovs = new byte[1][];
+          fovs[0] = tile;
+        }
+        else {
+          fovs = splitFOVs(region, tile, scale);
+
+          for (int f=0; f<fovs.length; f++) {
+            int fovRow = row*scale + (f / scale);
+            int fovColumn = column*scale + (f % scale);
+            Region fov = region.fovs.get(fovRow + "-" + fovColumn);
+            if (fov != null) {
+              int xx = (fovColumn * options.width / scale) - (fov.x / scale) - (fovColumn * scaledOverlapX);
+              int yy = (fovRow * options.height / scale) - (fov.y / scale) - (fovRow * scaledOverlapY);
+              fovPositions[f] = new Region(xx, yy, options.width / scale, options.height / scale);
+            }
+          }
+        }
+
+        for (int f=0; f<fovs.length; f++) {
+          if (fovPositions[f] == null) {
+            continue;
+          }
+          Region intersection = fovPositions[f].intersection(dest);
+
+          if (intersection.width > 0 && intersection.height > 0) {
+            int outputRowLen = dest.width * bpp;
+            int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
+            int rowLen = bpp * (int) Math.min(intersection.width, fovPositions[f].width);
+
+            int outputRow = intersection.y - dest.y;
+            int outputCol = intersection.x - dest.x;
+            int outputOffset = outputRow * outputRowLen + outputCol * bpp;
+            for (int c=0; c<getRGBChannelCount(); c++) {
+              int srcChannelOffset = c * (fovs[f].length / getRGBChannelCount());
+              int destChannelOffset = c * dest.width * dest.height * bpp;
+              for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+                int realRow = copyRow + intersection.y - fovPositions[f].y;
+                int inputOffset = bpp * (realRow * (region.tileSizeX / scale) + intersectionX);
+                System.arraycopy(fovs[f], srcChannelOffset + inputOffset,
+                  buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+              }
+            }
+          }
+        }
+      }
+    }
+    catch (SQLException e) {
+      LOGGER.warn("Failed to query tiles", e);
+    }
+    finally {
+      try {
+        conn.close();
+      }
+      catch (SQLException e) {
+        LOGGER.warn("Failed to close connection", e);
+      }
+    }
+  }
+
   private Connection openConnection(String file) throws IOException {
     Connection conn = null;
     try {
@@ -656,7 +754,22 @@ public class TissueFAXSReader extends FormatReader {
     public String file;
     public JSONObject regionMetadata;
     public int id;
+
+    // record the core index of the full resolution for the pyramid
+    // to which this region belongs
+    // separately, record the indexes of the resolutions in the pyramid
+    // for which this region applies
+    //
+    // for most data types, the resolutions list will include every resolution
+    // in the pyramid; there will be one region per timepoint
+    //
+    // for each TMA pyramid, though, expect one region whose resolutions list
+    // includes everything except resolution 0 (full resolution),
+    // and one or more regions with the same fullResolutionCoreIndex
+    // whose resolutions list contains only 0
     public int fullResolutionCoreIndex;
+    public List<Integer> resolutions = new ArrayList<Integer>();
+
     public int tileSizeX;
     public int tileSizeY;
     public int overlapX;
@@ -669,6 +782,9 @@ public class TissueFAXSReader extends FormatReader {
     public List<Channel> channels = new ArrayList<Channel>();
     public HashMap<String, Region> fovs = new HashMap<String, Region>();
 
+    public Integer tmaX;
+    public Integer tmaY;
+
     public void parseJSON() {
       // "Rows" and "Columns" in the JSON metadata here
       // reflect the canvas size, not the area (FOVs) actually acquired
@@ -677,6 +793,13 @@ public class TissueFAXSReader extends FormatReader {
       overlapX = regionMetadata.getInt("OverlapWidth");
       overlapY = regionMetadata.getInt("OverlapHeight");
       scaleFactor = regionMetadata.getInt("CacheStep");
+
+      if (regionMetadata.has("LocationOnTMABlockX")) {
+        tmaX = regionMetadata.getInt("LocationOnTMABlockX");
+      }
+      if (regionMetadata.has("LocationOnTMABlockY")) {
+        tmaY = regionMetadata.getInt("LocationOnTMABlockY");
+      }
     }
 
   }

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -579,70 +579,25 @@ public class TissueFAXSReader extends FormatReader {
     Connection conn = openConnection(region.file);
     try {
       PreparedStatement tiles = conn.prepareStatement(
-        "SELECT data, compression, row, column FROM images WHERE region=? AND level=? AND " +
-        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column"
+        "SELECT row, column FROM images WHERE region=? AND level=? AND " +
+        "channel=? AND is_zstack=? AND z_position=? ORDER BY row,column"
       );
-
-      int rowOffset = (int) Math.floor((double) region.tileRangeY[0] / scale);
-      int colOffset = (int) Math.floor((double) region.tileRangeX[0] / scale);
-
-      int startRow = (int) Math.floor((double) dest.y / region.tileSizeY) + rowOffset;
-      int startCol = (int) Math.floor((double) dest.x / region.tileSizeX) + colOffset;
-      int endRow = (int) Math.ceil((double) (dest.y + dest.height) / region.tileSizeY) + rowOffset;
-      int endCol = (int) Math.ceil((double) (dest.x + dest.width) / region.tileSizeX) + colOffset;
-
-      // if the region has TMA XY coordinates,
-      // then the row/column values in the images table for this region ID
-      // will be relative to this specific TMA block, not the overall image
-      // if we're somewhere within this TMA block, consider all FOVs for
-      // this TMA block
-      if (region.tmaX != null) {
-        int regionCol = region.tmaX * region.scaleFactor;
-        startCol -= regionCol;
-        endCol -= regionCol;
-        if (endCol >= 0 && startCol <= region.scaleFactor - 1) {
-          startCol = 0;
-          endCol = region.scaleFactor - 1;
-        }
-      }
-      if (region.tmaY != null) {
-        int regionRow = region.tmaY * region.scaleFactor;
-        startRow -= regionRow;
-        endRow -= regionRow;
-        if (endRow >= 0 && startRow <= region.scaleFactor - 1) {
-          startRow = 0;
-          endRow = region.scaleFactor - 1;
-        }
-      }
 
       tiles.setInt(1, region.id);
       tiles.setInt(2, level);
-      tiles.setInt(3, startRow);
-      tiles.setInt(4, endRow);
-      tiles.setInt(5, startCol);
-      tiles.setInt(6, endCol);
+      tiles.setInt(3, zct[1] + 1);
+      tiles.setInt(4, zct[0] > 0 ? 1 : 0);
+      tiles.setInt(5, region.zSteps[zct[0]]);
 
-      tiles.setInt(7, zct[1] + 1);
-      tiles.setInt(8, zct[0] > 0 ? 1 : 0);
-      tiles.setInt(9, region.zSteps[zct[0]]);
+      CodecOptions options = new CodecOptions();
+      options.bitsPerSample = bpp * 8;
+      options.width = region.tileSizeX;
+      options.height = region.tileSizeY;
 
       ResultSet subsetTiles = tiles.executeQuery();
       while (subsetTiles.next()) {
-        byte[] data = subsetTiles.getBytes(1);
-        int compression = subsetTiles.getInt(2);
-        int row = subsetTiles.getInt(3);
-        int column = subsetTiles.getInt(4);
-
-        LOGGER.debug("found {} bytes for row={}, column={}",
-          data.length, row, column);
-
-        CodecOptions options = new CodecOptions();
-        options.bitsPerSample = bpp * 8;
-        options.width = region.tileSizeX;
-        options.height = region.tileSizeY;
-
-        Codec codec = getCodec(compression);
-        byte[] tile = codec.decompress(data, options);
+        int row = subsetTiles.getInt(1);
+        int column = subsetTiles.getInt(2);
 
         int regionRow = row;
         int regionColumn = column;
@@ -660,7 +615,6 @@ public class TissueFAXSReader extends FormatReader {
         int pixelRow = relativeRow * options.height;
 
         // overlap handling
-        byte[][] fovs = null;
         Region[] fovPositions = new Region[scale * scale];
         if (level == 0) {
           Region fov = region.fovs.get(row + "-" + column);
@@ -677,13 +631,9 @@ public class TissueFAXSReader extends FormatReader {
           }
 
           fovPositions[0] = new Region(pixelColumn, pixelRow, options.width, options.height);
-          fovs = new byte[1][];
-          fovs[0] = tile;
         }
         else {
-          fovs = splitFOVs(region, tile, scale);
-
-          for (int f=0; f<fovs.length; f++) {
+          for (int f=0; f<fovPositions.length; f++) {
             int fovRow = row*scale + (f / scale);
             int fovColumn = column*scale + (f % scale);
             Region fov = region.fovs.get(fovRow + "-" + fovColumn);
@@ -695,13 +645,50 @@ public class TissueFAXSReader extends FormatReader {
           }
         }
 
-        for (int f=0; f<fovs.length; f++) {
+        byte[][] fovs = null;
+        for (int f=0; f<fovPositions.length; f++) {
           if (fovPositions[f] == null) {
             continue;
           }
           Region intersection = fovPositions[f].intersection(dest);
 
           if (intersection.width > 0 && intersection.height > 0) {
+            // if we actually want to copy data from this FOV, fetch and decompress it
+            if (fovs == null) {
+              PreparedStatement readTile = conn.prepareStatement(
+                "SELECT data, compression FROM images WHERE region=? AND level=? AND " +
+                "channel=? AND is_zstack=? AND z_position=? AND row=? AND column=?"
+              );
+
+              readTile.setInt(1, region.id);
+              readTile.setInt(2, level);
+              readTile.setInt(3, zct[1] + 1);
+              readTile.setInt(4, zct[0] > 0 ? 1 : 0);
+              readTile.setInt(5, region.zSteps[zct[0]]);
+              readTile.setInt(6, row);
+              readTile.setInt(7, column);
+
+              ResultSet resultTile = readTile.executeQuery();
+              if (resultTile.next()) {
+                byte[] data = resultTile.getBytes(1);
+                int compression = resultTile.getInt(2);
+
+                Codec codec = getCodec(compression);
+                byte[] tile = codec.decompress(data, options);
+                if (level == 0) {
+                  fovs = new byte[1][];
+                  fovs[0] = tile;
+                }
+                else {
+                  fovs = splitFOVs(region, tile, scale);
+                }
+              }
+              else {
+                throw new FormatException(
+                  "Could not get tile for row=" + row + ", column=" + column);
+              }
+            }
+
             int outputRowLen = dest.width * bpp;
             int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
             int rowLen = bpp * (int) Math.min(intersection.width, fovPositions[f].width);

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -448,6 +448,7 @@ public class TissueFAXSReader extends FormatReader {
     store.setInstrumentID(instrument, 0);
 
     ArrayList<Integer> populatedCoreIndexes = new ArrayList<Integer>();
+    int nextImage = 0;
     for (int i=0, index=0; i<regions.size(); index++) {
       ScanRegion region = regions.get(i);
 
@@ -458,7 +459,8 @@ public class TissueFAXSReader extends FormatReader {
         continue;
       }
       populatedCoreIndexes.add(region.fullResolutionCoreIndex);
-      int imageIndex = hasFlattenedResolutions() ? region.fullResolutionCoreIndex : index;
+      int imageIndex = hasFlattenedResolutions() ? region.fullResolutionCoreIndex : nextImage;
+      nextImage++;
 
       String objectiveID = MetadataTools.createLSID("Objective", 0, index);
       store.setObjectiveID(objectiveID, 0, index);
@@ -506,6 +508,14 @@ public class TissueFAXSReader extends FormatReader {
         if (!core.get(region.fullResolutionCoreIndex).rgb) {
           store.setChannelColor(ch.getColor(), imageIndex, c);
         }
+      }
+
+      if (region.correctionImageCoreIndex != null) {
+        int corrImage = nextImage;
+        nextImage++;
+
+        store.setImageName(region.regionMetadata.getString("Name") + " Correction Image", corrImage);
+        store.setObjectiveSettingsID(objectiveID, corrImage);
       }
 
       i += core.get(region.fullResolutionCoreIndex).sizeT;

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -89,7 +89,7 @@ public class TissueFAXSReader extends FormatReader {
 
   /** Constructs a new TissueGnostics TissueFAXS reader.*/
   public TissueFAXSReader() {
-    super("TissueFAXS", new String[] {"aqproj"});
+    super("TissueFAXS", new String[] {"aqproj", "tfcyto"});
     hasCompanionFiles = false;
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
     datasetDescription = "An .aqproj file with one or more .tfcyto database files";
@@ -142,10 +142,13 @@ public class TissueFAXSReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     ArrayList<String> files = new ArrayList<String>();
-    files.add(getCurrentFile());
+    files.add(new Location(getCurrentFile()).getAbsolutePath());
     if (!noPixels) {
       try {
-        files.add(getRegion().file);
+        String regionFile = getRegion().file;
+        if (!files.contains(regionFile)) {
+          files.add(regionFile);
+        }
       }
       catch (FormatException e) {
         LOGGER.warn("Could not get file", e);
@@ -446,7 +449,16 @@ public class TissueFAXSReader extends FormatReader {
 
   // -- Helper methods --
 
+  /**
+   * If a .tfcyto file was provided, then that is the only file that should be read.
+   * If an .aqproj file was provided, look for all associated .tfcyto files.
+   */
   private void findDBFiles() {
+    if (checkSuffix(getCurrentFile(), "tfcyto")) {
+      pixelsFiles.add(new Location(getCurrentFile()).getAbsolutePath());
+      return;
+    }
+
     Location dir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
     String[] list = dir.list(true);
     Arrays.sort(list);

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -71,12 +71,12 @@ import org.slf4j.LoggerFactory;
 import org.sqlite.SQLiteConfig;
 
 /**
- *
+ * Reader for TissueFAXS format from TissueGnostics.
  */
-public class TissuegnosticsReader extends FormatReader {
+public class TissueFAXSReader extends FormatReader {
 
   private static final Logger LOGGER =
-    LoggerFactory.getLogger(TissuegnosticsReader.class);
+    LoggerFactory.getLogger(TissueFAXSReader.class);
 
   // per specification, wavelengths outside this range should be ignored
   private static final int WAVE_MIN = 300;
@@ -87,9 +87,9 @@ public class TissuegnosticsReader extends FormatReader {
 
   // -- Constructor --
 
-  /** Constructs a new Tissuegnostics reader.*/
-  public TissuegnosticsReader() {
-    super("Tissuegnostics", new String[] {"aqproj"});
+  /** Constructs a new TissueGnostics TissueFAXS reader.*/
+  public TissueFAXSReader() {
+    super("TissueFAXS", new String[] {"aqproj"});
     hasCompanionFiles = false;
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
     datasetDescription = "An .aqproj file with one or more .tfcyto database files";

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -361,6 +361,7 @@ public class TissueFAXSReader extends FormatReader {
       if (m.sizeC == 1 && m.pixelType == FormatTools.UINT8) {
         m.sizeC = 3;
         m.rgb = true;
+        m.interleaved = true;
       }
 
       m.dimensionOrder = "XYCZT";
@@ -539,9 +540,10 @@ public class TissueFAXSReader extends FormatReader {
     byte[][] fovs = new byte[scale * scale][];
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int channels = getRGBChannelCount();
+    int pixel = bpp * channels;
 
-    int srcWidth = region.tileSizeX * bpp;
-    int destWidth = (region.tileSizeX / scale) * bpp;
+    int srcWidth = region.tileSizeX * pixel;
+    int destWidth = (region.tileSizeX / scale) * pixel;
     int srcHeight = region.tileSizeY;
     int destHeight = region.tileSizeY / scale;
 
@@ -549,18 +551,13 @@ public class TissueFAXSReader extends FormatReader {
       int fovRow = fov / scale;
       int fovCol = fov % scale;
 
-      fovs[fov] = new byte[destWidth * destHeight * bpp * channels];
+      fovs[fov] = new byte[destWidth * destHeight * pixel];
 
-      for (int c=0; c<channels; c++) {
-        int srcChannelOffset = c * srcWidth * srcHeight;
-        int destChannelOffset = c * destWidth * destHeight;
+      for (int row=0; row<destHeight; row++) {
+        int srcOffset = (((fovRow * destHeight) + row) * srcWidth) + (fovCol * destWidth);
+        int destOffset = row * destWidth;
 
-        for (int row=0; row<destHeight; row++) {
-          int srcOffset = srcChannelOffset + (((fovRow * destHeight) + row) * srcWidth) + (fovCol * destWidth);
-          int destOffset = destChannelOffset + (row * destWidth);
-
-          System.arraycopy(tile, srcOffset, fovs[fov], destOffset, destWidth);
-        }
+        System.arraycopy(tile, srcOffset, fovs[fov], destOffset, destWidth);
       }
     }
 
@@ -593,6 +590,7 @@ public class TissueFAXSReader extends FormatReader {
       options.bitsPerSample = bpp * 8;
       options.width = region.tileSizeX;
       options.height = region.tileSizeY;
+      options.interleaved = isInterleaved();
 
       ResultSet subsetTiles = tiles.executeQuery();
       while (subsetTiles.next()) {
@@ -697,22 +695,20 @@ public class TissueFAXSReader extends FormatReader {
               }
             }
 
-            int outputRowLen = dest.width * bpp;
+            int pixel = bpp * getRGBChannelCount();
+            int outputRowLen = dest.width * pixel;
             int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
-            int rowLen = bpp * (int) Math.min(intersection.width, fovPositions[f].width);
+            int rowLen = pixel * (int) Math.min(intersection.width, fovPositions[f].width);
 
             int outputRow = intersection.y - dest.y;
             int outputCol = intersection.x - dest.x;
-            int outputOffset = outputRow * outputRowLen + outputCol * bpp;
-            for (int c=0; c<getRGBChannelCount(); c++) {
-              int srcChannelOffset = c * (fovs[f].length / getRGBChannelCount());
-              int destChannelOffset = c * dest.width * dest.height * bpp;
-              for (int copyRow=0; copyRow<intersection.height; copyRow++) {
-                int realRow = copyRow + intersection.y - fovPositions[f].y;
-                int inputOffset = bpp * (realRow * (region.tileSizeX / scale) + intersectionX);
-                System.arraycopy(fovs[f], srcChannelOffset + inputOffset,
-                  buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
-              }
+            int outputOffset = outputRow * outputRowLen + outputCol * pixel;
+
+            for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+              int realRow = copyRow + intersection.y - fovPositions[f].y;
+              int inputOffset = pixel * (realRow * (region.tileSizeX / scale) + intersectionX);
+              System.arraycopy(fovs[f], inputOffset,
+                buf, outputOffset + copyRow*outputRowLen, rowLen);
             }
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -322,34 +322,43 @@ public class TissueFAXSReader extends FormatReader {
             currentRegion.resolutions.add(r);
           }
 
+          // older TissueFAXS data stored correction images differently,
+          // and did not include the 'channel_zstack' table
+          // catch any exceptions with the correction image queries separately,
+          // so that the rest of the data can be read even if the correction
+          // image can't be found
+          try {
+            PreparedStatement correctionQuery = conn.prepareStatement(
+              "SELECT correction_images.id, channel_zstack.channel_id, channel_zstack.position " +
+              "FROM correction_images JOIN channel_zstack ON correction_images.id = channel_zstack.cor_img_id "+
+              "WHERE channel_zstack.region_id=?"
+            );
+            correctionQuery.setInt(1, currentRegion.id);
+            ResultSet correctionImgs = correctionQuery.executeQuery();
+            while (correctionImgs.next()) {
+              int correctionID = correctionImgs.getInt(1);
+              int channel = correctionImgs.getInt(2);
+              int z = correctionImgs.getInt(3);
 
-          PreparedStatement correctionQuery = conn.prepareStatement(
-            "SELECT correction_images.id, channel_zstack.channel_id, channel_zstack.position " +
-            "FROM correction_images JOIN channel_zstack ON correction_images.id = channel_zstack.cor_img_id "+
-            "WHERE channel_zstack.region_id=?"
-          );
-          correctionQuery.setInt(1, currentRegion.id);
-          ResultSet correctionImgs = correctionQuery.executeQuery();
-          while (correctionImgs.next()) {
-            int correctionID = correctionImgs.getInt(1);
-            int channel = correctionImgs.getInt(2);
-            int z = correctionImgs.getInt(3);
-
-            currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
-            currentRegion.correctionImageIDs.put((channel - 1) + "-" + (z - 1), correctionID);
+              currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
+              currentRegion.correctionImageIDs.put((channel - 1) + "-" + (z - 1), correctionID);
+            }
+            correctionQuery = conn.prepareStatement(
+              "SELECT correction_images.id, channels.id " +
+              "FROM correction_images JOIN channels ON correction_images.id = channels.cor_img_id "+
+              "WHERE channels.region_id=?"
+            );
+            correctionQuery.setInt(1, currentRegion.id);
+            correctionImgs = correctionQuery.executeQuery();
+            while (correctionImgs.next()) {
+              int correctionID = correctionImgs.getInt(1);
+              int channelID = correctionImgs.getInt(2);
+              currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
+              currentRegion.correctionImageIDs.put((channelID - 1) + "-0", correctionID);
+            }
           }
-          correctionQuery = conn.prepareStatement(
-            "SELECT correction_images.id, channels.id " +
-            "FROM correction_images JOIN channels ON correction_images.id = channels.cor_img_id "+
-            "WHERE channels.region_id=?"
-          );
-          correctionQuery.setInt(1, currentRegion.id);
-          correctionImgs = correctionQuery.executeQuery();
-          while (correctionImgs.next()) {
-            int correctionID = correctionImgs.getInt(1);
-            int channelID = correctionImgs.getInt(2);
-            currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
-            currentRegion.correctionImageIDs.put((channelID - 1) + "-0", correctionID);
+          catch (SQLException e) {
+            LOGGER.warn("Failed to find correction image", e);
           }
         }
 
@@ -537,10 +546,12 @@ public class TissueFAXSReader extends FormatReader {
     int index = getCoreIndex();
     for (int i=regions.size()-1; i>=0; i--) {
       ScanRegion r = regions.get(i);
-      if (r.timepoint == t && r.correctionImageCoreIndex == index) {
+      if (r.timepoint == t && r.correctionImageCoreIndex != null &&
+        r.correctionImageCoreIndex == index)
+      {
         planeRegions.add(r);
         continue;
-      }
+     }
       if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
         int res = index - r.fullResolutionCoreIndex;
         if (r.resolutions.contains(res)) {
@@ -559,7 +570,9 @@ public class TissueFAXSReader extends FormatReader {
     int index = getCoreIndex();
     for (int i=regions.size()-1; i>=0; i--) {
       ScanRegion r = regions.get(i);
-      if (r.timepoint == t && r.correctionImageCoreIndex == index) {
+      if (r.timepoint == t && r.correctionImageCoreIndex != null &&
+        r.correctionImageCoreIndex == index)
+      {
         return r;
       }
       if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
@@ -573,6 +586,9 @@ public class TissueFAXSReader extends FormatReader {
   }
 
   private boolean isCorrectionImage(ScanRegion r) {
+    if (r.correctionImageCoreIndex == null) {
+      return false;
+    }
     return getCoreIndex() == r.correctionImageCoreIndex;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -634,12 +634,20 @@ public class TissueFAXSReader extends FormatReader {
         }
         else {
           for (int f=0; f<fovPositions.length; f++) {
+            // row and column are relative to the current resolution level
+            // need to convert to row and column indexes relative to the full resolution (level 0)
             int fovRow = row*scale + (f / scale);
             int fovColumn = column*scale + (f % scale);
             Region fov = region.fovs.get(fovRow + "-" + fovColumn);
             if (fov != null) {
-              int xx = (fovColumn * options.width / scale) - (fov.x / scale) - (fovColumn * scaledOverlapX);
-              int yy = (fovRow * options.height / scale) - (fov.y / scale) - (fovRow * scaledOverlapY);
+              // correct the row and column indexes so that the first acquired row/column
+              // relative to the full resolution lines up with (0,0) in the current resolution
+              // failing to correct for the first acquired row/column means a black border
+              // will appear at the top and/or left of the current resolutin image
+              int relativeFOVRow = fovRow - region.tileRangeY[0];
+              int relativeFOVColumn = fovColumn - region.tileRangeX[0];
+              int xx = (relativeFOVColumn * options.width / scale) - (fov.x / scale) - (relativeFOVColumn * scaledOverlapX);
+              int yy = (relativeFOVRow * options.height / scale) - (fov.y / scale) - (relativeFOVRow * scaledOverlapY);
               fovPositions[f] = new Region(xx, yy, options.width / scale, options.height / scale);
             }
           }

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -178,7 +178,12 @@ public class TissueFAXSReader extends FormatReader {
     // most datasets will have a single region per plane/resolution
     // TMA data will have multiple regions for each full resolution plane
     for (ScanRegion region : planeRegions) {
-      copyRegionToBuffer(region, level, dest, zct, buf);
+      if (isCorrectionImage(region)) {
+        copyCorrectionImageToBuffer(region, dest, zct, buf);
+      }
+      else {
+        copyRegionToBuffer(region, level, dest, zct, buf);
+      }
     }
 
     return buf;
@@ -316,6 +321,36 @@ public class TissueFAXSReader extends FormatReader {
           for (int r=min; r<=max; r++) {
             currentRegion.resolutions.add(r);
           }
+
+
+          PreparedStatement correctionQuery = conn.prepareStatement(
+            "SELECT correction_images.id, channel_zstack.channel_id, channel_zstack.position " +
+            "FROM correction_images JOIN channel_zstack ON correction_images.id = channel_zstack.cor_img_id "+
+            "WHERE channel_zstack.region_id=?"
+          );
+          correctionQuery.setInt(1, currentRegion.id);
+          ResultSet correctionImgs = correctionQuery.executeQuery();
+          while (correctionImgs.next()) {
+            int correctionID = correctionImgs.getInt(1);
+            int channel = correctionImgs.getInt(2);
+            int z = correctionImgs.getInt(3);
+
+            currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
+            currentRegion.correctionImageIDs.put((channel - 1) + "-" + (z - 1), correctionID);
+          }
+          correctionQuery = conn.prepareStatement(
+            "SELECT correction_images.id, channels.id " +
+            "FROM correction_images JOIN channels ON correction_images.id = channels.cor_img_id "+
+            "WHERE channels.region_id=?"
+          );
+          correctionQuery.setInt(1, currentRegion.id);
+          correctionImgs = correctionQuery.executeQuery();
+          while (correctionImgs.next()) {
+            int correctionID = correctionImgs.getInt(1);
+            int channelID = correctionImgs.getInt(2);
+            currentRegion.correctionImageCoreIndex = currentRegion.fullResolutionCoreIndex + m.resolutionCount;
+            currentRegion.correctionImageIDs.put((channelID - 1) + "-0", correctionID);
+          }
         }
 
         PreparedStatement channelQuery = conn.prepareStatement(
@@ -372,13 +407,27 @@ public class TissueFAXSReader extends FormatReader {
       m.littleEndian = true;
 
       core.add(m);
+      ScanRegion start = regions.get(startRegionIndex);
       for (int r=1; r<m.resolutionCount; r++) {
         CoreMetadata res = new CoreMetadata(m);
-        int scale = (int) Math.pow(regions.get(startRegionIndex).scaleFactor, r);
+        int scale = (int) Math.pow(start.scaleFactor, r);
         res.sizeX /= scale;
         res.sizeY /= scale;
         res.resolutionCount = 1;
         core.add(res);
+      }
+
+      if (start.correctionImageCoreIndex != null) {
+        CoreMetadata correction = new CoreMetadata(m);
+        correction.sizeX = start.tileSizeX;
+        correction.sizeY = start.tileSizeY;
+        correction.sizeC = m.rgb ? 1 : m.sizeC;
+        correction.rgb = false;
+        correction.pixelType = FormatTools.FLOAT;
+        correction.resolutionCount = 1;
+        correction.littleEndian = false;
+
+        core.add(correction);
       }
     }
 
@@ -489,6 +538,10 @@ public class TissueFAXSReader extends FormatReader {
     int index = getCoreIndex();
     for (int i=regions.size()-1; i>=0; i--) {
       ScanRegion r = regions.get(i);
+      if (r.timepoint == t && r.correctionImageCoreIndex == index) {
+        planeRegions.add(r);
+        continue;
+      }
       if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
         int res = index - r.fullResolutionCoreIndex;
         if (r.resolutions.contains(res)) {
@@ -507,6 +560,9 @@ public class TissueFAXSReader extends FormatReader {
     int index = getCoreIndex();
     for (int i=regions.size()-1; i>=0; i--) {
       ScanRegion r = regions.get(i);
+      if (r.timepoint == t && r.correctionImageCoreIndex == index) {
+        return r;
+      }
       if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
         int res = index - r.fullResolutionCoreIndex;
         if (r.resolutions.contains(res)) {
@@ -515,6 +571,10 @@ public class TissueFAXSReader extends FormatReader {
       }
     }
     throw new FormatException("Could not find ScanRegion (core index " + index + ", t=" + t + ")");
+  }
+
+  private boolean isCorrectionImage(ScanRegion r) {
+    return getCoreIndex() == r.correctionImageCoreIndex;
   }
 
   private int getLevel() throws FormatException {
@@ -537,6 +597,15 @@ public class TissueFAXSReader extends FormatReader {
       default:
         throw new UnsupportedCompressionException("Unsupported compression: " + compression);
     }
+  }
+
+  private CodecOptions getCodecOptions(ScanRegion region) {
+    CodecOptions options = new CodecOptions();
+    options.bitsPerSample = FormatTools.getBytesPerPixel(getPixelType()) * 8;
+    options.width = region.tileSizeX;
+    options.height = region.tileSizeY;
+    options.interleaved = isInterleaved();
+    return options;
   }
 
   /**
@@ -587,7 +656,6 @@ public class TissueFAXSReader extends FormatReader {
   private void copyRegionToBuffer(ScanRegion region, int level, Region dest, int[] zct, byte[] buf)
     throws FormatException, IOException
   {
-    int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int scale = (int) Math.pow(region.scaleFactor, level);
 
     int scaledOverlapX = region.overlapX / scale;
@@ -606,11 +674,7 @@ public class TissueFAXSReader extends FormatReader {
       tiles.setInt(4, zct[0] > 0 ? 1 : 0);
       tiles.setInt(5, region.zSteps[zct[0]]);
 
-      CodecOptions options = new CodecOptions();
-      options.bitsPerSample = bpp * 8;
-      options.width = region.tileSizeX;
-      options.height = region.tileSizeY;
-      options.interleaved = isInterleaved();
+      CodecOptions options = getCodecOptions(region);
 
       ResultSet subsetTiles = tiles.executeQuery();
       while (subsetTiles.next()) {
@@ -701,6 +765,7 @@ public class TissueFAXSReader extends FormatReader {
 
                 Codec codec = getCodec(compression);
                 byte[] tile = codec.decompress(data, options);
+                tile = applyTransformation(tile, region.id, level, zct[1] + 1, region.zSteps[0], row, column);
                 if (level == 0) {
                   fovs = new byte[1][];
                   fovs[0] = tile;
@@ -715,23 +780,76 @@ public class TissueFAXSReader extends FormatReader {
               }
             }
 
-            int pixel = bpp * getRGBChannelCount();
-            int outputRowLen = dest.width * pixel;
-            int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
-            int rowLen = pixel * (int) Math.min(intersection.width, fovPositions[f].width);
-
-            int outputRow = intersection.y - dest.y;
-            int outputCol = intersection.x - dest.x;
-            int outputOffset = outputRow * outputRowLen + outputCol * pixel;
-
-            for (int copyRow=0; copyRow<intersection.height; copyRow++) {
-              int realRow = copyRow + intersection.y - fovPositions[f].y;
-              int inputOffset = pixel * (realRow * (region.tileSizeX / scale) + intersectionX);
-              System.arraycopy(fovs[f], inputOffset,
-                buf, outputOffset + copyRow*outputRowLen, rowLen);
-            }
+            copyRegion(fovPositions[f], fovs[f], dest, buf, region.tileSizeX / scale);
           }
         }
+      }
+    }
+    catch (SQLException e) {
+      LOGGER.warn("Failed to query tiles", e);
+    }
+    finally {
+      try {
+        conn.close();
+      }
+      catch (SQLException e) {
+        LOGGER.warn("Failed to close connection", e);
+      }
+    }
+  }
+
+  private void copyRegion(Region srcRegion, byte[] src, Region destRegion, byte[] dest, int tileWidth) {
+    Region intersection = srcRegion.intersection(destRegion);
+    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    int pixel = bpp * getRGBChannelCount();
+    int outputRowLen = destRegion.width * pixel;
+    int intersectionX = (int) Math.max(0, destRegion.x - srcRegion.x);
+    int rowLen = pixel * (int) Math.min(intersection.width, srcRegion.width);
+
+    int outputRow = intersection.y - destRegion.y;
+    int outputCol = intersection.x - destRegion.x;
+    int outputOffset = outputRow * outputRowLen + outputCol * pixel;
+
+    for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+      int realRow = copyRow + intersection.y - srcRegion.y;
+      int inputOffset = pixel * (realRow * tileWidth + intersectionX);
+      System.arraycopy(src, inputOffset,
+        dest, outputOffset + copyRow*outputRowLen, rowLen);
+    }
+  }
+
+  private void copyCorrectionImageToBuffer(ScanRegion region, Region dest, int[] zct, byte[] buf)
+    throws FormatException, IOException
+  {
+    if (region.timepoint != zct[2]) {
+      return;
+    }
+
+    Connection conn = openConnection(region.file);
+    try {
+      PreparedStatement correctionQuery = conn.prepareStatement(
+        "SELECT compression, data FROM correction_images WHERE id=?"
+      );
+      Integer correctionID = region.correctionImageIDs.get(zct[1] + "-" + zct[0]);
+      if (correctionID == null) {
+        correctionID = region.correctionImageIDs.get(zct[1] + "-0");
+      }
+      if (correctionID == null) {
+        return;
+      }
+      correctionQuery.setInt(1, correctionID);
+      ResultSet correctionImgs = correctionQuery.executeQuery();
+      if (correctionImgs.next()) {
+        int compression = correctionImgs.getInt(1);
+        byte[] data = correctionImgs.getBytes(2);
+
+        CodecOptions options = getCodecOptions(region);
+
+        data = getCodec(compression).decompress(data, options);
+
+        Region correction = new Region(0, 0, options.width, options.height);
+
+        copyRegion(correction, data, dest, buf, options.width);
       }
     }
     catch (SQLException e) {
@@ -781,6 +899,7 @@ public class TissueFAXSReader extends FormatReader {
     // and one or more regions with the same fullResolutionCoreIndex
     // whose resolutions list contains only 0
     public int fullResolutionCoreIndex;
+    public Integer correctionImageCoreIndex = null;
     public List<Integer> resolutions = new ArrayList<Integer>();
 
     public int tileSizeX;
@@ -794,6 +913,7 @@ public class TissueFAXSReader extends FormatReader {
     public int timepoint;
     public List<Channel> channels = new ArrayList<Channel>();
     public HashMap<String, Region> fovs = new HashMap<String, Region>();
+    public HashMap<String, Integer> correctionImageIDs = new HashMap<String, Integer>();
 
     public Integer tmaX;
     public Integer tmaY;
@@ -832,6 +952,18 @@ public class TissueFAXSReader extends FormatReader {
       int blue = color & 0xff;
       return new Color(red, green, blue, alpha);
     }
+  }
+
+  /**
+   * Extension point for doing something to an FOV immediately
+   * after decompression, before any stitching or cropping.
+   * Overriding this in a subclass could be used to apply a correction image.
+   * Currently this method is a no-op.
+   */
+  public byte[] applyTransformation(byte[] tile, int regionID, int level,
+    int channel, int zIndex, int fovRow, int fovColumn)
+  {
+    return tile;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -421,8 +421,7 @@ public class TissueFAXSReader extends FormatReader {
         CoreMetadata correction = new CoreMetadata(m);
         correction.sizeX = start.tileSizeX;
         correction.sizeY = start.tileSizeY;
-        correction.sizeC = m.rgb ? 1 : m.sizeC;
-        correction.rgb = false;
+        correction.sizeC = m.rgb ? 4 : m.sizeC;
         correction.pixelType = FormatTools.FLOAT;
         correction.resolutionCount = 1;
         correction.littleEndian = false;

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -439,8 +439,6 @@ public class TissueFAXSReader extends FormatReader {
       }
     }
 
-    // TODO: parse ROIs from .aqproj
-
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this);
 

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -1,0 +1,515 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2024 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import loci.common.Constants;
+import loci.common.DataTools;
+import loci.common.DateTools;
+import loci.common.Location;
+import loci.common.Region;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.UnsupportedCompressionException;
+import loci.formats.codec.Codec;
+import loci.formats.codec.CodecOptions;
+import loci.formats.codec.JPEGCodec;
+import loci.formats.codec.JPEGXRCodec;
+import loci.formats.codec.PassthroughCodec;
+import loci.formats.meta.MetadataStore;
+
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sqlite.SQLiteConfig;
+
+/**
+ *
+ */
+public class TissuegnosticsReader extends FormatReader {
+
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(TissuegnosticsReader.class);
+
+  private List<String> pixelsFiles = new ArrayList<String>();
+  private int[] fullResolutionCoreIndex;
+  private int[] tileSizeX;
+  private int[] tileSizeY;
+  private int[] overlapX;
+  private int[] overlapY;
+  private int[] scaleFactor;
+  private int[][] tileRangeX;
+  private int[][] tileRangeY;
+
+  // -- Constructor --
+
+  /** Constructs a new Tissuegnostics reader.*/
+  public TissuegnosticsReader() {
+    super("Tissuegnostics", new String[] {"aqproj"});
+    hasCompanionFiles = false;
+    domains = new String[] {FormatTools.HCS_DOMAIN};
+    datasetDescription = "An .aqproj file with one or more .tfcyto database files";
+    suffixSufficient = true;
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      pixelsFiles.clear();
+      fullResolutionCoreIndex = null;
+      tileSizeX = null;
+      tileSizeY = null;
+      overlapX = null;
+      overlapY = null;
+      scaleFactor = null;
+      tileRangeX = null;
+      tileRangeY = null;
+    }
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    int region = getRegionIndex();
+    return tileSizeX[region] / (int) Math.pow(scaleFactor[region], getLevel());
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    int region = getRegionIndex();
+    return tileSizeY[region] / (int) Math.pow(scaleFactor[region], getLevel());
+  }
+
+  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(getCurrentFile());
+    if (!noPixels) {
+      files.add(getDBFile());
+    }
+    return files.toArray(new String[files.size()]);
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+    Arrays.fill(buf, getFillColor());
+
+    int regionIndex = getRegionIndex();
+    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    int level = getLevel();
+    int scale = (int) Math.pow(scaleFactor[regionIndex], level);
+
+    Region dest = new Region(x, y, w, h);
+    Connection conn = openConnection(getDBFile());
+    try {
+      PreparedStatement tiles = conn.prepareStatement(
+        "SELECT data, compression, row, column FROM images WHERE level=? AND row>=? AND row<=? AND column>=? AND column<=? AND channel=?"
+      );
+      // TODO: account for possiblity of overlap
+
+      int rowOffset = (int) Math.floor((double) tileRangeY[0][regionIndex] / scale);
+      int colOffset = (int) Math.floor((double) tileRangeX[0][regionIndex] / scale);
+
+      int startRow = (int) Math.floor((double) y / tileSizeY[regionIndex]) + rowOffset;
+      int startCol = (int) Math.floor((double) x / tileSizeX[regionIndex]) + colOffset;
+      int endRow = (int) Math.ceil((double) (y + h) / tileSizeY[regionIndex]) + rowOffset;
+      int endCol = (int) Math.ceil((double) (x + w) / tileSizeX[regionIndex]) + colOffset;
+
+      tiles.setInt(1, level);
+      tiles.setInt(2, startRow);
+      tiles.setInt(3, endRow);
+      tiles.setInt(4, startCol);
+      tiles.setInt(5, endCol);
+      tiles.setInt(6, getZCTCoords(no)[1] + 1);
+
+      // upper left corner of full resolution,
+      // in pixels relative to full canvas
+      int fullResUpperLeftX = tileRangeX[0][regionIndex] * tileSizeX[regionIndex];
+      int fullResUpperLeftY = tileRangeY[0][regionIndex] * tileSizeY[regionIndex];
+
+      // upper left corner of current resolution,
+      // in pixels relative to current resolution canvas
+      int currentResUpperLeftX = fullResUpperLeftX / scale;
+      int currentResUpperLeftY = fullResUpperLeftY / scale;
+
+      int relativeUpperLeftX = currentResUpperLeftX % tileSizeX[regionIndex];
+      int relativeUpperLeftY = currentResUpperLeftY % tileSizeY[regionIndex];
+
+      ResultSet subsetTiles = tiles.executeQuery();
+      while (subsetTiles.next()) {
+        byte[] data = subsetTiles.getBytes(1);
+        int compression = subsetTiles.getInt(2);
+        int row = subsetTiles.getInt(3);
+        int column = subsetTiles.getInt(4);
+
+        LOGGER.debug("found {} bytes for row={}, column={}",
+          data.length, row, column);
+
+        CodecOptions options = new CodecOptions();
+        options.bitsPerSample = bpp * 8;
+        options.width = tileSizeX[regionIndex];
+        options.height = tileSizeY[regionIndex];
+
+        Codec codec = getCodec(compression);
+        byte[] tile = codec.decompress(data, options);
+
+        int relativeColumn = column - (int) Math.floor((double) tileRangeX[0][regionIndex] / scale);
+        int relativeRow = row - (int) Math.floor((double) tileRangeY[0][regionIndex] / scale);
+        relativeColumn *= options.width;
+        relativeRow *= options.height;
+
+        if (level > 0) {
+          relativeRow -= relativeUpperLeftY;
+          relativeColumn -= relativeUpperLeftX;
+        }
+
+        Region src = new Region(relativeColumn, relativeRow, options.width, options.height);
+        Region intersection = src.intersection(dest);
+
+        int outputRowLen = w * bpp;
+        int intersectionX = (int) Math.max(0, dest.x - src.x);
+        int rowLen = bpp * (int) Math.min(intersection.width, tileSizeX[regionIndex]);
+
+        int outputRow = intersection.y - y;
+        int outputCol = intersection.x - x;
+        int outputOffset = outputRow * outputRowLen + outputCol * bpp;
+        for (int c=0; c<getRGBChannelCount(); c++) {
+          int srcChannelOffset = c * (tile.length / getRGBChannelCount());
+          int destChannelOffset = c * w * h * bpp;
+          for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+            int realRow = copyRow + intersection.y - src.y;
+            int inputOffset = bpp * (realRow * tileSizeX[regionIndex] + intersectionX);
+            System.arraycopy(tile, srcChannelOffset + inputOffset,
+              buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+          }
+        }
+      }
+    }
+    catch (SQLException e) {
+      LOGGER.warn("Failed to query tiles", e);
+    }
+    finally {
+      try {
+        conn.close();
+      }
+      catch (SQLException e) {
+        LOGGER.warn("Failed to close connection", e);
+      }
+    }
+
+    return buf;
+  }
+
+  // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
+
+    findDBFiles();
+
+    core.clear();
+
+    JSONObject[] regionMetadata = new JSONObject[pixelsFiles.size()];
+    fullResolutionCoreIndex = new int[pixelsFiles.size()];
+    tileSizeX = new int[pixelsFiles.size()];
+    tileSizeY = new int[pixelsFiles.size()];
+    overlapX = new int[pixelsFiles.size()];
+    overlapY = new int[pixelsFiles.size()];
+    scaleFactor = new int[pixelsFiles.size()];
+    tileRangeX = new int[2][pixelsFiles.size()];
+    tileRangeY = new int[2][pixelsFiles.size()];
+
+    Arrays.fill(tileRangeX[0], Integer.MAX_VALUE);
+    Arrays.fill(tileRangeY[0], Integer.MAX_VALUE);
+
+    for (int i=0; i<pixelsFiles.size(); i++) {
+      String file = pixelsFiles.get(i);
+      CoreMetadata m = new CoreMetadata();
+      m.pixelType = FormatTools.UINT8;
+
+      Connection conn = openConnection(file);
+      try {
+        PreparedStatement regionQuery = conn.prepareStatement(
+          "SELECT id, data FROM region"
+        );
+        ResultSet regionData = regionQuery.executeQuery();
+        // expect a single row returned
+        if (regionData.next()) {
+          String json = regionData.getString(2);
+          LOGGER.trace("{}", json);
+
+          try {
+            // expect trailing whitespace and line breaks
+            // in the value for "AcquisitionSettings",
+            // which will prevent parsing
+            json = json.trim();
+            json = json.replaceAll("\r\n", "_");
+            regionMetadata[i] = new JSONObject(json);
+          }
+          catch (JSONException je) {
+            throw new FormatException("Could not read metadata for region in " + file, je);
+          }
+
+          // "Rows" and "Columns" in the JSON metadata here
+          // reflect the canvas size, not the area (FOVs) actually acquired
+
+          tileSizeX[i] = regionMetadata[i].getInt("ImageWidth");
+          tileSizeY[i] = regionMetadata[i].getInt("ImageHeight");
+          overlapX[i] = regionMetadata[i].getInt("OverlapWidth");
+          overlapY[i] = regionMetadata[i].getInt("OverlapHeight");
+          scaleFactor[i] = regionMetadata[i].getInt("CacheStep");
+        }
+
+        PreparedStatement fovQuery = conn.prepareStatement(
+          "SELECT row, column FROM fovs"
+        );
+        ResultSet fovs = fovQuery.executeQuery();
+        while (fovs.next()) {
+          int row = fovs.getInt(1);
+          int col = fovs.getInt(2);
+          tileRangeY[0][i] = (int) Math.min(tileRangeY[0][i], row);
+          tileRangeY[1][i] = (int) Math.max(tileRangeY[1][i], row);
+          tileRangeX[0][i] = (int) Math.min(tileRangeX[0][i], col);
+          tileRangeX[1][i] = (int) Math.max(tileRangeX[1][i], col);
+        }
+        // TODO: no overlap handling yet
+        m.sizeX = (tileRangeX[1][i] - tileRangeX[0][i] + 1) * tileSizeX[i];
+        m.sizeY = (tileRangeY[1][i] - tileRangeY[0][i] + 1) * tileSizeY[i];
+
+        PreparedStatement maxLevelQuery = conn.prepareStatement(
+          "SELECT level FROM images ORDER BY level DESC"
+        );
+        ResultSet maxLevel = maxLevelQuery.executeQuery();
+        if (maxLevel.next()) {
+          int resolutionCount = maxLevel.getInt(1);
+          m.resolutionCount = resolutionCount + 1;
+        }
+
+        PreparedStatement channelQuery = conn.prepareStatement(
+          "SELECT id, name, color, save_16bit, excitation_wavelength, emission_wavelength FROM channels"
+        );
+        ResultSet channels = channelQuery.executeQuery();
+        while (channels.next()) {
+          m.sizeC++;
+
+          // TODO: save channel name, color, wavelengths
+
+          boolean save16 = channels.getBoolean(4);
+          if (save16) {
+            m.pixelType = FormatTools.UINT16;
+          }
+        }
+      }
+      catch (SQLException e) {
+        LOGGER.warn("Failed to initialize", e);
+      }
+      finally {
+        try {
+          conn.close();
+        }
+        catch (SQLException e) {
+          LOGGER.warn("Failed to close connection", e);
+        }
+      }
+
+      m.sizeZ = 1;
+      m.sizeT = 1;
+      m.imageCount = m.sizeZ * m.sizeC * m.sizeT;
+
+      // TODO: bad assumption in general?
+      if (m.sizeC == 1 && m.pixelType == FormatTools.UINT8) {
+        m.sizeC = 3;
+        m.rgb = true;
+      }
+
+      m.dimensionOrder = "XYCZT";
+
+      core.add(m);
+      fullResolutionCoreIndex[i] = core.size() - 1;
+      for (int r=1; r<m.resolutionCount; r++) {
+        CoreMetadata res = new CoreMetadata(m);
+        int scale = (int) Math.pow(scaleFactor[i], r);
+        res.sizeX /= scale;
+        res.sizeY /= scale;
+        res.resolutionCount = 1;
+        core.add(res);
+      }
+    }
+
+    // TODO: parse ROIs from .aqproj
+
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this);
+
+    String instrument = MetadataTools.createLSID("Instrument", 0);
+    store.setInstrumentID(instrument, 0);
+
+    for (int i=0; i<regionMetadata.length; i++) {
+      int imageIndex = hasFlattenedResolutions() ? fullResolutionCoreIndex[i] : i;
+
+      String objectiveID = MetadataTools.createLSID("Objective", 0, i);
+      store.setObjectiveID(objectiveID, 0, i);
+
+      Double lensNA = regionMetadata[i].getDouble("ObjectiveLensNA");
+      store.setObjectiveLensNA(lensNA, 0, i);
+
+      String immersion = regionMetadata[i].getString("ObjectiveImmersion");
+      store.setObjectiveImmersion(getImmersion(immersion), 0, i);
+
+      Double magnification = regionMetadata[i].getDouble("ObjectiveNominalMagnification");
+      store.setObjectiveNominalMagnification(magnification, 0, i);
+
+      String objectiveName = regionMetadata[i].getString("ObjectiveName");
+      store.setObjectiveModel(objectiveName, 0, i);
+
+      store.setImageName(regionMetadata[i].getString("Name"), imageIndex);
+      store.setObjectiveSettingsID(objectiveID, imageIndex);
+
+      Double physicalX = regionMetadata[i].getDouble("PhysicalSizeX");
+      Double physicalY = regionMetadata[i].getDouble("PhysicalSizeY");
+
+      store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(physicalX), imageIndex);
+      store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(physicalY), imageIndex);
+    }
+  }
+
+  // -- Helper methods --
+
+  private void findDBFiles() {
+    Location dir = new Location(getCurrentFile()).getAbsoluteFile().getParentFile();
+    String[] list = dir.list(true);
+    Arrays.sort(list);
+    for (String f : list) {
+      Location slide = new Location(dir, f);
+      if (f.startsWith("Slide ") && slide.isDirectory()) {
+        String[] dbFiles = slide.list(true);
+        Arrays.sort(dbFiles);
+        for (String db : dbFiles) {
+          if (checkSuffix(db, "tfcyto")) {
+            pixelsFiles.add(new Location(slide, db).getAbsolutePath());
+          }
+        }
+      }
+    }
+  }
+
+  private int getLevel() {
+    if (hasFlattenedResolutions()) {
+      int fullResIndex = fullResolutionCoreIndex[getRegionIndex()];
+      return getCoreIndex() - fullResIndex;
+    }
+    return getResolution();
+  }
+
+  private int getRegionIndex() {
+    if (hasFlattenedResolutions()) {
+      int index = getCoreIndex();
+      for (int i=fullResolutionCoreIndex.length-1; i>=0; i--) {
+        if (fullResolutionCoreIndex[i] < index) {
+          return i;
+        }
+      }
+    }
+    return getSeries();
+  }
+
+  private String getDBFile() {
+    return pixelsFiles.get(getRegionIndex());
+  }
+
+  private Codec getCodec(int compression) throws UnsupportedCompressionException {
+    switch (compression) {
+      case 0:
+      case 1:
+        return new PassthroughCodec();
+      case 6:
+        return new JPEGXRCodec();
+      case 7:
+        return new JPEGCodec();
+      default:
+        throw new UnsupportedCompressionException("Unsupported compression: " + compression);
+    }
+  }
+
+  private Connection openConnection(String file) throws IOException {
+    Connection conn = null;
+    try {
+      // see https://github.com/xerial/sqlite-jdbc/issues/247
+      SQLiteConfig config = new SQLiteConfig();
+      config.setReadOnly(true);
+      conn = config.createConnection("jdbc:sqlite:" +
+        new Location(file).getAbsolutePath());
+    }
+    catch (SQLException e) {
+      LOGGER.warn("Could not read from database");
+      throw new IOException(e);
+    }
+    return conn;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -78,15 +78,7 @@ public class TissuegnosticsReader extends FormatReader {
     LoggerFactory.getLogger(TissuegnosticsReader.class);
 
   private List<String> pixelsFiles = new ArrayList<String>();
-  private int[] fullResolutionCoreIndex;
-  private int[] tileSizeX;
-  private int[] tileSizeY;
-  private int[] overlapX;
-  private int[] overlapY;
-  private int[] scaleFactor;
-  private int[][] tileRangeX;
-  private int[][] tileRangeY;
-  private Integer[][] zSteps;
+  private List<ScanRegion> regions = new ArrayList<ScanRegion>();
 
   // -- Constructor --
 
@@ -107,15 +99,7 @@ public class TissuegnosticsReader extends FormatReader {
     super.close(fileOnly);
     if (!fileOnly) {
       pixelsFiles.clear();
-      fullResolutionCoreIndex = null;
-      tileSizeX = null;
-      tileSizeY = null;
-      overlapX = null;
-      overlapY = null;
-      scaleFactor = null;
-      tileRangeX = null;
-      tileRangeY = null;
-      zSteps = null;
+      regions.clear();
     }
   }
 
@@ -123,16 +107,28 @@ public class TissuegnosticsReader extends FormatReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
-    int region = getRegionIndex();
-    return tileSizeX[region] / (int) Math.pow(scaleFactor[region], getLevel());
+    try {
+      ScanRegion region = getRegion();
+      return region.tileSizeX / (int) Math.pow(region.scaleFactor, getLevel());
+    }
+    catch (FormatException e) {
+      LOGGER.warn("Could not get optimal tile width", e);
+    }
+    return super.getOptimalTileWidth();
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
-    int region = getRegionIndex();
-    return tileSizeY[region] / (int) Math.pow(scaleFactor[region], getLevel());
+    try {
+      ScanRegion region = getRegion();
+      return region.tileSizeY / (int) Math.pow(region.scaleFactor, getLevel());
+    }
+    catch (FormatException e) {
+      LOGGER.warn("Could not get optimal tile height", e);
+    }
+    return super.getOptimalTileHeight();
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -143,7 +139,12 @@ public class TissuegnosticsReader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(getCurrentFile());
     if (!noPixels) {
-      files.add(getDBFile());
+      try {
+        files.add(getRegion().file);
+      }
+      catch (FormatException e) {
+        LOGGER.warn("Could not get file", e);
+      }
     }
     return files.toArray(new String[files.size()]);
   }
@@ -159,50 +160,52 @@ public class TissuegnosticsReader extends FormatReader {
 
     Arrays.fill(buf, getFillColor());
 
-    int regionIndex = getRegionIndex();
+    int[] zct = getZCTCoords(no);
+    ScanRegion region = getRegion(zct[2]);
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int level = getLevel();
-    int scale = (int) Math.pow(scaleFactor[regionIndex], level);
+    int scale = (int) Math.pow(region.scaleFactor, level);
 
     Region dest = new Region(x, y, w, h);
-    Connection conn = openConnection(getDBFile());
+    Connection conn = openConnection(region.file);
     try {
       PreparedStatement tiles = conn.prepareStatement(
-        "SELECT data, compression, row, column FROM images WHERE level=? AND row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column DESC"
+        "SELECT data, compression, row, column FROM images WHERE region=? AND level=? AND " +
+        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column DESC"
       );
       // TODO: account for possiblity of overlap
 
-      int rowOffset = (int) Math.floor((double) tileRangeY[0][regionIndex] / scale);
-      int colOffset = (int) Math.floor((double) tileRangeX[0][regionIndex] / scale);
+      int rowOffset = (int) Math.floor((double) region.tileRangeY[0] / scale);
+      int colOffset = (int) Math.floor((double) region.tileRangeX[0] / scale);
 
-      int startRow = (int) Math.floor((double) y / tileSizeY[regionIndex]) + rowOffset;
-      int startCol = (int) Math.floor((double) x / tileSizeX[regionIndex]) + colOffset;
-      int endRow = (int) Math.ceil((double) (y + h) / tileSizeY[regionIndex]) + rowOffset;
-      int endCol = (int) Math.ceil((double) (x + w) / tileSizeX[regionIndex]) + colOffset;
+      int startRow = (int) Math.floor((double) y / region.tileSizeY) + rowOffset;
+      int startCol = (int) Math.floor((double) x / region.tileSizeX) + colOffset;
+      int endRow = (int) Math.ceil((double) (y + h) / region.tileSizeY) + rowOffset;
+      int endCol = (int) Math.ceil((double) (x + w) / region.tileSizeX) + colOffset;
 
-      tiles.setInt(1, level);
-      tiles.setInt(2, startRow);
-      tiles.setInt(3, endRow);
-      tiles.setInt(4, startCol);
-      tiles.setInt(5, endCol);
+      tiles.setInt(1, region.id);
+      tiles.setInt(2, level);
+      tiles.setInt(3, startRow);
+      tiles.setInt(4, endRow);
+      tiles.setInt(5, startCol);
+      tiles.setInt(6, endCol);
 
-      int[] zct = getZCTCoords(no);
-      tiles.setInt(6, zct[1] + 1);
-      tiles.setInt(7, zct[0] > 0 ? 1 : 0);
-      tiles.setInt(8, zSteps[regionIndex][zct[0]]);
+      tiles.setInt(7, zct[1] + 1);
+      tiles.setInt(8, zct[0] > 0 ? 1 : 0);
+      tiles.setInt(9, region.zSteps[zct[0]]);
 
       // upper left corner of full resolution,
       // in pixels relative to full canvas
-      int fullResUpperLeftX = tileRangeX[0][regionIndex] * tileSizeX[regionIndex];
-      int fullResUpperLeftY = tileRangeY[0][regionIndex] * tileSizeY[regionIndex];
+      int fullResUpperLeftX = region.tileRangeX[0] * region.tileSizeX;
+      int fullResUpperLeftY = region.tileRangeY[0] * region.tileSizeY;
 
       // upper left corner of current resolution,
       // in pixels relative to current resolution canvas
       int currentResUpperLeftX = fullResUpperLeftX / scale;
       int currentResUpperLeftY = fullResUpperLeftY / scale;
 
-      int relativeUpperLeftX = currentResUpperLeftX % tileSizeX[regionIndex];
-      int relativeUpperLeftY = currentResUpperLeftY % tileSizeY[regionIndex];
+      int relativeUpperLeftX = currentResUpperLeftX % region.tileSizeX;
+      int relativeUpperLeftY = currentResUpperLeftY % region.tileSizeY;
 
       ResultSet subsetTiles = tiles.executeQuery();
       while (subsetTiles.next()) {
@@ -216,14 +219,14 @@ public class TissuegnosticsReader extends FormatReader {
 
         CodecOptions options = new CodecOptions();
         options.bitsPerSample = bpp * 8;
-        options.width = tileSizeX[regionIndex];
-        options.height = tileSizeY[regionIndex];
+        options.width = region.tileSizeX;
+        options.height = region.tileSizeY;
 
         Codec codec = getCodec(compression);
         byte[] tile = codec.decompress(data, options);
 
-        int relativeColumn = column - (int) Math.floor((double) tileRangeX[0][regionIndex] / scale);
-        int relativeRow = row - (int) Math.floor((double) tileRangeY[0][regionIndex] / scale);
+        int relativeColumn = column - (int) Math.floor((double) region.tileRangeX[0] / scale);
+        int relativeRow = row - (int) Math.floor((double) region.tileRangeY[0] / scale);
         relativeColumn *= options.width;
         relativeRow *= options.height;
 
@@ -237,7 +240,7 @@ public class TissuegnosticsReader extends FormatReader {
 
         int outputRowLen = w * bpp;
         int intersectionX = (int) Math.max(0, dest.x - src.x);
-        int rowLen = bpp * (int) Math.min(intersection.width, tileSizeX[regionIndex]);
+        int rowLen = bpp * (int) Math.min(intersection.width, region.tileSizeX);
 
         int outputRow = intersection.y - y;
         int outputCol = intersection.x - x;
@@ -247,7 +250,7 @@ public class TissuegnosticsReader extends FormatReader {
           int destChannelOffset = c * w * h * bpp;
           for (int copyRow=0; copyRow<intersection.height; copyRow++) {
             int realRow = copyRow + intersection.y - src.y;
-            int inputOffset = bpp * (realRow * tileSizeX[regionIndex] + intersectionX);
+            int inputOffset = bpp * (realRow * region.tileSizeX + intersectionX);
             System.arraycopy(tile, srcChannelOffset + inputOffset,
               buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
           }
@@ -280,35 +283,31 @@ public class TissuegnosticsReader extends FormatReader {
 
     core.clear();
 
-    JSONObject[] regionMetadata = new JSONObject[pixelsFiles.size()];
-    fullResolutionCoreIndex = new int[pixelsFiles.size()];
-    tileSizeX = new int[pixelsFiles.size()];
-    tileSizeY = new int[pixelsFiles.size()];
-    overlapX = new int[pixelsFiles.size()];
-    overlapY = new int[pixelsFiles.size()];
-    scaleFactor = new int[pixelsFiles.size()];
-    tileRangeX = new int[2][pixelsFiles.size()];
-    tileRangeY = new int[2][pixelsFiles.size()];
-    zSteps = new Integer[pixelsFiles.size()][];
-
-    Arrays.fill(tileRangeX[0], Integer.MAX_VALUE);
-    Arrays.fill(tileRangeY[0], Integer.MAX_VALUE);
-
     for (int i=0; i<pixelsFiles.size(); i++) {
       String file = pixelsFiles.get(i);
       CoreMetadata m = new CoreMetadata();
       m.pixelType = FormatTools.UINT8;
 
+      int startRegionIndex = regions.size();
+
       Connection conn = openConnection(file);
       try {
         PreparedStatement regionQuery = conn.prepareStatement(
-          "SELECT id, data FROM region"
+          "SELECT id, data, is_timelapse FROM region ORDER BY id"
         );
         ResultSet regionData = regionQuery.executeQuery();
-        // expect a single row returned
-        if (regionData.next()) {
+
+        // expect one row per timepoint
+        while (regionData.next()) {
+          int regionID = regionData.getInt(1);
           String json = regionData.getString(2);
+          boolean isTimelapse = regionData.getBoolean(3);
+
           LOGGER.trace("{}", json);
+
+          ScanRegion region = new ScanRegion();
+          region.id = regionID;
+          region.file = file;
 
           try {
             // expect trailing whitespace and line breaks
@@ -316,45 +315,69 @@ public class TissuegnosticsReader extends FormatReader {
             // which will prevent parsing
             json = json.trim();
             json = json.replaceAll("\r\n", "_");
-            regionMetadata[i] = new JSONObject(json);
+            region.regionMetadata = new JSONObject(json);
           }
           catch (JSONException je) {
             throw new FormatException("Could not read metadata for region in " + file, je);
           }
 
-          // "Rows" and "Columns" in the JSON metadata here
-          // reflect the canvas size, not the area (FOVs) actually acquired
+          region.parseJSON();
+          region.timepoint = regions.size() - startRegionIndex;
 
-          tileSizeX[i] = regionMetadata[i].getInt("ImageWidth");
-          tileSizeY[i] = regionMetadata[i].getInt("ImageHeight");
-          overlapX[i] = regionMetadata[i].getInt("OverlapWidth");
-          overlapY[i] = regionMetadata[i].getInt("OverlapHeight");
-          scaleFactor[i] = regionMetadata[i].getInt("CacheStep");
+          // TODO: this means TMA regions are parsed, but not recorded separately
+          // that might be OK, but needs to be double-checked
+          if (isTimelapse || regions.size() == startRegionIndex) {
+            regions.add(region);
+          }
         }
+        int timepoints = regions.size() - startRegionIndex;
 
-        PreparedStatement fovQuery = conn.prepareStatement(
-          "SELECT row, column FROM fovs"
-        );
-        ResultSet fovs = fovQuery.executeQuery();
-        while (fovs.next()) {
-          int row = fovs.getInt(1);
-          int col = fovs.getInt(2);
-          tileRangeY[0][i] = (int) Math.min(tileRangeY[0][i], row);
-          tileRangeY[1][i] = (int) Math.max(tileRangeY[1][i], row);
-          tileRangeX[0][i] = (int) Math.min(tileRangeX[0][i], col);
-          tileRangeX[1][i] = (int) Math.max(tileRangeX[1][i], col);
-        }
-        // TODO: no overlap handling yet
-        m.sizeX = (tileRangeX[1][i] - tileRangeX[0][i] + 1) * tileSizeX[i];
-        m.sizeY = (tileRangeY[1][i] - tileRangeY[0][i] + 1) * tileSizeY[i];
+        for (int regionIndex=startRegionIndex; regionIndex<regions.size(); regionIndex++) {
+          ScanRegion currentRegion = regions.get(regionIndex);
 
-        PreparedStatement maxLevelQuery = conn.prepareStatement(
-          "SELECT level FROM images ORDER BY level DESC"
-        );
-        ResultSet maxLevel = maxLevelQuery.executeQuery();
-        if (maxLevel.next()) {
-          int resolutionCount = maxLevel.getInt(1);
-          m.resolutionCount = resolutionCount + 1;
+          PreparedStatement fovQuery = conn.prepareStatement(
+            "SELECT row, column FROM fovs WHERE region_id=?"
+          );
+          fovQuery.setInt(1, regions.get(regionIndex).id);
+
+          ResultSet fovs = fovQuery.executeQuery();
+          while (fovs.next()) {
+            int row = fovs.getInt(1);
+            int col = fovs.getInt(2);
+            currentRegion.tileRangeY[0] = (int) Math.min(currentRegion.tileRangeY[0], row);
+            currentRegion.tileRangeY[1] = (int) Math.max(currentRegion.tileRangeY[1], row);
+            currentRegion.tileRangeX[0] = (int) Math.min(currentRegion.tileRangeX[0], col);
+            currentRegion.tileRangeX[1] = (int) Math.max(currentRegion.tileRangeX[1], col);
+          }
+          // TODO: no overlap handling yet
+          m.sizeX = (currentRegion.tileRangeX[1] - currentRegion.tileRangeX[0] + 1) * currentRegion.tileSizeX;
+          m.sizeY = (currentRegion.tileRangeY[1] - currentRegion.tileRangeY[0] + 1) * currentRegion.tileSizeY;
+
+          PreparedStatement maxLevelQuery = conn.prepareStatement(
+            "SELECT level FROM images WHERE region=? ORDER BY level DESC"
+          );
+          maxLevelQuery.setInt(1, currentRegion.id);
+          ResultSet maxLevel = maxLevelQuery.executeQuery();
+          if (maxLevel.next()) {
+            int resolutionCount = maxLevel.getInt(1);
+            m.resolutionCount = resolutionCount + 1;
+          }
+
+          PreparedStatement zQuery = conn.prepareStatement(
+            "SELECT DISTINCT is_zstack,z_position FROM images WHERE region=? ORDER BY is_zstack,z_position"
+          );
+          zQuery.setInt(1, currentRegion.id);
+
+          ResultSet zs = zQuery.executeQuery();
+          ArrayList<Integer> tmpZ = new ArrayList<Integer>();
+          while (zs.next()) {
+            boolean isZ = zs.getBoolean(1);
+            int zPos = zs.getInt(2);
+
+            tmpZ.add(zPos);
+          }
+          currentRegion.zSteps = tmpZ.toArray(new Integer[tmpZ.size()]);
+          currentRegion.fullResolutionCoreIndex = core.size();
         }
 
         PreparedStatement channelQuery = conn.prepareStatement(
@@ -371,19 +394,6 @@ public class TissuegnosticsReader extends FormatReader {
             m.pixelType = FormatTools.UINT16;
           }
         }
-
-        PreparedStatement zQuery = conn.prepareStatement(
-          "SELECT DISTINCT is_zstack,z_position FROM images WHERE level=0 ORDER BY is_zstack,z_position"
-        );
-        ResultSet zs = zQuery.executeQuery();
-        ArrayList<Integer> tmpZ = new ArrayList<Integer>();
-        while (zs.next()) {
-          boolean isZ = zs.getBoolean(1);
-          int zPos = zs.getInt(2);
-
-          tmpZ.add(zPos);
-        }
-        zSteps[i] = tmpZ.toArray(new Integer[tmpZ.size()]);
       }
       catch (SQLException e) {
         LOGGER.warn("Failed to initialize", e);
@@ -397,8 +407,8 @@ public class TissuegnosticsReader extends FormatReader {
         }
       }
 
-      m.sizeZ = zSteps[i].length;
-      m.sizeT = 1;
+      m.sizeZ = regions.get(startRegionIndex).zSteps.length;
+      m.sizeT = regions.size() - startRegionIndex;
       m.imageCount = m.sizeZ * m.sizeC * m.sizeT;
 
       // TODO: bad assumption in general?
@@ -410,10 +420,9 @@ public class TissuegnosticsReader extends FormatReader {
       m.dimensionOrder = "XYCZT";
 
       core.add(m);
-      fullResolutionCoreIndex[i] = core.size() - 1;
       for (int r=1; r<m.resolutionCount; r++) {
         CoreMetadata res = new CoreMetadata(m);
-        int scale = (int) Math.pow(scaleFactor[i], r);
+        int scale = (int) Math.pow(regions.get(startRegionIndex).scaleFactor, r);
         res.sizeX /= scale;
         res.sizeY /= scale;
         res.resolutionCount = 1;
@@ -429,32 +438,35 @@ public class TissuegnosticsReader extends FormatReader {
     String instrument = MetadataTools.createLSID("Instrument", 0);
     store.setInstrumentID(instrument, 0);
 
-    for (int i=0; i<regionMetadata.length; i++) {
-      int imageIndex = hasFlattenedResolutions() ? fullResolutionCoreIndex[i] : i;
+    for (int i=0, index=0; i<regions.size(); index++) {
+      ScanRegion region = regions.get(i);
+      int imageIndex = hasFlattenedResolutions() ? region.fullResolutionCoreIndex : index;
 
-      String objectiveID = MetadataTools.createLSID("Objective", 0, i);
-      store.setObjectiveID(objectiveID, 0, i);
+      String objectiveID = MetadataTools.createLSID("Objective", 0, index);
+      store.setObjectiveID(objectiveID, 0, index);
 
-      Double lensNA = regionMetadata[i].getDouble("ObjectiveLensNA");
-      store.setObjectiveLensNA(lensNA, 0, i);
+      Double lensNA = region.regionMetadata.getDouble("ObjectiveLensNA");
+      store.setObjectiveLensNA(lensNA, 0, index);
 
-      String immersion = regionMetadata[i].getString("ObjectiveImmersion");
-      store.setObjectiveImmersion(getImmersion(immersion), 0, i);
+      String immersion = region.regionMetadata.getString("ObjectiveImmersion");
+      store.setObjectiveImmersion(getImmersion(immersion), 0, index);
 
-      Double magnification = regionMetadata[i].getDouble("ObjectiveNominalMagnification");
-      store.setObjectiveNominalMagnification(magnification, 0, i);
+      Double magnification = region.regionMetadata.getDouble("ObjectiveNominalMagnification");
+      store.setObjectiveNominalMagnification(magnification, 0, index);
 
-      String objectiveName = regionMetadata[i].getString("ObjectiveName");
-      store.setObjectiveModel(objectiveName, 0, i);
+      String objectiveName = region.regionMetadata.getString("ObjectiveName");
+      store.setObjectiveModel(objectiveName, 0, index);
 
-      store.setImageName(regionMetadata[i].getString("Name"), imageIndex);
+      store.setImageName(region.regionMetadata.getString("Name"), imageIndex);
       store.setObjectiveSettingsID(objectiveID, imageIndex);
 
-      Double physicalX = regionMetadata[i].getDouble("PhysicalSizeX");
-      Double physicalY = regionMetadata[i].getDouble("PhysicalSizeY");
+      Double physicalX = region.regionMetadata.getDouble("PhysicalSizeX");
+      Double physicalY = region.regionMetadata.getDouble("PhysicalSizeY");
 
       store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(physicalX), imageIndex);
       store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(physicalY), imageIndex);
+
+      i += core.get(imageIndex).sizeT;
     }
   }
 
@@ -478,28 +490,27 @@ public class TissuegnosticsReader extends FormatReader {
     }
   }
 
-  private int getLevel() {
-    if (hasFlattenedResolutions()) {
-      int fullResIndex = fullResolutionCoreIndex[getRegionIndex()];
-      return getCoreIndex() - fullResIndex;
-    }
-    return getResolution();
+  private ScanRegion getRegion() throws FormatException {
+    return getRegion(0);
   }
 
-  private int getRegionIndex() {
-    if (hasFlattenedResolutions()) {
-      int index = getCoreIndex();
-      for (int i=fullResolutionCoreIndex.length-1; i>=0; i--) {
-        if (fullResolutionCoreIndex[i] < index) {
-          return i;
-        }
+  private ScanRegion getRegion(int t) throws FormatException {
+    int index = getCoreIndex();
+    for (int i=regions.size()-1; i>=0; i--) {
+      ScanRegion r = regions.get(i);
+      if (r.timepoint == t && r.fullResolutionCoreIndex <= index) {
+        return r;
       }
     }
-    return getSeries();
+    throw new FormatException("Could not find ScanRegion (core index " + index + ", t=" + t + ")");
   }
 
-  private String getDBFile() {
-    return pixelsFiles.get(getRegionIndex());
+  private int getLevel() throws FormatException {
+    if (hasFlattenedResolutions()) {
+      ScanRegion region = getRegion();
+      return getCoreIndex() - region.fullResolutionCoreIndex;
+    }
+    return getResolution();
   }
 
   private Codec getCodec(int compression) throws UnsupportedCompressionException {
@@ -530,6 +541,33 @@ public class TissuegnosticsReader extends FormatReader {
       throw new IOException(e);
     }
     return conn;
+  }
+
+  class ScanRegion {
+    public String file;
+    public JSONObject regionMetadata;
+    public int id;
+    public int fullResolutionCoreIndex;
+    public int tileSizeX;
+    public int tileSizeY;
+    public int overlapX;
+    public int overlapY;
+    public int scaleFactor;
+    public int[] tileRangeX = new int[] {Integer.MAX_VALUE, 0};
+    public int[] tileRangeY = new int[] {Integer.MAX_VALUE, 0};
+    public Integer[] zSteps;
+    public int timepoint;
+
+    public void parseJSON() {
+      // "Rows" and "Columns" in the JSON metadata here
+      // reflect the canvas size, not the area (FOVs) actually acquired
+      tileSizeX = regionMetadata.getInt("ImageWidth");
+      tileSizeY = regionMetadata.getInt("ImageHeight");
+      overlapX = regionMetadata.getInt("OverlapWidth");
+      overlapY = regionMetadata.getInt("OverlapHeight");
+      scaleFactor = regionMetadata.getInt("CacheStep");
+    }
+
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -201,19 +201,6 @@ public class TissuegnosticsReader extends FormatReader {
       tiles.setInt(8, zct[0] > 0 ? 1 : 0);
       tiles.setInt(9, region.zSteps[zct[0]]);
 
-      // upper left corner of full resolution,
-      // in pixels relative to full canvas
-      int fullResUpperLeftX = region.tileRangeX[0] * region.tileSizeX;
-      int fullResUpperLeftY = region.tileRangeY[0] * region.tileSizeY;
-
-      // upper left corner of current resolution,
-      // in pixels relative to current resolution canvas
-      int currentResUpperLeftX = fullResUpperLeftX / scale;
-      int currentResUpperLeftY = fullResUpperLeftY / scale;
-
-      int relativeUpperLeftX = currentResUpperLeftX % region.tileSizeX;
-      int relativeUpperLeftY = currentResUpperLeftY % region.tileSizeY;
-
       ResultSet subsetTiles = tiles.executeQuery();
       while (subsetTiles.next()) {
         byte[] data = subsetTiles.getBytes(1);
@@ -238,13 +225,9 @@ public class TissuegnosticsReader extends FormatReader {
         int pixelColumn = relativeColumn * options.width;
         int pixelRow = relativeRow * options.height;
 
-        if (level > 0) {
-          pixelRow -= relativeUpperLeftY;
-          pixelColumn -= relativeUpperLeftX;
-        }
-
         // overlap handling
-        // TODO: make this work for subresolutions too
+        byte[][] fovs = null;
+        Region[] fovPositions = new Region[scale * scale];
         if (level == 0) {
           Region fov = region.fovs.get(row + "-" + column);
           pixelRow -= fov.y;
@@ -252,27 +235,49 @@ public class TissuegnosticsReader extends FormatReader {
 
           pixelRow -= (relativeRow * region.overlapY);
           pixelColumn -= (relativeColumn * region.overlapX);
+
+          fovPositions[0] = new Region(pixelColumn, pixelRow, options.width, options.height);
+          fovs = new byte[1][];
+          fovs[0] = tile;
+        }
+        else {
+          fovs = splitFOVs(region, tile, scale);
+
+          for (int f=0; f<fovs.length; f++) {
+            int fovRow = row*scale + (f / scale);
+            int fovColumn = column*scale + (f % scale);
+            Region fov = region.fovs.get(fovRow + "-" + fovColumn);
+            if (fov != null) {
+              int xx = (fovColumn * options.width / scale) - (fov.x / scale) - (fovColumn * scaledOverlapX);
+              int yy = (fovRow * options.height / scale) - (fov.y / scale) - (fovRow * scaledOverlapY);
+              fovPositions[f] = new Region(xx, yy, options.width / scale, options.height / scale);
+            }
+          }
         }
 
-        Region src = new Region(pixelColumn, pixelRow, options.width, options.height);
-        Region intersection = src.intersection(dest);
+        for (int f=0; f<fovs.length; f++) {
+          if (fovPositions[f] == null) {
+            continue;
+          }
+          Region intersection = fovPositions[f].intersection(dest);
 
-        if (intersection.width > 0 && intersection.height > 0) {
-          int outputRowLen = w * bpp;
-          int intersectionX = (int) Math.max(0, dest.x - src.x);
-          int rowLen = bpp * (int) Math.min(intersection.width, region.tileSizeX);
+          if (intersection.width > 0 && intersection.height > 0) {
+            int outputRowLen = w * bpp;
+            int intersectionX = (int) Math.max(0, dest.x - fovPositions[f].x);
+            int rowLen = bpp * (int) Math.min(intersection.width, fovPositions[f].width);
 
-          int outputRow = intersection.y - y;
-          int outputCol = intersection.x - x;
-          int outputOffset = outputRow * outputRowLen + outputCol * bpp;
-          for (int c=0; c<getRGBChannelCount(); c++) {
-            int srcChannelOffset = c * (tile.length / getRGBChannelCount());
-            int destChannelOffset = c * w * h * bpp;
-            for (int copyRow=0; copyRow<intersection.height; copyRow++) {
-              int realRow = copyRow + intersection.y - src.y;
-              int inputOffset = bpp * (realRow * region.tileSizeX + intersectionX);
-              System.arraycopy(tile, srcChannelOffset + inputOffset,
-                buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+            int outputRow = intersection.y - y;
+            int outputCol = intersection.x - x;
+            int outputOffset = outputRow * outputRowLen + outputCol * bpp;
+            for (int c=0; c<getRGBChannelCount(); c++) {
+              int srcChannelOffset = c * (fovs[f].length / getRGBChannelCount());
+              int destChannelOffset = c * w * h * bpp;
+              for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+                int realRow = copyRow + intersection.y - fovPositions[f].y;
+                int inputOffset = bpp * (realRow * (region.tileSizeX / scale) + intersectionX);
+                System.arraycopy(fovs[f], srcChannelOffset + inputOffset,
+                  buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+              }
             }
           }
         }
@@ -410,7 +415,7 @@ public class TissuegnosticsReader extends FormatReader {
         }
 
         PreparedStatement channelQuery = conn.prepareStatement(
-          "SELECT id, name, color, save_16bit, excitation_wavelength, emission_wavelength FROM channels ORDER BY id"
+          "SELECT DISTINCT id, name, color, save_16bit, excitation_wavelength, emission_wavelength FROM channels ORDER BY id"
         );
         ResultSet channels = channelQuery.executeQuery();
         while (channels.next()) {
@@ -576,6 +581,55 @@ public class TissuegnosticsReader extends FormatReader {
       default:
         throw new UnsupportedCompressionException("Unsupported compression: " + compression);
     }
+  }
+
+  /**
+   * The largest resolution stores one field of view (FOV) per tile.
+   * Each sub-resolution has the same tile size as the largest resolution,
+   * so the number of FOVs stored in one tile increases as the resolutions
+   * get smaller.
+   *
+   * For example, with a tile size of 2048x2048 and a downsample factor of 4,
+   * resolution 1 will have 16 (4x4) FOVs per tile, with each FOV being 512x512.
+   *
+   * However, none of the FOV positions or overlaps are taken into account.
+   * So the first step in assembling a sub-resolution is to split each tile
+   * into its component FOVs. Then each FOV can be repositioned according to
+   * its associated stitching rectangle and overlap.
+   *
+   * This method only splits the given tile into component FOVs.
+   * This is not necessary for the largest resolution, only sub-resolutions.
+   */
+  private byte[][] splitFOVs(ScanRegion region, byte[] tile, int scale) {
+    byte[][] fovs = new byte[scale * scale][];
+    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    int channels = getRGBChannelCount();
+
+    int srcWidth = region.tileSizeX * bpp;
+    int destWidth = (region.tileSizeX / scale) * bpp;
+    int srcHeight = region.tileSizeY;
+    int destHeight = region.tileSizeY / scale;
+
+    for (int fov=0; fov<fovs.length; fov++) {
+      int fovRow = fov / scale;
+      int fovCol = fov % scale;
+
+      fovs[fov] = new byte[destWidth * destHeight * bpp * channels];
+
+      for (int c=0; c<channels; c++) {
+        int srcChannelOffset = c * srcWidth * srcHeight;
+        int destChannelOffset = c * destWidth * destHeight;
+
+        for (int row=0; row<destHeight; row++) {
+          int srcOffset = srcChannelOffset + (((fovRow * destHeight) + row) * srcWidth) + (fovCol * destWidth);
+          int destOffset = destChannelOffset + (row * destWidth);
+
+          System.arraycopy(tile, srcOffset, fovs[fov], destOffset, destWidth);
+        }
+      }
+    }
+
+    return fovs;
   }
 
   private Connection openConnection(String file) throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -91,7 +91,7 @@ public class TissuegnosticsReader extends FormatReader {
   public TissuegnosticsReader() {
     super("Tissuegnostics", new String[] {"aqproj"});
     hasCompanionFiles = false;
-    domains = new String[] {FormatTools.HCS_DOMAIN};
+    domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
     datasetDescription = "An .aqproj file with one or more .tfcyto database files";
     suffixSufficient = true;
   }

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -171,14 +171,16 @@ public class TissuegnosticsReader extends FormatReader {
     int level = getLevel();
     int scale = (int) Math.pow(region.scaleFactor, level);
 
+    int scaledOverlapX = region.overlapX / scale;
+    int scaledOverlapY = region.overlapY / scale;
+
     Region dest = new Region(x, y, w, h);
     Connection conn = openConnection(region.file);
     try {
       PreparedStatement tiles = conn.prepareStatement(
         "SELECT data, compression, row, column FROM images WHERE region=? AND level=? AND " +
-        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column DESC"
+        "row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column"
       );
-      // TODO: account for possiblity of overlap
 
       int rowOffset = (int) Math.floor((double) region.tileRangeY[0] / scale);
       int colOffset = (int) Math.floor((double) region.tileRangeX[0] / scale);
@@ -232,32 +234,46 @@ public class TissuegnosticsReader extends FormatReader {
 
         int relativeColumn = column - (int) Math.floor((double) region.tileRangeX[0] / scale);
         int relativeRow = row - (int) Math.floor((double) region.tileRangeY[0] / scale);
-        relativeColumn *= options.width;
-        relativeRow *= options.height;
+
+        int pixelColumn = relativeColumn * options.width;
+        int pixelRow = relativeRow * options.height;
 
         if (level > 0) {
-          relativeRow -= relativeUpperLeftY;
-          relativeColumn -= relativeUpperLeftX;
+          pixelRow -= relativeUpperLeftY;
+          pixelColumn -= relativeUpperLeftX;
         }
 
-        Region src = new Region(relativeColumn, relativeRow, options.width, options.height);
+        // overlap handling
+        // TODO: make this work for subresolutions too
+        if (level == 0) {
+          Region fov = region.fovs.get(row + "-" + column);
+          pixelRow -= fov.y;
+          pixelColumn -= fov.x;
+
+          pixelRow -= (relativeRow * region.overlapY);
+          pixelColumn -= (relativeColumn * region.overlapX);
+        }
+
+        Region src = new Region(pixelColumn, pixelRow, options.width, options.height);
         Region intersection = src.intersection(dest);
 
-        int outputRowLen = w * bpp;
-        int intersectionX = (int) Math.max(0, dest.x - src.x);
-        int rowLen = bpp * (int) Math.min(intersection.width, region.tileSizeX);
+        if (intersection.width > 0 && intersection.height > 0) {
+          int outputRowLen = w * bpp;
+          int intersectionX = (int) Math.max(0, dest.x - src.x);
+          int rowLen = bpp * (int) Math.min(intersection.width, region.tileSizeX);
 
-        int outputRow = intersection.y - y;
-        int outputCol = intersection.x - x;
-        int outputOffset = outputRow * outputRowLen + outputCol * bpp;
-        for (int c=0; c<getRGBChannelCount(); c++) {
-          int srcChannelOffset = c * (tile.length / getRGBChannelCount());
-          int destChannelOffset = c * w * h * bpp;
-          for (int copyRow=0; copyRow<intersection.height; copyRow++) {
-            int realRow = copyRow + intersection.y - src.y;
-            int inputOffset = bpp * (realRow * region.tileSizeX + intersectionX);
-            System.arraycopy(tile, srcChannelOffset + inputOffset,
-              buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+          int outputRow = intersection.y - y;
+          int outputCol = intersection.x - x;
+          int outputOffset = outputRow * outputRowLen + outputCol * bpp;
+          for (int c=0; c<getRGBChannelCount(); c++) {
+            int srcChannelOffset = c * (tile.length / getRGBChannelCount());
+            int destChannelOffset = c * w * h * bpp;
+            for (int copyRow=0; copyRow<intersection.height; copyRow++) {
+              int realRow = copyRow + intersection.y - src.y;
+              int inputOffset = bpp * (realRow * region.tileSizeX + intersectionX);
+              System.arraycopy(tile, srcChannelOffset + inputOffset,
+                buf, destChannelOffset + outputOffset + copyRow*outputRowLen, rowLen);
+            }
           }
         }
       }
@@ -341,7 +357,7 @@ public class TissuegnosticsReader extends FormatReader {
           ScanRegion currentRegion = regions.get(regionIndex);
 
           PreparedStatement fovQuery = conn.prepareStatement(
-            "SELECT row, column FROM fovs WHERE region_id=?"
+            "SELECT row, column, stitch_rectangle_x, stitch_rectangle_y, stitch_rectangle_w, stitch_rectangle_h FROM fovs WHERE region_id=?"
           );
           fovQuery.setInt(1, regions.get(regionIndex).id);
 
@@ -349,14 +365,22 @@ public class TissuegnosticsReader extends FormatReader {
           while (fovs.next()) {
             int row = fovs.getInt(1);
             int col = fovs.getInt(2);
+            double x = fovs.getDouble(3);
+            double y = fovs.getDouble(4);
+            double w = fovs.getDouble(5);
+            double h = fovs.getDouble(6);
             currentRegion.tileRangeY[0] = (int) Math.min(currentRegion.tileRangeY[0], row);
             currentRegion.tileRangeY[1] = (int) Math.max(currentRegion.tileRangeY[1], row);
             currentRegion.tileRangeX[0] = (int) Math.min(currentRegion.tileRangeX[0], col);
             currentRegion.tileRangeX[1] = (int) Math.max(currentRegion.tileRangeX[1], col);
+
+            Region fov = new Region((int) x, (int) y, (int) w, (int) h);
+            currentRegion.fovs.put(row + "-" + col, fov);
           }
-          // TODO: no overlap handling yet
-          m.sizeX = (currentRegion.tileRangeX[1] - currentRegion.tileRangeX[0] + 1) * currentRegion.tileSizeX;
-          m.sizeY = (currentRegion.tileRangeY[1] - currentRegion.tileRangeY[0] + 1) * currentRegion.tileSizeY;
+          int xTiles = currentRegion.tileRangeX[1] - currentRegion.tileRangeX[0] + 1;
+          int yTiles = currentRegion.tileRangeY[1] - currentRegion.tileRangeY[0] + 1;
+          m.sizeX = xTiles * (currentRegion.tileSizeX - currentRegion.overlapX);
+          m.sizeY = yTiles * (currentRegion.tileSizeY - currentRegion.overlapY);
 
           PreparedStatement maxLevelQuery = conn.prepareStatement(
             "SELECT level FROM images WHERE region=? ORDER BY level DESC"
@@ -585,6 +609,7 @@ public class TissuegnosticsReader extends FormatReader {
     public Integer[] zSteps;
     public int timepoint;
     public List<Channel> channels = new ArrayList<Channel>();
+    public HashMap<String, Region> fovs = new HashMap<String, Region>();
 
     public void parseJSON() {
       // "Rows" and "Columns" in the JSON metadata here

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -86,6 +86,7 @@ public class TissuegnosticsReader extends FormatReader {
   private int[] scaleFactor;
   private int[][] tileRangeX;
   private int[][] tileRangeY;
+  private Integer[][] zSteps;
 
   // -- Constructor --
 
@@ -114,6 +115,7 @@ public class TissuegnosticsReader extends FormatReader {
       scaleFactor = null;
       tileRangeX = null;
       tileRangeY = null;
+      zSteps = null;
     }
   }
 
@@ -166,7 +168,7 @@ public class TissuegnosticsReader extends FormatReader {
     Connection conn = openConnection(getDBFile());
     try {
       PreparedStatement tiles = conn.prepareStatement(
-        "SELECT data, compression, row, column FROM images WHERE level=? AND row>=? AND row<=? AND column>=? AND column<=? AND channel=?"
+        "SELECT data, compression, row, column FROM images WHERE level=? AND row>=? AND row<=? AND column>=? AND column<=? AND channel=? AND is_zstack=? AND z_position=? ORDER BY row,column DESC"
       );
       // TODO: account for possiblity of overlap
 
@@ -183,7 +185,11 @@ public class TissuegnosticsReader extends FormatReader {
       tiles.setInt(3, endRow);
       tiles.setInt(4, startCol);
       tiles.setInt(5, endCol);
-      tiles.setInt(6, getZCTCoords(no)[1] + 1);
+
+      int[] zct = getZCTCoords(no);
+      tiles.setInt(6, zct[1] + 1);
+      tiles.setInt(7, zct[0] > 0 ? 1 : 0);
+      tiles.setInt(8, zSteps[regionIndex][zct[0]]);
 
       // upper left corner of full resolution,
       // in pixels relative to full canvas
@@ -283,6 +289,7 @@ public class TissuegnosticsReader extends FormatReader {
     scaleFactor = new int[pixelsFiles.size()];
     tileRangeX = new int[2][pixelsFiles.size()];
     tileRangeY = new int[2][pixelsFiles.size()];
+    zSteps = new Integer[pixelsFiles.size()][];
 
     Arrays.fill(tileRangeX[0], Integer.MAX_VALUE);
     Arrays.fill(tileRangeY[0], Integer.MAX_VALUE);
@@ -351,7 +358,7 @@ public class TissuegnosticsReader extends FormatReader {
         }
 
         PreparedStatement channelQuery = conn.prepareStatement(
-          "SELECT id, name, color, save_16bit, excitation_wavelength, emission_wavelength FROM channels"
+          "SELECT id, name, color, save_16bit, excitation_wavelength, emission_wavelength FROM channels ORDER BY id"
         );
         ResultSet channels = channelQuery.executeQuery();
         while (channels.next()) {
@@ -364,6 +371,19 @@ public class TissuegnosticsReader extends FormatReader {
             m.pixelType = FormatTools.UINT16;
           }
         }
+
+        PreparedStatement zQuery = conn.prepareStatement(
+          "SELECT DISTINCT is_zstack,z_position FROM images WHERE level=0 ORDER BY is_zstack,z_position"
+        );
+        ResultSet zs = zQuery.executeQuery();
+        ArrayList<Integer> tmpZ = new ArrayList<Integer>();
+        while (zs.next()) {
+          boolean isZ = zs.getBoolean(1);
+          int zPos = zs.getInt(2);
+
+          tmpZ.add(zPos);
+        }
+        zSteps[i] = tmpZ.toArray(new Integer[tmpZ.size()]);
       }
       catch (SQLException e) {
         LOGGER.warn("Failed to initialize", e);
@@ -377,7 +397,7 @@ public class TissuegnosticsReader extends FormatReader {
         }
       }
 
-      m.sizeZ = 1;
+      m.sizeZ = zSteps[i].length;
       m.sizeT = 1;
       m.imageCount = m.sizeZ * m.sizeC * m.sizeT;
 

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -418,6 +418,7 @@ public class TissuegnosticsReader extends FormatReader {
       }
 
       m.dimensionOrder = "XYCZT";
+      m.littleEndian = true;
 
       core.add(m);
       for (int r=1; r<m.resolutionCount; r++) {

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -519,7 +519,11 @@ public class TissuegnosticsReader extends FormatReader {
         if (ch.exWave >= WAVE_MIN && ch.exWave <= WAVE_MAX) {
           store.setChannelExcitationWavelength(FormatTools.getWavelength((double) ch.exWave), imageIndex, c);
         }
-        store.setChannelColor(ch.getColor(), imageIndex, c);
+        // don't set a channel color for brightfield data
+        // the channel color is expected to be white in that case
+        if (!core.get(imageIndex).rgb) {
+          store.setChannelColor(ch.getColor(), imageIndex, c);
+        }
       }
 
       i += core.get(imageIndex).sizeT;

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -521,12 +521,12 @@ public class TissuegnosticsReader extends FormatReader {
         }
         // don't set a channel color for brightfield data
         // the channel color is expected to be white in that case
-        if (!core.get(imageIndex).rgb) {
+        if (!core.get(region.fullResolutionCoreIndex).rgb) {
           store.setChannelColor(ch.getColor(), imageIndex, c);
         }
       }
 
-      i += core.get(imageIndex).sizeT;
+      i += core.get(region.fullResolutionCoreIndex).sizeT;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissuegnosticsReader.java
@@ -58,6 +58,7 @@ import loci.formats.meta.MetadataStore;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
@@ -76,6 +77,10 @@ public class TissuegnosticsReader extends FormatReader {
 
   private static final Logger LOGGER =
     LoggerFactory.getLogger(TissuegnosticsReader.class);
+
+  // per specification, wavelengths outside this range should be ignored
+  private static final int WAVE_MIN = 300;
+  private static final int WAVE_MAX = 800;
 
   private List<String> pixelsFiles = new ArrayList<String>();
   private List<ScanRegion> regions = new ArrayList<ScanRegion>();
@@ -387,12 +392,20 @@ public class TissuegnosticsReader extends FormatReader {
         while (channels.next()) {
           m.sizeC++;
 
-          // TODO: save channel name, color, wavelengths
+          Channel ch = new Channel();
+          ch.id = channels.getInt(1);
+          ch.name = channels.getString(2);
+          ch.color = channels.getInt(3);
 
           boolean save16 = channels.getBoolean(4);
           if (save16) {
             m.pixelType = FormatTools.UINT16;
           }
+
+          ch.exWave = channels.getInt(5);
+          ch.emWave = channels.getInt(6);
+
+          regions.get(startRegionIndex).channels.add(ch);
         }
       }
       catch (SQLException e) {
@@ -466,6 +479,19 @@ public class TissuegnosticsReader extends FormatReader {
 
       store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(physicalX), imageIndex);
       store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(physicalY), imageIndex);
+
+      for (int c=0; c<region.channels.size(); c++) {
+        Channel ch = region.channels.get(c);
+        store.setChannelName(ch.name, imageIndex, c);
+
+        if (ch.emWave >= WAVE_MIN && ch.emWave <= WAVE_MAX) {
+          store.setChannelEmissionWavelength(FormatTools.getWavelength((double) ch.emWave), imageIndex, c);
+        }
+        if (ch.exWave >= WAVE_MIN && ch.exWave <= WAVE_MAX) {
+          store.setChannelExcitationWavelength(FormatTools.getWavelength((double) ch.exWave), imageIndex, c);
+        }
+        store.setChannelColor(ch.getColor(), imageIndex, c);
+      }
 
       i += core.get(imageIndex).sizeT;
     }
@@ -558,6 +584,7 @@ public class TissuegnosticsReader extends FormatReader {
     public int[] tileRangeY = new int[] {Integer.MAX_VALUE, 0};
     public Integer[] zSteps;
     public int timepoint;
+    public List<Channel> channels = new ArrayList<Channel>();
 
     public void parseJSON() {
       // "Rows" and "Columns" in the JSON metadata here
@@ -569,6 +596,23 @@ public class TissuegnosticsReader extends FormatReader {
       scaleFactor = regionMetadata.getInt("CacheStep");
     }
 
+  }
+
+  class Channel {
+    public int id;
+    public String name;
+    public int color;
+    public int exWave;
+    public int emWave;
+
+    /** Color returned by DB is ARGB, OME model is RGBA. */
+    public Color getColor() {
+      int alpha = (color >> 24) & 0xff;
+      int red = (color >> 16) & 0xff;
+      int green = (color >> 8) & 0xff;
+      int blue = color & 0xff;
+      return new Color(red, green, blue, alpha);
+    }
   }
 
 }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2134,6 +2134,13 @@ public class FormatReaderTest {
             continue;
           }
 
+          // TissueFAXS can only be detected with .aqproj file
+          if (reader.getFormat().equals("TissueFAXS") &&
+            !base[i].toLowerCase().endsWith(".aqproj"))
+          {
+            continue;
+          }
+
           // Tecan datasets can only be detected with the .db file
           if (reader.getFormat().equals("Tecan Spark Cyto") &&
             !base[i].toLowerCase().endsWith(".db"))
@@ -2943,6 +2950,13 @@ public class FormatReaderTest {
             // MetaXpress TIFF reader can flag .HTD files from CellWorX
             if (result && r instanceof CellWorxReader &&
               readers[j] instanceof MetaxpressTiffReader)
+            {
+              continue;
+            }
+
+            // TissueFAXS data can only be detected with .aqproj
+            if (!result && readers[j] instanceof TissueFAXSReader &&
+              !used[i].toLowerCase().endsWith(".aqproj"))
             {
               continue;
             }


### PR DESCRIPTION
Backported from several private PRs.

Data upload in progress, to `curated/tissuefaxs/`; as indicated in readme, this data is for internal testing only and cannot be made public. There are 4 datasets each of brightfield and fluorescence.

This is a slide format with pyramids/larger images, so expect to use `showinf -noflat` on the .tfcyto files, with cropping as needed.