### PR TITLE
ND2: preserve pixel type when setting dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -1131,7 +1131,7 @@ public class ND2Reader extends SubResolutionFormatReader {
           in.skipBytes(skip);
         }
       }
-      
+
       if(currentCountSetted && imageMetadataLVOrder.length() > 0 && 
           (imageOffsets.size() == 0 || timeCount * zCount * XYCount == imageOffsets.size())) {
         setDimensions(timeCount, zCount, XYCount);
@@ -2803,6 +2803,7 @@ public class ND2Reader extends SubResolutionFormatReader {
       int tSize = ms0.sizeT;
       int c = ms0.sizeC;
       String order = ms0.dimensionOrder;
+      int type = ms0.pixelType;
       core = new CoreMetadataList();
       for (int i=0; i<numSeries; i++) {
         CoreMetadata ms = new CoreMetadata();
@@ -2813,6 +2814,7 @@ public class ND2Reader extends SubResolutionFormatReader {
         ms.sizeC = c == 0 ? 1 : c;
         ms.sizeT = tSize == 0 ? 1 : tSize;
         ms.dimensionOrder = order;
+        ms.pixelType = type;
       }
       ms0 = core.get(0, 0);
     }


### PR DESCRIPTION
Fixes #4297.

To test, use files in https://zenodo.org/records/15046688. Without this change, `N1_*_reconstructed-version.nd2` and `N2_*_reconstructed-version.nd2` should have pixel type uint8, and display obviously incorrectly. The other files in the dataset should have type uint16 (for raw) or float (for reconstructed).

With this change, `N1_*_reconstructed-version.nd2` and `N2_*_reconstructed-version.nd2` should have pixel type float consistent with the other reconstructed files. See also screenshots in forthcoming config PR. There should be no change in behavior for the other files in the dataset, or any of the other .nd2 files already in the repo.