### PR TITLE
ND2: don't reset pixel type when the bits per pixel doesn't make sense

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -485,7 +485,7 @@ public class ND2Handler extends BaseHandler {
           bits++;
         }
         try {
-          if (ms0.pixelType == 0) {
+          if (ms0.pixelType == 0 && bits <= 16) {
             ms0.pixelType =
               FormatTools.pixelTypeFromBytes(bits / 8, false, false);
           }


### PR DESCRIPTION
Fixes #3667.

Without this change, `showinf neuron.nd2` will show incorrect images, channel count, and pixel type as described in #3667. With this change, there should be 3 channels, pixel type of `uint8`, and reasonable images. See screenshots on forthcoming configuration PR.