### PR TITLE
CZI: ignore plate information if not activated

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3477,8 +3477,9 @@ public class ZeissCZIReader extends FormatReader {
       Element regionsSetup = getFirstNode(acquisition, "RegionsSetup");
 
       if (regionsSetup != null) {
+        String activated = regionsSetup.getAttribute("IsActivated");
         Element sampleHolder = getFirstNode(regionsSetup, "SampleHolder");
-        if (sampleHolder != null) {
+        if (sampleHolder != null && !"false".equalsIgnoreCase(activated)) {
           Element template = getFirstNode(sampleHolder, "Template");
           if (template != null) {
             Element templateRows = getFirstNode(template, "ShapeRows");


### PR DESCRIPTION
This is intended to handle the case where a plate is defined but not actually used, leading to a `Plate` being created in OME-XML unexpectedly.

No shareable test data for this at the moment, but trying to see if this approach causes test failures with any existing data.