### PR TITLE
Fix image ROI reference population in Zeiss LSM and MIAS readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -910,6 +910,7 @@ public class MIASReader extends FormatReader {
 
           int[] position = getPositionFromFile(file);
           int well = position[0];
+          int roiRefIndex = 0;
 
           if (name.endsWith("detail.txt")) {
             String data = DataTools.readFile(file);
@@ -925,7 +926,8 @@ public class MIASReader extends FormatReader {
 
             for (int j=start+1; j<lines.length; j++) {
               populateROI(columnNames, lines[j].split("\t"), well,
-                nextROI++, position[1], position[2], store);
+                nextROI++, position[1], position[2], store, roiRefIndex);
+              roiRefIndex++;
             }
           }
           else if (name.endsWith("AllModesOverlay.tif")) {
@@ -942,11 +944,15 @@ public class MIASReader extends FormatReader {
               store.setChannelColor(colors[position[3]], s, position[3]);
             }
             if (position[3] == 0) {
-              nextROI += parseMasks(store, well, nextROI, file);
+              int nOverlays = parseMasks(store, well, nextROI, file, roiRefIndex);
+              nextROI += nOverlays;
+              roiRefIndex += nOverlays;
             }
           }
           else if (name.endsWith("overlay.tif")) {
-            nextROI += parseMasks(store, well, nextROI, file);
+            int nOverlays = parseMasks(store, well, nextROI, file, roiRefIndex);
+            nextROI += nOverlays;
+            roiRefIndex += nOverlays;
           }
         }
       }
@@ -1029,24 +1035,24 @@ public class MIASReader extends FormatReader {
   }
 
   private void populateROI(List<String> columns, String[] data, int series,
-    int roi, int time, int z, MetadataStore store)
+    int roiIndex, int time, int z, MetadataStore store, int roiRefIndex)
   {
-    String roiID = MetadataTools.createLSID("ROI", roi, 0);
-    store.setROIID(roiID, roi);
-    store.setImageROIRef(roiID, series, roi);
+    String roiID = MetadataTools.createLSID("ROI", roiIndex, 0);
+    store.setROIID(roiID, roiIndex);
+    store.setImageROIRef(roiID, series, roiRefIndex);
 
-    store.setEllipseID(MetadataTools.createLSID("Shape", roi, 0), roi, 0);
-    store.setEllipseTheT(new NonNegativeInteger(time), roi, 0);
-    store.setEllipseTheZ(new NonNegativeInteger(z), roi, 0);
-    store.setEllipseX(DataTools.parseDouble(data[columns.indexOf("Col")]), roi, 0);
-    store.setEllipseY(DataTools.parseDouble(data[columns.indexOf("Row")]), roi, 0);
-    store.setEllipseText(data[columns.indexOf("Label")], roi, 0);
+    store.setEllipseID(MetadataTools.createLSID("Shape", roiIndex, 0), roiIndex, 0);
+    store.setEllipseTheT(new NonNegativeInteger(time), roiIndex, 0);
+    store.setEllipseTheZ(new NonNegativeInteger(z), roiIndex, 0);
+    store.setEllipseX(DataTools.parseDouble(data[columns.indexOf("Col")]), roiIndex, 0);
+    store.setEllipseY(DataTools.parseDouble(data[columns.indexOf("Row")]), roiIndex, 0);
+    store.setEllipseText(data[columns.indexOf("Label")], roiIndex, 0);
 
     double diam = Double.parseDouble(data[columns.indexOf("Cell Diam.")]);
     double radius = diam / 2;
 
-    store.setEllipseRadiusX(radius, roi, 0);
-    store.setEllipseRadiusY(radius, roi, 0);
+    store.setEllipseRadiusX(radius, roiIndex, 0);
+    store.setEllipseRadiusY(radius, roiIndex, 0);
 
     // NB: other attributes are "Nucleus Area", "Cell Type", and
     // "Mean Nucleus Intens."
@@ -1164,7 +1170,7 @@ public class MIASReader extends FormatReader {
     int roi = 0;
     parseMasks = true;
     for (AnalysisFile roiFile : roiFiles) {
-      roi += parseMasks(overlayStore, roiFile.well, roi, roiFile.filename);
+      roi += parseMasks(overlayStore, roiFile.well, roi, roiFile.filename, 0);
     }
     parseMasks = originalMaskParsing;
   }
@@ -1174,33 +1180,33 @@ public class MIASReader extends FormatReader {
    * MetadataStore.
    * @return the number of masks parsed
    */
-  private int parseMasks(MetadataStore store, int series, int roi,
-    String overlayTiff) throws FormatException, IOException
+  private int parseMasks(MetadataStore store, int series, int roiIndex,
+    String overlayTiff, int roiRefIndex) throws FormatException, IOException
   {
     if (!parseMasks || series >= getSeriesCount()) return 0;
     int nOverlays = 0;
     for (int i=0; i<3; i++) {
-      String roiId = MetadataTools.createLSID("ROI", series, roi + nOverlays);
+      String roiId = MetadataTools.createLSID("ROI", series, roiIndex + nOverlays);
       String maskId =
-        MetadataTools.createLSID("Mask", series, roi + nOverlays, 0);
+        MetadataTools.createLSID("Mask", series, roiIndex + nOverlays, 0);
       overlayFiles.put(maskId, overlayTiff);
       overlayPlanes.put(maskId, i);
 
-      boolean validMask = populateMaskPixels(series, roi + nOverlays, 0, store);
+      boolean validMask = populateMaskPixels(series, roiIndex + nOverlays, 0, store);
       if (validMask) {
-        store.setROIID(roiId, roi + nOverlays);
+        store.setROIID(roiId, roiIndex + nOverlays);
 
-        String maskID = MetadataTools.createLSID("Shape", roi + nOverlays, 0);
-        store.setMaskID(maskID, roi + nOverlays, 0);
-        store.setMaskX(0d, roi + nOverlays, 0);
-        store.setMaskY(0d, roi + nOverlays, 0);
-        store.setMaskWidth((double) getSizeX(), roi + nOverlays, 0);
-        store.setMaskHeight((double) getSizeY(), roi + nOverlays, 0);
+        String maskID = MetadataTools.createLSID("Shape", roiIndex + nOverlays, 0);
+        store.setMaskID(maskID, roiIndex + nOverlays, 0);
+        store.setMaskX(0d, roiIndex + nOverlays, 0);
+        store.setMaskY(0d, roiIndex + nOverlays, 0);
+        store.setMaskWidth((double) getSizeX(), roiIndex + nOverlays, 0);
+        store.setMaskHeight((double) getSizeY(), roiIndex + nOverlays, 0);
 
         int color = 0xff000000 | (0xff << (8 * (2 - i)));
-        store.setMaskStrokeColor(new Color(color), roi + nOverlays, 0);
-        store.setMaskFillColor(new Color(color), roi + nOverlays, 0);
-        store.setImageROIRef(roiId, series, roi + nOverlays);
+        store.setMaskStrokeColor(new Color(color), roiIndex + nOverlays, 0);
+        store.setMaskFillColor(new Color(color), roiIndex + nOverlays, 0);
+        store.setImageROIRef(roiId, series, roiRefIndex + nOverlays);
         nOverlays++;
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -903,6 +903,7 @@ public class MIASReader extends FormatReader {
         Color[] colors = new Color[getSizeC()];
 
         int nextROI = 0;
+        int roiRefIndex = 0;
         for (AnalysisFile af : analysisFiles) {
           String file = af.filename;
           String name = new Location(file).getName();
@@ -910,7 +911,6 @@ public class MIASReader extends FormatReader {
 
           int[] position = getPositionFromFile(file);
           int well = position[0];
-          int roiRefIndex = 0;
 
           if (name.endsWith("detail.txt")) {
             String data = DataTools.readFile(file);

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -187,6 +187,7 @@ public class ZeissLSMReader extends FormatReader {
   private double originX, originY, originZ;
 
   private int totalROIs = 0;
+  private transient int roiRefIndex;
 
   private int prevPlane = -1;
   private int prevChannel = 0;
@@ -973,6 +974,7 @@ public class ZeissLSMReader extends FormatReader {
 
       if (getMetadataOptions().getMetadataLevel() != MetadataLevel.NO_OVERLAYS)
       {
+        roiRefIndex = 0;
         for (int i=0; i<overlayOffsets.length; i++) {
           parseOverlays(series, overlayOffsets[i], overlayKeys[i], store);
         }
@@ -1614,7 +1616,7 @@ public class ZeissLSMReader extends FormatReader {
 
       String roiID = MetadataTools.createLSID("ROI", i);
       String shapeID = MetadataTools.createLSID("Shape", i, 0);
-      int roiRefIndex = i - totalROIs;
+      roiRefIndex++;
 
       Length fontSize = FormatTools.getFontSize(fontHeight);
       Length line = new Length(lineWidth, UNITS.PIXEL);

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -1614,6 +1614,7 @@ public class ZeissLSMReader extends FormatReader {
 
       String roiID = MetadataTools.createLSID("ROI", i);
       String shapeID = MetadataTools.createLSID("Shape", i, 0);
+      int roiRefIndex = i - totalROIs;
 
       Length fontSize = FormatTools.getFontSize(fontHeight);
       Length line = new Length(lineWidth, UNITS.PIXEL);
@@ -1632,7 +1633,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setLabelFontSize(fontSize, i, 0);
           }
           store.setLabelStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case LINE:
@@ -1652,7 +1653,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setLineFontSize(fontSize, i, 0);
           }
           store.setLineStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case SCALE_BAR:
@@ -1685,7 +1686,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setRectangleFontSize(fontSize, i, 0);
           }
           store.setRectangleStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case ELLIPSE:
@@ -1745,7 +1746,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setEllipseFontSize(fontSize, i, 0);
           }
           store.setEllipseStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case CIRCLE:
@@ -1768,7 +1769,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setEllipseFontSize(fontSize, i, 0);
           }
           store.setEllipseStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case CIRCLE_3POINT:
@@ -1808,7 +1809,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setEllipseFontSize(fontSize, i, 0);
           }
           store.setEllipseStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case ANGLE:
@@ -1835,7 +1836,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setPolylineFontSize(fontSize, i, 0);
           }
           store.setPolylineStrokeWidth(line, i, 0);
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case CLOSED_POLYLINE:
@@ -1875,7 +1876,7 @@ public class ZeissLSMReader extends FormatReader {
             store.setPolygonStrokeWidth(line, i, 0);
             store.setPolygonID(shapeID, i, 0);
           }
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         case CLOSED_BEZIER:
@@ -1915,7 +1916,7 @@ public class ZeissLSMReader extends FormatReader {
             }
             store.setPolygonStrokeWidth(line, i, 0);
           }
-          store.setImageROIRef(roiID, series, i);
+          store.setImageROIRef(roiID, series, roiRefIndex);
 
           break;
         default:


### PR DESCRIPTION
See #4394 and the failures reported in https://github.com/ome/bioformats/pull/4394#issuecomment-3718441504

When populating the OME metadata via `setImageRoiRef`, the Zeiss LSM and MIAS reader currently make use of the same index for the ROIRef as the ROI index. For multi-series, this means the setters are typically called as:

```
setImageROIRef("ROI:0",0,0);
setImageROIRef("ROI:1",0,1);
setImageROIRef("ROI:2",0,2);
setImageROIRef("ROI:3",1,3);
setImageROIRef("ROI:4",1,4);
setImageROIRef("ROI:5",1,5);
```

The sequence above was working with the current `ome-xml` implementation which was largely ignoring the `roiRefIndex` in `setImageROIRef` and using the order of the calls. With the changes proposed in https://github.com/ome/ome-model/pull/226 and released in `org.openmicroscopy:ome-xml:6.5.2` the index is now taken into account.

This change updates the readers to separate the `roiIndex` from the `roiRefIndex` and ensure each series starts with index 0.

Together with #4394, I expect this should address the failures in `mias` and `zeiss-lsm` although we likely still want to fix the underlying OME-XML library to support the scenario above which has been functional for years - see https://github.com/ome/ome-model/pull/229.