### PR TITLE
VSI: recognize calibration function tag

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -309,6 +309,7 @@ public class CellSensReader extends FormatReader {
   private static final int CONTRAST_BRIGHTNESS = 10047;
   private static final int ACQUISITION_PROPERTIES = 10048;
   private static final int GRADIENT_LUT = 10065;
+  private static final int CALIBRATION = 20051;
 
   // Stack types
   private static final int DEFAULT_IMAGE = 0;
@@ -2099,6 +2100,8 @@ public class CellSensReader extends FormatReader {
         return "Objective Working Distance ";
       case TIME_VALUE:
         return "Timestamp ";
+      case CALIBRATION:
+        return "Calibration Function ";
     }
     LOGGER.debug("Unhandled volume {}", tag);
     return "";


### PR DESCRIPTION
Fixes #4398.

The two deconvolved datasets in https://zenodo.org/records/18163893 (`*MLE.vsi`) should now have a `Calibration Function Value` key in the original metadata, instead of the calibration data being stored in an opaque `Value #n` key. The two original datasets should not have this original metadata key at all, as expected.