### PR TITLE
Remove unnecessary dead store to local variable

### DIFF
--- a/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
+++ b/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
@@ -350,7 +350,6 @@ public class DicomTag implements Comparable<DicomTag> {
         if (in.getFilePointer() + skipCount <= in.length()) {
           in.skipBytes(skipCount);
         }
-        location += elementLength;
         value = "";
       }
     }


### PR DESCRIPTION
Fixes #4235.

I am pretty sure this is not breaking, but we'll want to keep an eye out for test failures in tonight's build. It's probably also worth double-checking that converting one or two datasets to DICOM works as before; I tried `bfconvert -noflat CMU-1.svs CMU-1.dcm -compression JPEG` without issue, but an extra check can't hurt.

A more-breaking change would be to deprecate/remove the `location` variable from the constructors, but I'm not 100% certain that's what we want. Leaving the possibility of using `location` at a later date may still be useful.
