### PR TITLE
Report workflow: delay the first execution by 1 h

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -4,7 +4,7 @@ name: Report
 
 on:
   schedule:
-    - cron: '0 6-9 * * *'
+    - cron: '0 7-9 * * *'
 
 jobs:
   check:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -4,7 +4,7 @@ name: Report
 
 on:
   schedule:
-    - cron: '0 5-9 * * *'
+    - cron: '0 6-9 * * *'
 
 jobs:
   check:


### PR DESCRIPTION
Reports from the last 24h show the first execution is systematically failing as all jobs have not completed. Waiting for one more hour should reduce the daily false positives - see https://github.com/ome/bioformats/actions/workflows/report.yml