### PR TITLE
Require Java 11 at runtime, build on Java 21/25

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -7,13 +7,13 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -23,8 +23,8 @@ jobs:
             ant docs
       - name: Upload artifacts
         # upload just one set of artifacts for easier PR review
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
-        uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '21'
+        uses: actions/upload-artifact@v7
         with:
           path: artifacts/
           retention-days: 30

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - java: '21'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - java: '21'
@@ -22,9 +22,9 @@ jobs:
     env:
       maven_commands: install # default is install
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -36,7 +36,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Retrieve version
         id: get_version
         run: |
@@ -51,9 +51,9 @@ jobs:
               echo server='ome.releases' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: 8
+          java-version: 21
           distribution: 'zulu'
           server-id: ${{ steps.set_server.outputs.server }}
           server-username: MAVEN_USERNAME
@@ -69,7 +69,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Retrieve version
         id: get_version
         run: |
@@ -84,9 +84,9 @@ jobs:
             echo server='ome.releases' >> $GITHUB_OUTPUT
           fi
       - name: Set up Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: 8
+          java-version: 21
           distribution: 'zulu'
           server-id: ${{ steps.set_server.outputs.server }}
           server-username: MAVEN_USERNAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     name: Release artifacts
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: 8
+          java-version: 21
           distribution: 'zulu'
       - name: Build artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ following before submitting a pull request:
  * verify that the branch merges cleanly into ```develop```
  * verify that the branch compiles with the ```clean jars tools``` Ant targets
  * verify that the branch compiles using Maven
- * verify that the branch does not use syntax or API specific to Java 1.8+
+ * verify that the branch does not use syntax or API specific to Java > 11
  * run the unit tests (```ant test```) and correct any failures
  * test at least one file in each affected format, using the ```showinf```
    command

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -293,7 +293,7 @@ your FindBugs installation's lib directory. E.g.:
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/8/docs/api/"/>
+      <link href="http://docs.oracle.com/javase/11/docs/api/"/>
       <link href="https://imagej.net/developer/api/"
             offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -293,7 +293,7 @@ your FindBugs installation's lib directory. E.g.:
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/11/docs/api/"/>
+      <link href="https://docs.oracle.com/en/java/javase/11/docs/api/"/>
       <link href="https://imagej.net/developer/api/"
             offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -272,7 +272,7 @@ your FindBugs installation's lib directory. E.g.:
       <fileset dir="${utils.dir}" includes="**/*.class"/>
     </delete>
     <javac debug="true" includeantruntime="false" fork="true"
-      deprecation="true" source="1.8" target="1.8"
+      deprecation="true" source="11" target="11"
       encoding="UTF-8"
       srcdir="${utils.dir}" includes="**/*.java"
       classpath="${artifact.dir}/${component.jar}">

--- a/components/bio-formats-plugins/build.properties
+++ b/components/bio-formats-plugins/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats_plugins
 component.jar            = bio-formats_plugins.jar
 component.version        = ${release.version}
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
@@ -106,9 +106,9 @@ public final class LibraryChecker {
 
   /** Checks for a new enough version of the Java Runtime Environment. */
   public static boolean checkJava() {
-    if (!IJ.isJava18()) {
+    if (IJ.javaVersion() < 11) {
       IJ.error("Bio-Formats Plugins",
-        "Sorry, the Bio-Formats plugins require Java 1.8 or later.");
+        "Sorry, the Bio-Formats plugins require Java 11 or later.");
       return false;
     }
     return true;

--- a/components/bio-formats-tools/build.properties
+++ b/components/bio-formats-tools/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats-tools
 component.jar            = bio-formats-tools.jar
 component.version        = ${release.version}
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -41,7 +41,7 @@ Type "ant -p" for a list of targets.
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/11/docs/api/"/>
+      <link href="https://docs.oracle.com/en/java/javase/11/docs/api/"/>
       <link href="https://imagej.net/developer/api/"
             offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -41,7 +41,7 @@ Type "ant -p" for a list of targets.
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/8/docs/api/"/>
+      <link href="http://docs.oracle.com/javase/11/docs/api/"/>
       <link href="https://imagej.net/developer/api/"
             offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>

--- a/components/forks/turbojpeg/build.properties
+++ b/components/forks/turbojpeg/build.properties
@@ -9,7 +9,7 @@
 component.name           = turbojpeg
 component.jar            = turbojpeg.jar
 component.version        = 1.2.1
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/formats-api/build.properties
+++ b/components/formats-api/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-api
 component.jar            = formats-api.jar
 component.version        = ${release.version}
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  = 

--- a/components/formats-bsd/build.properties
+++ b/components/formats-bsd/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-bsd
 component.jar            = formats-bsd.jar
 component.version        = ${release.version}
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  = loci/formats/bio-formats-logo.png \

--- a/components/formats-gpl/build.properties
+++ b/components/formats-gpl/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-gpl
 component.jar            = formats-gpl.jar
 component.version        = ${release.version}
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  = loci/formats/bio-formats-logo.png \

--- a/components/test-suite/build.properties
+++ b/components/test-suite/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats-testing-framework
 component.jar            = bio-formats-testing-framework.jar
 component.version        = 1.0.0
-component.java-version   = 1.8
+component.java-version   = 11
 component.deprecation    = true
 
 component.resources-bin  =

--- a/config/BFSourceFormat.xml
+++ b/config/BFSourceFormat.xml
@@ -48,7 +48,7 @@
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="11"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
@@ -164,7 +164,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="11"/>
 <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
@@ -237,7 +237,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="11"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_member" value="insert"/>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.rootdir>${basedir}</project.rootdir>
     <imagej1.version>1.54c</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
-    <logback.version>1.3.16</logback.version>
+    <logback.version>1.5.34</logback.version>
     <ome-stubs.version>6.0.3</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
     <ome-metakit.version>5.3.10</ome-metakit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,20 +41,20 @@
     <imagej1.version>1.54c</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <logback.version>1.5.34</logback.version>
-    <ome-stubs.version>6.0.3</ome-stubs.version>
+    <ome-stubs.version>6.1.0</ome-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.10</ome-metakit.version>
+    <ome-metakit.version>5.4.0</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
     <ome-common.version>6.3.0</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
-    <ome-model.version>6.5.3</ome-model.version>
-    <ome-poi.version>5.3.11</ome-poi.version>
-    <ome-mdbtools.version>5.3.4</ome-mdbtools.version>
-    <ome-jai.version>0.1.5</ome-jai.version>
-    <ome-codecs.version>1.1.3</ome-codecs.version>
+    <ome-model.version>6.6.0</ome-model.version>
+    <ome-poi.version>5.4.0</ome-poi.version>
+    <ome-mdbtools.version>5.4.0</ome-mdbtools.version>
+    <ome-jai.version>0.2.0</ome-jai.version>
+    <ome-codecs.version>1.2.0</ome-codecs.version>
     <jxrlib.version>0.2.4</jxrlib.version>
     <xalan.version>2.7.3</xalan.version>
     <sqlite.version>3.49.1.0</sqlite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
             <use>false</use>
             <links>
               <!-- Java 8 -->
-              <link>http://docs.oracle.com/javase/8/docs/api/</link>
+              <link>http://docs.oracle.com/javase/11/docs/api/</link>
 
               <!-- ImageJ1 -->
               <link>http://jenkins.imagej.net/job/ImageJ1-javadoc/javadoc/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <sqlite.version>3.49.1.0</sqlite.version>
 
     <!-- Maven plugin versions -->
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -278,8 +278,8 @@
                  http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5101868 -->
             <use>false</use>
             <links>
-              <!-- Java 8 -->
-              <link>http://docs.oracle.com/javase/11/docs/api/</link>
+              <!-- Java 11 -->
+              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
 
               <!-- ImageJ1 -->
               <link>http://jenkins.imagej.net/job/ImageJ1-javadoc/javadoc/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
     <ome-metakit.version>5.4.0</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
-    <slf4j.version>2.0.9</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
     <ome-common.version>6.3.0</ome-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -211,11 +211,11 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
-          <!-- Require the Java 8 platform. -->
+          <!-- Require the Java 11 platform. -->
           <configuration>
-            <source>8</source>
-            <target>8</target>
-            <release>8</release>
+            <source>11</source>
+            <target>11</target>
+            <release>11</release>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <slf4j.version>2.0.9</slf4j.version>
     <kryo.version>5.4.0</kryo.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>6.2.1</ome-common.version>
+    <ome-common.version>6.3.0</ome-common.version>
     <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>6.5.3</ome-model.version>
     <ome-poi.version>5.3.11</ome-poi.version>


### PR DESCRIPTION
See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html.

Build is expected to fail here for now, as components are not yet updated to Java 11 (see e.g. https://github.com/ome/ome-metakit/pull/33). Component versions can be updated here as they are released though.