### PR TITLE
A few more ND2 dimension fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -2402,9 +2402,14 @@ public class ND2Reader extends SubResolutionFormatReader {
             stampIndex = getIndex(coords[0], !split ? coords[1] : 0, 0);
           }
           stampIndex += (coords[2] * getSeriesCount() + i) * zcPlanes;
-          if (tsT.size() == getImageCount()) stampIndex = n;
+          if (tsT.size() == getImageCount()) {
+            stampIndex = n;
+          }
           else if (tsT.size() == getSizeZ()) {
             stampIndex = coords[0];
+          }
+          else if (tsT.size() == getSizeZ() * getSizeT()) {
+            stampIndex = n / getEffectiveSizeC();
           }
           if (stampIndex < tsT.size()) {
             double stamp = tsT.get(stampIndex).doubleValue();

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -806,7 +806,7 @@ public class ND2Reader extends SubResolutionFormatReader {
               b.append("\n");
             }
             textStrings.add(b.toString());
-            validDimensions.add(blockCount > 2);
+            validDimensions.add(blockCount >= 2);
 
             // make sure the file pointer is at the end of the block
             in.seek(startFP + dataLength - 1);
@@ -1454,6 +1454,10 @@ public class ND2Reader extends SubResolutionFormatReader {
             ms.imageCount = imageOffsets.size() / getSeriesCount();
             ms.sizeZ = ms.imageCount / ms.sizeT;
             ms.dimensionOrder = "CZT";
+          }
+          else if (imageOffsets.size() % ms.sizeZ == 0) {
+            ms.imageCount = imageOffsets.size() / getSeriesCount();
+            ms.sizeT = ms.imageCount / ms.sizeZ;
           }
           else {
             ms.imageCount = imageOffsets.size() / getSeriesCount();
@@ -2683,6 +2687,12 @@ public class ND2Reader extends SubResolutionFormatReader {
 
           if (useDimensions) {
             handler.parseKeyAndValue(key, value, null);
+          }
+          if (useDimensions && key.equalsIgnoreCase("number of picture planes")) {
+            int v = Integer.parseInt(value);
+            if (v < core.get(0, 0).sizeC) {
+              useDimensions = false;
+            }
           }
 
           if (handler.isDimensions(key)) {


### PR DESCRIPTION
Fixes #4344.

Both public datasets referenced in #4344 should now have correct ZCT dimensions and series counts with this change. See forthcoming configuration PR for reference screenshots from NIS Elements.