### PR TITLE
fix Nd2 wellinfo missing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -513,17 +513,14 @@ public class ND2Handler extends BaseHandler {
       else if ("dPosX".equals(prevElement) && qName.startsWith("item_")) {
         final Double number = DataTools.parseDouble(value);
         posX.add(new Length(number, UNITS.MICROMETER));
-        metadata.put("X position for position #" + posX.size(), value);
       }
       else if ("dPosY".equals(prevElement) && qName.startsWith("item_")) {
         final Double number = DataTools.parseDouble(value);
         posY.add(new Length(number, UNITS.MICROMETER));
-        metadata.put("Y position for position #" + posY.size(), value);
       }
       else if ("dPosZ".equals(prevElement) && qName.startsWith("item_")) {
         final Double number = DataTools.parseDouble(value);
         posZ.add(new Length(number, UNITS.MICROMETER));
-        metadata.put("Z position for position #" + posZ.size(), value);
       }
       else if (qName.startsWith("item_")) {
         int v = Integer.parseInt(qName.substring(qName.indexOf('_') + 1));

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -522,6 +522,9 @@ public class ND2Handler extends BaseHandler {
         final Double number = DataTools.parseDouble(value);
         posZ.add(new Length(number, UNITS.MICROMETER));
       }
+      else if (qName.equals("dPosName") && value != null && !value.isEmpty()) {
+        posNames.add(value);
+      }
       else if (qName.startsWith("item_")) {
         int v = Integer.parseInt(qName.substring(qName.indexOf('_') + 1));
         if (v == numSeries) {

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -113,6 +113,7 @@ public class ND2Reader extends SubResolutionFormatReader {
   private ArrayList<Length> posX;
   private ArrayList<Length> posY;
   private ArrayList<Length> posZ;
+  private ArrayList<String> posNames = new ArrayList<String>();
   private ArrayList<Double> exposureTime = new ArrayList<Double>();
 
   private Map<String, Integer> channelColors;
@@ -380,6 +381,7 @@ public class ND2Reader extends SubResolutionFormatReader {
       objectiveMag = null;
       objectiveModel = null;
       exposureTime.clear();
+      posNames.clear();
       positionCount = 0;
     }
   }
@@ -2233,6 +2235,9 @@ public class ND2Reader extends SubResolutionFormatReader {
         else if (name.equals("sObjective")) {
           objectiveModel = value.toString();
         }
+        else if (name.equals("pPosName") || name.equals("sPosition") || name.equals("dPosName")) {
+          posNames.add(value.toString());
+        }
 
         if (type != 11 && type != 10 && type != 9) {    // if not level add global meta
           addGlobalMeta(name, value);
@@ -2257,12 +2262,13 @@ public class ND2Reader extends SubResolutionFormatReader {
 
     String filename = new Location(getCurrentFile()).getName();
     if (handler != null) {
-      ArrayList<String> posNames = handler.getPositionNames();
+      ArrayList<String> handlerPosNames = handler.getPositionNames();
+      ArrayList<String> effectivePosNames = handlerPosNames.size() > 0 ? handlerPosNames : this.posNames;
       int nameWidth = String.valueOf(getSeriesCount()).length();
       for (int i=0; i<getSeriesCount(); i++) {
         String seriesSuffix = String.format("(series %0" + nameWidth + "d)", i + 1);
-        String suffix = (i < posNames.size() && !posNames.get(i).equals("")) ?
-          posNames.get(i) : seriesSuffix;
+        String suffix = (i < effectivePosNames.size() && !effectivePosNames.get(i).equals("")) ?
+          effectivePosNames.get(i) : seriesSuffix;
         String name = filename + " " + suffix;
         store.setImageName(name.trim(), i);
       }
@@ -2393,8 +2399,8 @@ public class ND2Reader extends SubResolutionFormatReader {
     }
     int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
     for (int i=0; i<getSeriesCount(); i++) {
+      setSeries(i);
       if (tsT.size() > 0) {
-        setSeries(i);
         for (int n=0; n<getImageCount(); n++) {
           int[] coords = getZCTCoords(n);
           int stampIndex = coords[0];
@@ -2435,6 +2441,14 @@ public class ND2Reader extends SubResolutionFormatReader {
         if (posX == null) posX = handler.getXPositions();
         if (posY == null) posY = handler.getYPositions();
         if (posZ == null) posZ = handler.getZPositions();
+        ArrayList<String> handlerPosNames = handler.getPositionNames();
+        ArrayList<String> seriesPosNames = handlerPosNames.size() > 0 ? handlerPosNames : this.posNames;
+        if (i < seriesPosNames.size() && !seriesPosNames.get(i).equals("")) {
+          addSeriesMeta("Position name", seriesPosNames.get(i));
+        }
+      }
+      else if (i < this.posNames.size() && !this.posNames.get(i).equals("")) {
+        addSeriesMeta("Position name", this.posNames.get(i));
       }
 
       String pos = "for position";

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -2269,10 +2269,14 @@ public class ND2Reader extends SubResolutionFormatReader {
       int nameWidth = String.valueOf(getSeriesCount()).length();
       for (int i=0; i<getSeriesCount(); i++) {
         String seriesSuffix = String.format("(series %0" + nameWidth + "d)", i + 1);
-        String suffix = (i < effectivePosNames.size() && !effectivePosNames.get(i).equals("")) ?
-          effectivePosNames.get(i) : seriesSuffix;
+        boolean hasPosName =
+          i < effectivePosNames.size() && !effectivePosNames.get(i).equals("");
+        String suffix = hasPosName ? effectivePosNames.get(i) : seriesSuffix;
         String name = filename + " " + suffix;
         store.setImageName(name.trim(), i);
+        if (hasPosName) {
+          store.setStageLabelName(effectivePosNames.get(i), i);
+        }
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -2236,7 +2236,9 @@ public class ND2Reader extends SubResolutionFormatReader {
           objectiveModel = value.toString();
         }
         else if (name.equals("pPosName") || name.equals("sPosition") || name.equals("dPosName")) {
-          posNames.add(value.toString());
+          if (!value.toString().isEmpty()) {
+            posNames.add(value.toString());
+          }
         }
 
         if (type != 11 && type != 10 && type != 9) {    // if not level add global meta


### PR DESCRIPTION
## Problem

Users in our facility generate ND2 files containing multiple well positions from multiwell plate acquisitions. When loaded into Fiji or imported into OMERO, the well names are lost and series appear as generic `(series 01)`, `(series 02)`, etc. ; annoying when working with HCS plate data
The Python [nd2 library](https://pypi.org/project/nd2/) parses the well metadata correctly, so I investigated whether this could be fixed in Bio-Formats as well.

The root cause turned out to be two separate issues depending on the file structure of the ND2 files:

1. **Files with a flat XY position loop** (e.g. Z-stack per well): for the ND2 files available, the position names are stored in the binary metadata under `pPosName`, which the XML parsing path (`ND2Handler`) already captured. However, the binary parsing path did not extract them at all, so files without XML metadata fell back to `(series 01)`.

2. **Files with a nested TimeLoop → XYPosLoop structure**: position names are stored under `dPosName`. The binary CLX stream contains empty-string placeholder entries for each outer-loop level, followed by the actual names — causing a misalignment between name indices and series indices. Additionally, `ND2Handler` only captured `pPosName`, not `dPosName`.

Position names were also not accessible in series metadata, as reported in #3449. The same problem, position names not read per-position, with every series taking the name/metadata of the last position, was reported on image.sc: [Position info in .nd2 file can not be retrieved correctly by Bioformat](https://forum.image.sc/t/position-info-in-nd2-file-can-not-be-retrieved-correctly-by-bioformat/109544).

I would highly appreciate feedback on this PR. I am not an advanced Java programmer and received help from Claude, but given that this would be highly valuable for our users I created this PR. I have tested with ND2 files from our facility and the fix works as expected in Fiji and when imported into OMERO.

## Changes

- **Extract position names from binary ND2 blocks**: Position names can appear under different keys depending on the NIS-Elements version (`pPosName`, `sPosition`, or `dPosName`). The binary parsing path (`iterateIn`) now captures all three key variants, skipping empty-string placeholders that appear in nested loop structures.
- **Capture `dPosName` in ND2Handler XML path**: Files with a `TimeLoop → XYPosLoop` structure store position names under `dPosName` as a direct XML attribute. `ND2Handler` now captures these alongside the existing `pPosName` list-variant handling.
- **Fix `setSeries()` call placement**: `setSeries(i)` was previously called inside a conditional block (`if (tsT.size() > 0)`), meaning it was skipped when no timestamps were present. This caused subsequent series metadata operations (position X/Y/Z, position name) to run in the wrong series context.
- **Expose the position name via OME `StageLabel` and series metadata**: each series' OME-XML now carries a `<StageLabel Name="…">` (matching the convention used by `ZeissCZIReader`), and a "Position name" entry is added to the series metadata table. The raw `pPosName`/`dPosName` keys already appear in the global (original) metadata via the standard binary dump, so no separate global-list entry is added.
- **Drop redundant global X/Y/Z entries in `ND2Handler`**: the `dPosX`/`dPosY`/`dPosZ` items were written to global metadata here *and* again by `ND2Reader`'s per-series loop (which already emits them as both series **and** global metadata). The duplicate `ND2Handler` entries are removed; `posX`/`posY`/`posZ` are still collected for plane positions, so no position data is lost.

Binary and XML sources are combined so that XML-derived names take precedence when present, falling back to the binary-derived names otherwise.

The position naming format matches the Python nd2 library — raw position names from the metadata (e.g. `A10_0000`, `A3[H2Ax_KRT19]`) are used as-is.

Relates to #3449 and #4287. This PR partially addresses #4287 by storing the position name as **series** metadata and by removing the duplicate global X/Y/Z entries in `ND2Handler`. A full migration of the remaining per-position keys from global to series metadata (`ND2Reader` still also emits X/Y/Z into global) is left out of scope here.

## Testing (`showinf` / `ImageInfo`)

Flat XY position loop — `Seq0000.nd2` (24 series):

```
<Image ID="Image:0" Name="Seq0000.nd2 A10_0000"
<StageLabel Name="A10_0000"
<Image ID="Image:1" Name="Seq0000.nd2 A11_0000"
<StageLabel Name="A11_0000"
<Image ID="Image:2" Name="Seq0000.nd2 A12_0000"
<StageLabel Name="A12_0000"
```

Nested `TimeLoop → XYPosLoop` (`dPosName`):

```
<Image ID="Image:0" Name="…1002.nd2 A3[H2Ax_KRT19]"
<StageLabel Name="A3[H2Ax_KRT19]"
<Image ID="Image:1" Name="…1002.nd2 A2[NegatieCtr]"
<StageLabel Name="A2[NegatieCtr]"
```

Names match the Python `nd2` library's `Point.name`.

## Verification checklist

- [x] Branch rebased cleanly onto current `develop`
- [x] Correct authorship and signed-off-by line
- [x] Compiles with Maven
- [x] Unit tests pass Maven and Ant 
- [x] `showinf` on flat and nested ND2 files shows correct well names + `StageLabel` (see Testing section)
- [x] Tested in Fiji: series names correctly show well names (e.g. `A10_0000`, `A3[H2Ax_KRT19]`) for both flat and nested loop ND2 files
