### PR TITLE
Put the scanline padding to 4 bytes on the non-compressed reading.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -341,6 +341,7 @@ public class ND2Reader extends SubResolutionFormatReader {
 
     }
     else {
+      scanlinePad = w%4;
       // plane is not compressed
       readPlane(in, x, y, w, h, scanlinePad, buf);
     }

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -342,7 +342,7 @@ public class ND2Reader extends SubResolutionFormatReader {
     }
     else {
       //The scanline pad is set at 4 byte boundaries described by the pixel size in bytes.
-      scanlinePad = ((bpp * w)%4) / bpp;
+      scanlinePad = ((bpp * getSizeX())%4) / bpp;
       // plane is not compressed
       readPlane(in, x, y, w, h, scanlinePad, buf);
     }

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -341,7 +341,8 @@ public class ND2Reader extends SubResolutionFormatReader {
 
     }
     else {
-      scanlinePad = w%4;
+      //The scanline pad is set at 4 byte boundaries described by the pixel size in bytes.
+      scanlinePad = ((bpp * w)%4) / bpp;
       // plane is not compressed
       readPlane(in, x, y, w, h, scanlinePad, buf);
     }


### PR DESCRIPTION
A previous fix made the scanline padding at 4 byte boundaries. That was only for a specific reading branch. Another branch also requires 4 byte boundaries, but it is not clear why. The method 'getScanlinePadding' should probably be fixed to use 4 byte padding, but I don't know what conditions it worked, so maybe that will break something. 