### PR TITLE
Metamorph: read plane positions from multiple files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1231,9 +1231,14 @@ public class MetamorphReader extends BaseTiffReader {
         }
 
         if (perSeriesStageX != null && i < perSeriesStageX.length &&
-          perSeriesStageX[i] != null && p < perSeriesStageX[i].length)
+          perSeriesStageX[i] != null && perSeriesStageX[i].length > 0)
         {
-          store.setPlanePositionX(perSeriesStageX[i][p], i, p);
+          if (p < perSeriesStageX[i].length) {
+            store.setPlanePositionX(perSeriesStageX[i][p], i, p);
+          }
+          else {
+            store.setPlanePositionX(perSeriesStageX[i][0], i, p);
+          }
         }
         else if (stageX != null && p < stageX.length) {
           store.setPlanePositionX(stageX[p], i, p);
@@ -1243,9 +1248,14 @@ public class MetamorphReader extends BaseTiffReader {
         }
 
         if (perSeriesStageY != null && i < perSeriesStageY.length &&
-          perSeriesStageY[i] != null && p < perSeriesStageY[i].length)
+          perSeriesStageY[i] != null && perSeriesStageY[i].length > 0)
         {
-          store.setPlanePositionY(perSeriesStageY[i][p], i, p);
+          if (p < perSeriesStageY[i].length) {
+            store.setPlanePositionY(perSeriesStageY[i][p], i, p);
+          }
+          else {
+            store.setPlanePositionY(perSeriesStageY[i][0], i, p);
+          }
         }
         else if (stageY != null && p < stageY.length) {
           store.setPlanePositionY(stageY[p], i, p);

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -462,8 +462,28 @@ public class MetamorphReader extends BaseTiffReader {
             if (charCount > matchingChars || (charCount == matchingChars &&
               f.charAt(charCount) == '.'))
             {
-              ndfile = new Location(parent, f).getAbsoluteFile();
               matchingChars = charCount;
+              // sometimes the .tif or .stk will have a similar name to an
+              // .nd file, but will have trailing characters that do not match
+              // the expected format for a dataset with an .nd file
+              // e.g. abc_overview.tif, abc.nd, abc_w1.stk, abc_w2.stk
+              // in the same directory
+              // if the name format is unexpected, don't pick up the .nd file,
+              // just treat this as a single-file dataset
+              String extra = stkName.substring(charCount).toLowerCase();
+              boolean valid = true;
+              for (int i=0; i<extra.length()-1; i++) {
+                if (extra.charAt(i) == '_') {
+                  char checkChar = extra.charAt(i + 1);
+                  if (checkChar != 'w' && checkChar != 't' && checkChar != 's') {
+                    valid = false;
+                    break;
+                  }
+                }
+              }
+              if (valid) {
+                ndfile = new Location(parent, f).getAbsoluteFile();
+              }
             }
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -772,6 +772,9 @@ public class MetamorphReader extends BaseTiffReader {
       }
     }
 
+    Length[][] perSeriesStageX = null;
+    Length[][] perSeriesStageY = null;
+
     if (stks == null) {
       stkReaders = new MetamorphReader[1][1];
       stkReaders[0][0] = new MetamorphReader();
@@ -779,14 +782,27 @@ public class MetamorphReader extends BaseTiffReader {
     }
     else {
       stkReaders = new MetamorphReader[stks.length][];
+      perSeriesStageX = new Length[stks.length][];
+      perSeriesStageY = new Length[stks.length][];
       for (int i=0; i<stks.length; i++) {
         stkReaders[i] = new MetamorphReader[stks[i].length];
         for (int j=0; j<stkReaders[i].length; j++) {
           stkReaders[i][j] = new MetamorphReader();
           stkReaders[i][j].setCanLookForND(false);
+
           if (j > 0) {
             stkReaders[i][j].setMetadataOptions(
               new DefaultMetadataOptions(MetadataLevel.MINIMUM));
+          }
+          else {
+            try {
+              stkReaders[i][j].setId(stks[i][j]);
+              perSeriesStageX[i] = stkReaders[i][j].getStageX();
+              perSeriesStageY[i] = stkReaders[i][j].getStageY();
+            }
+            finally {
+              stkReaders[i][j].close();
+            }
           }
         }
       }
@@ -1213,13 +1229,24 @@ public class MetamorphReader extends BaseTiffReader {
           store.setPlaneExposureTime(new Time(expTime, UNITS.SECOND), i, p);
         }
 
-        if (stageX != null && p < stageX.length) {
+        if (perSeriesStageX != null && i < perSeriesStageX.length &&
+          p < perSeriesStageX[i].length)
+        {
+          store.setPlanePositionX(perSeriesStageX[i][p], i, p);
+        }
+        else if (stageX != null && p < stageX.length) {
           store.setPlanePositionX(stageX[p], i, p);
         }
         else if (positionX != null) {
           store.setPlanePositionX(positionX, i, p);
         }
-        if (stageY != null && p < stageY.length) {
+
+        if (perSeriesStageY != null && i < perSeriesStageY.length &&
+          p < perSeriesStageY[i].length)
+        {
+          store.setPlanePositionY(perSeriesStageY[i][p], i, p);
+        }
+        else if (stageY != null && p < stageY.length) {
           store.setPlanePositionY(stageY[p], i, p);
         }
         else if (positionY != null) {
@@ -1749,6 +1776,14 @@ public class MetamorphReader extends BaseTiffReader {
     in.seek(saveLoc);
 
     if (validZ) zStart = tempZ;
+  }
+
+  protected Length[] getStageX() {
+    return stageX;
+  }
+
+  protected Length[] getStageY() {
+    return stageY;
   }
 
   private void readStagePositions() throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -794,8 +794,9 @@ public class MetamorphReader extends BaseTiffReader {
             stkReaders[i][j].setMetadataOptions(
               new DefaultMetadataOptions(MetadataLevel.MINIMUM));
           }
-          else {
+          else if (stks[i][j] != null) {
             try {
+              LOGGER.debug("reading positions from {}", stks[i][j]);
               stkReaders[i][j].setId(stks[i][j]);
               perSeriesStageX[i] = stkReaders[i][j].getStageX();
               perSeriesStageY[i] = stkReaders[i][j].getStageY();
@@ -1230,7 +1231,7 @@ public class MetamorphReader extends BaseTiffReader {
         }
 
         if (perSeriesStageX != null && i < perSeriesStageX.length &&
-          p < perSeriesStageX[i].length)
+          perSeriesStageX[i] != null && p < perSeriesStageX[i].length)
         {
           store.setPlanePositionX(perSeriesStageX[i][p], i, p);
         }
@@ -1242,7 +1243,7 @@ public class MetamorphReader extends BaseTiffReader {
         }
 
         if (perSeriesStageY != null && i < perSeriesStageY.length &&
-          p < perSeriesStageY[i].length)
+          perSeriesStageY[i] != null && p < perSeriesStageY[i].length)
         {
           store.setPlanePositionY(perSeriesStageY[i][p], i, p);
         }


### PR DESCRIPTION
Fixes #4069.

As indicated in the commit message for a9166d7, the only way to get the correct position for a particular plane is to open the file containing the plane and read the relevant IFD tag. This change reads from the first file in each series, in an attempt to balance getting accurate metadata against the performance impact of always reading every file during initialization. For multi-file/multi-series data, though, this is going to slow down initialization (but not `openBytes`) - I really don't know of a way around this.

The dataset referenced in #4069 is already configured under `curated/metamorph/gh-4093`, so see forthcoming config PR for change in behavior.