### PR TITLE
TIFF: only adjust strip/tile byte counts for uncompressed data

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -773,7 +773,7 @@ public class TiffParser implements Closeable {
       countIndex = 0;
     }
     if (stripByteCounts[countIndex] == (rowsPerStrip[0] * tileWidth) &&
-      pixel > 1)
+      pixel > 1 && compression == TiffCompression.UNCOMPRESSED)
     {
       stripByteCounts[countIndex] *= pixel;
     }


### PR DESCRIPTION
Fixes #4442.

Without this change, `showinf` on the TIFF file linked to #4442 throws:

```
Exception in thread "main" loci.formats.FormatException: io.airlift.compress.MalformedInputException: Invalid magic prefix: d: offset=16400
	at ome.codecs.ZstdCodec.decompress(ZstdCodec.java:106)
	at ome.codecs.ZstdCodec.decompress(ZstdCodec.java:85)
	at loci.formats.codec.WrappedCodec.decompress(WrappedCodec.java:86)
	at loci.formats.codec.ZstdCodec.decompress(ZstdCodec.java:37)
	at loci.formats.tiff.TiffCompression.decompress(TiffCompression.java:288)
	at loci.formats.tiff.TiffParser.getTile(TiffParser.java:845)
	at loci.formats.tiff.TiffParser.getSamples(TiffParser.java:1135)
	at loci.formats.tiff.TiffParser.getSamples(TiffParser.java:885)
	at loci.formats.in.MinimalTiffReader.openBytes(MinimalTiffReader.java:312)
	at loci.formats.in.TiffDelegateReader.openBytes(TiffDelegateReader.java:71)
	at loci.formats.FormatReader.openBytes(FormatReader.java:922)
	at loci.formats.ImageReader.openBytes(ImageReader.java:450)
	at loci.formats.ReaderWrapper.openBytes(ReaderWrapper.java:336)
	at loci.formats.gui.BufferedImageReader.openImage(BufferedImageReader.java:86)
	at loci.formats.tools.ImageInfo.readPixels(ImageInfo.java:840)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1074)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1165)
Caused by: io.airlift.compress.MalformedInputException: Invalid magic prefix: d: offset=16400
	at io.airlift.compress.zstd.ZstdFrameDecompressor.verifyMagic(ZstdFrameDecompressor.java:976)
	at io.airlift.compress.zstd.ZstdFrameDecompressor.decompress(ZstdFrameDecompressor.java:153)
	at io.airlift.compress.zstd.ZstdDecompressor.decompress(ZstdDecompressor.java:44)
	at ome.codecs.ZstdCodec.decompress(ZstdCodec.java:103)
	... 16 more
```

`tiffdump` reports:

```
test1.tif:
Magic: 0x4949 <little-endian> Version: 0x2b <BigTIFF>
OffsetSize: 0x8 Unused: 0
Directory 0: offset 16400 (0x4010) next 0 (0)
ImageWidth (256) LONG (4) 1<128>
ImageLength (257) LONG (4) 1<128>
BitsPerSample (258) SHORT (3) 1<16>
Compression (259) SHORT (3) 1<50000>
Photometric (262) SHORT (3) 1<1>
ImageDescription (270) ASCII (2) 94<ImageJ=1.11a\nimages=1\nsl ...>
SamplesPerPixel (277) SHORT (3) 1<1>
Software (305) ASCII (2) 13<tiffwrite_rs\0>
DateTime (306) ASCII (2) 20<2026:06:05 17:25:50\0>
TileWidth (322) SHORT (3) 1<128>
TileLength (323) SHORT (3) 1<128>
TileOffsets (324) SHORT (3) 1<16>
TileByteCounts (325) SHORT (3) 1<16384>
```

As I believe we do have examples of TIFF variants (Zeiss LSM?) that store uncompressed strips with byte counts that do not reflect the bytes per pixel, I did not remove the correction in line 778, but it should now be bypassed for compressed strips/tiles. With this change, `showinf` on the test file opens the image without error.