### PR TITLE
Update ome-model, ome-codecs, ome-poi, ome-metakit to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,18 @@
     <logback.version>1.3.15</logback.version>
     <ome-stubs.version>6.0.3</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.9</ome-metakit.version>
+    <ome-metakit.version>5.3.10</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
     <ome-common.version>6.1.0</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.5.0</ome-model.version>
-    <ome-poi.version>5.3.10</ome-poi.version>
+    <ome-model.version>6.5.1</ome-model.version>
+    <ome-poi.version>5.3.11</ome-poi.version>
     <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
     <ome-jai.version>0.1.5</ome-jai.version>
-    <ome-codecs.version>1.1.1</ome-codecs.version>
+    <ome-codecs.version>1.1.2</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.3</xalan.version>
     <sqlite.version>3.49.1.0</sqlite.version>


### PR DESCRIPTION
Related to #4384, #4383. See:

- https://github.com/ome/ome-model/releases/tag/v6.5.1
- https://github.com/ome/ome-codecs/releases/tag/v1.1.2
- https://github.com/ome/ome-metakit/releases/tag/v5.3.10
- https://github.com/ome/ome-poi/releases/tag/v5.3.11