### PR TITLE
Refine estimate of bytes needed to write a TIFF plane

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -455,24 +455,6 @@ public class TiffWriter extends FormatWriter {
     ifd.put(IFD.Y_RESOLUTION,
       new TiffRational((long) (physicalSizeY * 1000 * 10000), 1000));
 
-    if (!isBigTiff) {
-      isBigTiff = (out.length() + 2
-          * (width * height * c * bytesPerPixel)) >= 4294967296L;
-      if (isBigTiff) {
-        throw new FormatException("File is too large; call setBigTiff(true)");
-      }
-    }
-
-    // write the image
-    ifd.put(IFD.LITTLE_ENDIAN, Boolean.valueOf(littleEndian));
-    if (!ifd.containsKey(IFD.REUSE)) {
-      ifd.put(IFD.REUSE, out.length());
-      out.seek(out.length());
-    }
-    else {
-      out.seek((Long) ifd.get(IFD.REUSE));
-    }
-
     ifd.putIFDValue(IFD.PLANAR_CONFIGURATION,
       interleaved || getSamplesPerPixel() == 1 ? 1 : 2);
 
@@ -487,6 +469,43 @@ public class TiffWriter extends FormatWriter {
     ifd.putIFDValue(IFD.IMAGE_DESCRIPTION,
       "ImageJ=\nhyperstack=true\nimages=" + (channels * z * t) + "\nchannels=" +
       channels + "\nslices=" + z + "\nframes=" + t);
+
+    if (!isBigTiff) {
+      long calculatedTileWidth = ifd.getTileWidth();
+      long calculatedTileLength = ifd.getTileLength();
+      if (calculatedTileLength == 0) {
+        // worst case, one row per strip
+        calculatedTileLength = 1;
+      }
+      long tileRows = (long) Math.ceil((double) ifd.getImageLength() / calculatedTileLength);
+      long tileCols = (long) Math.ceil((double) ifd.getImageWidth() / calculatedTileWidth);
+      // 4 bytes per tile offset plus 4 bytes per tile length
+      long tilePositionBytes = tileRows * tileCols * 4 * 2;
+
+      // check current file size,
+      // current IFD size,
+      // expected number of bytes to store tile byte counts and offsets,
+      // maximum number of bytes to store pixel data,
+      // and add a margin to allow for additional IFD entries that will be
+      // added when the tiles are actually written
+      isBigTiff = (out.length() + tilePositionBytes +
+        ifd.getByteCount(false) +
+        (width * height * c * bytesPerPixel) +
+        10 * TiffConstants.BYTES_PER_ENTRY + FormatTools.CREATOR.length()) >= 4294967296L;
+      if (isBigTiff) {
+        throw new FormatException("File is too large; call setBigTiff(true)");
+      }
+    }
+
+    // write the image
+    ifd.put(IFD.LITTLE_ENDIAN, Boolean.valueOf(littleEndian));
+    if (!ifd.containsKey(IFD.REUSE)) {
+      ifd.put(IFD.REUSE, out.length());
+      out.seek(out.length());
+    }
+    else {
+      out.seek((Long) ifd.get(IFD.REUSE));
+    }
 
     int index = (no * getResolutionCount()) + getResolution();
     int currentSeries = getSeries();

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -490,7 +490,7 @@ public class TiffWriter extends FormatWriter {
       // added when the tiles are actually written
       isBigTiff = (out.length() + tilePositionBytes +
         ifd.getByteCount(false) +
-        (width * height * c * bytesPerPixel) +
+        (calculatedTileWidth * calculatedTileLength * c * bytesPerPixel) +
         10 * TiffConstants.BYTES_PER_ENTRY + FormatTools.CREATOR.length()) >= 4294967296L;
       if (isBigTiff) {
         throw new FormatException("File is too large; call setBigTiff(true)");

--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -209,6 +209,42 @@ public class IFD extends HashMap<Integer, Object> {
 
   // -- Tag retrieval methods --
 
+  /** Get the maximum number of bytes needed to represent this IFD. */
+  public long getByteCount(boolean bigTiff) throws FormatException {
+    long count = 0;
+    for (Integer key : keySet()) {
+      count += bigTiff ? TiffConstants.BIG_TIFF_BYTES_PER_ENTRY : TiffConstants.BYTES_PER_ENTRY;
+
+      Object value = get(key);
+      if (value != null) {
+        if (value instanceof OnDemandLongArray) {
+          OnDemandLongArray dvalue = (OnDemandLongArray) value;
+          long nElements = dvalue.size();
+          count += nElements * 8;
+        }
+        else {
+          IFDType type = IFDType.getType(value, bigTiff);
+          int len = 1;
+          try {
+            len = Array.getLength(value);
+          }
+          catch (IllegalArgumentException e) {
+          }
+          int bytesPerElement = type.getBytesPerElement();
+          int bytes = len * bytesPerElement;
+
+          // only count if the value is large enough that it
+          // wouldn't be written inline
+          // the bytes per entry constants already allow for inline values
+          if (bytes > (bigTiff ? 8 : 4)) {
+            count += bytes;
+          }
+        }
+      }
+    }
+    return count;
+  }
+
   /** Gets whether this is a BigTIFF IFD. */
   public boolean isBigTiff() throws FormatException {
     return ((Boolean) getIFDValue(BIG_TIFF, Boolean.class)).booleanValue();

--- a/components/formats-bsd/src/loci/formats/tiff/IFDType.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFDType.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import loci.common.enumeration.CodedEnum;
 import loci.common.enumeration.EnumException;
 
+import loci.formats.FormatException;
+
 /**
  * An enumeration of IFD types.
  */
@@ -116,6 +118,42 @@ public enum IFDType implements CodedEnum {
    */
   public int getBytesPerElement() {
     return bytesPerElement;
+  }
+
+  /**
+   * Get the type corresponding to the given value.
+   *
+   * @param value IFD value
+   * @param bigTiff true if BigTIFF will be written (impacts long values)
+   * @return appropriate IFDType for the given value
+   * @throws FormatException if an appropriate IFDType cannot be determined
+   */
+  public static IFDType getType(Object value, boolean bigTiff)
+    throws FormatException
+  {
+    if (value instanceof Short || value instanceof short[]) {
+      return BYTE;
+    }
+    else if (value instanceof String) {
+      return ASCII;
+    }
+    else if (value instanceof Integer || value instanceof int[]) {
+      return SHORT;
+    }
+    else if (value instanceof Long || value instanceof long[]) {
+      return bigTiff ? LONG8 : LONG;
+    }
+    else if (value instanceof TiffRational || value instanceof TiffRational[]) {
+      return RATIONAL;
+    }
+    else if (value instanceof Float || value instanceof float[]) {
+      return FLOAT;
+    }
+    else if (value instanceof Double || value instanceof double[]) {
+      return DOUBLE;
+    }
+    throw new FormatException("Unknown IFD value type (" +
+      value.getClass().getName() + "): " + value);
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/tiff/IFDType.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFDType.java
@@ -152,6 +152,9 @@ public enum IFDType implements CodedEnum {
     else if (value instanceof Double || value instanceof double[]) {
       return DOUBLE;
     }
+    else if (value instanceof Boolean) {
+      return UNDEFINED;
+    }
     throw new FormatException("Unknown IFD value type (" +
       value.getClass().getName() + "): " + value);
   }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -618,9 +618,10 @@ public class TiffSaver implements Closeable {
 
     // write directory entry to output buffers
     out.writeShort(tag); // tag
+    IFDType ifdType = IFDType.getType(value, bigTiff);
+    out.writeShort(ifdType.getCode());
     if (value instanceof short[]) {
       short[] q = (short[]) value;
-      out.writeShort(IFDType.BYTE.getCode());
       writeIntValue(out, q.length);
       if (q.length <= dataLength) {
         for (int i=0; i<q.length; i++) out.writeByte(q[i]);
@@ -633,7 +634,6 @@ public class TiffSaver implements Closeable {
     }
     else if (value instanceof String) { // ASCII
       byte[] q = ((String) value).getBytes(Charset.forName(Constants.ENCODING));
-      out.writeShort(IFDType.ASCII.getCode()); // type
       writeIntValue(out, q.length + 1);
       if (q.length < dataLength) {
         for (int i=0; i<q.length; i++) out.writeByte(q[i]); // value(s)
@@ -647,7 +647,6 @@ public class TiffSaver implements Closeable {
     }
     else if (value instanceof int[]) { // SHORT
       int[] q = (int[]) value;
-      out.writeShort(IFDType.SHORT.getCode()); // type
       writeIntValue(out, q.length);
       if (q.length <= dataLength / 2) {
         for (int i=0; i<q.length; i++) {
@@ -667,8 +666,6 @@ public class TiffSaver implements Closeable {
     else if (value instanceof long[]) { // LONG
       long[] q = (long[]) value;
 
-      int type = bigTiff ? IFDType.LONG8.getCode() : IFDType.LONG.getCode();
-      out.writeShort(type);
       writeIntValue(out, q.length);
 
       int div = bigTiff ? 8 : 4;
@@ -690,7 +687,6 @@ public class TiffSaver implements Closeable {
     }
     else if (value instanceof TiffRational[]) { // RATIONAL
       TiffRational[] q = (TiffRational[]) value;
-      out.writeShort(IFDType.RATIONAL.getCode()); // type
       writeIntValue(out, q.length);
       if (bigTiff && q.length == 1) {
         out.writeInt((int) q[0].getNumerator());
@@ -706,7 +702,6 @@ public class TiffSaver implements Closeable {
     }
     else if (value instanceof float[]) { // FLOAT
       float[] q = (float[]) value;
-      out.writeShort(IFDType.FLOAT.getCode()); // type
       writeIntValue(out, q.length);
       if (q.length <= dataLength / 4) {
         for (int i=0; i<q.length; i++) {
@@ -725,7 +720,6 @@ public class TiffSaver implements Closeable {
     }
     else if (value instanceof double[]) { // DOUBLE
       double[] q = (double[]) value;
-      out.writeShort(IFDType.DOUBLE.getCode()); // type
       writeIntValue(out, q.length);
       writeIntValue(out, offset + extraOut.length());
       for (int i=0; i<q.length; i++) {

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -166,6 +166,7 @@ public class TiffWriterTest {
     writer.setBigTiff(true);
     writer.setId("test.tiff");
     writer.saveBytes(0, buf, ifd);
+    writer.saveBytes(1, buf, ifd);
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -135,16 +135,15 @@ public class TiffWriterTest {
 
   @Test
   public void testSetBigTiffFileTooLarge() throws IOException, FormatException {
-    // Test that no exception is thrown while below the big tiff limit (2147483648L)
-    // Exception is thrown when size is out.length() + 2 * (width * height * c * bytesPerPixel)
+    // Test that no exception is thrown while below the big tiff limit (4294967296L)
     writer.setMetadataRetrieve(metadata);
     ((TiffWriterMock)writer).createOutputBuffer(true);
-    long length = 4294967296L - (buf.length * 4);
+    long length = 4294967296L - (buf.length * 2);
     ((TiffWriterMock)writer).setBufferLength(length);
     writer.setId("test.tiff");
     writer.saveBytes(0, buf, ifd);
 
-    //Test format exception is thrown after the big tiff limit (2147483648L)
+    //Test format exception is thrown after the big tiff limit (4294967296L)
     boolean thrown = false;
     try {
       writer.saveBytes(1, buf, ifd);


### PR DESCRIPTION
Fixes #4113.

Instead of just doubling the number of pixel bytes, estimate the number of bytes needed to write the corresponding IFD. As a consequence, this adds methods to get the number of bytes needed to write an IFD and the IFDType for a particular value.

The test case in #4113 should now successfully convert without exception:

```bfconvert "test&sizeX=12000&sizeY=20000&sizeZ=8&sizeT=2.fake" test.tiff```

and the resulting file should be less than 4GB and readable as expected. Increasing the plane count in the test case should continue to throw an exception indicating that BigTIFF is required (but this is expected).

Given that this adds some new API to the TIFF classes and 8.4.0 is rapidly approaching, I'd be OK with pushing this PR to the next milestone if more time to review/discuss would be helpful.