### PR TITLE
Allow slices to be deleted from a virtual stack

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
@@ -274,9 +274,31 @@ public class BFVirtualStack extends VirtualStack {
   @Override
   public int getSize() {
     if (reader.getCurrentFile() == null) return 0;
+    if (planeIndexes != null) {
+      return planeIndexes.length;
+    }
     reader.setSeries(series);
     if (merge) return new ChannelMerger(reader).getImageCount();
     return planeIndexes == null ? reader.getImageCount() : planeIndexes.length;
+  }
+
+  @Override
+  public void deleteSlice(int n) {
+    if (planeIndexes == null) {
+      planeIndexes = new int[getSize() - 1];
+      for (int i=0; i<planeIndexes.length; i++) {
+        planeIndexes[i] = i;
+        if (i >= n - 1) {
+          planeIndexes[i]++;
+        }
+      }
+    }
+    else {
+      int[] newPlaneIndexes = new int[planeIndexes.length - 1];
+      System.arraycopy(planeIndexes, 0, newPlaneIndexes, 0, n - 1);
+      System.arraycopy(planeIndexes, n, newPlaneIndexes, n - 1, planeIndexes.length - n);
+      planeIndexes = newPlaneIndexes;
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #4004.

To test in ImageJ, open any file with multiple planes using `Plugins > Bio-Formats > Bio-Formats Importer` with `Use virtual stack` checked. Move the slider to any plane, and select `Image > Stacks > Delete Slice`. The stack size should decrease appropriately, and moving the slider through all planes should work as expected without error. Deleting additional slices from the same stack should also work.

As an initial test, it might be worth using one of the datasets in https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/bioformats-artificial/, as those have plane indexes visible on each image, so it should be easy to see if the correct planes are being read after deletion.