### PR TITLE
OMEXMLReader: escape values when re-assembling OME-XML

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -348,7 +348,7 @@ public class OMEXMLReader extends FormatReader {
     @Override
     public void characters(char[] ch, int start, int length) {
       if (!inPixels || currentQName.indexOf("BinData") < 0) {
-        xmlBuffer.append(new String(ch, start, length));
+        xmlBuffer.append(XMLTools.escapeXML(new String(ch, start, length)));
       }
     }
 


### PR DESCRIPTION
Intended to fix the case where an .ome.xml file has an `OriginalMetadataAnnotation` with escaped characters, e.g.:

```
<StructuredAnnotations>
    <XMLAnnotation ID="Annotation:0" Namespace="openmicroscopy.org/OriginalMetadata">
      <Value>
        <OriginalMetadata>
          <Key>key</Key>
          <Value>&lt;value&gt;</Value>
        </OriginalMetadata>
      </Value>
    </XMLAnnotation>
  </StructuredAnnotations>  
```

Without this change, an .ome.xml file with `BinData` and an annotation as above should throw an exception upon `showinf -omexml`. With this change, there should be no exception, and the OME-XML should display and validate as expected.