### PR TITLE
Bump logback version to 1.3.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.rootdir>${basedir}</project.rootdir>
     <imagej1.version>1.54c</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
-    <logback.version>1.3.15</logback.version>
+    <logback.version>1.3.16</logback.version>
     <ome-stubs.version>6.0.3</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
     <ome-metakit.version>5.3.9</ome-metakit.version>


### PR DESCRIPTION
See https://github.com/ome/ome-common-java/pull/106, https://github.com/ome/ome-model/pull/223, https://github.com/ome/ome-metakit/pull/29.

Expect that this will need to happen together with relevant component version updates. #4263 / #4265 is what we did the last time logback was updated.