### PR TITLE
Bump org.openmicroscopy:ome-model from 6.5.1 to 6.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.1.1</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.5.2</ome-model.version>
+    <ome-model.version>6.5.3</ome-model.version>
     <ome-poi.version>5.3.11</ome-poi.version>
     <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
     <ome-jai.version>0.1.5</ome-jai.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <testng.version>6.8</testng.version>
     <ome-common.version>6.1.1</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.5.1</ome-model.version>
+    <ome-model.version>6.5.2</ome-model.version>
     <ome-poi.version>5.3.11</ome-poi.version>
     <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
     <ome-jai.version>0.1.5</ome-jai.version>


### PR DESCRIPTION
See https://github.com/ome/ome-model/releases/tag/v6.5.2 and https://github.com/ome/ome-model/releases/tag/v6.5.3