### PR TITLE
ImageReader: do not check file handle for in-memory sources

### DIFF
--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -179,7 +179,7 @@ public class ImageReader implements IFormatReader {
 
    // NB: Check that we can generate a valid handle for the ID;
    // e.g., for files, this will throw an exception if the file is missing.
-   if (!fake && !omero) {
+   if (!fake && !omero && !Location.getIdMap().containsKey(id)) {
      Location.checkValidId(id);
      if (new Location(id).length() == 0) {
        LOGGER.error("File has length 0 and may be corrupt");


### PR DESCRIPTION
Fixes #4413 

If a file has been mapped into memory via the `Location.mapFile()` API, skip the location checks entirely instead of printing an ERROR level warning