### PR TITLE
OBF: Support complex data stacks

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -374,12 +374,19 @@ public class OBFReader extends FormatReader {
       final int type = in.readInt();
       meta_data.pixelType = getPixelType(type);
       meta_data.bitsPerPixel = getBitsPerPixel(type);
+      meta_data.interleaved = false;
+
+
+      if((type & 0x40000000) != 0)
+      {
+        meta_data.interleaved = true;
+        meta_data.sizeC *= 2;
+      }
 
       stack.bytesPerSample = meta_data.bitsPerPixel / 8;
 
       meta_data.indexed = false;
-      meta_data.rgb = false;
-      meta_data.interleaved = false;
+      meta_data.rgb = meta_data.interleaved;
 
       final int compression = in.readInt();
       stack.compression = getCompression(compression);
@@ -610,7 +617,7 @@ public class OBFReader extends FormatReader {
   }
 
   private int getPixelType(int type) throws FormatException {
-    switch (type) {
+    switch (type & 0xFFFFFFF) {
       case 0x01: return FormatTools.UINT8;
       case 0x02: return FormatTools.INT8;
       case 0x04: return FormatTools.UINT16;
@@ -633,6 +640,8 @@ public class OBFReader extends FormatReader {
       case 0x20: return 32;
       case 0x40: return 32;
       case 0x80: return 64;
+      case 0x40000040: return 64;
+      case 0x40000080: return 128;
       default: throw new FormatException("Unsupported data type " + type);
     }
   }


### PR DESCRIPTION
This is intended to add support for OBF complex number image pixel data.

I've attached a corresponding simulated test dataset here:
[IMG0005_Lifetime3.zip](https://github.com/user-attachments/files/22044180/IMG0005_Lifetime3.zip)

The OME XML schema has a `PixelType` "complex" which the dataset does use but bioformats and imagej presumably have no direct support for it. I tried to work around that here by making it look like each pixel has two interleaved float samples.

It beats not being able to open the file at all but I am not entirely happy with the result.
I would appreciate any insights into how this might be improved or done differently.