### PR TITLE
fix: Fix null pointer exception on reopen (for some readers)

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -946,9 +946,11 @@ public abstract class FormatReader extends FormatHandler
   /* @see IFormatReader#close(boolean) */
   @Override
   public void close(boolean fileOnly) throws IOException {
-    if (in != null) in.close();
-    if (!fileOnly) {
+    if (in != null) {
+      in.close();
       in = null;
+    }
+    if (!fileOnly) {
       currentId = null;
       resolution = 0;
       core = null;


### PR DESCRIPTION
Hello!  my first PR here so please put me in my place if i'm suggesting something stupid :)

Over in https://github.com/imaging-formats/bffile I'm working on a new python wrapper for bio-formats (essentially an improved variant of the one contributed a while back to aicsimageio/bioio).  As I was playing with some patterns I hit a `java.lang.java.lang.NullPointerException` upon calling `reopenFile()`, after having called `close()` with `fileOnly=True`.

After some time with claude I came to this fix, but it touches the actual FormatReader base...  I'll give you the full conversation we had here just so you can see my understanding (and naiveté 😄 )

<details>

I asked it:

  - DOES FormatReader.close definitely have a bug?  (or is it more complicated)\                                                                              
  - if it DOES have a bug, would fixing it in FormatReader be a rather risky maneuver, given how many things use it?  (or is setting in= null pretty safe)\   
  - if not, are there any other readers besides MinimalTiffReader that might be impacted, and what SHOULD be the fix?     
 
----

it said:

1. Does FormatReader.close definitely have a bug?

  YES, there is a clear bug. Here's the evidence:

  FormatReader.close(boolean fileOnly) (lines 946-956):
```
  @Override
  public void close(boolean fileOnly) throws IOException {
    if (in != null) in.close();  // ← Closes the stream
    if (!fileOnly) {
      in = null;                  // ← Only nulls when fileOnly=false
      currentId = null;
      resolution = 0;
      core = null;
    }
  }
```

  The Bug: When close(fileOnly=true) is called, the stream is closed but in is NOT set to null. This leaves in pointing to a closed RandomAccessInputStream
  object.

  Why This Matters:
  - MinimalTiffReader.initTiffParser() (line 698) checks if (in == null) to decide whether to create a new stream
  - After close(fileOnly=true), this check fails because in != null (it's just closed, not null)
  - The code tries to use the closed stream, causing errors

  2. Would fixing it in FormatReader be risky?

  NO, fixing it in FormatReader would be quite safe. Here's why:

  I examined all the reopenFile() implementations in the codebase (~186 readers total). They fall into three patterns:

  Pattern 1: Don't check, just recreate (TileJPEGReader, ICSReader, etc.):
```
  public void reopenFile() throws IOException {
    if (in != null) { in.close(); }
    in = new RandomAccessInputStream(currentId);
  }
```
  ✅ Would work fine with the fix (harmless to close null, and they recreate regardless)

  Pattern 2: Explicitly null first (MinimalTiffReader):
```
  public void reopenFile() throws IOException {
    in = null;  // ← Explicitly sets to null
    initTiffParser();
  }
```
  ✅ Would work fine with the fix (they already expect this behavior)

  Pattern 3: Delegate to super (FlowSightReader, OMETiffReader):
```  
public void reopenFile() throws IOException {
    super.reopenFile();  // ← Calls FormatReader.reopenFile()
    // ... additional logic
  }
```
  ✅ Would work fine with the fix (they rely on base class behavior)

  Conclusion: 
Adding in = null after in.close() in FormatReader.close(fileOnly=true) is safe and would not break any existing readers. In fact, it would fix
  latent bugs in multiple readers.

  3. Which readers are impacted?

  Potentially Affected Readers:
  - MinimalTiffReader (and all subclasses):
    - BaseTiffReader
    - SVSReader
    - OMETiffReader (partially - it has workarounds)
    - ~30+ other TIFF-based readers

  Any reader that uses an initialization pattern like:
```
  protected void initSomething() {
    if (in == null) {
      in = new RandomAccessInputStream(...);
    }
    // use in
  }
```
  Actual Impact in Practice:
  - Most readers don't encounter this because they don't use close(fileOnly=true) followed by reopenFile()
  - The bug only manifests when:
    a. close(fileOnly=true) is called
    b. Then reopenFile() or similar initialization is called
    c. The initialization checks if (in == null) before creating a stream

  ---
  Summary

  1. YES, FormatReader.close() has a bug when fileOnly=true
  2. NO, fixing it in FormatReader is NOT risky - it's actually the safest approach
  3. Multiple readers are potentially impacted, especially TIFF-based ones
  4. The proper fix is a one-line change in FormatReader.close() to set in = null after closing

  The current workaround in MinimalTiffReader (setting in = null in reopenFile()) masks the bug but doesn't fix the root cause. Fixing it in FormatReader would be
   the cleanest, safest, and most maintainable solution.

</details>


After making this change, all tests continued passing, and reopening SVS also passed.  Happy to have it rejected or modified of course 👍 