### PR TITLE
Open NetcdfFile from a RandomAccessFile instead of a String path

### DIFF
--- a/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
@@ -47,6 +47,7 @@ import ucar.nc2.Group;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Variable;
+import ucar.unidata.io.RandomAccessFile;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
@@ -79,6 +80,8 @@ public class NetCDFServiceImpl extends AbstractService
 
   /** NetCDF file instance. */
   private NetcdfFile netCDFFile;
+
+  private RandomAccessFile raf;
 
   /** Root of the NetCDF file. */
   private Group root;
@@ -219,10 +222,14 @@ public class NetCDFServiceImpl extends AbstractService
   @Override
   public void close() throws IOException {
     if (netCDFFile != null) netCDFFile.close();
+    if (raf != null) {
+      raf.close();
+    }
     currentFile = null;
     attributeList = null;
     variableList = null;
     netCDFFile = null;
+    raf = null;
     root = null;
   }
 
@@ -308,7 +315,9 @@ public class NetCDFServiceImpl extends AbstractService
     };
     System.setOut(throwaway);
     throwaway.close();
-    netCDFFile = NetcdfFiles.open(currentId);
+
+    raf = RandomAccessFile.acquire(currentId);
+    netCDFFile = NetcdfFiles.open(raf, currentId, null, null);
     System.setOut(outStream);
     root = netCDFFile.getRootGroup();
   }


### PR DESCRIPTION
Works around https://github.com/Unidata/netcdf-java/issues/1492, which is not yet released.

To test, use `curated/imaris/generated/filename-test/`, which includes an .ims file that was renamed to include `#`. Without this change, `showinf` should throw `FileNotFoundException`. With this change, `showinf` should read the file without error.