### PR TITLE
Remove use of DocumentBuilderFactory in favor of relevant XMLTools method

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -42,7 +42,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
@@ -1003,13 +1002,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
     OMEXMLMetadataRoot omeRoot1 = (OMEXMLMetadataRoot) src1.getRoot();
     OMEXMLMetadataRoot omeRoot2 = (OMEXMLMetadataRoot) src2.getRoot();
 
-    DocumentBuilder builder = null;
-    try {
-      builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-    }
-    catch (ParserConfigurationException e) {
-      return false;
-    }
+    DocumentBuilder builder = XMLTools.createBuilder();
 
     Document doc1 = builder.newDocument();
     Document doc2 = builder.newDocument();

--- a/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
+++ b/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
@@ -43,11 +43,10 @@ import java.io.InputStreamReader;
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import loci.common.Constants;
+import loci.common.xml.XMLTools;
 
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -82,14 +81,12 @@ public class XMLWindow extends JFrame {
     setDocument(null);
 
     // parse XML from string into DOM structure
-    DocumentBuilderFactory docFact = DocumentBuilderFactory.newInstance();
-    DocumentBuilder db = docFact.newDocumentBuilder();
-    ByteArrayInputStream is =
-      new ByteArrayInputStream(xml.getBytes(Constants.ENCODING));
-    Document doc = db.parse(is);
-    is.close();
-
-    setDocument(doc);
+    try (ByteArrayInputStream is =
+      new ByteArrayInputStream(xml.getBytes(Constants.ENCODING)))
+    {
+      Document doc = XMLTools.parseDOM(is);
+      setDocument(doc);
+    }
   }
 
   /** Displays XML from the given file. */
@@ -99,9 +96,7 @@ public class XMLWindow extends JFrame {
     setDocument(null);
 
     // parse XML from file into DOM structure
-    DocumentBuilderFactory docFact = DocumentBuilderFactory.newInstance();
-    DocumentBuilder db = docFact.newDocumentBuilder();
-    Document doc = db.parse(file);
+    Document doc = XMLTools.parseDOM(file);
 
     setDocument(doc);
   }

--- a/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
+++ b/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
@@ -35,7 +35,6 @@ package loci.formats.gui;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -81,12 +80,7 @@ public class XMLWindow extends JFrame {
     setDocument(null);
 
     // parse XML from string into DOM structure
-    try (ByteArrayInputStream is =
-      new ByteArrayInputStream(xml.getBytes(Constants.ENCODING)))
-    {
-      Document doc = XMLTools.parseDOM(is);
-      setDocument(doc);
-    }
+    setDocument(XMLTools.parseDOM(xml));
   }
 
   /** Displays XML from the given file. */
@@ -96,9 +90,7 @@ public class XMLWindow extends JFrame {
     setDocument(null);
 
     // parse XML from file into DOM structure
-    Document doc = XMLTools.parseDOM(file);
-
-    setDocument(doc);
+    setDocument(XMLTools.parseDOM(file));
   }
 
   /** Displays XML from the given document. */

--- a/components/formats-bsd/test/loci/formats/utests/BaseModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelMock.java
@@ -36,8 +36,7 @@ package loci.formats.utests;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -165,9 +164,7 @@ public class BaseModelMock implements ModelMock {
 
   public static void main(String[] args) throws Exception {
     BaseModelMock mock = new BaseModelMock();
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = mock.ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, true);

--- a/components/formats-bsd/test/loci/formats/utests/GenericExcitationMapTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/GenericExcitationMapTest.java
@@ -40,8 +40,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import ome.xml.model.Channel;
 import ome.xml.model.Image;
@@ -105,9 +104,7 @@ public class GenericExcitationMapTest {
 
   @Test
   public void testGenericExcitationSourceValid() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);
@@ -118,9 +115,7 @@ public class GenericExcitationMapTest {
 
   @Test
   public void testGenericExcitationSourceMapContent() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);

--- a/components/formats-bsd/test/loci/formats/utests/ImagingEnvironmentMapTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ImagingEnvironmentMapTest.java
@@ -40,8 +40,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import ome.xml.model.Image;
 import ome.xml.model.ImagingEnvironment;
@@ -94,9 +93,7 @@ public class ImagingEnvironmentMapTest {
 
   @Test
   public void testGenericExcitationSourceValid() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);
@@ -107,9 +104,7 @@ public class ImagingEnvironmentMapTest {
 
   @Test
   public void testGenericExcitationSourceMapContent() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);

--- a/components/formats-bsd/test/loci/formats/utests/MapAnnotationTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MapAnnotationTest.java
@@ -40,8 +40,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import ome.xml.model.Image;
 import ome.xml.model.MapAnnotation;
@@ -97,9 +96,7 @@ public class MapAnnotationTest {
 
   @Test
   public void testMapAnnotationValid() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);
@@ -110,9 +107,7 @@ public class MapAnnotationTest {
 
   @Test
   public void testMapAnnotationValueContent() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);

--- a/components/formats-bsd/test/loci/formats/utests/PumpWithLightSourceSettingsTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/PumpWithLightSourceSettingsTest.java
@@ -34,8 +34,7 @@ package loci.formats.utests;
 
 import static org.testng.AssertJUnit.assertEquals;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import ome.xml.model.Arc;
 import ome.xml.model.Channel;
@@ -93,9 +92,7 @@ public class PumpWithLightSourceSettingsTest {
 
   @Test
   public void testLightSourceType() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, false);

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
@@ -39,8 +39,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -49,6 +47,8 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
+import loci.common.xml.XMLTools;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -471,9 +471,7 @@ public class SPWModelMock implements ModelMock {
 
   public static void main(String[] args) throws Exception {
     SPWModelMock mock = new SPWModelMock(false);
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = mock.ome.asXMLElement(document);
     SPWModelMock.postProcess(root, document, true);

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
@@ -41,8 +41,7 @@ import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import loci.formats.ChannelFiller;
 import loci.formats.ChannelSeparator;
@@ -101,9 +100,7 @@ public class SPWModelReaderTest {
    */
   public static void writeMockToFile(ModelMock mock, File file,
   boolean withBinData) throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.newDocument();
+    Document document = XMLTools.createDocument();
     // Produce a valid OME DOM element hierarchy
     Element root = mock.getRoot().asXMLElement(document);
     SPWModelMock.postProcess(root, document, withBinData);

--- a/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
@@ -58,6 +56,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import loci.common.Constants;
 import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.meta.MetadataStore;
@@ -367,10 +366,8 @@ public class Schema_Transform_Test extends AbstractTest {
     private Map<String, List<String>> currentSchema() throws Exception
     {
         InputStream stream = getStream(CATALOG);
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         try {
-            DocumentBuilder builder = dbf.newDocumentBuilder();
-            Document doc = builder.parse(stream);
+            Document doc = XMLTools.parseDOM(stream);
             currentSchema = doc.getDocumentElement().getAttribute(CURRENT);
             if (currentSchema.trim().isEmpty())
                 throw new Exception("No schema specified.");

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -38,8 +38,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import loci.common.DataTools;
@@ -1127,20 +1125,14 @@ public class LIFReader extends FormatReader {
   private Element getMetadataRoot(String xml)
     throws FormatException, IOException
   {
-    ByteArrayInputStream s = null;
-    try {
-      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-      DocumentBuilder parser = factory.newDocumentBuilder();
-      s = new ByteArrayInputStream(xml.getBytes(ENCODING));
-      return parser.parse(s).getDocumentElement();
+    try (ByteArrayInputStream s = new ByteArrayInputStream(xml.getBytes(ENCODING))) {
+      return XMLTools.parseDOM(s).getDocumentElement();
     }
     catch (ParserConfigurationException e) {
       throw new FormatException(e);
     }
     catch (SAXException e) {
       throw new FormatException(e);
-    } finally {
-        if (s != null) s.close();
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaMicrosystemsMetadata/LMSXmlDocument.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaMicrosystemsMetadata/LMSXmlDocument.java
@@ -43,11 +43,10 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import loci.common.Location;
+import loci.common.xml.XMLTools;
 
 import org.xml.sax.InputSource;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -103,10 +102,8 @@ public abstract class LMSXmlDocument {
 
   // -- Methods --
   private void initFromXmlString(String xml) {
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     try {
-      DocumentBuilder db = dbf.newDocumentBuilder();
-      Document doc = db.parse(new InputSource(new StringReader(xml)));
+      Document doc = XMLTools.parseDOM(xml);
       doc.getDocumentElement().normalize();
       this.doc = doc;
       this.xPath = XPathFactory.newInstance().newXPath();
@@ -118,16 +115,12 @@ public abstract class LMSXmlDocument {
   }
 
   private void initFromFilepath(String filepath) {
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-    try {
-      DocumentBuilder db = dbf.newDocumentBuilder();
-      FileInputStream fi = new FileInputStream(Location.getMappedId(filepath));
-      Document doc = db.parse(fi);
-      fi.close();
-      doc.getDocumentElement().normalize();
-      this.doc = doc;
-      this.xPath = XPathFactory.newInstance().newXPath();
-      LMSFileReader.log.trace(this.toString());
+    try (FileInputStream fi = new FileInputStream(Location.getMappedId(filepath))) {
+        Document doc = XMLTools.parseDOM(fi);
+        doc.getDocumentElement().normalize();
+        this.doc = doc;
+        this.xPath = XPathFactory.newInstance().newXPath();
+        LMSFileReader.log.trace(this.toString());
     } catch (ParserConfigurationException | SAXException | IOException e) {
       LMSFileReader.log.error(e.getMessage());
       e.printStackTrace();

--- a/components/formats-gpl/test/loci/formats/utests/InOutCurrentTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/InOutCurrentTest.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -44,6 +42,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import loci.common.xml.XMLTools;
 import loci.formats.ome.OMEXMLMetadataImpl;
 
 import static org.testng.AssertJUnit.*;
@@ -310,9 +309,7 @@ public class InOutCurrentTest {
     Class mockClass = Class.forName(mockClassName);
     Constructor constructor = mockClass.getDeclaredConstructor();
     mock = (OMEModelMock) constructor.newInstance();
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    document = parser.newDocument();
+    document = XMLTools.createDocument();
     ome = (OMEXMLMetadataRoot) mock.getRoot();
     // Produce a valid OME DOM element hierarchy
     Element root = ome.asXMLElement(document);

--- a/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
@@ -28,8 +28,7 @@ package loci.formats.utests;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import loci.common.xml.XMLTools;
 
 import ome.xml.model.Annotation;
 import ome.xml.model.Channel;
@@ -56,9 +55,7 @@ public class XMLAnnotationTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder parser = factory.newDocumentBuilder();
-    Document document = parser.parse(
+    Document document = XMLTools.parseDOM(
         this.getClass().getResourceAsStream("XMLAnnotationTest.ome"));
     OMEModel model = new OMEModelImpl();
     // Read string XML in as a DOM tree and parse into the object hierarchy

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.1.2</ome-common.version>
+    <ome-common.version>6.2.0</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.5.3</ome-model.version>
     <ome-poi.version>5.3.11</ome-poi.version>


### PR DESCRIPTION
See #4400.

`git grep DocumentBuilderFactory` in this repo should be empty with this PR. Tests are expected to continue passing.

This is not sufficient to fully address #4400, but is the first of two steps. The next step is to update the `DocumentBuilderFactory` configuration in relevant `XMLTools` methods (in a PR against https://github.com/ome/ome-common-java).