### PR TITLE
Fix and refactor ModuloC handling in ImageJ plugins

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
@@ -147,16 +147,9 @@ public class DisplayHandler implements StatusListener {
   public void displayDataBrowser(ImagePlus imp) {
     IFormatReader r = process.getReader();
 
-    int[] subC;
-    String[] subCTypes;
     Modulo moduloC = r.getModuloC();
-    if (moduloC.length() > 1) {
-      subC = new int[] {r.getSizeC() / moduloC.length(), moduloC.length()};
-      subCTypes = new String[] {moduloC.parentType, moduloC.type};
-    } else {
-      subC = new int[] {r.getSizeC()};
-      subCTypes = new String[] {FormatTools.CHANNEL};
-    }
+    int[] subC = ImagePlusReader.getSubC(moduloC, r.getSizeC());
+    String[] subCTypes = ImagePlusReader.getSubCTypes(moduloC);
 
     new DataBrowser(imp, null, subCTypes, subC, xmlWindow);
   }

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Vector;
 import java.util.regex.Matcher;
 
+import loci.common.Constants;
 import loci.common.DateTools;
 import loci.common.Location;
 import loci.common.Region;
@@ -213,6 +214,38 @@ public class ImagePlusReader implements StatusReporter {
     }
 
     return stack;
+  }
+
+  public static int[] getSubC(Modulo moduloC, int sizeC) {
+    if (moduloC.length() > 1) {
+      // ordering of lengths and types in subC and subCTypes matters
+      // use the step size of the modulo to determine correct ordering
+      if (Math.abs(moduloC.step - 1) < Constants.EPSILON) {
+        return new int[] {moduloC.length(), sizeC / moduloC.length()};
+      }
+      else {
+        return new int[] {sizeC / moduloC.length(), moduloC.length()};
+      }
+    }
+    return new int[] {sizeC};
+  }
+
+  public static String[] getSubCTypes(Modulo moduloC) {
+    if (moduloC.length() > 1) {
+      String parentType = moduloC.parentType;
+      if (parentType == null) {
+        parentType = FormatTools.CHANNEL;
+      }
+      // ordering of lengths and types in subC and subCTypes matters
+      // use the step size of the modulo to determine correct ordering
+      if (Math.abs(moduloC.step - 1) < Constants.EPSILON) {
+        return new String[] {moduloC.type, parentType};
+      }
+      else {
+        return new String[] {parentType, moduloC.type};
+      }
+    }
+    return new String[] {FormatTools.CHANNEL};
   }
 
   // -- Helper methods - image reading --
@@ -575,13 +608,8 @@ public class ImagePlusReader implements StatusReporter {
       int[] subC;
       String[] subCTypes;
       Modulo moduloC = r.getModuloC();
-      if (moduloC.length() > 1) {
-        subC = new int[] {r.getSizeC() / moduloC.length(), moduloC.length()};
-        subCTypes = new String[] {moduloC.parentType, moduloC.type};
-      } else {
-        subC = new int[] {r.getSizeC()};
-        subCTypes = new String[] {FormatTools.CHANNEL};
-      }
+      subC = getSubC(moduloC, r.getSizeC());
+      subCTypes = getSubCTypes(moduloC);
       int[] subCPos = FormatTools.rasterToPosition(subC, coordinates[1]);
       StringBuffer channelString = new StringBuffer();
       for (int i=0; i<subC.length; i++) {

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -159,20 +159,14 @@ public class LociFunctions extends MacroFunctions {
 
   public void getChannelDimLength(Double i, Double[] channelDimLength) {
     Modulo moduloC = r.getModuloC();
-    if (i.intValue() == 0) { // index 0
-      channelDimLength[0] = Double.valueOf(moduloC.length() > 1 ? r.getSizeC() / moduloC.length() : r.getSizeC());
-    } else { // index 1
-      channelDimLength[0] = Double.valueOf(moduloC.length());
-    }
+    int[] subC = ImagePlusReader.getSubC(moduloC, r.getSizeC());
+    channelDimLength[0] = Double.valueOf(subC[i.intValue()]);
   }
 
-  public void getChannelDimType(Double i, Double[] channelDimType) {
+  public void getChannelDimType(Double i, String[] channelDimType) {
     Modulo moduloC = r.getModuloC();
-    if (i.intValue() == 0) { // index 0
-      channelDimType[0] = Double.valueOf(moduloC.length() > 1 ? moduloC.parentType : FormatTools.CHANNEL);
-    } else { // index 1
-      channelDimType[0] = Double.valueOf(moduloC.type);
-    }
+    String[] subCTypes = ImagePlusReader.getSubCTypes(moduloC);
+    channelDimType[0] = subCTypes[i.intValue()];
   }
 
 //  public void getThumbSizeX(Double[] thumbSizeX) {

--- a/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
@@ -44,6 +44,7 @@ import loci.formats.cache.Cache;
 import loci.formats.cache.CacheException;
 import loci.formats.cache.CacheStrategy;
 import loci.formats.cache.CrosshairStrategy;
+import loci.plugins.in.ImagePlusReader;
 import loci.plugins.util.RecordedImageProcessor.MethodEntry;
 
 /**
@@ -109,13 +110,8 @@ public class BFVirtualStack extends VirtualStack {
     this.series = r.getSeries();
 
     // set up cache
-    int[] subC;
     Modulo moduloC = r.getModuloC();
-    if (moduloC.length() > 1) {
-      subC = new int[] {r.getSizeC() / moduloC.length(), moduloC.length()};
-    } else {
-      subC = new int[] {r.getSizeC()};
-    }
+    int[] subC = ImagePlusReader.getSubC(moduloC, r.getSizeC());
     if (merge) subC = new int[] {new ChannelMerger(r).getEffectiveSizeC()};
     len = new int[subC.length + 2];
     System.arraycopy(subC, 0, len, 0, subC.length);


### PR DESCRIPTION
Fixes the primary issue in #3446.

With https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/modulo/FLIM-ModuloAlongC.ome.tiff and 8.3.0, open in ImageJ with the `Data Browser` option. Note that:

- there are 4 sliders as expected, but one has no label
- the bottom 2 sliders are for the channels, but the position of these 2 sliders will not match the positions recorded on the images

With the same dataset and this change, all sliders should have a suitable label, and scrolling through each slider should result in a position that matches the position recorded on the images.

Note though that only ModuloC has ever been supported in ImageJ plugins. Testing with any of the ModuloZ or ModuloT examples in https://docs.openmicroscopy.org/ome-model/6.0.0/ome-tiff/data.html#modulo-datasets will not show an extra slider for the modulo dimension. Adding ModuloZ and ModuloT is a lot more UI work in ImageJ, which I am inclined to think is outside the scope of what we can currently prioritize. If any strong feeling that we should keep an issue open for that, then it would make sense to split off as a separate issue from #3446 (which documents an actual bug).

Note also that the signature of `getChannelDimType` in `LociFunctions` has changed, as that method should never have returned `Double` values. Open to discussing whether it's better to deprecate the existing macro function and introduce something new, but `getChannelDimType` without this change is effectively unusable.