### PR TITLE
Review the list of cdm-core exclusions in formats-gpl

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -69,10 +69,6 @@
       <version>5.6.0</version>
       <exclusions>
         <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-s3</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.beust</groupId>
           <artifactId>jcommander</artifactId>
         </exclusion>
@@ -82,15 +78,7 @@
         </exclusion>
         <exclusion>
           <groupId>edu.ucar</groupId>
-          <artifactId>quartz</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>edu.ucar</groupId>
           <artifactId>udunits</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.jcip</groupId>
-          <artifactId>jcip-annotations</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -99,14 +87,6 @@
         <exclusion>
           <groupId>org.jdom</groupId>
           <artifactId>jdom2</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.quartz-scheduler</groupId>
-          <artifactId>quartz</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Most of these exclusions correspond to older versions of the library, likely before the netcdf/cdm-core split and are no longer applicable.

To test this PR, compare `mvn dependency:list` with and without this PR  and confirm the dependencies are identical.