### PR TITLE
VSI: surface CALIBRATION lookup table as named slope/origin/final keys

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1862,6 +1862,37 @@ public class CellSensReader extends FormatReader {
                     pyramid.originY = doubleValues[1];
                   }
                 }
+                else if (tag == VALUE
+                  && "Calibration Function ".equals(tagPrefix)
+                  && realType == DOUBLE_2
+                  && nDoubleValues >= 4
+                  && (nDoubleValues % 2) == 0)
+                {
+                  // Tag 20051 (CALIBRATION) sub-volumes carry a piecewise-
+                  // linear lookup table mapping a raw axis (e.g. uint16
+                  // pixel value) to a calibrated axis (e.g. Z position in
+                  // micrometres for DSX EFI height maps, or intensity in
+                  // counts for deconvolved fluorescence images). The LUT
+                  // is stored as (raw, calibrated) DOUBLE_2 pairs and is
+                  // linear, so a single (slope, origin) suffices to
+                  // reconstruct the mapping. Surface those summary values
+                  // as named metadata so downstream tools can convert
+                  // pixel values to calibrated units without reparsing
+                  // the full table from a long string.
+                  int nPairs = nDoubleValues / 2;
+                  double rawFirst = doubleValues[0];
+                  double calFirst = doubleValues[1];
+                  double rawLast  = doubleValues[2 * (nPairs - 1)];
+                  double calLast  = doubleValues[2 * (nPairs - 1) + 1];
+                  double dRaw = rawLast - rawFirst;
+                  if (dRaw != 0) {
+                    double slope = (calLast - calFirst) / dRaw;
+                    addGlobalMeta("Calibration Function Slope", slope);
+                    addGlobalMeta("Calibration Function Origin", calFirst);
+                    addGlobalMeta("Calibration Function Final", calLast);
+                    addGlobalMeta("Calibration Function NPoints", nPairs);
+                  }
+                }
                 break;
               case RGB:
                 int red = vsi.read();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 
 import loci.common.ByteArrayHandle;
+import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
@@ -1885,7 +1886,7 @@ public class CellSensReader extends FormatReader {
                   double rawLast  = doubleValues[2 * (nPairs - 1)];
                   double calLast  = doubleValues[2 * (nPairs - 1) + 1];
                   double dRaw = rawLast - rawFirst;
-                  if (dRaw != 0) {
+                  if (Math.abs(dRaw) > Constants.EPSILON) {
                     double slope = (calLast - calFirst) / dRaw;
                     addGlobalMeta("Calibration Function Slope", slope);
                     addGlobalMeta("Calibration Function Origin", calFirst);


### PR DESCRIPTION
Refs: #4398, #4417.

Tag 20051 contains a linear `(raw, calibrated)` lookup table. PR #4417 named the tag but didn't extract anything from it. A linear LUT is a slope and an offset. Two numbers. This patch writes them out as scalar keys.

Four new keys:

- `Calibration Function Slope`: `(cal_last - cal_first) / (raw_last - raw_first)`
- `Calibration Function Origin`: cal at the first raw point
- `Calibration Function Final`: cal at the last raw point
- `Calibration Function NPoints`

For DSX-2000 EFI height maps, Slope is the µm-per-uint16-count factor that converts a height-map pixel value to absolute Z. Without it, height-map TIFFs out of `bfconvert` are uncalibrated.

## Code

+31 lines, 0 deletions. Single case in `CellSensReader.java::readTags`, in the existing `DOUBLE_2` branch. Gated on:

```java
tag == VALUE
&& "Calibration Function ".equals(tagPrefix)
&& realType == DOUBLE_2
&& nDoubleValues >= 4
&& (nDoubleValues % 2) == 0
```

Doesn't run on files without the tag. Doesn't modify the existing string-form output.

## Validation

README pull-request testing checklist:

- Branch merges cleanly into the current `develop` (verified via `git merge-tree`).
- `ant clean jars tools`: BUILD SUCCESSFUL, 31s.
- Maven build: BUILD SUCCESS.
- `ant test`: 1833 tests across all phases (unit, long-running, no-ome-xml, no-exif, no-jhdf, spec). 0 failures, 0 skips. 3m35s.
- No Java 1.8+ syntax (the patch is plain `if/else` with primitives and `String.equals`).
- `showinf` end-to-end on representative `.vsi` files (see below).

`showinf` on the public CellSens samples at `downloads.openmicroscopy.org/images/CellSens/`:

- Deconvolved MLE files, the #4398 case: `Slope=1.290, Origin=47.23, Final=84606, NPoints=2`.
- Un-deconvolved siblings: silent.
- Evident BF and FL_3D: `Slope=0.1, Origin=-3276.8` (16-bit display LUT).
- metadataTest_01: silent.

`showinf` on 10 DSX-2000 EFI height-map `.vsi` files from a polymer-composite study I'm running. Each produces the four-scalar quartet. For the 40× porestack:

```
Calibration Function NPoints: 385
Calibration Function Origin:  14930.6
Calibration Function Final:   14738.6
Calibration Function Slope:   -0.002929732204165713
```

EFI scan range = 192 µm. Cross-checked against a from-scratch binary parser of the same file. Agrees to 6 decimals.

## Notes

I don't have access to the curated data repo, so `ant test-automated` against the full corpus is what I need from you.

Happy to upload a representative DSX file to the [Bio-Formats Zenodo community](https://zenodo.org/communities/bio-formats). Polymer composite, 314 KB `.vsi` plus 6 MB `.ets`, no biological content.

The existing string-form `Calibration Function Value` key is still silently dropped on some files by the filter around line 1997. The summary keys here come through unconditionally because they call `addGlobalMeta` directly. Fixing the underlying filter touches a hotter code path. Out of scope.

cc @melissalinkert (touched the same code in #4417)