### PR TITLE
Unify emission wavelength handling in NDPI and NDPIS readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -786,6 +786,13 @@ public class NDPIReader extends BaseTiffReader {
           if (zct[0] == 0 && zct[2] == 0) {
             String channelName = ifd.getIFDTextValue(FILTER_SET_NAME);
             store.setChannelName(channelName, i, zct[1]);
+
+            Object wave = ifd.getIFDValue(WAVELENGTH);
+            if (wave != null && wave instanceof Number) {
+              store.setChannelEmissionWavelength(
+                FormatTools.getEmissionWavelength(((Number) wave).doubleValue()),
+                i, zct[1]);
+            }
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -210,12 +210,14 @@ public class NDPISReader extends FormatReader {
       }
 
       String channelName = ifd.getIFDStringValue(TAG_CHANNEL);
-      Float wavelength = (Float) ifd.getIFDValue(TAG_EMISSION_WAVELENGTH);
+      Object waveTag = ifd.getIFDValue(TAG_EMISSION_WAVELENGTH);
+      Double wavelength = null;
 
       store.setChannelName(channelName, 0, c);
-      if (wavelength != null) {
-        store.setChannelEmissionWavelength(FormatTools.getEmissionWavelength(
-          (Double) wavelength.doubleValue()), 0, c);
+      if (waveTag != null && waveTag instanceof Number) {
+        wavelength = ((Number) waveTag).doubleValue();
+        store.setChannelEmissionWavelength(
+          FormatTools.getEmissionWavelength(wavelength), 0, c);
       }
 
       bandUsed[c] = 0;


### PR DESCRIPTION
If an emission wavelength tag is present in an NDPI file, then `EmissionWavelength` on `Channel` should be set accordingly when testing with `showinf -noflat -omexml`. In both readers, the tag value is no longer assumed to be `Float`, though in practice that is still the expected type.

There might be a few test failures if emission wavelengths are newly set for any existing datasets, in which case I'll open a follow-up configuration PR.