### PR TITLE
Update to ome-codecs 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <ome-poi.version>5.3.11</ome-poi.version>
     <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
     <ome-jai.version>0.1.5</ome-jai.version>
-    <ome-codecs.version>1.1.2</ome-codecs.version>
+    <ome-codecs.version>1.1.3</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.3</xalan.version>
     <sqlite.version>3.49.1.0</sqlite.version>


### PR DESCRIPTION
See https://github.com/ome/ome-codecs/releases/tag/v1.1.3.

No test failures expected since the ome-codecs merge build is now included in repository tests, but this should be included in at least one successful nightly build before merging just to be safe.