### PR TITLE
BDV: store relative path instead of absolute

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BDVReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BDVReader.java
@@ -154,7 +154,7 @@ public class BDVReader extends FormatReader {
     store.setXMLAnnotationValue(bdvxml, 0);
     String xml_id = MetadataTools.createLSID("XMLAnnotation", 0); 
     store.setXMLAnnotationID(xml_id, 0);
-    initializeJHDFService(h5Id);
+    initializeJHDFService(fetchH5Path());
     parseStructure();
 
     // The ImageJ RoiManager can not distinguish ROIs from different
@@ -181,6 +181,15 @@ public class BDVReader extends FormatReader {
     return xmlId;
   }
 
+  private String fetchH5Path() {
+    Location location = new Location(currentId).getAbsoluteFile();
+    Location parent = location.getParentFile();
+    if (h5Id != null) {
+      return new Location(parent, h5Id).getAbsolutePath();
+    }
+    return null;
+  }
+
   /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
@@ -193,7 +202,7 @@ public class BDVReader extends FormatReader {
         LOGGER.error("Unable to locate associated BDV XML for file: " + currentId);
       }
     }
-    return new String[] {xmlId, h5Id};
+    return new String[] {xmlId, fetchH5Path()};
   }
   
   /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
@@ -362,7 +371,7 @@ public class BDVReader extends FormatReader {
   @Override
   public void reopenFile() throws IOException {
     try {
-      initializeJHDFService(h5Id);
+      initializeJHDFService(fetchH5Path());
     }
     catch (MissingLibraryException e) {
       throw new IOException(e);
@@ -795,8 +804,7 @@ public class BDVReader extends FormatReader {
         if (currentQName.toLowerCase().equals("hdf5")) {
           String hdf5Contents = new String(ch, start, length);
           if (checkSuffix(hdf5Contents, "h5")) {
-            String parent = new Location(currentId).getAbsoluteFile().getParent();
-            h5Id = parent + File.separator + hdf5Contents;
+            h5Id = hdf5Contents;
           }
         }
         if (parsingTimepoints && currentQName.toLowerCase().equals("first")) {


### PR DESCRIPTION
Fixes #3957.

I could easily reproduce the original issue in #3957 with `curated/bdv/public/samples/`:

```
$ showinf -no-upgrade -cache HisYFP-SPIM.xml
$ mkdir tmp
$ mv HisYFP* tmp
$ mv .*.bfmemo tmp
$ cd tmp
$ $ showinf -no-upgrade -cache HisYFP-SPIM.xml 
Checking file format [BDV]
Initializing reader
Exception in thread "main" ch.systemsx.cisd.hdf5.exceptions.HDF5FileNotFoundException: Path does not exit. (/home/melissa/data/bf-data-repo/automated-tests/curated/bdv/public/samples/HisYFP-SPIM.h5)
	at ch.systemsx.cisd.hdf5.HDF5BaseReader.openFile(HDF5BaseReader.java:221)
	at ch.systemsx.cisd.hdf5.HDF5BaseReader.<init>(HDF5BaseReader.java:177)
	at ch.systemsx.cisd.hdf5.HDF5BaseReader.<init>(HDF5BaseReader.java:155)
	at ch.systemsx.cisd.hdf5.HDF5ReaderConfigurator.reader(HDF5ReaderConfigurator.java:81)
	at ch.systemsx.cisd.hdf5.HDF5FactoryProvider$HDF5Factory.openForReading(HDF5FactoryProvider.java:55)
	at ch.systemsx.cisd.hdf5.HDF5Factory.openForReading(HDF5Factory.java:62)
	at loci.formats.services.JHDFServiceImpl.setFile(JHDFServiceImpl.java:92)
	at loci.formats.in.BDVReader.initializeJHDFService(BDVReader.java:378)
	at loci.formats.in.BDVReader.reopenFile(BDVReader.java:365)
	at loci.formats.ImageReader.reopenFile(ImageReader.java:870)
	at loci.formats.Memoizer.setId(Memoizer.java:712)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:692)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1054)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1165)
```

This fix does not make it so that a pre-existing memo file will work, but does make it so that newly generated memo files no longer exhibit this problem.

I have not tried to address any more structural concerns about relative vs absolute paths in memo files that were mentioned in #3957. We likely need to discuss that internally first, given the potential impact on OMERO.