### PR TITLE
xmlvalid cleanup

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
@@ -66,7 +66,13 @@ public class XMLValidate {
     } finally {
       in.close();
     }
-    return XMLTools.validateXML(sb.toString(), label, OMEXMLServiceImpl.SCHEMA_CLASSPATH_READER);
+    return validate(sb.toString(), label);
+  }
+
+  public static boolean validate(String xml, String label)
+    throws IOException
+  {
+    return XMLTools.validateXML(xml, label, OMEXMLServiceImpl.SCHEMA_CLASSPATH_READER);
   }
 
   @Deprecated
@@ -103,7 +109,7 @@ public class XMLValidate {
             try (RandomAccessInputStream stream = new RandomAccessInputStream(file)) {
               comment = new TiffParser(stream).getComment();
             }
-            results[i] = validate(new BufferedReader(new StringReader(comment)), file);
+            results[i] = validate(comment, file);
           } else {
             results[i] = validate(new BufferedReader(new InputStreamReader(
                       new FileInputStream(file), Constants.ENCODING)), file);

--- a/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/XMLValidate.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -115,28 +116,34 @@ public class XMLValidate {
   public static void main(String[] args) throws Exception {
     CommandLineTools.runUpgradeCheck(args);
 
-    boolean result = true;
-    if (args.length == 0) {
+    boolean success = true;
+    if (args.length == 0 ||
+      (args.length == 1 && args[0].equals(CommandLineTools.NO_UPGRADE_CHECK)))
+    {
       // read from stdin
-      result = validate(new BufferedReader(
+      success = validate(new BufferedReader(
                 new InputStreamReader(System.in, Constants.ENCODING)), "<stdin>");
     }
     else {
-      // read from file(s)
-      boolean[] results = validate(args);
-      int count = 0;
-      for (int i = 0; i < results.length; i++) {
-        if (results[i]) {
-          count++;
+      ArrayList<String> filesToValidate = new ArrayList<String>();
+      for (String arg : args) {
+        if (!arg.equals(CommandLineTools.NO_UPGRADE_CHECK)) {
+          filesToValidate.add(arg);
         }
       }
-      //Check if all files are valid
-      result = (count == results.length);
+      // read from file(s)
+      boolean[] results = validate(filesToValidate.toArray(new String[0]));
+      for (boolean result : results) {
+        if (!result) {
+          success = false;
+          break;
+        }
+      }
     }
-    if (result) {
+    if (success) {
       System.exit(0);
     } else {
-      System.exit(1); 
+      System.exit(1);
     }
   }
 


### PR DESCRIPTION
Fixes #4432 and simplifies some of the existing logic.

With this change, basic `xmlvalid` usage should continue to work, e.g. `xmlvalid file.ome.tiff`, `xmlvalid file.ome.xml`, `cat file.ome.xml | xmlvalid`.

In addition, usage of the `-no-upgrade` option should no longer cause a problem. `xmlvalid -no-upgrade file.ome.xml` previously did not work, but now should validate `file.ome.xml`. Similarly, `cat file.ome.xml | xmlvalid -no-upgrade` should validate stdin instead of showing an error that `-no-upgrade` does not exist.