### PR TITLE
NDPIS: don't overwrite image names from NDPIReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -801,6 +801,10 @@ public class NDPIReader extends BaseTiffReader {
 
   // -- Helper methods --
 
+  protected int getPyramidHeight() {
+    return pyramidHeight;
+  }
+
   private int getIFDIndex(int seriesIndex, int zIndex) {
     if (seriesIndex < pyramidHeight) {
       return zIndex * pyramidHeight + seriesIndex;

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -198,7 +198,7 @@ public class NDPISReader extends FormatReader {
       ms.imageCount = ms.sizeC * ms.sizeZ * ms.sizeT;
     }
 
-    MetadataTools.populatePixels(store, this);
+    MetadataTools.populatePixels(store, this, false, false);
 
     bandUsed = new int[ndpiFiles.length];
     IFD ifd;

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -281,8 +281,7 @@ public class NDPISReader extends FormatReader {
 
   private boolean isPyramidResolution(int readerIndex, int coreIndex) {
     int pyramidHeight = ((NDPIReader) readers[readerIndex].getReader()).getPyramidHeight();
-    return (hasFlattenedResolutions() && coreIndex < pyramidHeight) ||
-      (!hasFlattenedResolutions() && coreIndex == 0);
+    return coreIndex < pyramidHeight;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -90,6 +90,7 @@ public class NDPISReader extends FormatReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
+    readers[0].setCoreIndex(getCoreIndex());
     return readers[0].getOptimalTileWidth();
   }
 
@@ -97,6 +98,7 @@ public class NDPISReader extends FormatReader {
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
+    readers[0].setCoreIndex(getCoreIndex());
     return readers[0].getOptimalTileHeight();
   }
 
@@ -121,6 +123,7 @@ public class NDPISReader extends FormatReader {
       readers[channel].openBytes(plane, buf, x, y, w, h);
     }
     else {
+      readers[0].setCoreIndex(getCoreIndex());
       readers[0].openBytes(no, buf, x, y, w, h);
     }
 

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -109,13 +109,20 @@ public class NDPISReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int[] zct = getZCTCoords(no);
-    int channel = zct[1];
-    readers[channel].setId(ndpiFiles[channel]);
-    readers[channel].setCoreIndex(getCoreIndex());
-    int cIndex = (bandUsed[channel] < readers[channel].getSizeC()) ? bandUsed[channel] : 0;
-    int plane = readers[channel].getIndex(zct[0], cIndex, zct[2]);
-    readers[channel].openBytes(plane, buf, x, y, w, h);
+    // if in the pyramid, read a single channel from the appropriate .ndpi file
+    // otherwise, read the extra images from the first file only
+    if (isPyramidResolution(0, getCoreIndex())) {
+      int[] zct = getZCTCoords(no);
+      int channel = zct[1];
+      readers[channel].setId(ndpiFiles[channel]);
+      readers[channel].setCoreIndex(getCoreIndex());
+      int cIndex = (bandUsed[channel] < readers[channel].getSizeC()) ? bandUsed[channel] : 0;
+      int plane = readers[channel].getIndex(zct[0], cIndex, zct[2]);
+      readers[channel].openBytes(plane, buf, x, y, w, h);
+    }
+    else {
+      readers[0].openBytes(no, buf, x, y, w, h);
+    }
 
     return buf;
   }
@@ -193,9 +200,13 @@ public class NDPISReader extends FormatReader {
     core = new ArrayList<CoreMetadata>(readers[0].getCoreMetadataList());
     for (int i=0; i<core.size(); i++) {
       CoreMetadata ms = core.get(i);
-      ms.sizeC = readers.length;
-      ms.rgb = false;
-      ms.imageCount = ms.sizeC * ms.sizeZ * ms.sizeT;
+      // only adjust the channel and image counts for the pyramid resolutions
+      // use the macro/mask images from the first file only
+      if (isPyramidResolution(0, i)) {
+        ms.sizeC = readers.length;
+        ms.rgb = false;
+        ms.imageCount = ms.sizeC * ms.sizeZ * ms.sizeT;
+      }
     }
 
     MetadataTools.populatePixels(store, this, false, false);
@@ -263,6 +274,12 @@ public class NDPISReader extends FormatReader {
         }
       }
     }
+  }
+
+  private boolean isPyramidResolution(int readerIndex, int coreIndex) {
+    int pyramidHeight = ((NDPIReader) readers[readerIndex].getReader()).getPyramidHeight();
+    return (hasFlattenedResolutions() && coreIndex < pyramidHeight) ||
+      (!hasFlattenedResolutions() && coreIndex == 0);
   }
 
 }


### PR DESCRIPTION
Backported from private PR.

This fixes image names reported by e.g. `showinf -omexml` on an .ndpis to match the image names that would be shown for one of the corresponding .ndpi files. In particular, this preserves the `macro image` and `macro mask image` names when the `-noflat` option is used.

See corresponding config PR for impact on existing data.