### PR TITLE
Bump org.openmicroscopy:ome-common from 6.1.1 to 6.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.1.1</ome-common.version>
+    <ome-common.version>6.1.2</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.5.1</ome-model.version>
     <ome-poi.version>5.3.11</ome-poi.version>


### PR DESCRIPTION
See https://github.com/ome/ome-common-java/releases/tag/v6.1.2 for the release notes