### PR TITLE
.vsi fill color fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -544,8 +544,13 @@ public class CellSensReader extends FormatReader {
       int pixel = getRGBChannelCount() * bpp;
       int outputRowLen = w * pixel;
 
+      int pyramidIndex = getCurrentPyramidIndex();
       Pyramid pyramid = getCurrentPyramid();
-      if (pyramid.fillColor != null) {
+      byte[] background = backgroundColor.get(pyramidIndex);
+      if (background != null && background.length > 0) {
+        Arrays.fill(buf, background[0]);
+      }
+      else if (pyramid.fillColor != null) {
         Arrays.fill(buf, pyramid.fillColor);
       }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -529,6 +529,7 @@ public class CellSensReader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    Arrays.fill(buf, getFillColor());
 
     if (getCoreIndex() < core.size() - 1 && getCoreIndex() < rows.size()) {
       int tileRows = rows.get(getCoreIndex());

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -545,6 +545,9 @@ public class CellSensReader extends FormatReader {
       int outputRowLen = w * pixel;
 
       Pyramid pyramid = getCurrentPyramid();
+      if (pyramid.fillColor != null) {
+        Arrays.fill(buf, pyramid.fillColor);
+      }
 
       for (int row=0; row<tileRows; row++) {
         for (int col=0; col<tileCols; col++) {
@@ -1958,6 +1961,9 @@ public class CellSensReader extends FormatReader {
               else if (tag == BLUE_OFFSET) {
                 pyramid.blueOffset = DataTools.parseDouble(value);
               }
+              else if (tag == DEFAULT_BACKGROUND_COLOR) {
+                pyramid.fillColor = Byte.parseByte(value);
+              }
               else if (tag == VALUE) {
                 if (tagPrefix.equals("Channel Wavelength ")) {
                   pyramid.channelWavelengths.add(DataTools.parseDouble(value));
@@ -2665,6 +2671,7 @@ public class CellSensReader extends FormatReader {
     public Double redOffset;
     public Double greenOffset;
     public Double blueOffset;
+    public Byte fillColor;
 
     public ArrayList<String> channelNames = new ArrayList<String>();
     public ArrayList<Double> channelWavelengths = new ArrayList<Double>();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -547,7 +547,9 @@ public class CellSensReader extends FormatReader {
       int pyramidIndex = getCurrentPyramidIndex();
       Pyramid pyramid = getCurrentPyramid();
       byte[] background = backgroundColor.get(pyramidIndex);
-      if (background != null && background.length > 0) {
+      LOGGER.trace("pyramid fill color = {}", pyramid.fillColor);
+      if (background != null && background.length > 0 && background[0] != (byte) 0xff) {
+        LOGGER.trace("background color = {}", background[0]);
         Arrays.fill(buf, background[0]);
       }
       else if (pyramid.fillColor != null) {


### PR DESCRIPTION
This is meant to make the default fill color for missing image data line up with what OlyVIA shows.

A default background color may be defined for each pyramid in the .vsi dataset. This change as written applies first applies the user-defined fill color (or 0 if not specified), then applies the pyramid fill color in the .vsi metadata (if found). This means that e.g. `showinf -fill 255 ...` will not show 255 for missing data if a pyramid fill color is found. I am open to changing the order of precedence though.

Right now just opening to see which tests might fail; I don't have specific test data just yet.