### PR TITLE
Check for null when calling TiffParser.checkHeader()

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -126,7 +126,12 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
       long[] allOffsets = null;
       try (RandomAccessInputStream in = new RandomAccessInputStream(id)) {
         TiffParser parser = new TiffParser(in);
-        littleEndian = parser.checkHeader();
+        Boolean writtenLittleEndian = parser.checkHeader();
+        if (writtenLittleEndian == null) {
+          // this would be extremely unexpected
+          throw new IOException("Endian check failed on written data");
+        }
+        littleEndian = writtenLittleEndian;
         allOffsets = parser.getIFDOffsets();
       }
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -114,7 +114,10 @@ public class TiffParser implements Closeable {
     doCaching = true;
     try {
       long fp = in.getFilePointer();
-      checkHeader();
+      Boolean littleEndian = checkHeader();
+      if (littleEndian == null) {
+        LOGGER.error("Endian check failed, this may be an invalid file");
+      }
       in.seek(fp);
     }
     catch (IOException e) { }

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
@@ -73,6 +73,7 @@ public class TiffParserTest {
   @Test
   public void testHeader() throws IOException {
     assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertTrue(tiffParser.checkHeader());
     assertFalse(tiffParser.isBigTiff());
   }
@@ -178,6 +179,8 @@ public class TiffParserTest {
   public void testNonUniformRowsPerStrip() throws IOException, FormatException {
     mock = new NonUniformRowsPerStripMock();
     tiffParser = mock.getTiffParser();
+    assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertTrue(tiffParser.checkHeader());
     tiffParser.getFirstIFD().getRowsPerStrip();
     mock.close();
@@ -187,6 +190,8 @@ public class TiffParserTest {
   public void testBitsPerSampleMismatch() throws IOException, FormatException {
     mock = new BitsPerSampleSamplesPerPixelMismatchMock();
     tiffParser = mock.getTiffParser();
+    assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertTrue(tiffParser.checkHeader());
     IFD ifd = tiffParser.getFirstIFD();
     int[] bitsPerSample = ifd.getBitsPerSample();

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
@@ -117,6 +117,7 @@ public class TiffSaverTest {
   public void testWriteHeaderBigEndianRegularTiff() throws IOException {
     tiffSaver.writeHeader();
     assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertFalse(tiffParser.checkHeader());
     assertFalse(tiffParser.isBigTiff());
   }
@@ -126,6 +127,7 @@ public class TiffSaverTest {
     tiffSaver.setLittleEndian(true);
     tiffSaver.writeHeader();
     assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertTrue(tiffParser.checkHeader());
     assertFalse(tiffParser.isBigTiff());
   }
@@ -136,6 +138,7 @@ public class TiffSaverTest {
     tiffSaver.setBigTiff(true);
     tiffSaver.writeHeader();
     assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertFalse(tiffParser.checkHeader());
     assertTrue(tiffParser.isBigTiff());
   }
@@ -146,6 +149,7 @@ public class TiffSaverTest {
     tiffSaver.setBigTiff(true);
     tiffSaver.writeHeader();
     assertTrue(tiffParser.isValidHeader());
+    // isValidHeader above makes sure that checkHeader is non-null
     assertTrue(tiffParser.checkHeader());
     assertTrue(tiffParser.isBigTiff());
   }

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -772,7 +772,11 @@ public class LeicaReader extends FormatReader {
 
       in = new RandomAccessInputStream(baseFile, 16);
       TiffParser tp = new TiffParser(in);
-      in.order(tp.checkHeader().booleanValue());
+      Boolean littleEndian = tp.checkHeader();
+      if (littleEndian == null) {
+        throw new FormatException("Invalid TIFF file");
+      }
+      in.order(littleEndian.booleanValue());
 
       in.seek(0);
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1170,7 +1170,10 @@ public class MetamorphReader extends BaseTiffReader {
               }
               stream = new RandomAccessInputStream(file, 16);
               tp = new TiffParser(stream);
-              tp.checkHeader();
+              Boolean tiffLittleEndian = tp.checkHeader();
+              if (tiffLittleEndian == null) {
+                throw new FormatException("Invalid TIFF file: " + file);
+              }
               IFDList f = tp.getMainIFDs();
               if (f.size() > 0) {
                 lastFile = fileIndex;

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -491,6 +491,9 @@ public class ZeissLSMReader extends FormatReader {
         int count = seriesCounts.get(lsmFilenames[i]);
         TiffParser tp = new TiffParser(stream);
         Boolean littleEndian = tp.checkHeader();
+        if (littleEndian == null) {
+          throw new FormatException("Invalid TIFF file: " + lsmFilenames[i]);
+        }
         long[] ifdOffsets = tp.getIFDOffsets();
         int ifdsPerSeries = (ifdOffsets.length / 2) / count;
 


### PR DESCRIPTION
Fixes #4232.

Most calls to `checkHeader` already check for a `null` return value, or follow a call to `isValidHeader` which checks for `null` itself. In the few remaining cases here, the changes are mostly throwing a more informative exception, or logging an error when that isn't reasonable. `checkHeader` returning `null` implies that the TIFF file is invalid, so throwing an exception of some kind is usually appropriate.

This should not be a breaking change, and is not expected to have any impact on tests.