### PR TITLE
Calculate resolution counts when generating pyramids with `bfconvert`

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -485,7 +485,7 @@ public final class ImageConverter {
     // TODO: there may be other options not compatible with -precompressed
     if (precompressed &&
       (width_crop > 0 || height_crop > 0 ||
-      pyramidResolutions > 1 ||
+      pyramidScale > 1 || pyramidResolutions > 1 ||
       fillColor != null ||
       autoscale
       ))
@@ -589,6 +589,19 @@ public final class ImageConverter {
     } else {
       width = Math.min(reader.getSizeX(), width_crop);
       height = Math.min(reader.getSizeY(), height_crop);
+    }
+
+    // want to generate a pyramid but no resolution count specified
+    // calculate based upon the scale and tile size
+    if (pyramidScale > 1 && pyramidResolutions == 1) {
+      pyramidResolutions = 0;
+      int checkWidth = width;
+      int checkHeight = height;
+      while (checkWidth > 0 && checkHeight > 0) {
+        pyramidResolutions++;
+        checkWidth /= pyramidScale;
+        checkHeight /= pyramidScale;
+      }
     }
 
     if (channel >= reader.getEffectiveSizeC()) {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -599,7 +599,9 @@ public final class ImageConverter {
       pyramidResolutions = 0;
       int checkWidth = width;
       int checkHeight = height;
-      while (checkWidth > saveTileWidth && checkHeight > saveTileHeight) {
+      while (checkWidth >= (int) Math.max(saveTileWidth, pyramidScale) &&
+        checkHeight >= (int) Math.max(saveTileHeight, pyramidScale))
+      {
         pyramidResolutions++;
         checkWidth /= pyramidScale;
         checkHeight /= pyramidScale;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -599,7 +599,7 @@ public final class ImageConverter {
       pyramidResolutions = 0;
       int checkWidth = width;
       int checkHeight = height;
-      while (checkWidth > 0 && checkHeight > 0) {
+      while (checkWidth > saveTileWidth && checkHeight > saveTileHeight) {
         pyramidResolutions++;
         checkWidth /= pyramidScale;
         checkHeight /= pyramidScale;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -592,7 +592,9 @@ public final class ImageConverter {
     }
 
     // want to generate a pyramid but no resolution count specified
-    // calculate based upon the scale and tile size
+    // calculate based upon the scale and image size
+    // the tile size has not been yet been set on the writer,
+    // and the writer needs a MetadataRetrieve with resolutions populated first
     if (pyramidScale > 1 && pyramidResolutions == 1) {
       pyramidResolutions = 0;
       int checkWidth = width;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -1227,6 +1227,12 @@ public final class ImageConverter {
       int height = meta.getPixelsSizeY(series).getValue();
       for (int i=1; i<pyramidResolutions; i++) {
         int scale = (int) Math.pow(pyramidScale, i);
+        if (width < scale || height < scale) {
+          LOGGER.warn("Specified pyramid resolutions {} too large; adjusted to {}",
+            pyramidResolutions, i);
+          pyramidResolutions = i;
+          break;
+        }
         ((OMEPyramidStore) meta).setResolutionSizeX(
           new PositiveInteger(width / scale), series, i);
         ((OMEPyramidStore) meta).setResolutionSizeY(

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -490,7 +490,7 @@ public class ImageConverterTest {
       "-pyramid-scale", "2",
       outFile.getAbsolutePath()
     };
-    resolutionCount = 11;
+    resolutionCount = 10;
     assertConversion(args, outFile.getAbsolutePath(), 7673);
 
     IMetadata meta = getOMEXMLMetadata(outFile);

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -421,6 +421,82 @@ public class ImageConverterTest {
     assertEquals(meta.getPixelsSizeT(0).getValue().intValue(), 1);
   }
 
+  /**
+   * Generate a pyramid with the defined number of resolutions.
+   */
+  @Test
+  public void testGenerateDefinedResolutions() throws FormatException, IOException {
+    outFile = getOutFile("defined-pyramid.ome.tiff");
+    String[] args = {
+      "defined-pyramid&sizeX=8100&sizeY=7500.fake",
+      "-pyramid-resolutions", "4",
+      "-pyramid-scale", "2",
+      outFile.getAbsolutePath()
+    };
+    resolutionCount = 4;
+    assertConversion(args, outFile.getAbsolutePath(), 8100);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+  }
+
+  /**
+   * Generate a pyramid with downsample factor of 3.
+   */
+  @Test
+  public void testPyramidFactor3() throws FormatException, IOException {
+    outFile = getOutFile("factor-3.ome.tiff");
+    String[] args = {
+      "factor-3&sizeX=8100&sizeY=7500.fake",
+      "-pyramid-resolutions", "4",
+      "-pyramid-scale", "3",
+      outFile.getAbsolutePath()
+    };
+    resolutionCount = 4;
+    assertConversion(args, outFile.getAbsolutePath(), 8100);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+  }
+
+  /**
+   * Generate a pyramid, where the defined number of resolutions is unreasonably large.
+   */
+  @Test
+  public void testGenerateTooManyResolutions() throws FormatException, IOException {
+    outFile = getOutFile("big-pyramid.ome.tiff");
+    String[] args = {
+      "big-pyramid&sizeX=6073&sizeY=9247.fake",
+      "-pyramid-resolutions", "20",
+      "-pyramid-scale", "2",
+      outFile.getAbsolutePath()
+    };
+    // 20 is too many, so the count should be reset
+    resolutionCount = 13;
+    assertConversion(args, outFile.getAbsolutePath(), 6073);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+  }
+
+  /**
+   * Generate a pyramid, but calculate internally how many resolutions are needed.
+   */
+  @Test
+  public void testGenerateCalculatedResolutions() throws FormatException, IOException {
+    outFile = getOutFile("calculated-pyramid.ome.tiff");
+    String[] args = {
+      "calculated-pyramid&sizeX=7673&sizeY=1541.fake",
+      "-pyramid-scale", "2",
+      outFile.getAbsolutePath()
+    };
+    resolutionCount = 11;
+    assertConversion(args, outFile.getAbsolutePath(), 7673);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+  }
+
   private Path getTempSubdir() throws IOException {
     Path subdir = Files.createTempDirectory(tempDir, "ImageConverterTest");
     subdir.toFile().deleteOnExit();

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -497,6 +497,27 @@ public class ImageConverterTest {
     assertEquals(meta.getImageCount(), 1);
   }
 
+  /**
+   * Generate a pyramid, but calculate internally how many resolutions are needed
+   * based on specified tile size.
+   */
+  @Test
+  public void testGenerateCalculatedResolutionsByTileSize() throws FormatException, IOException {
+    outFile = getOutFile("tile-size-calculated-pyramid.ome.tiff");
+    String[] args = {
+      "calculated-pyramid&sizeX=7673&sizeY=1541.fake",
+      "-pyramid-scale", "2",
+      "-tilex", "512",
+      "-tiley", "512",
+      outFile.getAbsolutePath()
+    };
+    resolutionCount = 2;
+    assertConversion(args, outFile.getAbsolutePath(), 7673);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+  }
+
   private Path getTempSubdir() throws IOException {
     Path subdir = Files.createTempDirectory(tempDir, "ImageConverterTest");
     subdir.toFile().deleteOnExit();


### PR DESCRIPTION
Fixes #3644.

35227e7 fixes the case where `-pyramid-resolutions` may be too large for the `-pyramid-scale` and XY image size. Something like `bfconvert -pyramid-scale 2 -pyramid-resolutions 15 "test&sizeX=2048&sizeY=2048.fake" test.ome.tiff` will show the difference. Without this PR, that should throw an exception as the smallest few resolutions would be 0x0. With this PR, there should be a logged warning that the resolution count was changed, and the conversion should complete without an exception.

b2c1d0d fixes the case where `-pyramid-resolutions` is not specified but `-pyramid-scale` is. Something like `bfconvert -pyramid-scale 2 "test&sizeX=2048&sizeY=2048.fake" test.ome.tiff` should show the difference. Without this PR, no pyramid is generated. With this PR, a whole pyramid with smallest resolution 1x1 should be generated without error.