### PR TITLE
Leica SCN: update list of scanner models without color correction

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -74,7 +74,9 @@ public class LeicaSCNReader extends BaseTiffReader {
   private static final String SCHEMA_2010_10 =
     "http://www.leica-microsystems.com/scn/2010/10/01";
 
-  private static final String[] MODELS_WITHOUT_CORRECTION = {"versa", "leica scn400"};
+  private static final String[] MODELS_WITHOUT_CORRECTION = {
+    "versa", "leica scn400", "aperio leica biosystems fl"
+  };
 
   // -- Fields --
   LeicaSCNHandler handler;


### PR DESCRIPTION
Fixes #4420.

Without this change, `showinf -noflat` on https://zenodo.org/records/19009239 should show pink images. With this change, the images should look normal.

This doesn't seem to impact existing Leica SCN test data when checking locally, but waiting for a passing nightly build before assigning for review.

I debated going ahead and adding a reader option to override the list of models as well, but I'm not sure how useful that would end up being in general. Thoughts welcome.