### PR TITLE
Add lens IDs 18113 and 18114

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/RCPNLReader.java
@@ -109,6 +109,28 @@ public class RCPNLReader extends DeltavisionReader {
           MetadataTools.getCorrection("PlanApo"), 0, 0);
         store.setObjectiveManufacturer("Nikon", 0, 0);
         break;
+      case 18113:
+        store.setObjectiveNominalMagnification(10.0, 0, 0);
+        store.setObjectiveLensNA(0.45, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanApo"), 0, 0);
+        store.setObjectiveWorkingDistance(
+          new Length(4.0, UNITS.MILLIMETER), 0, 0);
+        store.setObjectiveImmersion(MetadataTools.getImmersion("Air"), 0, 0);
+        store.setObjectiveModel("MRD70170", 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
+      case 18114:
+        store.setObjectiveNominalMagnification(4.0, 0, 0);
+        store.setObjectiveLensNA(0.13, 0, 0);
+        store.setObjectiveCorrection(
+          MetadataTools.getCorrection("PlanFluor"), 0, 0);
+        store.setObjectiveWorkingDistance(
+          new Length(17.2, UNITS.MILLIMETER), 0, 0);
+        store.setObjectiveImmersion(MetadataTools.getImmersion("Air"), 0, 0);
+        store.setObjectiveModel("MRH00045", 0, 0);
+        store.setObjectiveManufacturer("Nikon", 0, 0);
+        break;
     }
   }
 


### PR DESCRIPTION
See https://www.microscope.healthcare.nikon.com/products/optics/selector/comparison/-179798 and https://www.microscope.healthcare.nikon.com/products/optics/selector/comparison/-1824 respectively.

Backported from a private PR; similar to #4224. Test data is in `curated/deltavision/samples/lens-id-1811*/`.

Without this change, `showinf -nopix -omexml` on the test files should not show objective metadata in the OME-XML. With this change, the same command should result in a populated `Objective` that is consistent with the documentation linked above.