### PR TITLE
Remove unnecessary negative checks

### DIFF
--- a/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
+++ b/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
@@ -497,8 +497,8 @@ public class DicomTag implements Comparable<DicomTag> {
         int n2 = DataTools.bytesToShort(b, 2, 2, !in.isLittleEndian());
         n1 &= 0xffff;
         n2 &= 0xffff;
-        if (n1 < 0 || n1 + in.getFilePointer() > in.length()) return n2;
-        if (n2 < 0 || n2 + in.getFilePointer() > in.length()) return n1;
+        if (n1 + in.getFilePointer() > in.length()) return n2;
+        if (n2 + in.getFilePointer() > in.length()) return n1;
         return n1;
       case RESERVED:
         int len = DataTools.bytesToInt(b, 0, 4, in.isLittleEndian());

--- a/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
+++ b/components/formats-bsd/src/loci/formats/dicom/DicomTag.java
@@ -493,10 +493,8 @@ public class DicomTag implements Comparable<DicomTag> {
         if (attribute == LUT_DATA) {
           return DataTools.bytesToInt(b, 2, 2, in.isLittleEndian());
         }
-        int n1 = DataTools.bytesToShort(b, 2, 2, in.isLittleEndian());
-        int n2 = DataTools.bytesToShort(b, 2, 2, !in.isLittleEndian());
-        n1 &= 0xffff;
-        n2 &= 0xffff;
+        int n1 = DataTools.bytesToInt(b, 2, 2, in.isLittleEndian());
+        int n2 = DataTools.bytesToInt(b, 2, 2, !in.isLittleEndian());
         if (n1 + in.getFilePointer() > in.length()) return n2;
         if (n2 + in.getFilePointer() > in.length()) return n1;
         return n1;


### PR DESCRIPTION
Fixes #4393.

The fix proposed in #4393 results in several files failing to initialize. This change preserves the existing working behavior, but removes the negativity checks on `n1` and `n2` that are expected to always fail.

This passed tests on all of the DICOM files I have locally, but waiting for a successful nightly build before assigning review.