### PR TITLE
Remove explicit aircompressor dependency from formats-gpl

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -100,11 +100,6 @@
       <artifactId>kryo</artifactId>
       <version>${kryo.version}</version>
     </dependency>
-    <dependency>
-      <groupId>io.airlift</groupId>
-      <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
-    </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
 


### PR DESCRIPTION
This should be inherited from ome-codecs. No impact expected, but watch for any test failures, especially in the Imaris HDF LZ4 sample data.