### PR TITLE
bfconvert: make sure plane indexes are correct when writing single Z/C/T

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -801,14 +801,17 @@ public final class ImageConverter {
         int count = 0;
         for (int i=startPlane; i<endPlane; i++) {
           int[] coords = reader.getZCTCoords(i);
+          String outputName = FormatTools.getFilename(q, i, reader, out, zeroPadding);
 
           if ((zSection >= 0 && coords[0] != zSection) || (channel >= 0 &&
             coords[1] != channel) || (timepoint >= 0 && coords[2] != timepoint))
           {
+            if (i == endPlane - 1) {
+              nextOutputIndex.remove(outputName);
+            }
             continue;
           }
 
-          String outputName = FormatTools.getFilename(q, i, reader, out, zeroPadding);
           String tileName = FormatTools.getTileFilename(0, 0, 0, outputName);
 
           if (outputName.equals(tileName)) {

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -381,17 +381,44 @@ public class ImageConverterTest {
     };
     assertConversion(args);
 
-    try (TiffParser parser = new TiffParser(outFile.getAbsolutePath())) {
-      String comment = parser.getComment();
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getChannelCount(0), 1);
+  }
 
-      final OMEXMLService service =
-        new ServiceFactory().getInstance(OMEXMLService.class);
-      IMetadata meta = service.createOMEXMLMetadata(comment);
-      assertEquals(meta.getChannelCount(0), 1);
-    }
-    catch (Exception e) {
-      throw new FormatException(e);
-    }
+  @Test
+  public void testConvertResolutionsSingleChannel() throws FormatException, IOException {
+    outFile = getOutFile("multires-single-plane.ome.tiff");
+    String[] args = {
+      "pyramid&sizeC=2&resolutions=2&resolutionScale=2.fake",
+      "-noflat", "-channel", "0", outFile.getAbsolutePath()
+    };
+    resolutionCount = 2;
+    assertConversion(args);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+    assertEquals(meta.getChannelCount(0), 1);
+    assertEquals(meta.getPixelsSizeC(0).getValue().intValue(), 1);
+    assertEquals(meta.getPixelsSizeZ(0).getValue().intValue(), 1);
+    assertEquals(meta.getPixelsSizeT(0).getValue().intValue(), 1);
+  }
+
+  @Test
+  public void testConvertResolutionsSingleZ() throws FormatException, IOException {
+    outFile = getOutFile("multires-single-z.ome.tiff");
+    String[] args = {
+      "pyramid&sizeC=3&sizeZ=4&resolutions=2&resolutionScale=2.fake",
+      "-noflat", "-z", "1", outFile.getAbsolutePath()
+    };
+    resolutionCount = 2;
+    assertConversion(args);
+
+    IMetadata meta = getOMEXMLMetadata(outFile);
+    assertEquals(meta.getImageCount(), 1);
+    assertEquals(meta.getChannelCount(0), 3);
+    assertEquals(meta.getPixelsSizeC(0).getValue().intValue(), 3);
+    assertEquals(meta.getPixelsSizeZ(0).getValue().intValue(), 1);
+    assertEquals(meta.getPixelsSizeT(0).getValue().intValue(), 1);
   }
 
   private Path getTempSubdir() throws IOException {
@@ -402,5 +429,20 @@ public class ImageConverterTest {
 
   private File getOutFile(String name) throws IOException {
     return getTempSubdir().resolve(name).toFile();
+  }
+
+  private IMetadata getOMEXMLMetadata(File out) throws FormatException {
+    IMetadata meta = null;
+    try (TiffParser parser = new TiffParser(outFile.getAbsolutePath())) {
+      String comment = parser.getComment();
+
+      final OMEXMLService service =
+        new ServiceFactory().getInstance(OMEXMLService.class);
+      meta = service.createOMEXMLMetadata(comment);
+    }
+    catch (Exception e) {
+      throw new FormatException(e);
+    }
+    return meta;
   }
 }


### PR DESCRIPTION
Fixes #4356.

As noted in the original issue, something like `bfconvert 'pyramid&sizeC=2&resolutions=2&resolutionScale=2.fake' -noflat -channel 0 output.ome.tif` without this change will successfully write the only plane for the first resolution, but throw an exception when writing the second resolution. This isn't specific to `-channel`, but is also an issue for Z stacks with `-z` and timelapses with `-timepoint`.

With this change, the same tests should successfully write the correct number of planes for all resolutions with no exceptions. Reading the converted file with `showinf -noflat` should also be successful, with the correct plane and resolution counts.