### PR TITLE
New CV7000 reader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -3794,8 +3794,6 @@ public class CV7000Reader extends FormatReader {
   class MinMax {
     public int minZ = Integer.MAX_VALUE;
     public int maxZ = 0;
-    public int minC = Integer.MAX_VALUE;
-    public int maxC = 0;
     public int minT = Integer.MAX_VALUE;
     public int maxT = 0;
 
@@ -3811,15 +3809,6 @@ public class CV7000Reader extends FormatReader {
       }
       if (p.z < minZ) {
         minZ = p.z;
-      }
-
-      // Min and max channel indexes are not currently used, but keeping them
-      // complete makes future CV7000/8000 channel-layout work less fragile.
-      if (p.channelIndex > maxC) {
-        maxC = p.channelIndex;
-      }
-      if (p.channelIndex < minC) {
-        minC = p.channelIndex;
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -76,7 +76,9 @@ import org.xml.sax.Attributes;
  */
 public class CV7000Reader extends FormatReader {
 
-  // -- Constants --
+  // ###############
+  // ## Module 1: Constants, Options, And Reader State
+  // ###############
 
   public static final String DUPLICATE_PLANES_KEY = "cv7000.duplicate_missing_planes";
   public static final boolean DUPLICATE_PLANES_DEFAULT = false;
@@ -84,6 +86,8 @@ public class CV7000Reader extends FormatReader {
   public static final boolean PRESERVE_RAW_SIDECARS_DEFAULT = true;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
+  private static final CV7000ChannelMapper CHANNEL_MAPPER =
+    new CV7000ChannelMapper();
 
   private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
   private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
@@ -134,8 +138,6 @@ public class CV7000Reader extends FormatReader {
   private OTFGeometryParameters otfGeometryParameters;
   private YokogawaParsing parsing = new YokogawaParsing();
 
-  // -- Constructor --
-
   /** Constructs a new Yokogawa CV7000 reader. */
   public CV7000Reader() {
     super("Yokogawa CV7000", new String[] {"wpi"});
@@ -144,7 +146,9 @@ public class CV7000Reader extends FormatReader {
     datasetDescription = "Directory with XML files and one .tif/.tiff file per plane";
   }
 
-  // -- CV7000Reader API methods --
+  // ###############
+  // ## Module 2: Public Reader API And Pixel Access
+  // ###############
 
   public boolean duplicatePlanes() {
     MetadataOptions options = getMetadataOptions();
@@ -283,6 +287,7 @@ public class CV7000Reader extends FormatReader {
       targetSystem = null;
       measurementHandler = null;
       crosstalkParameters = null;
+      otfGeometryParameters = null;
       reversePlaneLookup = null;
       extraFiles = null;
       seriesLayout = null;
@@ -330,7 +335,9 @@ public class CV7000Reader extends FormatReader {
     return buf;
   }
 
-  // -- Internal FormatReader API methods --
+  // ###############
+  // ## Module 3: Dataset Path Resolution And Sidecar Parsing
+  // ###############
 
   /* @see loci.formats.FormatReader#getAvailableOptions() */
   @Override
@@ -345,10 +352,7 @@ public class CV7000Reader extends FormatReader {
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
-    rawModel = new CV7000RawModel();
-    seriesLayout = null;
-    measurementOperatorName = null;
-    targetSystem = null;
+    resetParsedState();
     CV7000DatasetPaths paths = getDatasetPaths(id);
     datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
@@ -364,6 +368,30 @@ public class CV7000Reader extends FormatReader {
     populateReversePlaneLookup(layout);
     populateMetadataStore(plate, layout);
     setSeries(0);
+  }
+
+  /** Reset parsed CV7000 state before opening a dataset on a reused reader. */
+  private void resetParsedState() {
+    rawModel = new CV7000RawModel();
+    seriesLayout = null;
+    datasetPaths = null;
+    planeData = null;
+    reversePlaneLookup = null;
+    lightSources = null;
+    channels = null;
+    startTime = null;
+    endTime = null;
+    measurementOperatorName = null;
+    targetSystem = null;
+    extraFiles = null;
+    measurementHandler = null;
+    crosstalkParameters = null;
+    otfGeometryParameters = null;
+    wppPath = null;
+    detailPath = null;
+    measurementPath = null;
+    settingsPath = null;
+    allFiles.clear();
   }
 
   private CV7000DatasetPaths getDatasetPaths(String id) {
@@ -507,6 +535,10 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
+  // ###############
+  // ## Module 4: Channel Normalization And Channel Lookup
+  // ###############
+
   /** Normalize channel order and paths after all optional channel sources are parsed. */
   private void normalizeChannels(Location parent) {
     if (channels == null) {
@@ -538,6 +570,18 @@ public class CV7000Reader extends FormatReader {
       }
     }
   }
+
+  private int getLogicalChannelIndex(Plane p) {
+    return CHANNEL_MAPPER.getLogicalChannelIndex(channels, p);
+  }
+
+  private Channel lookupChannel(Plane p) {
+    return CHANNEL_MAPPER.lookupChannel(rawModel, channels, p);
+  }
+
+  // ###############
+  // ## Module 5: Series Layout And Plane Lookup Construction
+  // ###############
 
   /**
    * Build the field/channel/time/z layout before touching Bio-Formats core
@@ -623,14 +667,6 @@ public class CV7000Reader extends FormatReader {
         layout.uniqueChannels.add(p.channelIndex);
       }
     }
-  }
-
-  /** Use detailed action/channel mapping when present; fall back to raw channel IDs. */
-  private int getLogicalChannelIndex(Plane p) {
-    if (channels == null) {
-      return p.channel;
-    }
-    return getChannelIndex(p);
   }
 
   /** Initialize the Bio-Formats core metadata once the logical layout is known. */
@@ -724,6 +760,10 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
+  // ###############
+  // ## Module 6: OME Plate, Image, Pixels, And Plane Metadata
+  // ###############
+
   /** Populate OME metadata after core metadata and plane lookup are complete. */
   private void populateMetadataStore(WPIHandler plate, CV7000SeriesLayout layout)
     throws FormatException
@@ -774,6 +814,10 @@ public class CV7000Reader extends FormatReader {
     }
     return indexes;
   }
+
+  // ###############
+  // ## Module 7: OME Instrument, Channel, And Filter Metadata
+  // ###############
 
   private void populateMicroscope(MetadataStore store) {
     if (targetSystem == null) {
@@ -1581,6 +1625,10 @@ public class CV7000Reader extends FormatReader {
     return new PercentFraction(Float.valueOf((float) fraction));
   }
 
+  // ###############
+  // ## Module 8: Yokogawa Provenance And Raw Sidecar Annotations
+  // ###############
+
   private void addYokogawaOriginalMetadata(MetadataStore store,
     boolean hasInstrument)
   {
@@ -1928,6 +1976,10 @@ public class CV7000Reader extends FormatReader {
     }
     return CV7000FileRole.UNKNOWN;
   }
+
+  // ###############
+  // ## Module 9: File Classification, Utilities, And Plane Lookup Helpers
+  // ###############
 
   private boolean isTiffFile(String name) {
     return name != null && checkSuffix(name, new String[] {"tif", "tiff"});
@@ -2452,23 +2504,6 @@ public class CV7000Reader extends FormatReader {
     return parsing.parseInteger(value);
   }
 
-  private int getChannelIndex(Plane p) {
-    int index = -1;
-    for (int action=0; action<=p.actionIndex; action++) {
-      for (Channel ch : channels) {
-        if (ch.timelineIndex == p.timelineIndex &&
-          ch.actionIndex == action)
-        {
-          index++;
-          if (ch.index == p.channel && ch.actionIndex == p.actionIndex) {
-            return index;
-          }
-        }
-      }
-    }
-    return index;
-  }
-
   private Length getPhysicalSizeZ(int series) {
     Double physicalSizeZ = null;
     boolean foundChannel = false;
@@ -2492,33 +2527,6 @@ public class CV7000Reader extends FormatReader {
       }
     }
     return foundChannel ? FormatTools.getPhysicalSizeZ(physicalSizeZ) : null;
-  }
-
-  private Channel lookupChannel(Plane p) {
-    Channel matched = rawModel.getChannel(p.timelineIndex, p.actionIndex, p.channel);
-    if (matched != null) {
-      return matched;
-    }
-
-    Channel rawChannel = null;
-    Channel populatedRawChannel = null;
-    for (Channel ch : channels) {
-      if (ch.index == p.channel &&
-        ch.timelineIndex == p.timelineIndex &&
-        ch.actionIndex == p.actionIndex)
-      {
-        return ch;
-      }
-      if (ch.index == p.channel) {
-        if (rawChannel == null) {
-          rawChannel = ch;
-        }
-        if (populatedRawChannel == null && ch.hasChannelSettings()) {
-          populatedRawChannel = ch;
-        }
-      }
-    }
-    return populatedRawChannel == null ? rawChannel : populatedRawChannel;
   }
 
   private Plane lookupFirstBackedPlane(int series) {
@@ -2573,7 +2581,9 @@ public class CV7000Reader extends FormatReader {
     return p;
   }
 
-  // -- Helper classes --
+  // ###############
+  // ## Module 10: Data Model Classes
+  // ###############
 
   private enum CV7000FileRole {
     TIFF_PLANE,
@@ -2586,6 +2596,65 @@ public class CV7000Reader extends FormatReader {
     OTF_CROSSTALK,
     OTF_GEOMETRY,
     UNKNOWN
+  }
+
+  /** Centralizes Yokogawa action/channel matching and reader channel indexing. */
+  private static class CV7000ChannelMapper {
+    public int getLogicalChannelIndex(ArrayList<Channel> channels, Plane plane) {
+      if (channels == null) {
+        return plane.channel;
+      }
+      return getChannelIndex(channels, plane);
+    }
+
+    public int getChannelIndex(ArrayList<Channel> channels, Plane plane) {
+      int index = -1;
+      for (int action=0; action<=plane.actionIndex; action++) {
+        for (Channel channel : channels) {
+          if (channel.timelineIndex == plane.timelineIndex &&
+            channel.actionIndex == action)
+          {
+            index++;
+            if (channel.index == plane.channel &&
+              channel.actionIndex == plane.actionIndex)
+            {
+              return index;
+            }
+          }
+        }
+      }
+      return index;
+    }
+
+    public Channel lookupChannel(CV7000RawModel rawModel,
+      ArrayList<Channel> channels, Plane plane)
+    {
+      Channel matched = rawModel.getChannel(
+        plane.timelineIndex, plane.actionIndex, plane.channel);
+      if (matched != null) {
+        return matched;
+      }
+
+      Channel rawChannel = null;
+      Channel populatedRawChannel = null;
+      for (Channel channel : channels) {
+        if (channel.index == plane.channel &&
+          channel.timelineIndex == plane.timelineIndex &&
+          channel.actionIndex == plane.actionIndex)
+        {
+          return channel;
+        }
+        if (channel.index == plane.channel) {
+          if (rawChannel == null) {
+            rawChannel = channel;
+          }
+          if (populatedRawChannel == null && channel.hasChannelSettings()) {
+            populatedRawChannel = channel;
+          }
+        }
+      }
+      return populatedRawChannel == null ? rawChannel : populatedRawChannel;
+    }
   }
 
   /** Resolved dataset paths used during the parsing phase. */
@@ -2806,6 +2875,19 @@ public class CV7000Reader extends FormatReader {
       }
       return binning + "x" + binning;
     }
+
+    public String getAttribute(Attributes attributes, String name) {
+      if (attributes == null || name == null) {
+        return null;
+      }
+      for (int i=0; i<attributes.getLength(); i++) {
+        if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
+          String value = attributes.getValue(i);
+          return clean(value);
+        }
+      }
+      return null;
+    }
   }
 
   /** OME instrument indexes shared by channel metadata population. */
@@ -2967,6 +3049,10 @@ public class CV7000Reader extends FormatReader {
   private static class MeasurementSettingsResult {
     public ArrayList<LightSource> lightSources = new ArrayList<LightSource>();
   }
+
+  // ###############
+  // ## Module 11: SAX Sidecar Handlers
+  // ###############
 
   private class WPIHandler extends BaseHandler {
     private int plateRows;
@@ -3265,94 +3351,16 @@ public class CV7000Reader extends FormatReader {
         addYokogawaAttributes("Yokogawa MES MeasurementSetting ", attributes);
       }
       else if (qName.equals("bts:LightSource")) {
-        LightSource l = new LightSource();
-        l.name = attributes.getValue("bts:Name");
-        l.type = attributes.getValue("bts:Type");
-        addYokogawaAttributes("Yokogawa MES LightSource " + l.name + " ", attributes);
-
-        String wavelength = attributes.getValue("bts:WaveLength");
-        String power = attributes.getValue("bts:Power");
-
-        l.wavelength = DataTools.parseDouble(wavelength);
-        l.power = DataTools.parseDouble(power);
-
-        result.lightSources.add(l);
+        parseLightSource(attributes);
       }
       else if (qName.equals("bts:Channel")) {
-        currentChannelIndex = -1;
-        String ch = attributes.getValue("bts:Ch");
-        if (ch != null) {
-          int index = Integer.parseInt(ch) - 1;
-          if (index >= 0 && index < parsedChannels.size()) {
-            currentChannelIndex = index;
-
-            Channel template = new Channel();
-            template.index = index;
-            template.target = attributes.getValue("bts:Target");
-            addYokogawaAttributes(
-              "Yokogawa MES Channel " + (template.index + 1) + " ", attributes);
-            template.objectiveID = attributes.getValue("bts:ObjectiveID");
-            template.objective = attributes.getValue("bts:Objective");
-            template.binning = attributes.getValue("bts:Binning");
-            template.methodID = attributes.getValue("bts:MethodID");
-            template.method = attributes.getValue("bts:Method");
-            template.filterID = attributes.getValue("bts:FilterID");
-            template.kind = attributes.getValue("bts:Kind");
-            template.andorParameterID = attributes.getValue("bts:AndorParameterID");
-            template.andorParameter = attributes.getValue("bts:AndorParameter");
-            template.detectorGain = parsing.parseYokogawaGain(template.andorParameter);
-            template.cameraType = attributes.getValue("bts:CameraType");
-            template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
-
-            String mag = attributes.getValue("bts:Magnification");
-            template.magnification = DataTools.parseDouble(mag);
-
-            String exposure = attributes.getValue("bts:ExposureTime");
-            template.exposureTime = DataTools.parseDouble(exposure);
-
-            String color = attributes.getValue("bts:Color");
-            if (color != null) {
-              color = color.replaceAll("#", "");
-              // ignore unless at least R, G, B are defined
-              if (color.length() >= 6) {
-                int[] colors = new int[color.length() / 2];
-                for (int i=0; i<color.length(); i+=2) {
-                  colors[i / 2] = Integer.parseInt(color.substring(i, i + 2), 16);
-                }
-                int alpha = colors.length == 4 ? colors[0] : 255;
-                int red = colors[colors.length - 3];
-                int green = colors[colors.length - 2];
-                int blue = colors[colors.length - 1];
-                template.color = new Color(red, green, blue, alpha);
-              }
-            }
-
-            template.acquisition = attributes.getValue("bts:Acquisition");
-            // Yokogawa Acquisition values such as BP676/29 identify detection
-            // filters.  Excitation comes from the LightSourceName link.
-            template.detectionFilter = parsing.parseDetectionFilter(template.acquisition);
-
-            template.fluor = attributes.getValue("bts:Fluorophore");
-            applyChannelSettings(template);
-          }
-        }
+        parseChannelTemplate(attributes);
       }
       else if (qName.equals("bts:Timeline")) {
-        timelineIndex++;
-        actionIndex = -1;
-        targetWellIndex = -1;
-        pointIndex = -1;
-        currentPhysicalSizeZ = null;
-        actionRunMode = null;
-        actionAFSearch = null;
-        addYokogawaAttributes(
-          "Yokogawa MES Timeline " + (timelineIndex + 1) + " ", attributes);
+        startTimeline(attributes);
       }
       else if (qName.equals("bts:TargetWell")) {
-        targetWellIndex++;
-        addYokogawaAttributes(
-          "Yokogawa MES Timeline " + (timelineIndex + 1) +
-          " TargetWell " + (targetWellIndex + 1) + " ", attributes);
+        startTargetWell(attributes);
       }
       else if (qName.equals("bts:PointSequence")) {
         addYokogawaAttributes(
@@ -3371,27 +3379,10 @@ public class CV7000Reader extends FormatReader {
           " Point " + (pointIndex + 1) + " ", attributes);
       }
       else if (qName.equals("bts:ActionList")) {
-        actionRunMode = attributes.getValue("bts:RunMode");
-        actionAFSearch = attributes.getValue("bts:AFSearch");
-        addYokogawaAttributes(
-          "Yokogawa MES Timeline " + (timelineIndex + 1) +
-          " ActionList ", attributes);
+        startActionList(attributes);
       }
       else if (qName.startsWith("bts:ActionAcquire")) {
-        actionIndex++;
-        currentActionType = getYokogawaAttributeName(qName);
-        currentActionXOffset = attributes.getValue("bts:XOffset");
-        currentActionYOffset = attributes.getValue("bts:YOffset");
-        currentActionAFShiftBase = attributes.getValue("bts:AFShiftBase");
-        currentActionTopDistance = attributes.getValue("bts:TopDistance");
-        currentActionBottomDistance = attributes.getValue("bts:BottomDistance");
-        currentActionSliceLength = attributes.getValue("bts:SliceLength");
-        currentActionUseSoftFocus = attributes.getValue("bts:UseSoftFocus");
-        addYokogawaAttributes(
-          "Yokogawa MES Timeline " + (timelineIndex + 1) +
-          " Action " + (actionIndex + 1) + " ", attributes);
-        currentPhysicalSizeZ = DataTools.parseDouble(
-          attributes.getValue("bts:SliceLength"));
+        startActionAcquire(qName, attributes);
       }
     }
 
@@ -3417,47 +3408,183 @@ public class CV7000Reader extends FormatReader {
         currentChannelIndex = -1;
       }
       else if (qName.equals("bts:Ch")) {
-        int channelIndex = Integer.parseInt(value) - 1;
-        if (channelIndex >= 0 && channelIndex < parsedChannels.size()) {
-          // the same channel may be acquired multiple times
-          // if this is the first time the channel is acquired, set the indexes
-          // if this is the second (or more) time the channel is acquired,
-          // duplicate the channel so that each action has its own copy with
-          // the correct indexes
-          Channel ch = parsedChannels.get(channelIndex);
-          if (ch.timelineIndex == -1 && ch.actionIndex == -1) {
-            ch.timelineIndex = timelineIndex;
-            ch.actionIndex = actionIndex;
-            ch.physicalSizeZ = currentPhysicalSizeZ;
-            ch.copyActionSettings(actionRunMode, actionAFSearch, currentActionType,
-              currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
-              currentActionTopDistance, currentActionBottomDistance,
-              currentActionSliceLength, currentActionUseSoftFocus);
-          }
-          else {
-            Channel duplicate = new Channel(ch);
-            duplicate.timelineIndex = timelineIndex;
-            duplicate.actionIndex = actionIndex;
-            duplicate.physicalSizeZ = currentPhysicalSizeZ;
-            duplicate.copyActionSettings(actionRunMode, actionAFSearch, currentActionType,
-              currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
-              currentActionTopDistance, currentActionBottomDistance,
-              currentActionSliceLength, currentActionUseSoftFocus);
-            parsedChannels.add(duplicate);
-          }
-        }
+        assignActionChannel(value);
       }
       else if (qName.startsWith("bts:ActionAcquire")) {
-        currentPhysicalSizeZ = null;
-        currentActionType = null;
-        currentActionXOffset = null;
-        currentActionYOffset = null;
-        currentActionAFShiftBase = null;
-        currentActionTopDistance = null;
-        currentActionBottomDistance = null;
-        currentActionSliceLength = null;
-        currentActionUseSoftFocus = null;
+        clearActionAcquireState();
       }
+    }
+
+    private void parseLightSource(Attributes attributes) {
+      LightSource lightSource = new LightSource();
+      lightSource.name = attributes.getValue("bts:Name");
+      lightSource.type = attributes.getValue("bts:Type");
+      addYokogawaAttributes(
+        "Yokogawa MES LightSource " + lightSource.name + " ", attributes);
+
+      String wavelength = attributes.getValue("bts:WaveLength");
+      String power = attributes.getValue("bts:Power");
+
+      lightSource.wavelength = DataTools.parseDouble(wavelength);
+      lightSource.power = DataTools.parseDouble(power);
+
+      result.lightSources.add(lightSource);
+    }
+
+    private void parseChannelTemplate(Attributes attributes) {
+      currentChannelIndex = -1;
+      String ch = attributes.getValue("bts:Ch");
+      if (ch == null) {
+        return;
+      }
+
+      int index = Integer.parseInt(ch) - 1;
+      if (index < 0 || index >= parsedChannels.size()) {
+        return;
+      }
+
+      currentChannelIndex = index;
+
+      Channel template = new Channel();
+      template.index = index;
+      template.target = attributes.getValue("bts:Target");
+      addYokogawaAttributes(
+        "Yokogawa MES Channel " + (template.index + 1) + " ", attributes);
+      template.objectiveID = attributes.getValue("bts:ObjectiveID");
+      template.objective = attributes.getValue("bts:Objective");
+      template.binning = attributes.getValue("bts:Binning");
+      template.methodID = attributes.getValue("bts:MethodID");
+      template.method = attributes.getValue("bts:Method");
+      template.filterID = attributes.getValue("bts:FilterID");
+      template.kind = attributes.getValue("bts:Kind");
+      template.andorParameterID = attributes.getValue("bts:AndorParameterID");
+      template.andorParameter = attributes.getValue("bts:AndorParameter");
+      template.detectorGain = parsing.parseYokogawaGain(template.andorParameter);
+      template.cameraType = attributes.getValue("bts:CameraType");
+      template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
+
+      String mag = attributes.getValue("bts:Magnification");
+      template.magnification = DataTools.parseDouble(mag);
+
+      String exposure = attributes.getValue("bts:ExposureTime");
+      template.exposureTime = DataTools.parseDouble(exposure);
+
+      populateChannelColor(template, attributes.getValue("bts:Color"));
+
+      template.acquisition = attributes.getValue("bts:Acquisition");
+      // Yokogawa Acquisition values such as BP676/29 identify detection
+      // filters.  Excitation comes from the LightSourceName link.
+      template.detectionFilter = parsing.parseDetectionFilter(template.acquisition);
+
+      template.fluor = attributes.getValue("bts:Fluorophore");
+      applyChannelSettings(template);
+    }
+
+    private void populateChannelColor(Channel template, String color) {
+      if (color == null) {
+        return;
+      }
+
+      color = color.replaceAll("#", "");
+      // ignore unless at least R, G, B are defined
+      if (color.length() < 6) {
+        return;
+      }
+
+      int[] colors = new int[color.length() / 2];
+      for (int i=0; i<color.length(); i+=2) {
+        colors[i / 2] = Integer.parseInt(color.substring(i, i + 2), 16);
+      }
+      int alpha = colors.length == 4 ? colors[0] : 255;
+      int red = colors[colors.length - 3];
+      int green = colors[colors.length - 2];
+      int blue = colors[colors.length - 1];
+      template.color = new Color(red, green, blue, alpha);
+    }
+
+    private void startTimeline(Attributes attributes) {
+      timelineIndex++;
+      actionIndex = -1;
+      targetWellIndex = -1;
+      pointIndex = -1;
+      currentPhysicalSizeZ = null;
+      actionRunMode = null;
+      actionAFSearch = null;
+      addYokogawaAttributes(
+        "Yokogawa MES Timeline " + (timelineIndex + 1) + " ", attributes);
+    }
+
+    private void startTargetWell(Attributes attributes) {
+      targetWellIndex++;
+      addYokogawaAttributes(
+        "Yokogawa MES Timeline " + (timelineIndex + 1) +
+        " TargetWell " + (targetWellIndex + 1) + " ", attributes);
+    }
+
+    private void startActionList(Attributes attributes) {
+      actionRunMode = attributes.getValue("bts:RunMode");
+      actionAFSearch = attributes.getValue("bts:AFSearch");
+      addYokogawaAttributes(
+        "Yokogawa MES Timeline " + (timelineIndex + 1) +
+        " ActionList ", attributes);
+    }
+
+    private void startActionAcquire(String qName, Attributes attributes) {
+      actionIndex++;
+      currentActionType = getYokogawaAttributeName(qName);
+      currentActionXOffset = attributes.getValue("bts:XOffset");
+      currentActionYOffset = attributes.getValue("bts:YOffset");
+      currentActionAFShiftBase = attributes.getValue("bts:AFShiftBase");
+      currentActionTopDistance = attributes.getValue("bts:TopDistance");
+      currentActionBottomDistance = attributes.getValue("bts:BottomDistance");
+      currentActionSliceLength = attributes.getValue("bts:SliceLength");
+      currentActionUseSoftFocus = attributes.getValue("bts:UseSoftFocus");
+      addYokogawaAttributes(
+        "Yokogawa MES Timeline " + (timelineIndex + 1) +
+        " Action " + (actionIndex + 1) + " ", attributes);
+      currentPhysicalSizeZ = DataTools.parseDouble(
+        attributes.getValue("bts:SliceLength"));
+    }
+
+    private void assignActionChannel(String value) {
+      int channelIndex = Integer.parseInt(value) - 1;
+      if (channelIndex < 0 || channelIndex >= parsedChannels.size()) {
+        return;
+      }
+
+      // The same channel may be acquired multiple times. First occurrence
+      // receives the action indexes; later occurrences get action-specific copies.
+      Channel channel = parsedChannels.get(channelIndex);
+      if (channel.timelineIndex == -1 && channel.actionIndex == -1) {
+        assignActionSettings(channel);
+      }
+      else {
+        Channel duplicate = new Channel(channel);
+        assignActionSettings(duplicate);
+        parsedChannels.add(duplicate);
+      }
+    }
+
+    private void assignActionSettings(Channel channel) {
+      channel.timelineIndex = timelineIndex;
+      channel.actionIndex = actionIndex;
+      channel.physicalSizeZ = currentPhysicalSizeZ;
+      channel.copyActionSettings(actionRunMode, actionAFSearch, currentActionType,
+        currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
+        currentActionTopDistance, currentActionBottomDistance,
+        currentActionSliceLength, currentActionUseSoftFocus);
+    }
+
+    private void clearActionAcquireState() {
+      currentPhysicalSizeZ = null;
+      currentActionType = null;
+      currentActionXOffset = null;
+      currentActionYOffset = null;
+      currentActionAFShiftBase = null;
+      currentActionTopDistance = null;
+      currentActionBottomDistance = null;
+      currentActionSliceLength = null;
+      currentActionUseSoftFocus = null;
     }
 
     private void applyChannelSettings(Channel template) {
@@ -3496,38 +3623,38 @@ public class CV7000Reader extends FormatReader {
       String name = getYokogawaAttributeName(qName);
       if ("EMFilter".equals(name)) {
         currentFilter = new CrosstalkFilter();
-        currentFilter.filterID = getAttribute(attributes, "FilterID");
+        currentFilter.filterID = parsing.getAttribute(attributes, "FilterID");
         currentFilter.cameraNumber = DataTools.parseInteger(
-          getAttribute(attributes, "CameraID"));
-        currentFilter.acquisition = getAttribute(attributes, "Acquisition");
+          parsing.getAttribute(attributes, "CameraID"));
+        currentFilter.acquisition = parsing.getAttribute(attributes, "Acquisition");
         currentFilter.averageTransmittance = DataTools.parseDouble(
-          getAttribute(attributes, "AverageTransmittance"));
+          parsing.getAttribute(attributes, "AverageTransmittance"));
         currentFilter.minWaveLength = DataTools.parseDouble(
-          getAttribute(attributes, "MinWaveLength"));
+          parsing.getAttribute(attributes, "MinWaveLength"));
         currentFilter.maxWaveLength = DataTools.parseDouble(
-          getAttribute(attributes, "MaxWaveLength"));
+          parsing.getAttribute(attributes, "MaxWaveLength"));
         parameters.addFilter(currentFilter);
       }
       else if ("ISDM".equals(name) && currentFilter != null) {
         CrosstalkDichroic dichroic = new CrosstalkDichroic();
-        dichroic.id = getAttribute(attributes, "ID");
-        dichroic.name = getAttribute(attributes, "Name");
-        dichroic.reflection = getAttribute(attributes, "Reflection");
+        dichroic.id = parsing.getAttribute(attributes, "ID");
+        dichroic.name = parsing.getAttribute(attributes, "Name");
+        dichroic.reflection = parsing.getAttribute(attributes, "Reflection");
         dichroic.averageTransmittance = DataTools.parseDouble(
-          getAttribute(attributes, "AverageTransmittance"));
+          parsing.getAttribute(attributes, "AverageTransmittance"));
         currentFilter.dichroics.add(dichroic);
       }
       else if ("Fluorophore".equals(name)) {
         currentFluorophore = new CrosstalkFluorophore();
-        currentFluorophore.name = getAttribute(attributes, "Name");
+        currentFluorophore.name = parsing.getAttribute(attributes, "Name");
         parameters.fluorophores.add(currentFluorophore);
       }
       else if ("FluorophoreIntensity".equals(name) && currentFluorophore != null) {
         CrosstalkFluorophoreIntensity intensity =
           new CrosstalkFluorophoreIntensity();
-        intensity.filterID = getAttribute(attributes, "FilterID");
+        intensity.filterID = parsing.getAttribute(attributes, "FilterID");
         intensity.averageIntensity = DataTools.parseDouble(
-          getAttribute(attributes, "AverageIntensity"));
+          parsing.getAttribute(attributes, "AverageIntensity"));
         currentFluorophore.intensities.add(intensity);
       }
     }
@@ -3543,18 +3670,6 @@ public class CV7000Reader extends FormatReader {
       }
     }
 
-    private String getAttribute(Attributes attributes, String name) {
-      if (attributes == null || name == null) {
-        return null;
-      }
-      for (int i=0; i<attributes.getLength(); i++) {
-        if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
-          String value = attributes.getValue(i);
-          return value == null || value.trim().length() == 0 ? null : value;
-        }
-      }
-      return null;
-    }
   }
 
   private class OTFGeometryHandler extends BaseHandler {
@@ -3570,7 +3685,7 @@ public class CV7000Reader extends FormatReader {
     {
       String name = getYokogawaAttributeName(qName);
       if ("GeometryParameter".equals(name)) {
-        parameters.mode = getAttribute(attributes, "Mode");
+        parameters.mode = parsing.getAttribute(attributes, "Mode");
         return;
       }
       if (!"AffineParameter".equals(name)) {
@@ -3578,38 +3693,29 @@ public class CV7000Reader extends FormatReader {
       }
 
       OTFGeometryAffine affine = new OTFGeometryAffine();
-      affine.methodID = getAttribute(attributes, "MethodID");
-      affine.method = getAttribute(attributes, "Method");
-      affine.objectiveID = getAttribute(attributes, "ObjectiveID");
-      affine.objective = getAttribute(attributes, "Objective");
+      affine.methodID = parsing.getAttribute(attributes, "MethodID");
+      affine.method = parsing.getAttribute(attributes, "Method");
+      affine.objectiveID = parsing.getAttribute(attributes, "ObjectiveID");
+      affine.objective = parsing.getAttribute(attributes, "Objective");
       affine.magnification = DataTools.parseDouble(
-        getAttribute(attributes, "Magnification"));
-      affine.filterID = getAttribute(attributes, "FilterID");
-      affine.acquisition = getAttribute(attributes, "Acquisition");
-      affine.use = getAttribute(attributes, "Use");
-      affine.updateTime = getAttribute(attributes, "UpdateTime");
-      affine.a = DataTools.parseDouble(getAttribute(attributes, "A"));
-      affine.b = DataTools.parseDouble(getAttribute(attributes, "B"));
-      affine.c = DataTools.parseDouble(getAttribute(attributes, "C"));
-      affine.d = DataTools.parseDouble(getAttribute(attributes, "D"));
-      affine.e = DataTools.parseDouble(getAttribute(attributes, "E"));
-      affine.f = DataTools.parseDouble(getAttribute(attributes, "F"));
+        parsing.getAttribute(attributes, "Magnification"));
+      affine.filterID = parsing.getAttribute(attributes, "FilterID");
+      affine.acquisition = parsing.getAttribute(attributes, "Acquisition");
+      affine.use = parsing.getAttribute(attributes, "Use");
+      affine.updateTime = parsing.getAttribute(attributes, "UpdateTime");
+      affine.a = DataTools.parseDouble(parsing.getAttribute(attributes, "A"));
+      affine.b = DataTools.parseDouble(parsing.getAttribute(attributes, "B"));
+      affine.c = DataTools.parseDouble(parsing.getAttribute(attributes, "C"));
+      affine.d = DataTools.parseDouble(parsing.getAttribute(attributes, "D"));
+      affine.e = DataTools.parseDouble(parsing.getAttribute(attributes, "E"));
+      affine.f = DataTools.parseDouble(parsing.getAttribute(attributes, "F"));
       parameters.addAffine(affine);
     }
-
-    private String getAttribute(Attributes attributes, String name) {
-      if (attributes == null || name == null) {
-        return null;
-      }
-      for (int i=0; i<attributes.getLength(); i++) {
-        if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
-          String value = attributes.getValue(i);
-          return value == null || value.trim().length() == 0 ? null : value;
-        }
-      }
-      return null;
-    }
   }
+
+  // ###############
+  // ## Module 12: OTF, Crosstalk, Objective, Channel, And Plane Models
+  // ###############
 
   private static class OTFGeometryParameters {
     public String mode;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1218,7 +1218,11 @@ public class CV7000Reader extends FormatReader {
         String detectorID = MetadataTools.createLSID("Detector", 0, detector);
         store.setDetectorID(detectorID, 0, detector);
         populateDetectorCameraType(store, detector, c.cameraType);
-        store.setDetectorType(MetadataTools.getDetectorType("Other"), 0, detector);
+        // The CV7000 manual describes the detector as sCMOS. OME-XML has
+        // CMOS, but not literal sCMOS, in the Detector.Type enum. Manual
+        // sensor pitch and nominal sensor dimensions are hardware reference
+        // values, so do not emit them as image size or pixel calibration.
+        store.setDetectorType(MetadataTools.getDetectorType("CMOS"), 0, detector);
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -684,24 +684,35 @@ public class CV7000Reader extends FormatReader {
 
       p.no = FormatTools.positionToRaster(planeLengths,
         new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
-      assignPlaneLookup(i, p);
+      assignPlaneLookup(i, p, layout);
       layout.indexPlane(p);
     }
   }
 
   /** Prefer a real plane over metadata-only duplicate records for each position. */
-  private void assignPlaneLookup(int planeIndex, Plane p) {
+  private void assignPlaneLookup(int planeIndex, Plane p,
+    CV7000SeriesLayout layout)
+  {
     if (reversePlaneLookup[p.series][p.no] < 0) {
       reversePlaneLookup[p.series][p.no] = planeIndex;
     }
     else {
-      Plane existing = planeData.get(reversePlaneLookup[p.series][p.no]);
+      int existingIndex = reversePlaneLookup[p.series][p.no];
+      Plane existing = planeData.get(existingIndex);
       if ((existing == null || existing.file == null) && p.file != null) {
         reversePlaneLookup[p.series][p.no] = planeIndex;
+        layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
+          existing, existingIndex, p, "REPLACED_BY_TIFF"));
       }
       else if (p.file != null) {
         LOGGER.warn("Ignoring file {}", p.file);
         extraFiles.add(p.file);
+        layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
+          p, planeIndex, existing, "IGNORED_TIFF_DUPLICATE"));
+      }
+      else {
+        layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
+          p, planeIndex, existing, "IGNORED_METADATA_ONLY_DUPLICATE"));
       }
     }
   }
@@ -1626,6 +1637,7 @@ public class CV7000Reader extends FormatReader {
     }
     addCrosstalkOriginalMetadata();
     addOTFGeometryOriginalMetadata();
+    addPlaneProvenanceOriginalMetadata();
     if (channels == null) {
       emitYokogawaMapAnnotations(store, plateAnnotationRef, hasInstrument);
       return;
@@ -2057,6 +2069,12 @@ public class CV7000Reader extends FormatReader {
       return;
     }
 
+    if (isPlaneProvenanceAnnotationScope(scope) &&
+      linkPlaneProvenanceAnnotation(store, annotationID, scope, refs))
+    {
+      return;
+    }
+
     if (isImageOrChannelAnnotationScope(scope) &&
       linkToMatchingSeriesAndChannels(store, annotationID, scope, refs))
     {
@@ -2076,6 +2094,21 @@ public class CV7000Reader extends FormatReader {
     return scope != null && (scope.startsWith("Yokogawa MES Timeline ") ||
       scope.startsWith("Yokogawa MES Channel ") ||
       scope.startsWith("Yokogawa Timeline "));
+  }
+
+  private boolean isPlaneProvenanceAnnotationScope(String scope) {
+    return scope != null && scope.startsWith("Yokogawa Plane Provenance Image ");
+  }
+
+  private boolean linkPlaneProvenanceAnnotation(MetadataStore store,
+    String annotationID, String scope, AnnotationRefIndexes refs)
+  {
+    Integer image = getIndexedScopeValue(scope, "Image");
+    if (image == null || image < 0 || image >= getSeriesCount()) {
+      return false;
+    }
+    store.setImageAnnotationRef(annotationID, image, refs.nextImage(image));
+    return true;
   }
 
   private boolean linkToMatchingSeriesAndChannels(MetadataStore store,
@@ -2168,6 +2201,188 @@ public class CV7000Reader extends FormatReader {
   private void addYokogawaMetaList(String prefix, String name, Object value) {
     YokogawaAnnotationGroup group = getYokogawaAnnotationGroup(prefix);
     group.putList(name, value);
+  }
+
+  private void addPlaneProvenanceOriginalMetadata() {
+    if (seriesLayout == null || reversePlaneLookup == null) {
+      return;
+    }
+
+    HashMap<Integer, ArrayList<DuplicatePlaneCandidate>> duplicateCandidates =
+      getDuplicateCandidatesBySeries();
+    for (int series=0; series<reversePlaneLookup.length; series++) {
+      String prefix = "Yokogawa Plane Provenance Image " + (series + 1) + " ";
+      PlaneProvenanceSummary summary = buildPlaneProvenanceSummary(
+        series, duplicateCandidates.get(Integer.valueOf(series)));
+      Field field = seriesLayout.getField(series);
+
+      addYokogawaMeta(prefix, "SeriesIndex", series);
+      addYokogawaMeta(prefix, "ImageIndex", series);
+      if (field != null) {
+        addYokogawaMeta(prefix, "Well", getWellName(field));
+        addYokogawaMeta(prefix, "FieldIndex", field.field + 1);
+      }
+      addYokogawaMeta(prefix, "PlaneCount", summary.planeCount);
+      addYokogawaMeta(prefix, "TiffBackedCount", summary.tiffBackedCount);
+      addYokogawaMeta(prefix, "FilledCount", summary.filledCount);
+      addYokogawaMeta(prefix, "DuplicatedCount", summary.duplicatedCount);
+      addYokogawaMeta(prefix, "MetadataOnlyCount", summary.metadataOnlyCount);
+      addYokogawaMeta(prefix, "NoMLFRecordCount", summary.noMLFRecordCount);
+      addYokogawaMeta(prefix, "DuplicateCandidateCount",
+        summary.duplicateCandidateCount);
+      for (String anomaly : summary.anomalies) {
+        addYokogawaMetaList(prefix, "Anomaly", anomaly);
+      }
+    }
+  }
+
+  private HashMap<Integer, ArrayList<DuplicatePlaneCandidate>>
+    getDuplicateCandidatesBySeries()
+  {
+    HashMap<Integer, ArrayList<DuplicatePlaneCandidate>> bySeries =
+      new HashMap<Integer, ArrayList<DuplicatePlaneCandidate>>();
+    if (seriesLayout == null || seriesLayout.duplicateCandidates == null) {
+      return bySeries;
+    }
+
+    for (DuplicatePlaneCandidate candidate : seriesLayout.duplicateCandidates) {
+      if (candidate == null || candidate.candidate == null) {
+        continue;
+      }
+      Integer series = Integer.valueOf(candidate.candidate.series);
+      ArrayList<DuplicatePlaneCandidate> candidates = bySeries.get(series);
+      if (candidates == null) {
+        candidates = new ArrayList<DuplicatePlaneCandidate>();
+        bySeries.put(series, candidates);
+      }
+      candidates.add(candidate);
+    }
+    return bySeries;
+  }
+
+  private PlaneProvenanceSummary buildPlaneProvenanceSummary(int series,
+    ArrayList<DuplicatePlaneCandidate> duplicateCandidates)
+  {
+    PlaneProvenanceSummary summary = new PlaneProvenanceSummary();
+    int planeCount = reversePlaneLookup[series].length;
+    summary.planeCount = planeCount;
+
+    for (int no=0; no<planeCount; no++) {
+      Plane plane = lookupPlane(series, no);
+      if (plane != null && plane.file != null) {
+        summary.tiffBackedCount++;
+        continue;
+      }
+
+      String reason;
+      if (plane == null) {
+        reason = "NO_MLF_RECORD";
+        summary.noMLFRecordCount++;
+      }
+      else {
+        reason = "MLF_METADATA_ONLY";
+        summary.metadataOnlyCount++;
+      }
+
+      Plane duplicate = getDuplicatePlane(series, no);
+      if (duplicate != null) {
+        summary.duplicatedCount++;
+        summary.anomalies.add(formatPlaneProvenanceAnomaly(
+          series, no, "DUPLICATED", reason, duplicate, null));
+      }
+      else {
+        summary.filledCount++;
+        summary.anomalies.add(formatPlaneProvenanceAnomaly(
+          series, no, "FILL", reason, null, null));
+      }
+    }
+
+    if (duplicateCandidates != null) {
+      summary.duplicateCandidateCount = duplicateCandidates.size();
+      for (DuplicatePlaneCandidate candidate : duplicateCandidates) {
+        if (candidate == null || candidate.candidate == null) {
+          continue;
+        }
+        summary.anomalies.add(formatPlaneProvenanceAnomaly(
+          series, candidate.candidate.no, "DUPLICATE_CANDIDATE_IGNORED",
+          candidate.reason, candidate.selected, candidate.candidate));
+      }
+    }
+    return summary;
+  }
+
+  private Plane getDuplicatePlane(int series, int no) {
+    if (!duplicatePlanes() || no <= 0) {
+      return null;
+    }
+
+    int[] zct = getZCTCoords(series, no);
+    int dupPlane = getIndex(series, 0, zct[1], 0);
+    if (dupPlane == no) {
+      dupPlane = 0;
+    }
+    Plane duplicate = lookupPlane(series, dupPlane);
+    return duplicate != null && duplicate.file != null ? duplicate : null;
+  }
+
+  private int[] getZCTCoords(int series, int no) {
+    int[] lengths = new int[] {
+      core.get(series).sizeC / reader.getSizeC(),
+      core.get(series).sizeZ,
+      core.get(series).sizeT
+    };
+    int[] czt = FormatTools.rasterToPosition(lengths, no);
+    return new int[] {czt[1], czt[0], czt[2]};
+  }
+
+  private int getIndex(int series, int z, int c, int t) {
+    int[] lengths = new int[] {
+      core.get(series).sizeC / reader.getSizeC(),
+      core.get(series).sizeZ,
+      core.get(series).sizeT
+    };
+    return FormatTools.positionToRaster(lengths, new int[] {c, z, t});
+  }
+
+  private String formatPlaneProvenanceAnomaly(int series, int no, String status,
+    String reason, Plane source, Plane anomalyPlane)
+  {
+    int[] zct = getZCTCoords(series, no);
+    StringBuilder row = new StringBuilder();
+    row.append("no=").append(no);
+    row.append(";z=").append(zct[0]);
+    row.append(";c=").append(zct[1]);
+    row.append(";t=").append(zct[2]);
+    row.append(";status=").append(status);
+    row.append(";reason=").append(reason);
+    if (source != null) {
+      row.append(";sourceNo=").append(source.no);
+      if (source.file != null) {
+        row.append(";file=").append(new Location(source.file).getName());
+      }
+    }
+    else if (anomalyPlane != null && anomalyPlane.file != null) {
+      row.append(";file=").append(new Location(anomalyPlane.file).getName());
+    }
+    return row.toString();
+  }
+
+  private String getWellName(Field field) {
+    if (field == null) {
+      return null;
+    }
+    return getRowName(field.row) + String.format("%02d", field.column + 1);
+  }
+
+  private String getRowName(int row) {
+    StringBuilder name = new StringBuilder();
+    int value = row;
+    do {
+      name.insert(0, (char) ('A' + (value % 26)));
+      value = (value / 26) - 1;
+    }
+    while (value >= 0);
+    return name.toString();
   }
 
   private YokogawaAnnotationGroup getYokogawaAnnotationGroup(String prefix) {
@@ -2453,6 +2668,8 @@ public class CV7000Reader extends FormatReader {
       new LinkedHashMap<String, ArrayList<Field>>();
     public HashMap<String, Boolean> acquiredWells =
       new HashMap<String, Boolean>();
+    public ArrayList<DuplicatePlaneCandidate> duplicateCandidates =
+      new ArrayList<DuplicatePlaneCandidate>();
     private HashMap<String, Plane> representativePlanes =
       new HashMap<String, Plane>();
 
@@ -2469,6 +2686,13 @@ public class CV7000Reader extends FormatReader {
 
     public Plane getRepresentativePlane(int series, int channel) {
       return representativePlanes.get(getPlaneKey(series, channel));
+    }
+
+    public Field getField(int series) {
+      if (series < 0 || series >= acquiredFields.size()) {
+        return null;
+      }
+      return acquiredFields.get(series);
     }
 
     private String getPlaneKey(int series, int channel) {
@@ -2659,6 +2883,33 @@ public class CV7000Reader extends FormatReader {
       int value = next == null ? 0 : next.intValue();
       channelRefs.put(key, Integer.valueOf(value + 1));
       return value;
+    }
+  }
+
+  class PlaneProvenanceSummary {
+    public int planeCount;
+    public int tiffBackedCount;
+    public int filledCount;
+    public int duplicatedCount;
+    public int metadataOnlyCount;
+    public int noMLFRecordCount;
+    public int duplicateCandidateCount;
+    public ArrayList<String> anomalies = new ArrayList<String>();
+  }
+
+  class DuplicatePlaneCandidate {
+    public Plane candidate;
+    public int candidateIndex;
+    public Plane selected;
+    public String reason;
+
+    public DuplicatePlaneCandidate(Plane candidate, int candidateIndex,
+      Plane selected, String reason)
+    {
+      this.candidate = candidate;
+      this.candidateIndex = candidateIndex;
+      this.selected = selected;
+      this.reason = reason;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -2328,9 +2328,11 @@ public class CV7000Reader extends FormatReader {
     }
     switch (role) {
       case WPI:
+      case MEASUREMENT_DATA:
       case MEASUREMENT_DETAIL:
       case MEASUREMENT_SETTINGS:
       case WELL_PLATE_PRODUCT:
+      case POST_PROCESS:
       case OTF_CROSSTALK:
       case OTF_GEOMETRY:
         return true;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -104,6 +104,7 @@ public class CV7000Reader extends FormatReader {
     "openmicroscopy.org/OriginalMetadata/Yokogawa/CV7000";
   private static final String XML_MIME_TYPE = "application/xml";
   private static final String CV7000_DIMENSION_ORDER = "XYZCT";
+  private static final int CHANNEL_NOT_FOUND = -1;
   // Manual objective table plus observed CV7000 objective labels in OTF geometry. These correctly resolve known objectives in local data and available data from public repositories.
   private static final KnownObjectiveSpec[] KNOWN_OBJECTIVES =
     new KnownObjectiveSpec[] {
@@ -585,8 +586,8 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private int getLogicalChannelIndex(Plane p) {
-    return CHANNEL_MAPPER.getLogicalChannelIndex(channels, p);
+  private int getLogicalChannelIndex(Plane p, CV7000ChannelMappingMode mode) {
+    return CHANNEL_MAPPER.getLogicalChannelIndex(channels, p, mode);
   }
 
   private Channel lookupChannel(Plane p) {
@@ -609,6 +610,7 @@ public class CV7000Reader extends FormatReader {
       throw new FormatException("No readable TIFF planes found in " + measurementPath);
     }
 
+    determineChannelMappingMode(layout, acquiredFieldSet);
     sortAcquiredFields(layout.acquiredFields);
     indexAcquiredFields(layout);
     collectPlaneExtents(layout, acquiredFieldSet);
@@ -635,6 +637,60 @@ public class CV7000Reader extends FormatReader {
       }
     }
     return acquiredFieldSet;
+  }
+
+  /** Choose action-aware channel indexing only when all acquired planes map. */
+  private void determineChannelMappingMode(CV7000SeriesLayout layout,
+    HashSet<Field> acquiredFieldSet)
+  {
+    if (channels == null || channels.size() == 0) {
+      setRawMLFChannelMapping(layout, "NO_CHANNEL_SIDECAR_METADATA");
+      return;
+    }
+    if (!hasActionChannelMapping()) {
+      setRawMLFChannelMapping(layout, "NO_ACTION_CHANNEL_MAPPING");
+      LOGGER.warn("Falling back to raw CV7000 MLF channel indexes; " +
+        "channel sidecar metadata has no action/channel assignments");
+      return;
+    }
+
+    for (Plane p : planeData) {
+      if (p == null || !acquiredFieldSet.contains(p.field)) {
+        continue;
+      }
+      int channel = CHANNEL_MAPPER.getActionMappedChannelIndex(channels, p);
+      if (channel == CHANNEL_NOT_FOUND) {
+        setRawMLFChannelMapping(layout, "INCOMPLETE_ACTION_CHANNEL_MAPPING");
+        LOGGER.warn("Falling back to raw CV7000 MLF channel indexes; " +
+          "no exact action/channel metadata for timeline {}, action {}, channel {}",
+          p.timelineIndex + 1, p.actionIndex + 1, p.channel + 1);
+        return;
+      }
+    }
+
+    layout.channelMappingMode = CV7000ChannelMappingMode.ACTION_MAPPED;
+  }
+
+  /** MES action parsing assigns non-negative action and timeline indexes. */
+  private boolean hasActionChannelMapping() {
+    if (channels == null) {
+      return false;
+    }
+    for (Channel channel : channels) {
+      if (channel != null && channel.timelineIndex >= 0 &&
+        channel.actionIndex >= 0)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Record raw-channel fallback for later provenance annotation emission. */
+  private void setRawMLFChannelMapping(CV7000SeriesLayout layout, String reason) {
+    layout.channelMappingMode = CV7000ChannelMappingMode.RAW_MLF;
+    addYokogawaMeta("Yokogawa Channel Mapping ", "Mode", layout.channelMappingMode);
+    addYokogawaMeta("Yokogawa Channel Mapping ", "FallbackReason", reason);
   }
 
   /** Series order follows plate row, plate column, then Yokogawa field index. */
@@ -671,7 +727,7 @@ public class CV7000Reader extends FormatReader {
   private void collectPlaneExtents(CV7000SeriesLayout layout, HashSet<Field> acquiredFieldSet) {
     for (Plane p : planeData) {
       if (p != null && acquiredFieldSet.contains(p.field)) {
-        p.channelIndex = getLogicalChannelIndex(p);
+        p.channelIndex = getLogicalChannelIndex(p, layout.channelMappingMode);
 
         if (!layout.minMax.containsKey(p.field)) {
           layout.minMax.put(p.field, new MinMax());
@@ -2611,16 +2667,23 @@ public class CV7000Reader extends FormatReader {
     UNKNOWN
   }
 
+  private enum CV7000ChannelMappingMode {
+    ACTION_MAPPED,
+    RAW_MLF
+  }
+
   /** Centralizes Yokogawa action/channel matching and reader channel indexing. */
   private static class CV7000ChannelMapper {
-    public int getLogicalChannelIndex(ArrayList<Channel> channels, Plane plane) {
-      if (channels == null) {
+    public int getLogicalChannelIndex(ArrayList<Channel> channels, Plane plane,
+      CV7000ChannelMappingMode mode)
+    {
+      if (mode == CV7000ChannelMappingMode.RAW_MLF || channels == null) {
         return plane.channel;
       }
-      return getChannelIndex(channels, plane);
+      return getActionMappedChannelIndex(channels, plane);
     }
 
-    public int getChannelIndex(ArrayList<Channel> channels, Plane plane) {
+    public int getActionMappedChannelIndex(ArrayList<Channel> channels, Plane plane) {
       int index = -1;
       for (int action=0; action<=plane.actionIndex; action++) {
         for (Channel channel : channels) {
@@ -2636,7 +2699,7 @@ public class CV7000Reader extends FormatReader {
           }
         }
       }
-      return index;
+      return CHANNEL_NOT_FOUND;
     }
 
     public Channel lookupChannel(CV7000RawModel rawModel,
@@ -2723,6 +2786,8 @@ public class CV7000Reader extends FormatReader {
     public Integer[] channelIndexes;
     public HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
     public int[][] reversePlaneLookup;
+    public CV7000ChannelMappingMode channelMappingMode =
+      CV7000ChannelMappingMode.ACTION_MAPPED;
     public LinkedHashMap<String, ArrayList<Field>> fieldsByWell =
       new LinkedHashMap<String, ArrayList<Field>>();
     public HashMap<String, Boolean> acquiredWells =

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -732,7 +732,7 @@ public class CV7000Reader extends FormatReader {
 
   private Channel lookupChannel(Plane p) {
     Channel rawChannel = null;
-    boolean ambiguousRawChannel = false;
+    Channel populatedRawChannel = null;
     for (Channel ch : channels) {
       if (ch.index == p.channel &&
         ch.timelineIndex == p.timelineIndex &&
@@ -741,13 +741,15 @@ public class CV7000Reader extends FormatReader {
         return ch;
       }
       if (ch.index == p.channel) {
-        if (rawChannel != null) {
-          ambiguousRawChannel = true;
+        if (rawChannel == null) {
+          rawChannel = ch;
         }
-        rawChannel = ch;
+        if (populatedRawChannel == null && ch.hasChannelSettings()) {
+          populatedRawChannel = ch;
+        }
       }
     }
-    return ambiguousRawChannel ? null : rawChannel;
+    return populatedRawChannel == null ? rawChannel : populatedRawChannel;
   }
 
   private Plane lookupFirstBackedPlane(int series) {
@@ -982,8 +984,8 @@ public class CV7000Reader extends FormatReader {
   }
 
   class MeasurementSettingsHandler extends BaseHandler {
-    private Channel currentChannel = null;
     private StringBuffer currentValue = new StringBuffer();
+    private int currentChannelIndex = -1;
     private int timelineIndex = -1;
     private int actionIndex = -1;
 
@@ -1014,21 +1016,24 @@ public class CV7000Reader extends FormatReader {
         lightSources.add(l);
       }
       else if (qName.equals("bts:Channel")) {
+        currentChannelIndex = -1;
         String ch = attributes.getValue("bts:Ch");
         if (ch != null) {
           int index = Integer.parseInt(ch) - 1;
           if (index >= 0 && index < channels.size()) {
-            currentChannel = channels.get(index);
+            currentChannelIndex = index;
 
-            currentChannel.objectiveID = attributes.getValue("bts:ObjectiveID");
-            currentChannel.objective = attributes.getValue("bts:Objective");
-            currentChannel.binning = attributes.getValue("bts:Binning");
+            Channel template = new Channel();
+            template.index = index;
+            template.objectiveID = attributes.getValue("bts:ObjectiveID");
+            template.objective = attributes.getValue("bts:Objective");
+            template.binning = attributes.getValue("bts:Binning");
 
             String mag = attributes.getValue("bts:Magnification");
-            currentChannel.magnification = DataTools.parseDouble(mag);
+            template.magnification = DataTools.parseDouble(mag);
 
             String exposure = attributes.getValue("bts:ExposureTime");
-            currentChannel.exposureTime = DataTools.parseDouble(exposure);
+            template.exposureTime = DataTools.parseDouble(exposure);
 
             String color = attributes.getValue("bts:Color");
             if (color != null) {
@@ -1043,7 +1048,7 @@ public class CV7000Reader extends FormatReader {
                 int red = colors[colors.length - 3];
                 int green = colors[colors.length - 2];
                 int blue = colors[colors.length - 1];
-                currentChannel.color = new Color(red, green, blue, alpha);
+                template.color = new Color(red, green, blue, alpha);
               }
             }
 
@@ -1052,11 +1057,12 @@ public class CV7000Reader extends FormatReader {
               if (acquisition.indexOf("/") > 0) {
                 acquisition = acquisition.replaceAll("BP", "");
                 String wave = acquisition.substring(0, acquisition.indexOf("/"));
-                currentChannel.excitation = DataTools.parseDouble(wave);
+                template.excitation = DataTools.parseDouble(wave);
               }
             }
 
-            currentChannel.fluor = attributes.getValue("bts:Fluorophore");
+            template.fluor = attributes.getValue("bts:Fluorophore");
+            applyChannelSettings(template);
           }
         }
       }
@@ -1073,7 +1079,7 @@ public class CV7000Reader extends FormatReader {
     public void endElement(String uri, String localName, String qName) {
       String value = currentValue.toString();
 
-      if (qName.equals("bts:LightSourceName") && currentChannel != null) {
+      if (qName.equals("bts:LightSourceName") && currentChannelIndex >= 0) {
         int index = -1;
         for (int i=0; i<lightSources.size(); i++) {
           if (lightSources.get(i).name.equals(value)) {
@@ -1081,8 +1087,11 @@ public class CV7000Reader extends FormatReader {
           }
         }
         if (index >= 0) {
-          currentChannel.lightSourceRefs.add(index);
+          addLightSourceRef(currentChannelIndex, index);
         }
+      }
+      else if (qName.equals("bts:Channel")) {
+        currentChannelIndex = -1;
       }
       else if (qName.equals("bts:Ch")) {
         int channelIndex = Integer.parseInt(value) - 1;
@@ -1103,6 +1112,24 @@ public class CV7000Reader extends FormatReader {
             duplicate.actionIndex = actionIndex;
             channels.add(duplicate);
           }
+        }
+      }
+    }
+
+    private void applyChannelSettings(Channel template) {
+      for (Channel ch : channels) {
+        if (ch.index == template.index) {
+          ch.copyChannelSettings(template);
+        }
+      }
+    }
+
+    private void addLightSourceRef(int rawChannelIndex, int lightSourceIndex) {
+      for (Channel ch : channels) {
+        if (ch.index == rawChannelIndex &&
+          !ch.lightSourceRefs.contains(lightSourceIndex))
+        {
+          ch.lightSourceRefs.add(lightSourceIndex);
         }
       }
     }
@@ -1145,7 +1172,7 @@ public class CV7000Reader extends FormatReader {
       ySize = ch.ySize;
       cameraNumber = ch.cameraNumber;
       correctionFile = ch.correctionFile;
-      lightSourceRefs = ch.lightSourceRefs;
+      lightSourceRefs = new ArrayList<Integer>(ch.lightSourceRefs);
       excitation = ch.excitation;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
@@ -1154,6 +1181,24 @@ public class CV7000Reader extends FormatReader {
       binning = ch.binning;
       color = ch.color;
       fluor = ch.fluor;
+    }
+
+    public void copyChannelSettings(Channel ch) {
+      excitation = ch.excitation;
+      objectiveID = ch.objectiveID;
+      objective = ch.objective;
+      magnification = ch.magnification;
+      exposureTime = ch.exposureTime;
+      binning = ch.binning;
+      color = ch.color;
+      fluor = ch.fluor;
+    }
+
+    public boolean hasChannelSettings() {
+      return objectiveID != null || objective != null || magnification != null ||
+        exposureTime != null || binning != null || color != null ||
+        excitation != null || fluor != null ||
+        (lightSourceRefs != null && lightSourceRefs.size() > 0);
     }
 
     @Override

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -671,6 +671,8 @@ public class CV7000Reader extends FormatReader {
   {
     if (channels == null || channels.size() == 0) {
       setRawMLFChannelMapping(layout, "NO_CHANNEL_SIDECAR_METADATA");
+      LOGGER.warn("Falling back to raw CV7000 MLF channel indexes; " +
+        "no channel sidecar metadata is available");
       return;
     }
     if (!hasActionChannelMapping()) {
@@ -2969,10 +2971,17 @@ public class CV7000Reader extends FormatReader {
     public Channel lookupChannel(CV7000RawModel rawModel,
       ArrayList<Channel> channels, Plane plane)
     {
+      if (plane == null) {
+        return null;
+      }
       Channel matched = rawModel.getChannel(
         plane.timelineIndex, plane.actionIndex, plane.channel);
       if (matched != null) {
         return matched;
+      }
+
+      if (channels == null) {
+        return null;
       }
 
       Channel rawChannel = null;
@@ -2993,7 +3002,15 @@ public class CV7000Reader extends FormatReader {
           }
         }
       }
-      return populatedRawChannel == null ? rawChannel : populatedRawChannel;
+      Channel fallback =
+        populatedRawChannel == null ? rawChannel : populatedRawChannel;
+      if (fallback != null && rawModel.markRawChannelFallback(plane)) {
+        LOGGER.warn("Falling back to CV7000 raw channel metadata for " +
+          "timeline {}, action {}, raw channel {}; no exact acquisition " +
+          "metadata is available", plane.timelineIndex + 1,
+          plane.actionIndex + 1, plane.channel + 1);
+      }
+      return fallback;
     }
   }
 
@@ -3014,9 +3031,12 @@ public class CV7000Reader extends FormatReader {
       new YokogawaOriginalMetadata();
     public HashMap<ChannelKey, Channel> channelsByAcquisition =
       new HashMap<ChannelKey, Channel>();
+    private HashSet<ChannelKey> warnedRawChannelFallbacks =
+      new HashSet<ChannelKey>();
 
     public void indexChannels(ArrayList<Channel> channels) {
       channelsByAcquisition.clear();
+      warnedRawChannelFallbacks.clear();
       if (channels == null) {
         return;
       }
@@ -3032,6 +3052,11 @@ public class CV7000Reader extends FormatReader {
     public Channel getChannel(int timelineIndex, int actionIndex, int rawChannel) {
       return channelsByAcquisition.get(
         new ChannelKey(timelineIndex, actionIndex, rawChannel));
+    }
+
+    private boolean markRawChannelFallback(Plane plane) {
+      return warnedRawChannelFallbacks.add(new ChannelKey(
+        plane.timelineIndex, plane.actionIndex, plane.channel));
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -652,13 +652,72 @@ public class CV7000Reader extends FormatReader {
         ch.resolvedCorrectionFile = resolved;
         ch.correctionFile = getRelativePath(parentPath, resolved);
         Location correction = new Location(resolved);
-        if (correction.exists() && correction.canRead() &&
-          !correction.isDirectory() && isTiffFile(correction.getName()))
-        {
+        if (!correction.exists()) {
+          Location fallback = findCorrectionFile(correction);
+          if (fallback != null) {
+            correction = fallback;
+            ch.resolvedCorrectionFile = correction.getAbsolutePath();
+            ch.correctionFile =
+              getRelativePath(parentPath, ch.resolvedCorrectionFile);
+          }
+        }
+        if (isReadableTiff(correction)) {
           correctionFiles.add(correction.getAbsolutePath());
         }
       }
     }
+  }
+
+  /** Find one TIFF whose stem contains the missing metadata filename stem. */
+  private Location findCorrectionFile(Location expected) {
+    Location directory = expected.getParentFile();
+    if (directory == null || !directory.isDirectory() ||
+      !directory.canRead())
+    {
+      return null;
+    }
+
+    String expectedStem = getFilenameStem(expected.getName());
+    if (expectedStem.length() == 0) {
+      return null;
+    }
+
+    String[] listedFiles = directory.list(true);
+    if (listedFiles == null) {
+      return null;
+    }
+    Arrays.sort(listedFiles);
+    ArrayList<Location> matches = new ArrayList<Location>();
+    for (String listedFile : listedFiles) {
+      Location candidate = new Location(directory, listedFile);
+      if (isReadableTiff(candidate) &&
+        getFilenameStem(candidate.getName()).contains(expectedStem))
+      {
+        matches.add(candidate);
+      }
+    }
+
+    if (matches.size() == 1) {
+      return matches.get(0);
+    }
+    if (matches.size() > 1) {
+      LOGGER.warn("Ambiguous CV7000 shading correction source {}: {}",
+        expected.getAbsolutePath(), matches);
+    }
+    return null;
+  }
+
+  private boolean isReadableTiff(Location file) {
+    return file.exists() && file.canRead() && !file.isDirectory() &&
+      isTiffFile(file.getName());
+  }
+
+  private String getFilenameStem(String name) {
+    if (name == null) {
+      return "";
+    }
+    int dot = name.lastIndexOf('.');
+    return dot < 0 ? name : name.substring(0, dot);
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -62,6 +62,7 @@ import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 import ome.xml.model.enums.AcquisitionMode;
 import ome.xml.model.enums.ContrastMethod;
+import ome.xml.model.enums.NamingConvention;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -677,6 +678,8 @@ public class CV7000Reader extends FormatReader {
     store.setPlateExternalIdentifier(plate.getPlateID(), 0);
     store.setPlateRows(new PositiveInteger(plate.getPlateRows()), 0);
     store.setPlateColumns(new PositiveInteger(plate.getPlateColumns()), 0);
+    store.setPlateRowNamingConvention(NamingConvention.LETTER, 0);
+    store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
     store.setPlateWellOriginX(FormatTools.createLength(0.0, UNITS.MICROMETER), 0);
     store.setPlateWellOriginY(FormatTools.createLength(0.0, UNITS.MICROMETER), 0);
 
@@ -739,8 +742,9 @@ public class CV7000Reader extends FormatReader {
             (col + 1) + ", Field " + (field.field + 1);
           store.setImageName(name, nextImage);
           if (timings[nextImage].startTimestamp != null) {
-            store.setImageAcquisitionDate(
-              new Timestamp(timings[nextImage].startTimestamp), nextImage);
+            Timestamp timepoint = new Timestamp(timings[nextImage].startTimestamp);
+            store.setImageAcquisitionDate(timepoint, nextImage);
+            store.setWellSampleTimepoint(timepoint, 0, nextWell, wellSample);
           }
           store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
 
@@ -836,8 +840,7 @@ public class CV7000Reader extends FormatReader {
         store.setObjectiveSettingsID(objectiveID, series);
       }
 
-      store.setChannelName("Action #" + (p.actionIndex + 1) +
-        ", Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, series, c);
+      store.setChannelName(getChannelDisplayName(channel, p), series, c);
 
       AcquisitionMode acquisitionMode = getYokogawaAcquisitionMode(channel);
       if (acquisitionMode != null) {
@@ -860,6 +863,43 @@ public class CV7000Reader extends FormatReader {
       populateDetectorSettings(store, series, c, channel, detectorIndexes);
       populateExposureTime(store, series, c, channel);
     }
+  }
+
+  private String getChannelDisplayName(Channel channel, Plane plane) {
+    String acquisition = clean(channel.acquisition);
+    if (channel.isBrightfield()) {
+      return acquisition == null ? BRIGHTFIELD : "BF / " + acquisition;
+    }
+
+    String target = clean(channel.target);
+    if (target != null && acquisition != null) {
+      return target + " / " + acquisition;
+    }
+    if (target != null) {
+      return target;
+    }
+    if (acquisition != null) {
+      return acquisition;
+    }
+    return getChannelProvenance(channel, plane);
+  }
+
+  private String getChannelProvenance(Channel channel) {
+    return getChannelProvenance(channel, null);
+  }
+
+  private String getChannelProvenance(Channel channel, Plane plane) {
+    int action = plane == null ? channel.actionIndex : plane.actionIndex;
+    return "Action #" + (action + 1) + ", Channel #" +
+      (channel.index + 1) + ", Camera #" + channel.cameraNumber;
+  }
+
+  private String clean(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.length() == 0 ? null : trimmed;
   }
 
   private void populateChannelLightSourceSettings(MetadataStore store, int series,
@@ -1249,6 +1289,7 @@ public class CV7000Reader extends FormatReader {
       addYokogawaMeta(prefix, "ActionUseSoftFocus", c.actionUseSoftFocus);
       addYokogawaMeta(prefix, "FilterID", c.filterID);
       addYokogawaMeta(prefix, "Acquisition", c.acquisition);
+      addYokogawaMeta(prefix, "ChannelProvenance", getChannelProvenance(c));
       if (c.detectionFilter != null) {
         addYokogawaMeta(prefix, "DetectionFilterType", c.detectionFilter.filterType);
         addYokogawaMeta(prefix, "DetectionFilterCenter", c.detectionFilter.center);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -26,8 +26,12 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -37,7 +41,6 @@ import java.util.Map;
 
 import loci.common.DataTools;
 import loci.common.Location;
-import loci.common.RandomAccessInputStream;
 import loci.common.xml.BaseHandler;
 import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
@@ -46,8 +49,6 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
-import loci.formats.tiff.IFD;
-import loci.formats.tiff.TiffParser;
 
 import ome.units.UNITS;
 import ome.units.quantity.Length;
@@ -55,9 +56,10 @@ import ome.units.quantity.Power;
 import ome.units.quantity.Time;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
+import ome.xml.model.enums.AcquisitionMode;
+import ome.xml.model.enums.ContrastMethod;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +82,7 @@ public class CV7000Reader extends FormatReader {
   private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
   private static final String POST_PROCESS = "PostProcess.ppf";
   private static final String BRIGHTFIELD = "Brightfield";
+  private static final int RAW_XML_CHUNK_SIZE = 7600;
 
   // -- Fields --
 
@@ -95,6 +98,7 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<Channel> channels;
   private String startTime, endTime;
   private ArrayList<String> extraFiles;
+  private MeasurementDataHandler measurementHandler;
 
   private transient Map<String, Boolean> acquiredWells = new HashMap<String, Boolean>();
 
@@ -220,6 +224,7 @@ public class CV7000Reader extends FormatReader {
       channels = null;
       startTime = null;
       endTime = null;
+      measurementHandler = null;
       reversePlaneLookup = null;
       extraFiles = null;
       acquiredWells.clear();
@@ -280,11 +285,40 @@ public class CV7000Reader extends FormatReader {
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
-    WPIHandler plate = new WPIHandler();
-    String wpiXML = readSanitizedXML(id);
-    XMLTools.parseXML(wpiXML, plate);
+    DatasetPaths paths = getDatasetPaths(id);
+    WPIHandler plate = parsePlate(paths.wpiPath);
 
-    Location parent = new Location(id).getAbsoluteFile().getParentFile();
+    collectDatasetFiles(paths.parent);
+    parseMeasurementData(paths);
+    parseOptionalSidecars(paths);
+    normalizeChannels(paths.parent);
+
+    SeriesLayout layout = buildSeriesLayout();
+    initializeCoreMetadata(layout);
+    populateReversePlaneLookup(layout);
+    populateMetadataStore(plate, layout);
+    setSeries(0);
+  }
+
+  private DatasetPaths getDatasetPaths(String id) {
+    DatasetPaths paths = new DatasetPaths();
+    Location wpi = new Location(id).getAbsoluteFile();
+    paths.wpiPath = wpi.getAbsolutePath();
+    paths.parent = wpi.getParentFile();
+    paths.measurementData = new Location(paths.parent, MEASUREMENT_FILE);
+    paths.measurementDetail = new Location(paths.parent, MEASUREMENT_DETAIL);
+    return paths;
+  }
+
+  /** Parse the .wpi file, which defines the plate dimensions and identity. */
+  private WPIHandler parsePlate(String wpiPath) throws IOException {
+    WPIHandler plate = new WPIHandler();
+    XMLTools.parseXML(readSanitizedXML(wpiPath), plate);
+    return plate;
+  }
+
+  /** Keep a dataset-level inventory for getUsedFiles and original metadata. */
+  private void collectDatasetFiles(Location parent) {
     String[] listedFiles = parent.list(true);
     Arrays.sort(listedFiles);
     for (int i=0; i<listedFiles.length; i++) {
@@ -293,35 +327,57 @@ public class CV7000Reader extends FormatReader {
         allFiles.add(file.getAbsolutePath());
       }
     }
-    Location measurementData = new Location(parent, MEASUREMENT_FILE);
+  }
 
-    if (!measurementData.exists()) {
+  /** Parse the required plane manifest and resolve readable TIFF plane paths. */
+  private void parseMeasurementData(DatasetPaths paths)
+    throws FormatException, IOException
+  {
+    if (!paths.measurementData.exists()) {
       throw new FormatException("Missing " + MEASUREMENT_FILE + " file");
     }
 
-    measurementPath = measurementData.getAbsolutePath();
-    MeasurementDataHandler measurementHandler = new MeasurementDataHandler(parent.getAbsolutePath());
+    measurementPath = paths.measurementData.getAbsolutePath();
+    measurementHandler = new MeasurementDataHandler(paths.parent.getAbsolutePath());
     XMLTools.parseXML(readSanitizedXML(measurementPath), measurementHandler);
-
     planeData = measurementHandler.getPlanes();
+  }
 
-    Location measurementDetail = new Location(parent, MEASUREMENT_DETAIL);
-    if (!measurementDetail.exists()) {
+  /** Parse optional XML sidecars that enrich channel, instrument, and raw metadata. */
+  private void parseOptionalSidecars(DatasetPaths paths) throws IOException {
+    parseMeasurementDetail(paths);
+    parseWellPlateProduct();
+    parseMeasurementSettings();
+  }
+
+  /** MeasurementDetail links the acquisition settings sidecars and seeds channels. */
+  private void parseMeasurementDetail(DatasetPaths paths) throws IOException {
+    if (!paths.measurementDetail.exists()) {
       LOGGER.warn("Missing " + MEASUREMENT_DETAIL + " file");
-    }
-    else {
-      channels = new ArrayList<Channel>();
-      detailPath = measurementDetail.getAbsolutePath();
-      MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
-      XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
-      if (wppPath != null) {
-        wppPath = new Location(parent, wppPath).getAbsolutePath();
-      }
-      if (settingsPath != null) {
-        settingsPath = new Location(parent, settingsPath).getAbsolutePath();
-      }
+      return;
     }
 
+    channels = new ArrayList<Channel>();
+    detailPath = paths.measurementDetail.getAbsolutePath();
+    MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
+    XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
+    if (wppPath != null) {
+      wppPath = new Location(paths.parent, wppPath).getAbsolutePath();
+    }
+    if (settingsPath != null) {
+      settingsPath = new Location(paths.parent, settingsPath).getAbsolutePath();
+    }
+  }
+
+  /** WPP is optional plate-product metadata; missing files preserve legacy behavior. */
+  private void parseWellPlateProduct() throws IOException {
+    if (wppPath != null && new Location(wppPath).exists()) {
+      XMLTools.parseXML(readSanitizedXML(wppPath), new WPPHandler());
+    }
+  }
+
+  /** Measurement settings attach light sources, actions, filters, and channel modes. */
+  private void parseMeasurementSettings() throws IOException {
     if (settingsPath != null && new Location(settingsPath).exists()) {
       lightSources = new ArrayList<LightSource>();
       MeasurementSettingsHandler settingsHandler = new MeasurementSettingsHandler();
@@ -330,7 +386,19 @@ public class CV7000Reader extends FormatReader {
         XMLTools.parseXML(xml, settingsHandler);
       }
     }
+  }
 
+  /** Normalize channel order and paths after all optional channel sources are parsed. */
+  private void normalizeChannels(Location parent) {
+    if (channels == null) {
+      return;
+    }
+    sortChannelsByActionThenIndex();
+    resolveCorrectionFiles(parent);
+  }
+
+  /** Yokogawa logical channels are ordered by action first, then channel index. */
+  private void sortChannelsByActionThenIndex() {
     channels.sort(new Comparator<Channel>() {
       @Override
       public int compare(Channel c1, Channel c2) {
@@ -340,38 +408,58 @@ public class CV7000Reader extends FormatReader {
         return c1.index - c2.index;
       }
     });
+  }
 
+  /** Shading correction paths are relative to the dataset directory in the XML. */
+  private void resolveCorrectionFiles(Location parent) {
     for (Channel ch : channels) {
       if (ch.correctionFile != null) {
         ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
       }
     }
+  }
 
-    String firstFile = null;
-    HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
+  /**
+   * Build the field/channel/time/z layout before touching Bio-Formats core
+   * metadata.  This keeps Yokogawa indexing separate from reader indexing.
+   */
+  private SeriesLayout buildSeriesLayout() throws FormatException {
+    SeriesLayout layout = new SeriesLayout();
+    HashSet<Field> acquiredFieldSet = collectAcquiredFields(layout);
 
-    ArrayList<Field> acquiredFields = new ArrayList<Field>();
+    if (layout.firstFile == null) {
+      throw new FormatException("No readable TIFF planes found in " + measurementPath);
+    }
+
+    sortAcquiredFields(layout.acquiredFields);
+    collectPlaneExtents(layout, acquiredFieldSet);
+    layout.channelIndexes = layout.uniqueChannels.toArray(
+      new Integer[layout.uniqueChannels.size()]);
+    Arrays.sort(layout.channelIndexes);
+    return layout;
+  }
+
+  /** Only fields with at least one readable plane become Bio-Formats series. */
+  private HashSet<Field> collectAcquiredFields(SeriesLayout layout) {
     HashSet<Field> acquiredFieldSet = new HashSet<Field>();
-    HashSet<Integer> uniqueChannels = new HashSet<Integer>();
-
     for (Plane p : planeData) {
       if (p != null && p.file != null) {
         if (!allFiles.contains(p.file)) {
           allFiles.add(p.file);
         }
-        if (firstFile == null) {
-          firstFile = p.file;
+        if (layout.firstFile == null) {
+          layout.firstFile = p.file;
         }
         if (acquiredFieldSet.add(p.field)) {
-          acquiredFields.add(p.field);
+          layout.acquiredFields.add(p.field);
         }
       }
     }
+    return acquiredFieldSet;
+  }
 
-    if (firstFile == null) {
-      throw new FormatException("No readable TIFF planes found in " + measurementPath);
-    }
-
+  /** Series order follows plate row, plate column, then Yokogawa field index. */
+  private void sortAcquiredFields(ArrayList<Field> acquiredFields) {
     Collections.sort(acquiredFields, new Comparator<Field>() {
       @Override
       public int compare(Field f1, Field f2) {
@@ -384,72 +472,62 @@ public class CV7000Reader extends FormatReader {
         return f1.field - f2.field;
       }
     });
+  }
 
+  /** Determine SizeZ/SizeT/channel coverage for every acquired field. */
+  private void collectPlaneExtents(SeriesLayout layout, HashSet<Field> acquiredFieldSet) {
     for (Plane p : planeData) {
       if (p != null && acquiredFieldSet.contains(p.field)) {
-        p.channelIndex = getChannelIndex(p);
+        p.channelIndex = getLogicalChannelIndex(p);
 
-        if (!minMax.containsKey(p.field)) {
-          minMax.put(p.field, new MinMax());
+        if (!layout.minMax.containsKey(p.field)) {
+          layout.minMax.put(p.field, new MinMax());
         }
-        MinMax m = minMax.get(p.field);
-
-        if (p.timepoint > m.maxT) {
-          m.maxT = p.timepoint;
-        }
-        if (p.timepoint < m.minT) {
-          m.minT = p.timepoint;
-        }
-        if (p.z > m.maxZ) {
-          m.maxZ = p.z;
-        }
-        if (p.z < m.minZ) {
-          m.minZ = p.z;
-        }
-
-        // min and max channel indexes not currently used,
-        // but continue to calculate for completeness
-        // they may be needed in future CV7000/8000 work
-        if (p.channelIndex > m.maxC) {
-          m.maxC = p.channelIndex;
-        }
-        if (p.channelIndex < m.minC) {
-          m.minC = p.channelIndex;
-        }
-        uniqueChannels.add(p.channelIndex);
+        MinMax m = layout.minMax.get(p.field);
+        m.update(p);
+        layout.uniqueChannels.add(p.channelIndex);
       }
     }
+  }
 
+  /** Use detailed action/channel mapping when present; fall back to raw channel IDs. */
+  private int getLogicalChannelIndex(Plane p) {
+    if (channels == null) {
+      return p.channel;
+    }
+    return getChannelIndex(p);
+  }
+
+  /** Initialize the Bio-Formats core metadata once the logical layout is known. */
+  private void initializeCoreMetadata(SeriesLayout layout) throws FormatException, IOException {
     reader = new MinimalTiffReader();
-    reader.setId(firstFile);
+    reader.setId(layout.firstFile);
     core.clear();
     core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));
 
     core.get(0).dimensionOrder = "XYCZT";
+    reversePlaneLookup = new int[layout.acquiredFields.size()][];
 
-    reversePlaneLookup = new int[acquiredFields.size()][];
-
-    Integer[] channelIndexes = uniqueChannels.toArray(new Integer[uniqueChannels.size()]);
-    Arrays.sort(channelIndexes);
-
-    HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
-    for (int i=0; i<acquiredFields.size(); i++) {
+    for (int i=0; i<layout.acquiredFields.size(); i++) {
       if (i > 0) {
         core.add(new CoreMetadata(core.get(0)));
       }
 
-      Field field = acquiredFields.get(i);
-      fieldToSeries.put(field, i);
-      MinMax m = minMax.get(field);
+      Field field = layout.acquiredFields.get(i);
+      layout.fieldToSeries.put(field, i);
+      MinMax m = layout.minMax.get(field);
       core.get(i).sizeZ = (m.maxZ - m.minZ) + 1;
       core.get(i).sizeT = (m.maxT - m.minT) + 1;
-      core.get(i).sizeC = reader.getSizeC() * uniqueChannels.size();
+      core.get(i).sizeC = reader.getSizeC() * layout.channelIndexes.length;
       core.get(i).imageCount = core.get(i).sizeZ * core.get(i).sizeT *
         (core.get(i).sizeC / reader.getSizeC());
       reversePlaneLookup[i] = new int[core.get(i).imageCount];
       Arrays.fill(reversePlaneLookup[i], -1);
     }
+  }
 
+  /** Map each Yokogawa plane record to the reader's series and plane index. */
+  private void populateReversePlaneLookup(SeriesLayout layout) {
     int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
 
     extraFiles = new ArrayList<String>();
@@ -459,19 +537,17 @@ public class CV7000Reader extends FormatReader {
         continue;
       }
 
-      Integer series = fieldToSeries.get(p.field);
+      Integer series = layout.fieldToSeries.get(p.field);
       if (series == null) {
         continue;
       }
 
-      // reindex so that the plane's channel index is into
-      // the list of unique acquired channels, not the list of all channels
-      // that might have been acquired
-      // this eliminates the need to correct for the minimum C index later on
-      p.channelIndex = Arrays.binarySearch(channelIndexes, p.channelIndex);
+      // Reindex from Yokogawa's channel/action numbering into the compact
+      // channel list exposed by this reader for the current dataset.
+      p.channelIndex = Arrays.binarySearch(layout.channelIndexes, p.channelIndex);
 
       p.series = series.intValue();
-      MinMax m = minMax.get(p.field);
+      MinMax m = layout.minMax.get(p.field);
 
       planeLengths[0] = core.get(p.series).sizeC / reader.getSizeC();
       planeLengths[1] = core.get(p.series).sizeZ;
@@ -479,27 +555,74 @@ public class CV7000Reader extends FormatReader {
 
       p.no = FormatTools.positionToRaster(planeLengths,
         new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
+      assignPlaneLookup(i, p);
+    }
+  }
 
-      if (reversePlaneLookup[p.series][p.no] < 0) {
-        reversePlaneLookup[p.series][p.no] = i;
+  /** Prefer a real plane over metadata-only duplicate records for each position. */
+  private void assignPlaneLookup(int planeIndex, Plane p) {
+    if (reversePlaneLookup[p.series][p.no] < 0) {
+      reversePlaneLookup[p.series][p.no] = planeIndex;
+    }
+    else {
+      Plane existing = planeData.get(reversePlaneLookup[p.series][p.no]);
+      if ((existing == null || existing.file == null) && p.file != null) {
+        reversePlaneLookup[p.series][p.no] = planeIndex;
       }
-      else {
-        Plane existing = planeData.get(reversePlaneLookup[p.series][p.no]);
-        if ((existing == null || existing.file == null) && p.file != null) {
-          reversePlaneLookup[p.series][p.no] = i;
-        }
-        else if (p.file != null) {
-          LOGGER.warn("Ignoring file {}", p.file);
-          extraFiles.add(p.file);
-        }
+      else if (p.file != null) {
+        LOGGER.warn("Ignoring file {}", p.file);
+        extraFiles.add(p.file);
       }
     }
+  }
 
-    // populate the MetadataStore
+  /** Populate OME metadata after core metadata and plane lookup are complete. */
+  private void populateMetadataStore(WPIHandler plate, SeriesLayout layout)
+    throws FormatException
+  {
+    SeriesTiming[] timings = buildSeriesTimings();
 
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 
+    populatePlateMetadata(store, plate, layout.acquiredFields, timings);
+    setSeries(0);
+
+    if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
+      store.setPlateName(plate.getPlateName(), 0);
+      store.setPlateDescription(plate.getPlateDescription(), 0);
+      store.setPlateExternalIdentifier(plate.getPlateID(), 0);
+
+      InstrumentMetadataIndexes indexes = populateInstrumentMetadata(store);
+      populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
+        indexes.detectorIndexes, indexes.filterIndexes, indexes.usedObjectiveIDs, timings);
+      setSeries(0);
+    }
+  }
+
+  /** Build reusable instrument indexes before linking each Image/channel to them. */
+  private InstrumentMetadataIndexes populateInstrumentMetadata(MetadataStore store)
+    throws FormatException
+  {
+    InstrumentMetadataIndexes indexes = new InstrumentMetadataIndexes();
+    if ((lightSources != null && lightSources.size() > 0) ||
+      (channels != null && channels.size() > 0))
+    {
+      indexes.instrument = MetadataTools.createLSID("Instrument", 0);
+
+      store.setInstrumentID(indexes.instrument, 0);
+      populateLightSources(store, indexes.lightSourceIndexes);
+      populateObjectives(store, indexes.usedObjectiveIDs);
+      populateDetectors(store, indexes.detectorIndexes);
+      populateFilters(store, indexes.filterIndexes);
+      addYokogawaOriginalMetadata();
+    }
+    return indexes;
+  }
+
+  private void populatePlateMetadata(MetadataStore store, WPIHandler plate,
+    ArrayList<Field> acquiredFields, SeriesTiming[] timings)
+  {
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateName(plate.getPlateName(), 0);
     store.setPlateDescription(plate.getPlateDescription(), 0);
@@ -565,11 +688,14 @@ public class CV7000Reader extends FormatReader {
           String name = "Well " + FormatTools.getWellRowName(row) +
             (col + 1) + ", Field " + (field.field + 1);
           store.setImageName(name, nextImage);
+          if (timings[nextImage].startTimestamp != null) {
+            store.setImageAcquisitionDate(
+              new Timestamp(timings[nextImage].startTimestamp), nextImage);
+          }
           store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
 
           setSeries(nextImage);
 
-          // find the first plane with pixels to set WellSample positions
           Plane p = lookupFirstBackedPlane(nextImage);
           if (p != null) {
             store.setWellSamplePositionX(
@@ -586,151 +712,265 @@ public class CV7000Reader extends FormatReader {
         nextWell++;
       }
     }
-    setSeries(0);
+  }
 
-    if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      store.setPlateName(plate.getPlateName(), 0);
-      store.setPlateDescription(plate.getPlateDescription(), 0);
-      store.setPlateExternalIdentifier(plate.getPlateID(), 0);
-
-      String instrument = null;
-      HashMap<Integer, Integer> lightSourceIndexes = new HashMap<Integer, Integer>();
-      HashMap<Integer, Integer> detectorIndexes = new HashMap<Integer, Integer>();
-      HashMap<FilterKey, Integer> filterIndexes = new HashMap<FilterKey, Integer>();
-      List<String> usedObjectiveIDs = new ArrayList<String>();
-      if ((lightSources != null && lightSources.size() > 0) ||
-        (channels != null && channels.size() > 0))
-      {
-        instrument = MetadataTools.createLSID("Instrument", 0);
-
-        store.setInstrumentID(instrument, 0);
-        populateLightSources(store, lightSourceIndexes);
-        populateObjectives(store, usedObjectiveIDs);
-        populateDetectors(store, detectorIndexes);
-        populateFilters(store, filterIndexes);
-        addYokogawaOriginalMetadata();
+  private void populateSeriesMetadata(MetadataStore store, String instrument,
+    HashMap<Integer, Integer> lightSourceIndexes,
+    HashMap<Integer, Integer> detectorIndexes,
+    HashMap<FilterKey, Integer> filterIndexes,
+    List<String> usedObjectiveIDs, SeriesTiming[] timings)
+  {
+    for (int i=0; i<getSeriesCount(); i++) {
+      setSeries(i);
+      if (instrument != null) {
+        store.setImageInstrumentRef(instrument, i);
       }
-
-      for (int i=0; i<getSeriesCount(); i++) {
-        setSeries(i);
-        if (instrument != null) {
-          store.setImageInstrumentRef(instrument, i);
-        }
-        if (channels != null) {
-          Length physicalSizeZ = getPhysicalSizeZ(i);
-          if (physicalSizeZ != null) {
-            store.setPixelsPhysicalSizeZ(physicalSizeZ, i);
-          }
-
-          boolean physicalSizeSet = false;
-          for (int c=0; c<getSizeC(); c++) {
-            Plane p = lookupRepresentativePlane(i, c);
-            if (p == null) {
-              // There was likely an error during acquisition for this
-              // particular channel.  Skip it.
-              continue;
-            }
-            Channel channel = lookupChannel(p);
-            if (channel == null) {
-              continue;
-            }
-
-            if (!physicalSizeSet) {
-              store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(channel.xSize), i);
-              store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.ySize), i);
-              physicalSizeSet = true;
-            }
-
-            int objective = -1;
-            if (channel.objectiveID != null) {
-              objective = usedObjectiveIDs.indexOf(channel.objectiveID);
-            }
-
-            if (channel.magnification != null && objective >= 0) {
-              store.setObjectiveNominalMagnification(channel.magnification, 0, objective);
-            }
-            if (objective >= 0) {
-              String objectiveID = MetadataTools.createLSID("Objective", 0, objective);
-              store.setObjectiveSettingsID(objectiveID, i);
-            }
-
-            // the index here is the original bts:Ch index in
-            // the *.mes and *.mrf files
-            store.setChannelName("Action #" + (p.actionIndex + 1) +
-              ", Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, i, c);
-
-            if (channel.color != null) {
-              store.setChannelColor(channel.color, i, c);
-            }
-            if (channel.fluor != null && !channel.fluor.isEmpty()) {
-              store.setChannelFluor(channel.fluor, i, c);
-            }
-
-            Integer lightSource = getLinkedLaser(channel);
-            if (lightSource != null && lightSourceIndexes.containsKey(lightSource)) {
-              LightSource source = lightSources.get(lightSource);
-              if (source.wavelength != null && source.wavelength > 0) {
-                int index = lightSourceIndexes.get(lightSource);
-                store.setChannelLightSourceSettingsID(
-                  MetadataTools.createLSID("LightSource", 0, index), i, c);
-                store.setChannelExcitationWavelength(
-                  new Length(source.wavelength, UNITS.NANOMETER), i, c);
-              }
-            }
-
-            if (!channel.isBrightfield() && channel.detectionFilter != null &&
-              channel.detectionFilter.center != null)
-            {
-              store.setChannelEmissionWavelength(
-                new Length(channel.detectionFilter.center, UNITS.NANOMETER), i, c);
-            }
-
-            FilterKey filter = new FilterKey(channel);
-            if (filterIndexes.containsKey(filter)) {
-              store.setLightPathEmissionFilterRef(
-                MetadataTools.createLSID("Filter", 0, filterIndexes.get(filter)), i, c, 0);
-            }
-
-            if (detectorIndexes.containsKey(channel.cameraNumber)) {
-              String detectorID = MetadataTools.createLSID(
-                "Detector", 0, detectorIndexes.get(channel.cameraNumber));
-              store.setDetectorSettingsID(detectorID, i, c);
-              String binning = getBinningValue(channel.binning);
-              if (binning != null) {
-                try {
-                  store.setDetectorSettingsBinning(
-                    MetadataTools.getBinning(binning), i, c);
-                }
-                catch (FormatException e) {
-                  LOGGER.debug("Ignoring invalid CV7000 binning value {}", binning, e);
-                }
-              }
-            }
-
-            if (channel.exposureTime != null) {
-              Time exposure = new Time(channel.exposureTime, UNITS.MILLISECOND);
-              for (int z=0; z<getSizeZ(); z++) {
-                for (int t=0; t<getSizeT(); t++) {
-                  int plane = getIndex(z, c, t);
-                  store.setPlaneExposureTime(exposure, i, plane);
-                }
-              }
-            }
-          }
-        }
-
-        for (int p=0; p<getImageCount(); p++) {
-          Plane plane = lookupPlane(i, p);
-          if (plane == null) {
-            continue;
-          }
-          store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), i, p);
-          store.setPlanePositionY(FormatTools.createLength(plane.ypos, UNITS.REFERENCEFRAME), i, p);
-          store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), i, p);
-        }
-      }
-      setSeries(0);
+      populateChannelMetadata(store, i, lightSourceIndexes, detectorIndexes,
+        filterIndexes, usedObjectiveIDs);
+      populatePlaneMetadata(store, i, timings[i]);
     }
+  }
+
+  private void populateChannelMetadata(MetadataStore store, int series,
+    HashMap<Integer, Integer> lightSourceIndexes,
+    HashMap<Integer, Integer> detectorIndexes,
+    HashMap<FilterKey, Integer> filterIndexes,
+    List<String> usedObjectiveIDs)
+  {
+    if (channels == null) {
+      return;
+    }
+
+    Length physicalSizeZ = getPhysicalSizeZ(series);
+    if (physicalSizeZ != null) {
+      store.setPixelsPhysicalSizeZ(physicalSizeZ, series);
+    }
+
+    boolean physicalSizeSet = false;
+    for (int c=0; c<getSizeC(); c++) {
+      Plane p = lookupRepresentativePlane(series, c);
+      if (p == null) {
+        // Acquisition errors can leave metadata-only logical channels.
+        continue;
+      }
+      Channel channel = lookupChannel(p);
+      if (channel == null) {
+        continue;
+      }
+
+      if (!physicalSizeSet) {
+        store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(channel.xSize), series);
+        store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.ySize), series);
+        physicalSizeSet = true;
+      }
+
+      int objective = -1;
+      if (channel.objectiveID != null) {
+        objective = usedObjectiveIDs.indexOf(channel.objectiveID);
+      }
+
+      if (channel.magnification != null && objective >= 0) {
+        store.setObjectiveNominalMagnification(channel.magnification, 0, objective);
+      }
+      if (objective >= 0) {
+        String objectiveID = MetadataTools.createLSID("Objective", 0, objective);
+        store.setObjectiveSettingsID(objectiveID, series);
+      }
+
+      store.setChannelName("Action #" + (p.actionIndex + 1) +
+        ", Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, series, c);
+
+      AcquisitionMode acquisitionMode = getYokogawaAcquisitionMode(channel);
+      if (acquisitionMode != null) {
+        store.setChannelAcquisitionMode(acquisitionMode, series, c);
+      }
+      ContrastMethod contrastMethod = getYokogawaContrastMethod(channel);
+      if (contrastMethod != null) {
+        store.setChannelContrastMethod(contrastMethod, series, c);
+      }
+
+      if (channel.color != null) {
+        store.setChannelColor(channel.color, series, c);
+      }
+      if (channel.fluor != null && !channel.fluor.isEmpty()) {
+        store.setChannelFluor(channel.fluor, series, c);
+      }
+
+      populateChannelLightSourceSettings(store, series, c, channel, lightSourceIndexes);
+      populateChannelFilterSettings(store, series, c, channel, filterIndexes);
+      populateDetectorSettings(store, series, c, channel, detectorIndexes);
+      populateExposureTime(store, series, c, channel);
+    }
+  }
+
+  private void populateChannelLightSourceSettings(MetadataStore store, int series,
+    int channelIndex, Channel channel, HashMap<Integer, Integer> lightSourceIndexes)
+  {
+    Integer lightSource = getLinkedLaser(channel);
+    if (lightSource == null || !lightSourceIndexes.containsKey(lightSource)) {
+      return;
+    }
+
+    LightSource source = lightSources.get(lightSource);
+    if (source.wavelength != null && source.wavelength > 0) {
+      int index = lightSourceIndexes.get(lightSource);
+      store.setChannelLightSourceSettingsID(
+        MetadataTools.createLSID("LightSource", 0, index), series, channelIndex);
+      // Yokogawa BP labels are detection filters; excitation comes from the
+      // linked laser light-source wavelength.
+      store.setChannelExcitationWavelength(
+        new Length(source.wavelength, UNITS.NANOMETER), series, channelIndex);
+    }
+  }
+
+  private void populateChannelFilterSettings(MetadataStore store, int series,
+    int channelIndex, Channel channel, HashMap<FilterKey, Integer> filterIndexes)
+  {
+    if (!channel.isBrightfield() && channel.detectionFilter != null &&
+      channel.detectionFilter.center != null)
+    {
+      store.setChannelEmissionWavelength(
+        new Length(channel.detectionFilter.center, UNITS.NANOMETER), series, channelIndex);
+    }
+
+    FilterKey filter = new FilterKey(channel);
+    if (filterIndexes.containsKey(filter)) {
+      store.setLightPathEmissionFilterRef(
+        MetadataTools.createLSID("Filter", 0, filterIndexes.get(filter)),
+        series, channelIndex, 0);
+    }
+  }
+
+  private void populateDetectorSettings(MetadataStore store, int series,
+    int channelIndex, Channel channel, HashMap<Integer, Integer> detectorIndexes)
+  {
+    if (!detectorIndexes.containsKey(channel.cameraNumber)) {
+      return;
+    }
+
+    String detectorID = MetadataTools.createLSID(
+      "Detector", 0, detectorIndexes.get(channel.cameraNumber));
+    store.setDetectorSettingsID(detectorID, series, channelIndex);
+    String binning = getBinningValue(channel.binning);
+    if (binning != null) {
+      try {
+        store.setDetectorSettingsBinning(
+          MetadataTools.getBinning(binning), series, channelIndex);
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Ignoring invalid CV7000 binning value {}", binning, e);
+      }
+    }
+  }
+
+  private void populateExposureTime(MetadataStore store, int series,
+    int channelIndex, Channel channel)
+  {
+    if (channel.exposureTime == null) {
+      return;
+    }
+
+    Time exposure = new Time(channel.exposureTime, UNITS.MILLISECOND);
+    for (int z=0; z<getSizeZ(); z++) {
+      for (int t=0; t<getSizeT(); t++) {
+        int plane = getIndex(z, channelIndex, t);
+        store.setPlaneExposureTime(exposure, series, plane);
+      }
+    }
+  }
+
+  private void populatePlaneMetadata(MetadataStore store, int series, SeriesTiming timing) {
+    for (int p=0; p<getImageCount(); p++) {
+      Plane plane = lookupPlane(series, p);
+      if (plane == null) {
+        continue;
+      }
+      store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), series, p);
+      store.setPlanePositionY(FormatTools.createLength(plane.ypos, UNITS.REFERENCEFRAME), series, p);
+      store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), series, p);
+      Double deltaT = getPlaneDeltaTSeconds(plane, timing.startMillis);
+      if (deltaT != null) {
+        store.setPlaneDeltaT(new Time(deltaT, UNITS.SECOND), series, p);
+      }
+    }
+  }
+
+  private SeriesTiming[] buildSeriesTimings() {
+    SeriesTiming[] timings = new SeriesTiming[getSeriesCount()];
+    for (int i=0; i<timings.length; i++) {
+      timings[i] = new SeriesTiming();
+      if (reversePlaneLookup == null || i >= reversePlaneLookup.length) {
+        continue;
+      }
+      for (int no=0; no<reversePlaneLookup[i].length; no++) {
+        Plane p = lookupPlane(i, no);
+        if (p == null) {
+          continue;
+        }
+        Long timestamp = parseTimestampMillis(p.timestamp);
+        if (timestamp != null &&
+          (timings[i].startMillis == null || timestamp < timings[i].startMillis))
+        {
+          timings[i].startMillis = timestamp;
+          timings[i].startTimestamp = p.timestamp;
+        }
+      }
+    }
+    return timings;
+  }
+
+  private Long parseTimestampMillis(String timestamp) {
+    if (timestamp == null || timestamp.trim().length() == 0) {
+      return null;
+    }
+    try {
+      return new Timestamp(timestamp).asInstant().getMillis();
+    }
+    catch (RuntimeException e) {
+      LOGGER.debug("Ignoring invalid CV7000 timestamp {}", timestamp, e);
+    }
+    return null;
+  }
+
+  private Double getPlaneDeltaTSeconds(Plane plane, Long seriesStart) {
+    if (plane == null || seriesStart == null) {
+      return null;
+    }
+    Long timestamp = parseTimestampMillis(plane.timestamp);
+    if (timestamp == null) {
+      return null;
+    }
+    // DeltaT describes elapsed time within this OME Image/series. Yokogawa
+    // timeline and timepoint indexes are acquisition planning coordinates and
+    // are not expanded into SizeT here.
+    return (timestamp - seriesStart) / 1000.0;
+  }
+
+  private AcquisitionMode getYokogawaAcquisitionMode(Channel channel) {
+    if (channel == null) {
+      return null;
+    }
+    if (isConfocalFluorescence(channel)) {
+      return AcquisitionMode.SPINNINGDISKCONFOCAL;
+    }
+    return null;
+  }
+
+  private boolean isConfocalFluorescence(Channel channel) {
+    return "ConfocalFluorescence".equals(channel.kind);
+  }
+
+  private ContrastMethod getYokogawaContrastMethod(Channel channel) {
+    if (channel == null || !channel.isBrightfield()) {
+      return null;
+    }
+    try {
+      return MetadataTools.getContrastMethod(BRIGHTFIELD);
+    }
+    catch (FormatException e) {
+      LOGGER.debug("Ignoring unsupported CV7000 contrast method {}", BRIGHTFIELD, e);
+    }
+    return null;
   }
 
   private void populateLightSources(MetadataStore store,
@@ -828,12 +1068,22 @@ public class CV7000Reader extends FormatReader {
   }
 
   private void addYokogawaOriginalMetadata() {
+    if (allFiles != null) {
+      for (String file : allFiles) {
+        if (file != null && !checkSuffix(file, "tif")) {
+          addRawSidecarMetadata(file);
+          addYokogawaMetaList("Yokogawa Sidecar ", "File",
+            new Location(file).getName());
+        }
+      }
+    }
+    addMeasurementDataOriginalMetadata();
     if (lightSources != null) {
       for (LightSource source : lightSources) {
         String prefix = "Yokogawa LightSource " + source.name + " ";
-        addGlobalMeta(prefix + "Type", source.type);
-        addGlobalMeta(prefix + "WaveLength", source.wavelength);
-        addGlobalMeta(prefix + "Power", source.power);
+        addYokogawaMeta(prefix, "Type", source.type);
+        addYokogawaMeta(prefix, "WaveLength", source.wavelength);
+        addYokogawaMeta(prefix, "Power", source.power);
       }
     }
     if (channels == null) {
@@ -847,32 +1097,164 @@ public class CV7000Reader extends FormatReader {
       }
       String prefix = "Yokogawa Timeline " + (c.timelineIndex + 1) +
         " Action " + (c.actionIndex + 1) + " Channel " + (c.index + 1) + " ";
-      addGlobalMeta(prefix + "Target", c.target);
-      addGlobalMeta(prefix + "Kind", c.kind);
-      addGlobalMeta(prefix + "MethodID", c.methodID);
-      addGlobalMeta(prefix + "Method", c.method);
-      addGlobalMeta(prefix + "FilterID", c.filterID);
-      addGlobalMeta(prefix + "Acquisition", c.acquisition);
+      // Raw Yokogawa planning fields are kept even when a subset is promoted
+      // to core OME fields; this makes enum/wavelength decisions auditable.
+      addYokogawaMeta(prefix, "Target", c.target);
+      addYokogawaMeta(prefix, "Kind", c.kind);
+      addYokogawaMeta(prefix, "MethodID", c.methodID);
+      addYokogawaMeta(prefix, "Method", c.method);
+      addYokogawaMeta(prefix, "ActionType", c.actionType);
+      addYokogawaMeta(prefix, "ActionRunMode", c.actionRunMode);
+      addYokogawaMeta(prefix, "ActionAFSearch", c.actionAFSearch);
+      addYokogawaMeta(prefix, "ActionXOffset", c.actionXOffset);
+      addYokogawaMeta(prefix, "ActionYOffset", c.actionYOffset);
+      addYokogawaMeta(prefix, "ActionAFShiftBase", c.actionAFShiftBase);
+      addYokogawaMeta(prefix, "ActionTopDistance", c.actionTopDistance);
+      addYokogawaMeta(prefix, "ActionBottomDistance", c.actionBottomDistance);
+      addYokogawaMeta(prefix, "ActionSliceLength", c.actionSliceLength);
+      addYokogawaMeta(prefix, "ActionUseSoftFocus", c.actionUseSoftFocus);
+      addYokogawaMeta(prefix, "FilterID", c.filterID);
+      addYokogawaMeta(prefix, "Acquisition", c.acquisition);
       if (c.detectionFilter != null) {
-        addGlobalMeta(prefix + "DetectionFilterType", c.detectionFilter.filterType);
-        addGlobalMeta(prefix + "DetectionFilterCenter", c.detectionFilter.center);
-        addGlobalMeta(prefix + "DetectionFilterWidth", c.detectionFilter.width);
-        addGlobalMeta(prefix + "DetectionFilterCutIn", c.detectionFilter.cutIn);
-        addGlobalMeta(prefix + "DetectionFilterCutOut", c.detectionFilter.cutOut);
+        addYokogawaMeta(prefix, "DetectionFilterType", c.detectionFilter.filterType);
+        addYokogawaMeta(prefix, "DetectionFilterCenter", c.detectionFilter.center);
+        addYokogawaMeta(prefix, "DetectionFilterWidth", c.detectionFilter.width);
+        addYokogawaMeta(prefix, "DetectionFilterCutIn", c.detectionFilter.cutIn);
+        addYokogawaMeta(prefix, "DetectionFilterCutOut", c.detectionFilter.cutOut);
       }
-      addGlobalMeta(prefix + "CameraNumber", c.cameraNumber);
-      addGlobalMeta(prefix + "CameraType", c.cameraType);
-      addGlobalMeta(prefix + "Binning", c.binning);
-      addGlobalMeta(prefix + "AndorParameterID", c.andorParameterID);
-      addGlobalMeta(prefix + "AndorParameter", c.andorParameter);
-      addGlobalMeta(prefix + "InputBitDepth", c.inputBitDepth);
-      addGlobalMeta(prefix + "InputLevel", c.inputLevel);
-      addGlobalMeta(prefix + "HorizontalPixels", c.horizontalPixels);
-      addGlobalMeta(prefix + "VerticalPixels", c.verticalPixels);
-      addGlobalMeta(prefix + "FilterWheelPosition", c.filterWheelPosition);
-      addGlobalMeta(prefix + "FilterPosition", c.filterPosition);
-      addGlobalMeta(prefix + "ShadingCorrectionSource", c.correctionFile);
+      addYokogawaMeta(prefix, "CameraNumber", c.cameraNumber);
+      addYokogawaMeta(prefix, "CameraType", c.cameraType);
+      addYokogawaMeta(prefix, "Binning", c.binning);
+      addYokogawaMeta(prefix, "AndorParameterID", c.andorParameterID);
+      addYokogawaMeta(prefix, "AndorParameter", c.andorParameter);
+      addYokogawaMeta(prefix, "InputBitDepth", c.inputBitDepth);
+      addYokogawaMeta(prefix, "InputLevel", c.inputLevel);
+      addYokogawaMeta(prefix, "HorizontalPixels", c.horizontalPixels);
+      addYokogawaMeta(prefix, "VerticalPixels", c.verticalPixels);
+      addYokogawaMeta(prefix, "FilterWheelPosition", c.filterWheelPosition);
+      addYokogawaMeta(prefix, "FilterPosition", c.filterPosition);
+      addYokogawaMeta(prefix, "ShadingCorrectionSource", c.correctionFile);
     }
+  }
+
+  private void addRawSidecarMetadata(String file) {
+    Location location = new Location(file);
+    String name = location.getName();
+    if (name == null || MEASUREMENT_FILE.equals(name) || !isRawXMLSidecar(file)) {
+      return;
+    }
+
+    try {
+      String xml = DataTools.readFile(file);
+      byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
+      String encoded = Base64.getEncoder().encodeToString(bytes);
+      int chunkCount = (encoded.length() + RAW_XML_CHUNK_SIZE - 1) / RAW_XML_CHUNK_SIZE;
+      String prefix = "Yokogawa Raw XML " + name + " ";
+
+      addYokogawaMeta(prefix, "Encoding", "base64; charset=UTF-8");
+      addYokogawaMeta(prefix, "ByteLength", bytes.length);
+      addYokogawaMeta(prefix, "SHA-256", sha256(bytes));
+      addYokogawaMeta(prefix, "ChunkCount", chunkCount);
+      for (int chunk=0; chunk<chunkCount; chunk++) {
+        int start = chunk * RAW_XML_CHUNK_SIZE;
+        int end = Math.min(start + RAW_XML_CHUNK_SIZE, encoded.length());
+        addYokogawaMeta(prefix, "Chunk " + zeroPad(chunk + 1, 4),
+          encoded.substring(start, end));
+      }
+    }
+    catch (IOException e) {
+      LOGGER.debug("Could not preserve raw CV7000 sidecar {}", file, e);
+    }
+  }
+
+  private boolean isRawXMLSidecar(String file) {
+    return checkSuffix(file, "wpi") || checkSuffix(file, "mrf") ||
+      checkSuffix(file, "mes") || checkSuffix(file, "wpp") ||
+      checkSuffix(file, "xml");
+  }
+
+  private void addMeasurementDataOriginalMetadata() {
+    if (measurementPath == null) {
+      return;
+    }
+
+    try {
+      String xml = DataTools.readFile(measurementPath);
+      byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
+      addYokogawaMeta("Yokogawa MLF ", "File", new Location(measurementPath).getName());
+      addYokogawaMeta("Yokogawa MLF ", "Encoding", "UTF-8");
+      addYokogawaMeta("Yokogawa MLF ", "ByteLength", bytes.length);
+      addYokogawaMeta("Yokogawa MLF ", "SHA-256", sha256(bytes));
+    }
+    catch (IOException e) {
+      LOGGER.debug("Could not summarize CV7000 measurement data {}", measurementPath, e);
+    }
+
+    if (measurementHandler != null) {
+      addYokogawaMeta("Yokogawa MLF ", "IMGRecordCount",
+        measurementHandler.getImageRecordCount());
+      addYokogawaMeta("Yokogawa MLF ", "FirstPlaneTime",
+        measurementHandler.getFirstTimestamp());
+      addYokogawaMeta("Yokogawa MLF ", "LastPlaneTime",
+        measurementHandler.getLastTimestamp());
+      addYokogawaMeta("Yokogawa MLF ", "FirstPlaneAction",
+        measurementHandler.getFirstAction());
+      addYokogawaMeta("Yokogawa MLF ", "LastPlaneAction",
+        measurementHandler.getLastAction());
+    }
+  }
+
+  private String sha256(byte[] bytes) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder hex = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        String value = Integer.toHexString(b & 0xff);
+        if (value.length() == 1) {
+          hex.append('0');
+        }
+        hex.append(value);
+      }
+      return hex.toString();
+    }
+    catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("SHA-256 not available", e);
+    }
+  }
+
+  private String zeroPad(int value, int width) {
+    String s = String.valueOf(value);
+    while (s.length() < width) {
+      s = "0" + s;
+    }
+    return s;
+  }
+
+  private void addYokogawaMeta(String prefix, String name, Object value) {
+    addGlobalMeta(prefix + name, value);
+  }
+
+  private void addYokogawaMetaList(String prefix, String name, Object value) {
+    addGlobalMetaList(prefix + name, value);
+  }
+
+  private void addYokogawaAttributes(String prefix, Attributes attributes) {
+    if (attributes == null) {
+      return;
+    }
+    for (int i=0; i<attributes.getLength(); i++) {
+      addYokogawaMeta(prefix, getYokogawaAttributeName(attributes.getQName(i)),
+        attributes.getValue(i));
+    }
+  }
+
+  private String getYokogawaAttributeName(String qName) {
+    if (qName == null) {
+      return "";
+    }
+    int colon = qName.indexOf(":");
+    return colon < 0 ? qName : qName.substring(colon + 1);
   }
 
   private Integer getLinkedLaser(Channel channel) {
@@ -1068,6 +1450,41 @@ public class CV7000Reader extends FormatReader {
 
   // -- Helper classes --
 
+  /** Resolved dataset paths used during the parsing phase. */
+  class DatasetPaths {
+    public Location parent;
+    public String wpiPath;
+    public Location measurementData;
+    public Location measurementDetail;
+  }
+
+  /** Intermediate layout data used to translate Yokogawa records into series. */
+  class SeriesLayout {
+    public String firstFile;
+    public ArrayList<Field> acquiredFields = new ArrayList<Field>();
+    public HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
+    public HashSet<Integer> uniqueChannels = new HashSet<Integer>();
+    public Integer[] channelIndexes;
+    public HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
+  }
+
+  /** OME instrument indexes shared by channel metadata population. */
+  class InstrumentMetadataIndexes {
+    public String instrument;
+    public HashMap<Integer, Integer> lightSourceIndexes =
+      new HashMap<Integer, Integer>();
+    public HashMap<Integer, Integer> detectorIndexes =
+      new HashMap<Integer, Integer>();
+    public HashMap<FilterKey, Integer> filterIndexes =
+      new HashMap<FilterKey, Integer>();
+    public List<String> usedObjectiveIDs = new ArrayList<String>();
+  }
+
+  class SeriesTiming {
+    public Long startMillis;
+    public String startTimestamp;
+  }
+
   class WPIHandler extends BaseHandler {
     private int plateRows;
     private int plateColumns;
@@ -1114,6 +1531,11 @@ public class CV7000Reader extends FormatReader {
     private String btsType;
     private ArrayList<Plane> planes = new ArrayList<Plane>();
     private String parentDir;
+    private int imageRecordCount;
+    private String firstTimestamp;
+    private String lastTimestamp;
+    private String firstAction;
+    private String lastAction;
 
     private int currentField = -1;
 
@@ -1124,6 +1546,26 @@ public class CV7000Reader extends FormatReader {
 
     public ArrayList<Plane> getPlanes() {
       return planes;
+    }
+
+    public int getImageRecordCount() {
+      return imageRecordCount;
+    }
+
+    public String getFirstTimestamp() {
+      return firstTimestamp;
+    }
+
+    public String getLastTimestamp() {
+      return lastTimestamp;
+    }
+
+    public String getFirstAction() {
+      return firstAction;
+    }
+
+    public String getLastAction() {
+      return lastAction;
     }
 
     // -- DefaultHandler API methods --
@@ -1164,6 +1606,14 @@ public class CV7000Reader extends FormatReader {
           p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
           p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
           p.timestamp = attributes.getValue("bts:Time");
+          p.actionName = attributes.getValue("bts:Action");
+          imageRecordCount++;
+          if (firstTimestamp == null) {
+            firstTimestamp = p.timestamp;
+            firstAction = p.actionName;
+          }
+          lastTimestamp = p.timestamp;
+          lastAction = p.actionName;
           planes.add(p);
         }
       }
@@ -1203,6 +1653,7 @@ public class CV7000Reader extends FormatReader {
       Attributes attributes)
     {
       if (qName.equals("bts:MeasurementSamplePlate")) {
+        addYokogawaAttributes("Yokogawa MRF MeasurementSamplePlate ", attributes);
         wppPath = attributes.getValue("bts:WellPlateProductFileName");
         if (wppPath != null && wppPath.trim().length() == 0) {
           wppPath = null;
@@ -1211,6 +1662,8 @@ public class CV7000Reader extends FormatReader {
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
         c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
+        addYokogawaAttributes(
+          "Yokogawa MRF Channel " + (c.index + 1) + " ", attributes);
         c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
         c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
@@ -1227,6 +1680,7 @@ public class CV7000Reader extends FormatReader {
         channels.add(c);
       }
       else if (qName.equals("bts:MeasurementDetail")) {
+        addYokogawaAttributes("Yokogawa MRF MeasurementDetail ", attributes);
         startTime = attributes.getValue("bts:BeginTime");
         endTime = attributes.getValue("bts:EndTime");
         settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
@@ -1241,12 +1695,37 @@ public class CV7000Reader extends FormatReader {
 
   }
 
+  class WPPHandler extends BaseHandler {
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      if (qName.equals("bts:WellPlateProduct")) {
+        addYokogawaAttributes("Yokogawa WPP ", attributes);
+      }
+    }
+
+  }
+
   class MeasurementSettingsHandler extends BaseHandler {
     private StringBuffer currentValue = new StringBuffer();
     private int currentChannelIndex = -1;
     private int timelineIndex = -1;
     private int actionIndex = -1;
+    private int targetWellIndex = -1;
+    private int pointIndex = -1;
     private Double currentPhysicalSizeZ;
+    private String actionRunMode;
+    private String actionAFSearch;
+    private String currentActionType;
+    private String currentActionXOffset;
+    private String currentActionYOffset;
+    private String currentActionAFShiftBase;
+    private String currentActionTopDistance;
+    private String currentActionBottomDistance;
+    private String currentActionSliceLength;
+    private String currentActionUseSoftFocus;
 
     // -- DefaultHandler API methods --
 
@@ -1261,10 +1740,14 @@ public class CV7000Reader extends FormatReader {
       Attributes attributes)
     {
       currentValue.setLength(0);
-      if (qName.equals("bts:LightSource")) {
+      if (qName.equals("bts:MeasurementSetting")) {
+        addYokogawaAttributes("Yokogawa MES MeasurementSetting ", attributes);
+      }
+      else if (qName.equals("bts:LightSource")) {
         LightSource l = new LightSource();
         l.name = attributes.getValue("bts:Name");
         l.type = attributes.getValue("bts:Type");
+        addYokogawaAttributes("Yokogawa MES LightSource " + l.name + " ", attributes);
 
         String wavelength = attributes.getValue("bts:WaveLength");
         String power = attributes.getValue("bts:Power");
@@ -1285,6 +1768,8 @@ public class CV7000Reader extends FormatReader {
             Channel template = new Channel();
             template.index = index;
             template.target = attributes.getValue("bts:Target");
+            addYokogawaAttributes(
+              "Yokogawa MES Channel " + (template.index + 1) + " ", attributes);
             template.objectiveID = attributes.getValue("bts:ObjectiveID");
             template.objective = attributes.getValue("bts:Objective");
             template.binning = attributes.getValue("bts:Binning");
@@ -1333,10 +1818,56 @@ public class CV7000Reader extends FormatReader {
       else if (qName.equals("bts:Timeline")) {
         timelineIndex++;
         actionIndex = -1;
+        targetWellIndex = -1;
+        pointIndex = -1;
         currentPhysicalSizeZ = null;
+        actionRunMode = null;
+        actionAFSearch = null;
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) + " ", attributes);
+      }
+      else if (qName.equals("bts:TargetWell")) {
+        targetWellIndex++;
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " TargetWell " + (targetWellIndex + 1) + " ", attributes);
+      }
+      else if (qName.equals("bts:PointSequence")) {
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " PointSequence ", attributes);
+      }
+      else if (qName.equals("bts:FixedPosition")) {
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " FixedPosition ", attributes);
+      }
+      else if (qName.equals("bts:Point")) {
+        pointIndex++;
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " Point " + (pointIndex + 1) + " ", attributes);
+      }
+      else if (qName.equals("bts:ActionList")) {
+        actionRunMode = attributes.getValue("bts:RunMode");
+        actionAFSearch = attributes.getValue("bts:AFSearch");
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " ActionList ", attributes);
       }
       else if (qName.startsWith("bts:ActionAcquire")) {
         actionIndex++;
+        currentActionType = getYokogawaAttributeName(qName);
+        currentActionXOffset = attributes.getValue("bts:XOffset");
+        currentActionYOffset = attributes.getValue("bts:YOffset");
+        currentActionAFShiftBase = attributes.getValue("bts:AFShiftBase");
+        currentActionTopDistance = attributes.getValue("bts:TopDistance");
+        currentActionBottomDistance = attributes.getValue("bts:BottomDistance");
+        currentActionSliceLength = attributes.getValue("bts:SliceLength");
+        currentActionUseSoftFocus = attributes.getValue("bts:UseSoftFocus");
+        addYokogawaAttributes(
+          "Yokogawa MES Timeline " + (timelineIndex + 1) +
+          " Action " + (actionIndex + 1) + " ", attributes);
         currentPhysicalSizeZ = DataTools.parseDouble(
           attributes.getValue("bts:SliceLength"));
       }
@@ -1347,6 +1878,9 @@ public class CV7000Reader extends FormatReader {
       String value = currentValue.toString();
 
       if (qName.equals("bts:LightSourceName") && currentChannelIndex >= 0) {
+        addYokogawaMeta(
+          "Yokogawa MES Channel " + (currentChannelIndex + 1) + " ",
+          "LightSourceName", value);
         int index = -1;
         for (int i=0; i<lightSources.size(); i++) {
           if (lightSources.get(i).name.equals(value)) {
@@ -1373,18 +1907,34 @@ public class CV7000Reader extends FormatReader {
             ch.timelineIndex = timelineIndex;
             ch.actionIndex = actionIndex;
             ch.physicalSizeZ = currentPhysicalSizeZ;
+            ch.copyActionSettings(actionRunMode, actionAFSearch, currentActionType,
+              currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
+              currentActionTopDistance, currentActionBottomDistance,
+              currentActionSliceLength, currentActionUseSoftFocus);
           }
           else {
             Channel duplicate = new Channel(ch);
             duplicate.timelineIndex = timelineIndex;
             duplicate.actionIndex = actionIndex;
             duplicate.physicalSizeZ = currentPhysicalSizeZ;
+            duplicate.copyActionSettings(actionRunMode, actionAFSearch, currentActionType,
+              currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
+              currentActionTopDistance, currentActionBottomDistance,
+              currentActionSliceLength, currentActionUseSoftFocus);
             channels.add(duplicate);
           }
         }
       }
       else if (qName.startsWith("bts:ActionAcquire")) {
         currentPhysicalSizeZ = null;
+        currentActionType = null;
+        currentActionXOffset = null;
+        currentActionYOffset = null;
+        currentActionAFShiftBase = null;
+        currentActionTopDistance = null;
+        currentActionBottomDistance = null;
+        currentActionSliceLength = null;
+        currentActionUseSoftFocus = null;
       }
     }
 
@@ -1526,6 +2076,16 @@ public class CV7000Reader extends FormatReader {
     public String andorParameter;
     public String objectiveID;
     public String objective;
+    public String actionType;
+    public String actionRunMode;
+    public String actionAFSearch;
+    public String actionXOffset;
+    public String actionYOffset;
+    public String actionAFShiftBase;
+    public String actionTopDistance;
+    public String actionBottomDistance;
+    public String actionSliceLength;
+    public String actionUseSoftFocus;
     public Double magnification;
     public Double exposureTime;
     public Double physicalSizeZ;
@@ -1562,12 +2122,38 @@ public class CV7000Reader extends FormatReader {
       andorParameter = ch.andorParameter;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
+      actionType = ch.actionType;
+      actionRunMode = ch.actionRunMode;
+      actionAFSearch = ch.actionAFSearch;
+      actionXOffset = ch.actionXOffset;
+      actionYOffset = ch.actionYOffset;
+      actionAFShiftBase = ch.actionAFShiftBase;
+      actionTopDistance = ch.actionTopDistance;
+      actionBottomDistance = ch.actionBottomDistance;
+      actionSliceLength = ch.actionSliceLength;
+      actionUseSoftFocus = ch.actionUseSoftFocus;
       magnification = ch.magnification;
       exposureTime = ch.exposureTime;
       physicalSizeZ = ch.physicalSizeZ;
       binning = ch.binning;
       color = ch.color;
       fluor = ch.fluor;
+    }
+
+    public void copyActionSettings(String runMode, String afSearch, String type,
+      String xOffset, String yOffset, String afShiftBase, String topDistance,
+      String bottomDistance, String sliceLength, String useSoftFocus)
+    {
+      actionRunMode = runMode;
+      actionAFSearch = afSearch;
+      actionType = type;
+      actionXOffset = xOffset;
+      actionYOffset = yOffset;
+      actionAFShiftBase = afShiftBase;
+      actionTopDistance = topDistance;
+      actionBottomDistance = bottomDistance;
+      actionSliceLength = sliceLength;
+      actionUseSoftFocus = useSoftFocus;
     }
 
     public void copyChannelSettings(Channel ch) {
@@ -1612,6 +2198,7 @@ public class CV7000Reader extends FormatReader {
   class Plane {
     public String file;
     public String timestamp;
+    public String actionName;
     public Field field;
     public int timepoint;
     public int z;
@@ -1656,6 +2243,30 @@ public class CV7000Reader extends FormatReader {
     public int maxC = 0;
     public int minT = Integer.MAX_VALUE;
     public int maxT = 0;
+
+    public void update(Plane p) {
+      if (p.timepoint > maxT) {
+        maxT = p.timepoint;
+      }
+      if (p.timepoint < minT) {
+        minT = p.timepoint;
+      }
+      if (p.z > maxZ) {
+        maxZ = p.z;
+      }
+      if (p.z < minZ) {
+        minZ = p.z;
+      }
+
+      // Min and max channel indexes are not currently used, but keeping them
+      // complete makes future CV7000/8000 channel-layout work less fragile.
+      if (p.channelIndex > maxC) {
+        maxC = p.channelIndex;
+      }
+      if (p.channelIndex < minC) {
+        minC = p.channelIndex;
+      }
+    }
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -63,6 +63,7 @@ import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 import ome.xml.model.enums.AcquisitionMode;
 import ome.xml.model.enums.ContrastMethod;
+import ome.xml.model.enums.IlluminationType;
 import ome.xml.model.enums.NamingConvention;
 
 import org.slf4j.Logger;
@@ -115,6 +116,7 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<String> extraFiles;
   private MeasurementDataHandler measurementHandler;
   private CrosstalkParameters crosstalkParameters;
+  private OTFGeometryParameters otfGeometryParameters;
   private YokogawaParsing parsing = new YokogawaParsing();
 
   // -- Constructor --
@@ -404,6 +406,7 @@ public class CV7000Reader extends FormatReader {
     parseMeasurementDetail(paths);
     parseWellPlateProduct();
     parseMeasurementSettings();
+    parseOTFGeometry(paths);
     parseOTFCrosstalk(paths);
   }
 
@@ -447,6 +450,27 @@ public class CV7000Reader extends FormatReader {
       if (xml.length() > 0) {
         XMLTools.parseXML(xml, settingsHandler);
       }
+    }
+  }
+
+  /** OTF geometry stores objective catalog entries and affine calibration rows. */
+  private void parseOTFGeometry(CV7000DatasetPaths paths) {
+    Location geometry = paths.otfGeometry;
+    if (!geometry.exists()) {
+      return;
+    }
+
+    try {
+      OTFGeometryHandler handler = new OTFGeometryHandler();
+      XMLTools.parseXML(readSanitizedXML(geometry.getAbsolutePath()), handler);
+      otfGeometryParameters = handler.getParameters();
+      rawModel.otfGeometryParameters = otfGeometryParameters;
+    }
+    catch (Exception e) {
+      otfGeometryParameters = null;
+      rawModel.otfGeometryParameters = null;
+      LOGGER.warn("Could not parse CV7000 OTF geometry sidecar {}",
+        geometry.getAbsolutePath(), e);
     }
   }
 
@@ -708,7 +732,9 @@ public class CV7000Reader extends FormatReader {
   {
     InstrumentMetadataIndexes indexes = new InstrumentMetadataIndexes();
     if ((lightSources != null && lightSources.size() > 0) ||
-      (channels != null && channels.size() > 0))
+      (channels != null && channels.size() > 0) ||
+      (otfGeometryParameters != null &&
+        otfGeometryParameters.objectivesByID.size() > 0))
     {
       indexes.instrument = MetadataTools.createLSID("Instrument", 0);
 
@@ -900,6 +926,10 @@ public class CV7000Reader extends FormatReader {
       if (contrastMethod != null) {
         store.setChannelContrastMethod(contrastMethod, series, c);
       }
+      IlluminationType illuminationType = getYokogawaIlluminationType(channel);
+      if (illuminationType != null) {
+        store.setChannelIlluminationType(illuminationType, series, c);
+      }
 
       if (channel.color != null) {
         store.setChannelColor(channel.color, series, c);
@@ -942,6 +972,12 @@ public class CV7000Reader extends FormatReader {
     int action = plane == null ? channel.actionIndex : plane.actionIndex;
     return "Action #" + (action + 1) + ", Channel #" +
       (channel.index + 1) + ", Camera #" + channel.cameraNumber;
+  }
+
+  private String getYokogawaChannelScope(Channel channel) {
+    return "Yokogawa Timeline " + (channel.timelineIndex + 1) +
+      " Action " + (channel.actionIndex + 1) +
+      " Channel " + (channel.index + 1) + " ";
   }
 
   private String clean(String value) {
@@ -1115,6 +1151,17 @@ public class CV7000Reader extends FormatReader {
     if (isConfocalFluorescence(channel)) {
       return AcquisitionMode.SPINNINGDISKCONFOCAL;
     }
+    if (channel.isBrightfield()) {
+      try {
+        return MetadataTools.getAcquisitionMode("BrightField");
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Ignoring unsupported CV7000 acquisition mode BrightField", e);
+      }
+    }
+    if (isEpifluorescence(channel)) {
+      return AcquisitionMode.WIDEFIELD;
+    }
     return null;
   }
 
@@ -1122,15 +1169,53 @@ public class CV7000Reader extends FormatReader {
     return "ConfocalFluorescence".equals(channel.kind);
   }
 
+  private boolean isEpifluorescence(Channel channel) {
+    return channel != null && channel.method != null &&
+      channel.method.toLowerCase().startsWith("epifluorescence");
+  }
+
   private ContrastMethod getYokogawaContrastMethod(Channel channel) {
-    if (channel == null || !channel.isBrightfield()) {
+    if (channel == null) {
+      return null;
+    }
+    String method = null;
+    if (channel.isBrightfield()) {
+      method = BRIGHTFIELD;
+    }
+    else if (isConfocalFluorescence(channel) || isEpifluorescence(channel)) {
+      method = "Fluorescence";
+    }
+    if (method == null) {
       return null;
     }
     try {
-      return MetadataTools.getContrastMethod(BRIGHTFIELD);
+      return MetadataTools.getContrastMethod(method);
     }
     catch (FormatException e) {
-      LOGGER.debug("Ignoring unsupported CV7000 contrast method {}", BRIGHTFIELD, e);
+      LOGGER.debug("Ignoring unsupported CV7000 contrast method {}", method, e);
+    }
+    return null;
+  }
+
+  private IlluminationType getYokogawaIlluminationType(Channel channel) {
+    if (channel == null) {
+      return null;
+    }
+    String illumination = null;
+    if (channel.isBrightfield()) {
+      illumination = "Transmitted";
+    }
+    else if (isConfocalFluorescence(channel) || isEpifluorescence(channel)) {
+      illumination = "Epifluorescence";
+    }
+    if (illumination == null) {
+      return null;
+    }
+    try {
+      return MetadataTools.getIlluminationType(illumination);
+    }
+    catch (FormatException e) {
+      LOGGER.debug("Ignoring unsupported CV7000 illumination type {}", illumination, e);
     }
     return null;
   }
@@ -1148,6 +1233,8 @@ public class CV7000Reader extends FormatReader {
       if (isLaser(l)) {
         String laserID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
         store.setLaserID(laserID, 0, nextLightSource);
+        store.setLaserModel(getLightSourceModel(l), 0, nextLightSource);
+        store.setLaserType(MetadataTools.getLaserType("Other"), 0, nextLightSource);
         if (l.wavelength != null) {
           store.setLaserWavelength(
             new Length(l.wavelength, UNITS.NANOMETER), 0, nextLightSource);
@@ -1167,6 +1254,10 @@ public class CV7000Reader extends FormatReader {
         // Type="Lamp", so keep the filament type as Other.
         store.setFilamentType(MetadataTools.getFilamentType("Other"),
           0, nextLightSource);
+        if (l.power != null) {
+          store.setFilamentPower(
+            new Power(l.power, UNITS.MILLIWATT), 0, nextLightSource);
+        }
         lightSourceIndexes.put(i, nextLightSource);
         nextLightSource++;
       }
@@ -1190,18 +1281,138 @@ public class CV7000Reader extends FormatReader {
   }
 
   private void populateObjectives(MetadataStore store, List<String> usedObjectiveIDs) {
-    if (channels == null) {
-      return;
-    }
-    for (Channel c : channels) {
-      if (c.objectiveID != null && !usedObjectiveIDs.contains(c.objectiveID)) {
-        int index = usedObjectiveIDs.size();
-        String objectiveID = MetadataTools.createLSID("Objective", 0, index);
-        store.setObjectiveID(objectiveID, 0, index);
-        store.setObjectiveModel(c.objective, 0, index);
-        usedObjectiveIDs.add(c.objectiveID);
+    if (channels != null) {
+      for (Channel c : channels) {
+        if (c.objectiveID != null && !usedObjectiveIDs.contains(c.objectiveID)) {
+          int index = usedObjectiveIDs.size();
+          String objectiveID = MetadataTools.createLSID("Objective", 0, index);
+          store.setObjectiveID(objectiveID, 0, index);
+          populateObjectiveModel(store, index, c.objectiveID, c.objective,
+            c.magnification);
+          usedObjectiveIDs.add(c.objectiveID);
+        }
       }
     }
+
+    if (otfGeometryParameters != null) {
+      for (OTFGeometryObjective objective :
+        otfGeometryParameters.objectivesByID.values())
+      {
+        if (objective.objectiveID != null &&
+          !usedObjectiveIDs.contains(objective.objectiveID))
+        {
+          int index = usedObjectiveIDs.size();
+          String objectiveID = MetadataTools.createLSID("Objective", 0, index);
+          store.setObjectiveID(objectiveID, 0, index);
+          populateObjectiveModel(store, index, objective.objectiveID,
+            objective.objective, objective.magnification);
+          usedObjectiveIDs.add(objective.objectiveID);
+        }
+      }
+    }
+  }
+
+  private void populateObjectiveModel(MetadataStore store, int objectiveIndex,
+    String objectiveID, String model, Double magnification)
+  {
+    if (model != null) {
+      store.setObjectiveModel(model, 0, objectiveIndex);
+    }
+    if (magnification != null) {
+      store.setObjectiveNominalMagnification(magnification, 0, objectiveIndex);
+    }
+    CV7000ObjectiveSpec spec = getObjectiveSpec(objectiveID, model);
+    if (spec == null) {
+      return;
+    }
+    if (spec.lensNA != null) {
+      store.setObjectiveLensNA(spec.lensNA, 0, objectiveIndex);
+    }
+    if (spec.immersion != null) {
+      try {
+        store.setObjectiveImmersion(
+          MetadataTools.getImmersion(spec.immersion), 0, objectiveIndex);
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Ignoring unsupported CV7000 objective immersion {}",
+          spec.immersion, e);
+      }
+    }
+  }
+
+  private CV7000ObjectiveSpec getObjectiveSpec(String objectiveID, String model) {
+    // CV7000 objective NA and immersion values come from the user manual,
+    // section 14, "MS Code" / "Objective Lens".
+    ObjectiveModelTokens tokens = parseObjectiveModel(model);
+    if (isObjectiveMagnification(tokens, 4) ||
+      (tokens.magnification == null && "4000".equals(objectiveID)))
+    {
+      return new CV7000ObjectiveSpec(0.16, "Air");
+    }
+    if (isObjectiveMagnification(tokens, 10)) {
+      return new CV7000ObjectiveSpec(tokens.phase ? 0.30 : 0.40, "Air");
+    }
+    if (tokens.magnification == null && "10000".equals(objectiveID)) {
+      return new CV7000ObjectiveSpec(0.40, "Air");
+    }
+    if (isObjectiveMagnification(tokens, 20)) {
+      return new CV7000ObjectiveSpec(
+        tokens.phase || tokens.longWorkingDistance ? 0.45 : 0.75, "Air");
+    }
+    if (tokens.magnification == null && "20003".equals(objectiveID)) {
+      return new CV7000ObjectiveSpec(0.45, "Air");
+    }
+    if (tokens.magnification == null && "20000".equals(objectiveID)) {
+      return new CV7000ObjectiveSpec(0.75, "Air");
+    }
+    if (isObjectiveMagnification(tokens, 40) ||
+      (tokens.magnification == null && "40000".equals(objectiveID)))
+    {
+      return new CV7000ObjectiveSpec(0.95, "Air");
+    }
+    if (isObjectiveMagnification(tokens, 60) ||
+      (tokens.magnification == null && "60004".equals(objectiveID)))
+    {
+      return new CV7000ObjectiveSpec(1.2, "Water");
+    }
+    return null;
+  }
+
+  private ObjectiveModelTokens parseObjectiveModel(String model) {
+    String cleaned = clean(model);
+    ObjectiveModelTokens tokens = new ObjectiveModelTokens();
+    if (cleaned == null) {
+      return tokens;
+    }
+    String normalized = cleaned.toLowerCase().replace('\u00d7', 'x');
+    normalized = normalized.replaceAll("[^a-z0-9]+", " ").trim();
+    normalized = normalized.replaceAll("\\s+", " ");
+    String[] parts = normalized.split(" ");
+    for (String part : parts) {
+      if (part.endsWith("x") && part.length() > 1) {
+        tokens.magnification = parseInteger(part.substring(0, part.length() - 1));
+      }
+      if ("ph".equals(part) || "phase".equals(part)) {
+        tokens.phase = true;
+      }
+      if ("lwd".equals(part) || "long".equals(part)) {
+        tokens.longWorkingDistance = true;
+      }
+      if ("water".equals(part)) {
+        tokens.water = true;
+      }
+      if ("w".equals(part)) {
+        tokens.water = true;
+      }
+    }
+    return tokens;
+  }
+
+  private boolean isObjectiveMagnification(ObjectiveModelTokens tokens,
+    int magnification)
+  {
+    return tokens != null && tokens.magnification != null &&
+      tokens.magnification.intValue() == magnification;
   }
 
   private void populateDetectors(MetadataStore store,
@@ -1384,6 +1595,7 @@ public class CV7000Reader extends FormatReader {
       }
     }
     addCrosstalkOriginalMetadata();
+    addOTFGeometryOriginalMetadata();
     if (channels == null) {
       emitYokogawaMapAnnotations(store, plateAnnotationRef, hasInstrument);
       return;
@@ -1394,8 +1606,7 @@ public class CV7000Reader extends FormatReader {
       if (!seen.add(key)) {
         continue;
       }
-      String prefix = "Yokogawa Timeline " + (c.timelineIndex + 1) +
-        " Action " + (c.actionIndex + 1) + " Channel " + (c.index + 1) + " ";
+      String prefix = getYokogawaChannelScope(c);
       // Raw Yokogawa planning fields are kept even when a subset is promoted
       // to core OME fields; this makes enum/wavelength decisions auditable.
       addYokogawaMeta(prefix, "Target", c.target);
@@ -1473,6 +1684,85 @@ public class CV7000Reader extends FormatReader {
           intensity.averageIntensity);
       }
     }
+  }
+
+  private void addOTFGeometryOriginalMetadata() {
+    if (otfGeometryParameters == null) {
+      return;
+    }
+
+    addYokogawaMeta("Yokogawa OTF Geometry ", "Mode",
+      otfGeometryParameters.mode);
+
+    int objectiveIndex = 1;
+    for (OTFGeometryObjective objective :
+      otfGeometryParameters.objectivesByID.values())
+    {
+      String prefix = "Yokogawa OTF Geometry Objective " + objectiveIndex + " ";
+      addYokogawaMeta(prefix, "ObjectiveID", objective.objectiveID);
+      addYokogawaMeta(prefix, "Objective", objective.objective);
+      addYokogawaMeta(prefix, "Magnification", objective.magnification);
+      CV7000ObjectiveSpec spec =
+        getObjectiveSpec(objective.objectiveID, objective.objective);
+      if (spec != null) {
+        addYokogawaMeta(prefix, "MappedLensNA", spec.lensNA);
+        addYokogawaMeta(prefix, "MappedImmersion", spec.immersion);
+      }
+      objectiveIndex++;
+    }
+
+    int affineIndex = 1;
+    for (OTFGeometryAffine affine : otfGeometryParameters.affines) {
+      String prefix = "Yokogawa OTF Geometry Affine " + affineIndex + " ";
+      addOTFGeometryAffineMetadata(prefix, affine);
+
+      if (channels != null) {
+        for (Channel channel : channels) {
+          if (matchesAffine(channel, affine)) {
+            addOTFGeometryAffineMetadata(getYokogawaChannelScope(channel) +
+              "OTFGeometry ", affine);
+          }
+        }
+      }
+      affineIndex++;
+    }
+  }
+
+  private void addOTFGeometryAffineMetadata(String prefix,
+    OTFGeometryAffine affine)
+  {
+    addYokogawaMeta(prefix, "MethodID", affine.methodID);
+    addYokogawaMeta(prefix, "Method", affine.method);
+    addYokogawaMeta(prefix, "ObjectiveID", affine.objectiveID);
+    addYokogawaMeta(prefix, "Objective", affine.objective);
+    addYokogawaMeta(prefix, "Magnification", affine.magnification);
+    addYokogawaMeta(prefix, "FilterID", affine.filterID);
+    addYokogawaMeta(prefix, "Acquisition", affine.acquisition);
+    addYokogawaMeta(prefix, "Use", affine.use);
+    addYokogawaMeta(prefix, "UpdateTime", affine.updateTime);
+    addYokogawaMeta(prefix, "A", affine.a);
+    addYokogawaMeta(prefix, "B", affine.b);
+    addYokogawaMeta(prefix, "C", affine.c);
+    addYokogawaMeta(prefix, "D", affine.d);
+    addYokogawaMeta(prefix, "E", affine.e);
+    addYokogawaMeta(prefix, "F", affine.f);
+  }
+
+  private boolean matchesAffine(Channel channel, OTFGeometryAffine affine) {
+    if (channel == null || affine == null) {
+      return false;
+    }
+    return sameYokogawaValue(affine.methodID, channel.methodID) &&
+      sameYokogawaValue(affine.method, channel.method) &&
+      sameYokogawaValue(affine.objectiveID, channel.objectiveID) &&
+      sameYokogawaValue(affine.filterID, channel.filterID) &&
+      sameYokogawaValue(affine.acquisition, channel.acquisition);
+  }
+
+  private boolean sameYokogawaValue(String a, String b) {
+    String cleanA = clean(a);
+    String cleanB = clean(b);
+    return cleanA == null ? cleanB == null : cleanA.equals(cleanB);
   }
 
   private void addSidecarSummaryMetadata(String file, CV7000FileRole role) {
@@ -2071,6 +2361,7 @@ public class CV7000Reader extends FormatReader {
     public String settingsPath;
     public MeasurementDataHandler measurementHandler;
     public CrosstalkParameters crosstalkParameters;
+    public OTFGeometryParameters otfGeometryParameters;
     public ArrayList<String> allFiles = new ArrayList<String>();
     public YokogawaOriginalMetadata originalMetadata =
       new YokogawaOriginalMetadata();
@@ -2282,18 +2573,6 @@ public class CV7000Reader extends FormatReader {
           Double parsedWidth = DataTools.parseDouble(width);
           if (parsedCenter != null && parsedWidth != null) {
             return DetectionFilter.bandPass(parsedCenter, parsedWidth);
-          }
-        }
-        else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
-          Double cutIn = DataTools.parseDouble(trimmed.substring(2));
-          if (cutIn != null) {
-            return DetectionFilter.longPass(cutIn);
-          }
-        }
-        else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
-          Double cutOut = DataTools.parseDouble(trimmed.substring(2));
-          if (cutOut != null) {
-            return DetectionFilter.shortPass(cutOut);
           }
         }
       }
@@ -2996,6 +3275,115 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
+  class OTFGeometryHandler extends BaseHandler {
+    private OTFGeometryParameters parameters = new OTFGeometryParameters();
+
+    public OTFGeometryParameters getParameters() {
+      return parameters;
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      String name = getYokogawaAttributeName(qName);
+      if ("GeometryParameter".equals(name)) {
+        parameters.mode = getAttribute(attributes, "Mode");
+        return;
+      }
+      if (!"AffineParameter".equals(name)) {
+        return;
+      }
+
+      OTFGeometryAffine affine = new OTFGeometryAffine();
+      affine.methodID = getAttribute(attributes, "MethodID");
+      affine.method = getAttribute(attributes, "Method");
+      affine.objectiveID = getAttribute(attributes, "ObjectiveID");
+      affine.objective = getAttribute(attributes, "Objective");
+      affine.magnification = DataTools.parseDouble(
+        getAttribute(attributes, "Magnification"));
+      affine.filterID = getAttribute(attributes, "FilterID");
+      affine.acquisition = getAttribute(attributes, "Acquisition");
+      affine.use = getAttribute(attributes, "Use");
+      affine.updateTime = getAttribute(attributes, "UpdateTime");
+      affine.a = DataTools.parseDouble(getAttribute(attributes, "A"));
+      affine.b = DataTools.parseDouble(getAttribute(attributes, "B"));
+      affine.c = DataTools.parseDouble(getAttribute(attributes, "C"));
+      affine.d = DataTools.parseDouble(getAttribute(attributes, "D"));
+      affine.e = DataTools.parseDouble(getAttribute(attributes, "E"));
+      affine.f = DataTools.parseDouble(getAttribute(attributes, "F"));
+      parameters.addAffine(affine);
+    }
+
+    private String getAttribute(Attributes attributes, String name) {
+      if (attributes == null || name == null) {
+        return null;
+      }
+      for (int i=0; i<attributes.getLength(); i++) {
+        if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
+          String value = attributes.getValue(i);
+          return value == null || value.trim().length() == 0 ? null : value;
+        }
+      }
+      return null;
+    }
+  }
+
+  class OTFGeometryParameters {
+    public String mode;
+    public LinkedHashMap<String, OTFGeometryObjective> objectivesByID =
+      new LinkedHashMap<String, OTFGeometryObjective>();
+    public ArrayList<OTFGeometryAffine> affines =
+      new ArrayList<OTFGeometryAffine>();
+
+    public void addAffine(OTFGeometryAffine affine) {
+      affines.add(affine);
+      if (affine.objectiveID == null) {
+        return;
+      }
+      OTFGeometryObjective objective = objectivesByID.get(affine.objectiveID);
+      if (objective == null) {
+        objective = new OTFGeometryObjective();
+        objective.objectiveID = affine.objectiveID;
+        objective.objective = affine.objective;
+        objective.magnification = affine.magnification;
+        objectivesByID.put(objective.objectiveID, objective);
+      }
+      else {
+        if (objective.objective == null) {
+          objective.objective = affine.objective;
+        }
+        if (objective.magnification == null) {
+          objective.magnification = affine.magnification;
+        }
+      }
+    }
+  }
+
+  class OTFGeometryObjective {
+    public String objectiveID;
+    public String objective;
+    public Double magnification;
+  }
+
+  class OTFGeometryAffine {
+    public String methodID;
+    public String method;
+    public String objectiveID;
+    public String objective;
+    public Double magnification;
+    public String filterID;
+    public String acquisition;
+    public String use;
+    public String updateTime;
+    public Double a;
+    public Double b;
+    public Double c;
+    public Double d;
+    public Double e;
+    public Double f;
+  }
+
   class CrosstalkParameters {
     public LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter> filters =
       new LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter>();
@@ -3086,6 +3474,23 @@ public class CV7000Reader extends FormatReader {
     public Double power;
   }
 
+  class CV7000ObjectiveSpec {
+    public Double lensNA;
+    public String immersion;
+
+    public CV7000ObjectiveSpec(Double lensNA, String immersion) {
+      this.lensNA = lensNA;
+      this.immersion = immersion;
+    }
+  }
+
+  class ObjectiveModelTokens {
+    public Integer magnification;
+    public boolean phase;
+    public boolean longWorkingDistance;
+    public boolean water;
+  }
+
   static class DetectionFilter {
     public String filterType;
     public Double center;
@@ -3099,18 +3504,6 @@ public class CV7000Reader extends FormatReader {
       filter.width = width;
       filter.cutIn = center - (width / 2);
       filter.cutOut = center + (width / 2);
-      return filter;
-    }
-
-    public static DetectionFilter longPass(Double cutIn) {
-      DetectionFilter filter = new DetectionFilter("LongPass");
-      filter.cutIn = cutIn;
-      return filter;
-    }
-
-    public static DetectionFilter shortPass(Double cutOut) {
-      DetectionFilter filter = new DetectionFilter("ShortPass");
-      filter.cutOut = cutOut;
       return filter;
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -568,12 +568,8 @@ public class CV7000Reader extends FormatReader {
 
           setSeries(nextImage);
 
-          // find the first valid plane to set WellSample positions
-          int no = 0;
-          Plane p = lookupPlane(nextImage, no);
-          while (p == null && no < getImageCount()) {
-            p = lookupPlane(nextImage, no++);
-          }
+          // find the first plane with pixels to set WellSample positions
+          Plane p = lookupFirstBackedPlane(nextImage);
           if (p != null) {
             store.setWellSamplePositionX(
               FormatTools.createLength(p.xpos, UNITS.REFERENCEFRAME),
@@ -629,6 +625,7 @@ public class CV7000Reader extends FormatReader {
       for (int i=0; i<getSeriesCount(); i++) {
         setSeries(i);
         if (channels != null) {
+          boolean physicalSizeSet = false;
           for (int c=0; c<getSizeC(); c++) {
             Plane p = lookupRepresentativePlane(i, c);
             if (p == null) {
@@ -641,9 +638,10 @@ public class CV7000Reader extends FormatReader {
               continue;
             }
 
-            if (c == 0) {
+            if (!physicalSizeSet) {
               store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(channel.xSize), i);
               store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.ySize), i);
+              physicalSizeSet = true;
             }
 
             int objective = -1;
@@ -750,6 +748,16 @@ public class CV7000Reader extends FormatReader {
       }
     }
     return ambiguousRawChannel ? null : rawChannel;
+  }
+
+  private Plane lookupFirstBackedPlane(int series) {
+    for (int no=0; no<reversePlaneLookup[series].length; no++) {
+      Plane p = lookupPlane(series, no);
+      if (p != null && p.file != null) {
+        return p;
+      }
+    }
+    return null;
   }
 
   private Plane lookupRepresentativePlane(int series, int channel) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -677,6 +677,8 @@ public class CV7000Reader extends FormatReader {
     store.setPlateExternalIdentifier(plate.getPlateID(), 0);
     store.setPlateRows(new PositiveInteger(plate.getPlateRows()), 0);
     store.setPlateColumns(new PositiveInteger(plate.getPlateColumns()), 0);
+    store.setPlateWellOriginX(FormatTools.createLength(0.0, UNITS.MICROMETER), 0);
+    store.setPlateWellOriginY(FormatTools.createLength(0.0, UNITS.MICROMETER), 0);
 
     String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, 0);
     store.setPlateAcquisitionID(plateAcqID, 0, 0);
@@ -746,11 +748,18 @@ public class CV7000Reader extends FormatReader {
 
           Plane p = lookupFirstBackedPlane(nextImage);
           if (p != null) {
+            // CV7000 sidecars mix coordinate systems. WPP plate dimensions and
+            // pitch are in millimeters, while MRF pixel sizes are in um/pixel.
+            // MLF X/Y ranges match field centers fitting inside the WPP well
+            // bottom when interpreted as micrometers around 0,0; they would be
+            // impossible as millimeters and do not shift by the 9000 um well
+            // pitch. Treat them as well-center-relative field offsets, not
+            // absolute stage positions.
             store.setWellSamplePositionX(
-              FormatTools.createLength(p.xpos, UNITS.REFERENCEFRAME),
+              FormatTools.createLength(p.xpos, UNITS.MICROMETER),
               0, nextWell, wellSample);
             store.setWellSamplePositionY(
-              FormatTools.createLength(p.ypos, UNITS.REFERENCEFRAME),
+              FormatTools.createLength(p.ypos, UNITS.MICROMETER),
               0, nextWell, wellSample);
           }
 
@@ -949,9 +958,11 @@ public class CV7000Reader extends FormatReader {
       if (plane == null) {
         continue;
       }
-      store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), series, p);
-      store.setPlanePositionY(FormatTools.createLength(plane.ypos, UNITS.REFERENCEFRAME), series, p);
-      store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), series, p);
+      // MLF Z values match MES AFShiftBase + (ZIndex - 1) * SliceLength,
+      // where SliceLength is the physical Z spacing in micrometers. AFSearch
+      // indicates the reference is the autofocus/base surface, so this is an
+      // AF-relative stack coordinate, not a proven absolute stage Z.
+      store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.MICROMETER), series, p);
       Double deltaT = getPlaneDeltaTSeconds(plane, timing.startMillis);
       if (deltaT != null) {
         store.setPlaneDeltaT(new Time(deltaT, UNITS.SECOND), series, p);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -701,7 +701,7 @@ public class CV7000Reader extends FormatReader {
 
         for (int p=0; p<getImageCount(); p++) {
           Plane plane = lookupPlane(i, p);
-          if (plane == null || plane.file == null) {
+          if (plane == null) {
             continue;
           }
           store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), i, p);
@@ -761,13 +761,17 @@ public class CV7000Reader extends FormatReader {
   }
 
   private Plane lookupRepresentativePlane(int series, int channel) {
+    Plane metadataPlane = null;
     for (int no=0; no<reversePlaneLookup[series].length; no++) {
       Plane p = lookupPlane(series, no);
       if (p != null && p.file != null && p.channelIndex == channel) {
         return p;
       }
+      if (p != null && p.channelIndex == channel && metadataPlane == null) {
+        metadataPlane = p;
+      }
     }
-    return null;
+    return metadataPlane;
   }
 
   private String readSanitizedXML(String filename) throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1074,6 +1074,7 @@ public class CV7000Reader extends FormatReader {
     if (allFiles != null) {
       for (String file : allFiles) {
         if (file != null && !checkSuffix(file, "tif")) {
+          addPostProcessOriginalMetadata(file);
           addRawSidecarMetadata(file);
           addYokogawaMetaList("Yokogawa Sidecar ", "File",
             new Location(file).getName());
@@ -1174,7 +1175,23 @@ public class CV7000Reader extends FormatReader {
   private boolean isRawXMLSidecar(String file) {
     return checkSuffix(file, "wpi") || checkSuffix(file, "mrf") ||
       checkSuffix(file, "mes") || checkSuffix(file, "wpp") ||
-      checkSuffix(file, "xml");
+      checkSuffix(file, "ppf") || checkSuffix(file, "xml");
+  }
+
+  private void addPostProcessOriginalMetadata(String file) {
+    Location location = new Location(file);
+    if (!POST_PROCESS.equals(location.getName())) {
+      return;
+    }
+    try {
+      String xml = readSanitizedXML(file);
+      if (xml.length() > 0) {
+        XMLTools.parseXML(xml, new PostProcessHandler());
+      }
+    }
+    catch (IOException e) {
+      LOGGER.debug("Could not parse CV7000 post-processing sidecar {}", file, e);
+    }
   }
 
   private void addMeasurementDataOriginalMetadata() {
@@ -1388,7 +1405,9 @@ public class CV7000Reader extends FormatReader {
         continue;
       }
       Channel channel = lookupChannel(p);
-      if (channel == null || channel.physicalSizeZ == null) {
+      if (channel == null || channel.physicalSizeZ == null ||
+        channel.physicalSizeZ <= 0)
+      {
         return null;
       }
       foundChannel = true;
@@ -1741,6 +1760,28 @@ public class CV7000Reader extends FormatReader {
     {
       if (qName.equals("bts:WellPlateProduct")) {
         addYokogawaAttributes("Yokogawa WPP ", attributes);
+      }
+    }
+
+  }
+
+  class PostProcessHandler extends BaseHandler {
+    private int actionIndex = -1;
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      if (qName.equals("cvpp:PostProcess") || qName.equals("PostProcess")) {
+        addYokogawaAttributes("Yokogawa PPF PostProcess ", attributes);
+      }
+      else if (qName.equals("cvpp:PostProcessAction") ||
+        qName.equals("PostProcessAction"))
+      {
+        actionIndex++;
+        addYokogawaAttributes(
+          "Yokogawa PPF PostProcessAction " + (actionIndex + 1) + " ",
+          attributes);
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1150,9 +1150,10 @@ public class CV7000Reader extends FormatReader {
         String filamentID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
         store.setFilamentID(filamentID, 0, nextLightSource);
         store.setFilamentModel(getLightSourceModel(l), 0, nextLightSource);
-        // The CV7000 user manual identifies white-light illumination as a
-        // 100 W halogen lamp; MES fixtures expose only generic Type="Lamp".
-        store.setFilamentType(MetadataTools.getFilamentType("Halogen"),
+        // The CV7000 manual describes the white-light lamp as halogen, but
+        // installed hardware may differ and the sidecars expose only generic
+        // Type="Lamp", so keep the filament type as Other.
+        store.setFilamentType(MetadataTools.getFilamentType("Other"),
           0, nextLightSource);
         lightSourceIndexes.put(i, nextLightSource);
         nextLightSource++;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -851,6 +851,9 @@ public class CV7000Reader extends FormatReader {
     String detectorID = MetadataTools.createLSID(
       "Detector", 0, detectorIndexes.get(channel.cameraNumber));
     store.setDetectorSettingsID(detectorID, series, channelIndex);
+    if (channel.detectorGain != null) {
+      store.setDetectorSettingsGain(channel.detectorGain, series, channelIndex);
+    }
     String binning = getBinningValue(channel.binning);
     if (binning != null) {
       try {
@@ -1127,6 +1130,7 @@ public class CV7000Reader extends FormatReader {
       addYokogawaMeta(prefix, "Binning", c.binning);
       addYokogawaMeta(prefix, "AndorParameterID", c.andorParameterID);
       addYokogawaMeta(prefix, "AndorParameter", c.andorParameter);
+      addYokogawaMeta(prefix, "DetectorGain", c.detectorGain);
       addYokogawaMeta(prefix, "InputBitDepth", c.inputBitDepth);
       addYokogawaMeta(prefix, "InputLevel", c.inputLevel);
       addYokogawaMeta(prefix, "HorizontalPixels", c.horizontalPixels);
@@ -1292,20 +1296,20 @@ public class CV7000Reader extends FormatReader {
       if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
         String center = trimmed.substring(2, trimmed.indexOf("/"));
         String width = trimmed.substring(trimmed.indexOf("/") + 1);
-        Double parsedCenter = DataTools.parseDouble(center);
-        Double parsedWidth = DataTools.parseDouble(width);
+        Double parsedCenter = parseYokogawaDouble(center);
+        Double parsedWidth = parseYokogawaDouble(width);
         if (parsedCenter != null && parsedWidth != null) {
           return DetectionFilter.bandPass(parsedCenter, parsedWidth);
         }
       }
       else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
-        Double cutIn = DataTools.parseDouble(trimmed.substring(2));
+        Double cutIn = parseYokogawaDouble(trimmed.substring(2));
         if (cutIn != null) {
           return DetectionFilter.longPass(cutIn);
         }
       }
       else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
-        Double cutOut = DataTools.parseDouble(trimmed.substring(2));
+        Double cutOut = parseYokogawaDouble(trimmed.substring(2));
         if (cutOut != null) {
           return DetectionFilter.shortPass(cutOut);
         }
@@ -1315,6 +1319,54 @@ public class CV7000Reader extends FormatReader {
       LOGGER.debug("Ignoring invalid CV7000 detection filter value {}", acquisition, e);
     }
     return null;
+  }
+  
+  /**
+   * Parse a Yokogawa floating-point value, which may use a comma as the decimal
+   * separator. This is not directly observed in the test data, but the existence
+   * of the "," character in the Yokogawa XML DTD reminds me of the locality of
+   * the Zeiss XML format, which does use commas in some locales. This is a defensive
+   * parsing measure to avoid potential issues with future data.
+   */
+  private Double parseYokogawaDouble(String value) {
+    if (value == null || value.trim().length() == 0) {
+      return null;
+    }
+    return DataTools.parseDouble(value.trim().replace(',', '.'));
+  }
+
+  private Double parseYokogawaGain(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (!trimmed.regionMatches(true, 0, "gain", 0, 4)) {
+      return null;
+    }
+    int start = -1;
+    for (int i=4; i<trimmed.length(); i++) {
+      char ch = trimmed.charAt(i);
+      if (Character.isDigit(ch) || ch == '+' || ch == '-' ||
+        ch == '.' || ch == ',')
+      {
+        start = i;
+        break;
+      }
+    }
+    if (start < 0) {
+      return null;
+    }
+    int end = start + 1;
+    while (end < trimmed.length()) {
+      char ch = trimmed.charAt(end);
+      if (!(Character.isDigit(ch) || ch == '+' || ch == '-' ||
+        ch == '.' || ch == ',' || ch == 'e' || ch == 'E'))
+      {
+        break;
+      }
+      end++;
+    }
+    return parseYokogawaDouble(trimmed.substring(start, end));
   }
 
   private Integer parseInteger(String value) {
@@ -1602,9 +1654,9 @@ public class CV7000Reader extends FormatReader {
             currentField = p.field.field;
           }
 
-          p.xpos = DataTools.parseDouble(attributes.getValue("bts:X"));
-          p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
-          p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
+          p.xpos = parseYokogawaDouble(attributes.getValue("bts:X"));
+          p.ypos = parseYokogawaDouble(attributes.getValue("bts:Y"));
+          p.zpos = parseYokogawaDouble(attributes.getValue("bts:Z"));
           p.timestamp = attributes.getValue("bts:Time");
           p.actionName = attributes.getValue("bts:Action");
           imageRecordCount++;
@@ -1664,8 +1716,8 @@ public class CV7000Reader extends FormatReader {
         c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
         addYokogawaAttributes(
           "Yokogawa MRF Channel " + (c.index + 1) + " ", attributes);
-        c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
-        c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
+        c.xSize = parseYokogawaDouble(attributes.getValue("bts:HorizontalPixelDimension"));
+        c.ySize = parseYokogawaDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
         c.inputBitDepth = parseInteger(attributes.getValue("bts:InputBitDepth"));
         c.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
@@ -1752,8 +1804,8 @@ public class CV7000Reader extends FormatReader {
         String wavelength = attributes.getValue("bts:WaveLength");
         String power = attributes.getValue("bts:Power");
 
-        l.wavelength = DataTools.parseDouble(wavelength);
-        l.power = DataTools.parseDouble(power);
+        l.wavelength = parseYokogawaDouble(wavelength);
+        l.power = parseYokogawaDouble(power);
 
         lightSources.add(l);
       }
@@ -1779,14 +1831,15 @@ public class CV7000Reader extends FormatReader {
             template.kind = attributes.getValue("bts:Kind");
             template.andorParameterID = attributes.getValue("bts:AndorParameterID");
             template.andorParameter = attributes.getValue("bts:AndorParameter");
+            template.detectorGain = parseYokogawaGain(template.andorParameter);
             template.cameraType = attributes.getValue("bts:CameraType");
             template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
 
             String mag = attributes.getValue("bts:Magnification");
-            template.magnification = DataTools.parseDouble(mag);
+            template.magnification = parseYokogawaDouble(mag);
 
             String exposure = attributes.getValue("bts:ExposureTime");
-            template.exposureTime = DataTools.parseDouble(exposure);
+            template.exposureTime = parseYokogawaDouble(exposure);
 
             String color = attributes.getValue("bts:Color");
             if (color != null) {
@@ -1868,7 +1921,7 @@ public class CV7000Reader extends FormatReader {
         addYokogawaAttributes(
           "Yokogawa MES Timeline " + (timelineIndex + 1) +
           " Action " + (actionIndex + 1) + " ", attributes);
-        currentPhysicalSizeZ = DataTools.parseDouble(
+        currentPhysicalSizeZ = parseYokogawaDouble(
           attributes.getValue("bts:SliceLength"));
       }
     }
@@ -2074,6 +2127,7 @@ public class CV7000Reader extends FormatReader {
     public String cameraType;
     public String andorParameterID;
     public String andorParameter;
+    public Double detectorGain;
     public String objectiveID;
     public String objective;
     public String actionType;
@@ -2120,6 +2174,7 @@ public class CV7000Reader extends FormatReader {
       cameraType = ch.cameraType;
       andorParameterID = ch.andorParameterID;
       andorParameter = ch.andorParameter;
+      detectorGain = ch.detectorGain;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
       actionType = ch.actionType;
@@ -2167,6 +2222,7 @@ public class CV7000Reader extends FormatReader {
       cameraType = ch.cameraType;
       andorParameterID = ch.andorParameterID;
       andorParameter = ch.andorParameter;
+      detectorGain = ch.detectorGain;
       inputLevel = ch.inputLevel;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
@@ -2179,7 +2235,7 @@ public class CV7000Reader extends FormatReader {
 
     public boolean hasChannelSettings() {
       return objectiveID != null || objective != null || magnification != null ||
-        exposureTime != null || binning != null || color != null ||
+        exposureTime != null || detectorGain != null || binning != null || color != null ||
         acquisition != null || detectionFilter != null || fluor != null ||
         (lightSourceRefs != null && lightSourceRefs.size() > 0);
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -103,6 +103,7 @@ public class CV7000Reader extends FormatReader {
   private static final String YOKOGAWA_ANNOTATION_NAMESPACE =
     "openmicroscopy.org/OriginalMetadata/Yokogawa/CV7000";
   private static final String XML_MIME_TYPE = "application/xml";
+  private static final String CV7000_DIMENSION_ORDER = "XYZCT";
   // Manual objective table plus observed CV7000 objective labels in OTF geometry. These correctly resolve known objectives in local data and available data from public repositories.
   private static final KnownObjectiveSpec[] KNOWN_OBJECTIVES =
     new KnownObjectiveSpec[] {
@@ -329,9 +330,9 @@ public class CV7000Reader extends FormatReader {
       return reader.openBytes(0, buf, x, y, w, h);
     }
     else if (duplicatePlanes() && no > 0) {
-      int[] zct = getZCTCoords(no);
+      int[] zct = getLogicalZCTCoords(getSeries(), no);
       // pick the first plane in the same channel
-      int dupPlane = getIndex(0, zct[1], 0);
+      int dupPlane = getLogicalPlaneIndex(getSeries(), 0, zct[1], 0);
 
       // very unlikely to happen, but catching the case
       // where no is the first plane in the channel prevents
@@ -689,7 +690,7 @@ public class CV7000Reader extends FormatReader {
     core.clear();
     core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));
 
-    core.get(0).dimensionOrder = "XYCZT";
+    core.get(0).dimensionOrder = CV7000_DIMENSION_ORDER;
     layout.reversePlaneLookup = new int[layout.acquiredFields.size()][];
     reversePlaneLookup = layout.reversePlaneLookup;
 
@@ -712,9 +713,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Map each Yokogawa plane record to the reader's series and plane index. */
-  private void populateReversePlaneLookup(CV7000SeriesLayout layout) {
-    int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
-
+  private void populateReversePlaneLookup(CV7000SeriesLayout layout) throws FormatException {
     extraFiles = new ArrayList<String>();
     for (int i=0; i<planeData.size(); i++) {
       Plane p = planeData.get(i);
@@ -730,16 +729,16 @@ public class CV7000Reader extends FormatReader {
       // Reindex from Yokogawa's channel/action numbering into the compact
       // channel list exposed by this reader for the current dataset.
       p.channelIndex = Arrays.binarySearch(layout.channelIndexes, p.channelIndex);
+      if (p.channelIndex < 0) {
+        throw new FormatException("Could not map CV7000 channel " +
+          (p.channel + 1) + " to a compact reader channel index");
+      }
 
       p.series = series.intValue();
       MinMax m = layout.minMax.get(p.field);
 
-      planeLengths[0] = core.get(p.series).sizeC / reader.getSizeC();
-      planeLengths[1] = core.get(p.series).sizeZ;
-      planeLengths[2] = core.get(p.series).sizeT;
-
-      p.no = FormatTools.positionToRaster(planeLengths,
-        new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
+      p.no = getLogicalPlaneIndex(p.series, p.z - m.minZ, p.channelIndex,
+        p.timepoint - m.minT);
       assignPlaneLookup(i, p, layout);
       layout.indexPlane(p);
     }
@@ -1174,7 +1173,7 @@ public class CV7000Reader extends FormatReader {
     Time exposure = new Time(channel.exposureTime, UNITS.MILLISECOND);
     for (int z=0; z<getSizeZ(); z++) {
       for (int t=0; t<getSizeT(); t++) {
-        int plane = getIndex(z, channelIndex, t);
+        int plane = getLogicalPlaneIndex(series, z, channelIndex, t);
         store.setPlaneExposureTime(exposure, series, plane);
       }
     }
@@ -2391,8 +2390,8 @@ public class CV7000Reader extends FormatReader {
       return null;
     }
 
-    int[] zct = getZCTCoords(series, no);
-    int dupPlane = getIndex(series, 0, zct[1], 0);
+    int[] zct = getLogicalZCTCoords(series, no);
+    int dupPlane = getLogicalPlaneIndex(series, 0, zct[1], 0);
     if (dupPlane == no) {
       dupPlane = 0;
     }
@@ -2400,29 +2399,28 @@ public class CV7000Reader extends FormatReader {
     return duplicate != null && duplicate.file != null ? duplicate : null;
   }
 
-  private int[] getZCTCoords(int series, int no) {
-    int[] lengths = new int[] {
-      core.get(series).sizeC / reader.getSizeC(),
-      core.get(series).sizeZ,
-      core.get(series).sizeT
-    };
-    int[] czt = FormatTools.rasterToPosition(lengths, no);
-    return new int[] {czt[1], czt[0], czt[2]};
+  private int getLogicalChannelCount(int series) {
+    return core.get(series).sizeC / reader.getSizeC();
   }
 
-  private int getIndex(int series, int z, int c, int t) {
-    int[] lengths = new int[] {
-      core.get(series).sizeC / reader.getSizeC(),
-      core.get(series).sizeZ,
-      core.get(series).sizeT
-    };
-    return FormatTools.positionToRaster(lengths, new int[] {c, z, t});
+  private int[] getLogicalZCTCoords(int series, int no) {
+    CoreMetadata metadata = core.get(series);
+    return FormatTools.getZCTCoords(metadata.dimensionOrder,
+      metadata.sizeZ, getLogicalChannelCount(series), metadata.sizeT,
+      metadata.imageCount, no);
+  }
+
+  private int getLogicalPlaneIndex(int series, int z, int c, int t) {
+    CoreMetadata metadata = core.get(series);
+    return FormatTools.getIndex(metadata.dimensionOrder,
+      metadata.sizeZ, getLogicalChannelCount(series), metadata.sizeT,
+      metadata.imageCount, z, c, t);
   }
 
   private String formatPlaneProvenanceAnomaly(int series, int no, String status,
     String reason, Plane source, Plane anomalyPlane)
   {
-    int[] zct = getZCTCoords(series, no);
+    int[] zct = getLogicalZCTCoords(series, no);
     StringBuilder row = new StringBuilder();
     row.append("no=").append(no);
     row.append(";z=").append(zct[0]);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -113,6 +113,8 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<LightSource> lightSources;
   private ArrayList<Channel> channels;
   private String startTime, endTime;
+  private String measurementOperatorName;
+  private String targetSystem;
   private ArrayList<String> extraFiles;
   private MeasurementDataHandler measurementHandler;
   private CrosstalkParameters crosstalkParameters;
@@ -264,6 +266,8 @@ public class CV7000Reader extends FormatReader {
       channels = null;
       startTime = null;
       endTime = null;
+      measurementOperatorName = null;
+      targetSystem = null;
       measurementHandler = null;
       crosstalkParameters = null;
       reversePlaneLookup = null;
@@ -330,6 +334,8 @@ public class CV7000Reader extends FormatReader {
     super.initFile(id);
     rawModel = new CV7000RawModel();
     seriesLayout = null;
+    measurementOperatorName = null;
+    targetSystem = null;
     CV7000DatasetPaths paths = getDatasetPaths(id);
     datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
@@ -718,9 +724,10 @@ public class CV7000Reader extends FormatReader {
       store.setPlateExternalIdentifier(plate.getPlateID(), 0);
 
       InstrumentMetadataIndexes indexes = populateInstrumentMetadata(store);
+      String experimenter = populateExperimenterMetadata(store);
       populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
         indexes.detectorIndexes, indexes.filterIndexes, indexes.dichroicIndexes,
-        indexes.usedObjectiveIDs, timings);
+        indexes.usedObjectiveIDs, experimenter, timings);
       new CV7000OriginalMetadataPopulator().populate(store, indexes.instrument != null);
       setSeries(0);
     }
@@ -734,11 +741,13 @@ public class CV7000Reader extends FormatReader {
     if ((lightSources != null && lightSources.size() > 0) ||
       (channels != null && channels.size() > 0) ||
       (otfGeometryParameters != null &&
-        otfGeometryParameters.objectivesByID.size() > 0))
+        otfGeometryParameters.objectivesByID.size() > 0) ||
+      targetSystem != null)
     {
       indexes.instrument = MetadataTools.createLSID("Instrument", 0);
 
       store.setInstrumentID(indexes.instrument, 0);
+      populateMicroscope(store);
       populateLightSources(store, indexes.lightSourceIndexes);
       populateObjectives(store, indexes.usedObjectiveIDs);
       populateDetectors(store, indexes.detectorIndexes);
@@ -746,6 +755,24 @@ public class CV7000Reader extends FormatReader {
       populateFilters(store, indexes.filterIndexes);
     }
     return indexes;
+  }
+
+  private void populateMicroscope(MetadataStore store) {
+    if (targetSystem == null) {
+      return;
+    }
+    store.setMicroscopeManufacturer("Yokogawa", 0);
+    store.setMicroscopeModel(targetSystem, 0);
+  }
+
+  private String populateExperimenterMetadata(MetadataStore store) {
+    if (measurementOperatorName == null) {
+      return null;
+    }
+    String experimenter = MetadataTools.createLSID("Experimenter", 0);
+    store.setExperimenterID(experimenter, 0);
+    store.setExperimenterUserName(measurementOperatorName, 0);
+    return experimenter;
   }
 
   private void populatePlateMetadata(MetadataStore store, WPIHandler plate,
@@ -856,12 +883,15 @@ public class CV7000Reader extends FormatReader {
     HashMap<Integer, Integer> detectorIndexes,
     HashMap<FilterKey, Integer> filterIndexes,
     HashMap<String, Integer> dichroicIndexes,
-    List<String> usedObjectiveIDs, SeriesTiming[] timings)
+    List<String> usedObjectiveIDs, String experimenter, SeriesTiming[] timings)
   {
     for (int i=0; i<getSeriesCount(); i++) {
       setSeries(i);
       if (instrument != null) {
         store.setImageInstrumentRef(instrument, i);
+      }
+      if (experimenter != null) {
+        store.setImageExperimenterRef(experimenter, i);
       }
       populateChannelMetadata(store, i, lightSourceIndexes, detectorIndexes,
         filterIndexes, dichroicIndexes, usedObjectiveIDs);
@@ -2900,12 +2930,16 @@ public class CV7000Reader extends FormatReader {
         rawModel.endTime = endTime;
         settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
         rawModel.settingsPath = settingsPath;
+        measurementOperatorName = clean(attributes.getValue("bts:OperatorName"));
 
         String system = attributes.getValue("bts:TargetSystem");
+        targetSystem = clean(system);
         addYokogawaMeta(
           "Yokogawa MRF MeasurementDetail ", "AcquisitionSystem", system);
-        if (system != null && !system.toLowerCase().startsWith("cv7000")) {
-          LOGGER.warn("Found data from {}; this is not well-supported", system);
+        if (targetSystem != null &&
+          !targetSystem.toLowerCase().startsWith("cv7000"))
+        {
+          LOGGER.warn("Found data from {}; this is not well-supported", targetSystem);
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -52,7 +52,6 @@ import loci.formats.meta.MetadataStore;
 
 import ome.units.UNITS;
 import ome.units.quantity.Length;
-import ome.units.quantity.Power;
 import ome.units.quantity.Time;
 import ome.xml.model.MapPair;
 import ome.xml.model.primitives.Color;
@@ -1157,6 +1156,12 @@ public class CV7000Reader extends FormatReader {
     store.setChannelLightSourceSettingsID(
       MetadataTools.createLSID("LightSource", 0, index), series, channelIndex);
 
+    PercentFraction attenuation = getLightSourceAttenuation(source);
+    if (attenuation != null) {
+      store.setChannelLightSourceSettingsAttenuation(
+        attenuation, series, channelIndex);
+    }
+
     if (isLaser(source) && source.wavelength != null && source.wavelength > 0) {
       // Yokogawa BP labels are detection filters; excitation comes from the
       // linked laser light-source wavelength.
@@ -1394,13 +1399,11 @@ public class CV7000Reader extends FormatReader {
         String laserID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
         store.setLaserID(laserID, 0, nextLightSource);
         store.setLaserModel(getLightSourceModel(l), 0, nextLightSource);
-        store.setLaserType(MetadataTools.getLaserType("Other"), 0, nextLightSource);
+        // The Yokogawa CV7000 user manual identifies the lasers as solid-state.
+        store.setLaserType(MetadataTools.getLaserType("SolidState"), 0, nextLightSource);
         if (l.wavelength != null) {
           store.setLaserWavelength(
             new Length(l.wavelength, UNITS.NANOMETER), 0, nextLightSource);
-        }
-        if (l.power != null) {
-          store.setLaserPower(new Power(l.power, UNITS.MILLIWATT), 0, nextLightSource);
         }
         lightSourceIndexes.put(i, nextLightSource);
         nextLightSource++;
@@ -1414,10 +1417,6 @@ public class CV7000Reader extends FormatReader {
         // Type="Lamp", so keep the filament type as Other.
         store.setFilamentType(MetadataTools.getFilamentType("Other"),
           0, nextLightSource);
-        if (l.power != null) {
-          store.setFilamentPower(
-            new Power(l.power, UNITS.MILLIWATT), 0, nextLightSource);
-        }
         lightSourceIndexes.put(i, nextLightSource);
         nextLightSource++;
       }
@@ -1430,6 +1429,29 @@ public class CV7000Reader extends FormatReader {
 
   private boolean isLamp(LightSource source) {
     return source != null && "Lamp".equalsIgnoreCase(source.type);
+  }
+
+  private PercentFraction getLightSourceAttenuation(LightSource source) {
+    if (source == null || source.attenuation == null) {
+      return null;
+    }
+
+    double attenuation = source.attenuation;
+    if (Double.isNaN(attenuation) || Double.isInfinite(attenuation) ||
+      attenuation < 0 || attenuation > 100)
+    {
+      LOGGER.warn("Could not store CV7000 light source '{}' attenuation value '{}' " +
+        "in LightSourceSettings.Attenuation", source.name, source.attenuation);
+      return null;
+    }
+
+    // Yokogawa bts:Power is not a physical power measurement. Values in real
+    // sidecars are commonly 0..100, so treat them as percent-like attenuation
+    // only when they can be represented in OME's 0..1 PercentFraction.
+    if (attenuation > 1) {
+      attenuation /= 100.0;
+    }
+    return new PercentFraction((float) attenuation);
   }
 
   private String getLightSourceModel(LightSource source) {
@@ -1733,7 +1755,7 @@ public class CV7000Reader extends FormatReader {
         String prefix = "Yokogawa LightSource " + source.name + " ";
         addYokogawaMeta(prefix, "Type", source.type);
         addYokogawaMeta(prefix, "WaveLength", source.wavelength);
-        addYokogawaMeta(prefix, "Power", source.power);
+        addYokogawaMeta(prefix, "Power", source.attenuation);
       }
     }
     addCrosstalkOriginalMetadata();
@@ -3503,7 +3525,7 @@ public class CV7000Reader extends FormatReader {
       String power = attributes.getValue("bts:Power");
 
       lightSource.wavelength = DataTools.parseDouble(wavelength);
-      lightSource.power = DataTools.parseDouble(power);
+      lightSource.attenuation = DataTools.parseDouble(power);
 
       result.lightSources.add(lightSource);
     }
@@ -3936,7 +3958,7 @@ public class CV7000Reader extends FormatReader {
     public String name;
     public String type;
     public Double wavelength;
-    public Double power;
+    public Double attenuation;
   }
 
   private static class CV7000ObjectiveSpec {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1296,20 +1296,20 @@ public class CV7000Reader extends FormatReader {
       if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
         String center = trimmed.substring(2, trimmed.indexOf("/"));
         String width = trimmed.substring(trimmed.indexOf("/") + 1);
-        Double parsedCenter = parseYokogawaDouble(center);
-        Double parsedWidth = parseYokogawaDouble(width);
+        Double parsedCenter = DataTools.parseDouble(center);
+        Double parsedWidth = DataTools.parseDouble(width);
         if (parsedCenter != null && parsedWidth != null) {
           return DetectionFilter.bandPass(parsedCenter, parsedWidth);
         }
       }
       else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
-        Double cutIn = parseYokogawaDouble(trimmed.substring(2));
+        Double cutIn = DataTools.parseDouble(trimmed.substring(2));
         if (cutIn != null) {
           return DetectionFilter.longPass(cutIn);
         }
       }
       else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
-        Double cutOut = parseYokogawaDouble(trimmed.substring(2));
+        Double cutOut = DataTools.parseDouble(trimmed.substring(2));
         if (cutOut != null) {
           return DetectionFilter.shortPass(cutOut);
         }
@@ -1319,20 +1319,6 @@ public class CV7000Reader extends FormatReader {
       LOGGER.debug("Ignoring invalid CV7000 detection filter value {}", acquisition, e);
     }
     return null;
-  }
-  
-  /**
-   * Parse a Yokogawa floating-point value, which may use a comma as the decimal
-   * separator. This is not directly observed in the test data, but the existence
-   * of the "," character in the Yokogawa XML DTD reminds me of the locality of
-   * the Zeiss XML format, which does use commas in some locales. This is a defensive
-   * parsing measure to avoid potential issues with future data.
-   */
-  private Double parseYokogawaDouble(String value) {
-    if (value == null || value.trim().length() == 0) {
-      return null;
-    }
-    return DataTools.parseDouble(value.trim().replace(',', '.'));
   }
 
   private Double parseYokogawaGain(String value) {
@@ -1366,7 +1352,7 @@ public class CV7000Reader extends FormatReader {
       }
       end++;
     }
-    return parseYokogawaDouble(trimmed.substring(start, end));
+    return DataTools.parseDouble(trimmed.substring(start, end));
   }
 
   private Integer parseInteger(String value) {
@@ -1654,9 +1640,9 @@ public class CV7000Reader extends FormatReader {
             currentField = p.field.field;
           }
 
-          p.xpos = parseYokogawaDouble(attributes.getValue("bts:X"));
-          p.ypos = parseYokogawaDouble(attributes.getValue("bts:Y"));
-          p.zpos = parseYokogawaDouble(attributes.getValue("bts:Z"));
+          p.xpos = DataTools.parseDouble(attributes.getValue("bts:X"));
+          p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
+          p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
           p.timestamp = attributes.getValue("bts:Time");
           p.actionName = attributes.getValue("bts:Action");
           imageRecordCount++;
@@ -1716,8 +1702,8 @@ public class CV7000Reader extends FormatReader {
         c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
         addYokogawaAttributes(
           "Yokogawa MRF Channel " + (c.index + 1) + " ", attributes);
-        c.xSize = parseYokogawaDouble(attributes.getValue("bts:HorizontalPixelDimension"));
-        c.ySize = parseYokogawaDouble(attributes.getValue("bts:VerticalPixelDimension"));
+        c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
+        c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
         c.inputBitDepth = parseInteger(attributes.getValue("bts:InputBitDepth"));
         c.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
@@ -1804,8 +1790,8 @@ public class CV7000Reader extends FormatReader {
         String wavelength = attributes.getValue("bts:WaveLength");
         String power = attributes.getValue("bts:Power");
 
-        l.wavelength = parseYokogawaDouble(wavelength);
-        l.power = parseYokogawaDouble(power);
+        l.wavelength = DataTools.parseDouble(wavelength);
+        l.power = DataTools.parseDouble(power);
 
         lightSources.add(l);
       }
@@ -1836,10 +1822,10 @@ public class CV7000Reader extends FormatReader {
             template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
 
             String mag = attributes.getValue("bts:Magnification");
-            template.magnification = parseYokogawaDouble(mag);
+            template.magnification = DataTools.parseDouble(mag);
 
             String exposure = attributes.getValue("bts:ExposureTime");
-            template.exposureTime = parseYokogawaDouble(exposure);
+            template.exposureTime = DataTools.parseDouble(exposure);
 
             String color = attributes.getValue("bts:Color");
             if (color != null) {
@@ -1921,7 +1907,7 @@ public class CV7000Reader extends FormatReader {
         addYokogawaAttributes(
           "Yokogawa MES Timeline " + (timelineIndex + 1) +
           " Action " + (actionIndex + 1) + " ", attributes);
-        currentPhysicalSizeZ = parseYokogawaDouble(
+        currentPhysicalSizeZ = DataTools.parseDouble(
           attributes.getValue("bts:SliceLength"));
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -92,6 +92,9 @@ public class CV7000Reader extends FormatReader {
   public static final String COMPRESS_RAW_SIDECARS_KEY =
     "cv7000.compress_raw_sidecars";
   public static final boolean COMPRESS_RAW_SIDECARS_DEFAULT = true;
+  public static final String MAX_PROVENANCE_RECORDS_KEY =
+    "cv7000.max_provenance_records";
+  public static final int MAX_PROVENANCE_RECORDS_DEFAULT = 500;
   public static final String INFER_OBJECTIVE_LENS_NA_KEY =
     "cv7000.infer_objective_lens_na";
   public static final boolean INFER_OBJECTIVE_LENS_NA_DEFAULT = false;
@@ -188,6 +191,27 @@ public class CV7000Reader extends FormatReader {
        COMPRESS_RAW_SIDECARS_KEY, COMPRESS_RAW_SIDECARS_DEFAULT);
     }
     return COMPRESS_RAW_SIDECARS_DEFAULT;
+  }
+
+  public int maxProvenanceRecords() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      try {
+        Integer value = ((DynamicMetadataOptions) options).getInteger(
+          MAX_PROVENANCE_RECORDS_KEY, MAX_PROVENANCE_RECORDS_DEFAULT);
+        if (value != null && value.intValue() >= 0) {
+          return value.intValue();
+        }
+      }
+      catch (RuntimeException e) {
+        LOGGER.warn("Invalid {} value; using default {}",
+          MAX_PROVENANCE_RECORDS_KEY, MAX_PROVENANCE_RECORDS_DEFAULT);
+        return MAX_PROVENANCE_RECORDS_DEFAULT;
+      }
+      LOGGER.warn("Negative {} value; using default {}",
+        MAX_PROVENANCE_RECORDS_KEY, MAX_PROVENANCE_RECORDS_DEFAULT);
+    }
+    return MAX_PROVENANCE_RECORDS_DEFAULT;
   }
 
   public boolean inferObjectiveLensNA() {
@@ -368,6 +392,7 @@ public class CV7000Reader extends FormatReader {
     optionsList.add(DUPLICATE_PLANES_KEY);
     optionsList.add(PRESERVE_RAW_SIDECARS_KEY);
     optionsList.add(COMPRESS_RAW_SIDECARS_KEY);
+    optionsList.add(MAX_PROVENANCE_RECORDS_KEY);
     optionsList.add(INFER_OBJECTIVE_LENS_NA_KEY);
     return optionsList;
   }
@@ -487,7 +512,8 @@ public class CV7000Reader extends FormatReader {
   /** MeasurementDetail links the acquisition settings sidecars and seeds channels. */
   private void parseMeasurementDetail(CV7000DatasetPaths paths) throws IOException {
     if (!new Location(paths.measurementDetailPath).exists()) {
-      LOGGER.warn("Missing " + MEASUREMENT_DETAIL + " file");
+      LOGGER.warn("Missing CV7000 measurement detail sidecar {}",
+        paths.measurementDetailPath);
       return;
     }
 
@@ -512,24 +538,39 @@ public class CV7000Reader extends FormatReader {
 
   /** WPP is optional plate-product metadata; missing files preserve legacy behavior. */
   private void parseWellPlateProduct() throws IOException {
-    if (wppPath != null && new Location(wppPath).exists()) {
-      XMLTools.parseXML(readSanitizedXML(wppPath), new WPPHandler());
+    if (wppPath == null) {
+      return;
     }
+    if (!new Location(wppPath).exists()) {
+      LOGGER.warn("Missing referenced CV7000 well plate product sidecar {}",
+        wppPath);
+      return;
+    }
+    XMLTools.parseXML(readSanitizedXML(wppPath), new WPPHandler());
   }
 
   /** Measurement settings attach light sources, actions, filters, and channel modes. */
   private void parseMeasurementSettings() throws IOException {
-    if (settingsPath != null && new Location(settingsPath).exists()) {
-      MeasurementSettingsHandler settingsHandler =
-        new MeasurementSettingsHandler(channels);
-      String xml = readSanitizedXML(settingsPath);
-      if (xml.length() > 0) {
-        XMLTools.parseXML(xml, settingsHandler);
-      }
-      MeasurementSettingsResult result = settingsHandler.getResult();
-      lightSources = result.lightSources;
-      channels = result.channels;
+    if (settingsPath == null) {
+      return;
     }
+    if (!new Location(settingsPath).exists()) {
+      LOGGER.warn("Missing referenced CV7000 measurement settings sidecar {}",
+        settingsPath);
+      return;
+    }
+    MeasurementSettingsHandler settingsHandler =
+      new MeasurementSettingsHandler(channels);
+    String xml = readSanitizedXML(settingsPath);
+    if (xml.length() == 0) {
+      LOGGER.warn("Referenced CV7000 measurement settings sidecar is empty: {}",
+        settingsPath);
+      return;
+    }
+    XMLTools.parseXML(xml, settingsHandler);
+    MeasurementSettingsResult result = settingsHandler.getResult();
+    lightSources = result.lightSources;
+    channels = result.channels;
   }
 
   /** OTF geometry stores objective catalog entries and affine calibration rows. */
@@ -1781,7 +1822,8 @@ public class CV7000Reader extends FormatReader {
     for (int i=0; i<parts.length; i++) {
       String part = parts[i];
       if (part.endsWith("x") && part.length() > 1) {
-        tokens.magnification = parseInteger(part.substring(0, part.length() - 1));
+        tokens.magnification = parsing.parseInteger(
+          part.substring(0, part.length() - 1));
       }
       if ("ph".equals(part) || "phase".equals(part)) {
         tokens.phase = true;
@@ -2366,8 +2408,191 @@ public class CV7000Reader extends FormatReader {
       }
     }
     catch (IOException e) {
-      LOGGER.debug("Could not parse CV7000 post-processing sidecar {}", file, e);
+      LOGGER.warn("Could not parse CV7000 post-processing sidecar {}", file, e);
     }
+  }
+
+  private void emitPostProcessMetadata(PostProcessResult result,
+    int unknownElementCount)
+  {
+    String rootPrefix = "Yokogawa PPF PostProcess ";
+    addSanitizedPPFAttributes(rootPrefix, result.root);
+    addYokogawaMeta(rootPrefix, "ActionCount", result.actions.size());
+    addYokogawaMeta(rootPrefix, "LogCount", result.logs.size());
+    addYokogawaMeta(rootPrefix, "UnknownElementCount", unknownElementCount);
+    Long begin = parseTimestampMillis(result.root.get("BeginTime"));
+    Long end = parseTimestampMillis(result.root.get("EndTime"));
+    if (begin != null && end != null) {
+      addYokogawaMeta(rootPrefix, "DurationSeconds", (end - begin) / 1000.0);
+    }
+
+    LinkedHashMap<String, Integer> actionTypes =
+      new LinkedHashMap<String, Integer>();
+    LinkedHashMap<String, Integer> actionStatuses =
+      new LinkedHashMap<String, Integer>();
+    for (int i=0; i<result.actions.size(); i++) {
+      PostProcessAction action = result.actions.get(i);
+      incrementCount(actionTypes, action.type);
+      incrementCount(actionStatuses, clean(action.attributes.get("Status")));
+      String prefix = "Yokogawa PPF Action " + (i + 1) + " ";
+      addYokogawaMeta(prefix, "ActionType", action.type);
+      addSanitizedPPFAttributes(prefix, action.attributes);
+    }
+    for (Map.Entry<String, Integer> entry : actionTypes.entrySet()) {
+      addYokogawaMeta("Yokogawa PPF Action Summary ",
+        "Type " + entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, Integer> entry : actionStatuses.entrySet()) {
+      addYokogawaMeta("Yokogawa PPF Action Summary ",
+        "Status " + entry.getKey(), entry.getValue());
+    }
+
+    LinkedHashMap<String, Integer> levels = new LinkedHashMap<String, Integer>();
+    LinkedHashMap<String, Integer> titles = new LinkedHashMap<String, Integer>();
+    ArrayList<PostProcessLog> nonRoutine = new ArrayList<PostProcessLog>();
+    PostProcessLog firstRoutine = null;
+    PostProcessLog lastRoutine = null;
+    int warningCount = 0;
+    int errorCount = 0;
+    int fatalCount = 0;
+    for (PostProcessLog log : result.logs) {
+      String level = clean(log.level);
+      incrementCount(levels, level == null ? "Missing" : level);
+      if (level != null && level.equalsIgnoreCase("Warning")) {
+        warningCount++;
+      }
+      else if (level != null && level.equalsIgnoreCase("Error")) {
+        errorCount++;
+      }
+      else if (level != null && level.equalsIgnoreCase("Fatal")) {
+        fatalCount++;
+      }
+      if (clean(log.title) != null) {
+        incrementCount(titles, clean(log.title));
+      }
+      if (isRoutinePPFLog(log)) {
+        if (firstRoutine == null) {
+          firstRoutine = log;
+        }
+        lastRoutine = log;
+      }
+      else {
+        nonRoutine.add(log);
+      }
+    }
+    String logPrefix = "Yokogawa PPF Log Summary ";
+    addYokogawaMeta(logPrefix, "TotalCount", result.logs.size());
+    addYokogawaMeta(logPrefix, "NonRoutineCount", nonRoutine.size());
+    addYokogawaMeta(logPrefix, "WarningCount", warningCount);
+    addYokogawaMeta(logPrefix, "ErrorCount", errorCount);
+    addYokogawaMeta(logPrefix, "FatalCount", fatalCount);
+    if (!result.logs.isEmpty()) {
+      addYokogawaMeta(logPrefix, "FirstTime", result.logs.get(0).timestamp);
+      addYokogawaMeta(logPrefix, "LastTime",
+        result.logs.get(result.logs.size() - 1).timestamp);
+    }
+    for (Map.Entry<String, Integer> entry : levels.entrySet()) {
+      addYokogawaMeta(logPrefix, "Level " + entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, Integer> entry : titles.entrySet()) {
+      addYokogawaMeta(logPrefix, "Title " + entry.getKey(), entry.getValue());
+    }
+
+    ArrayList<PostProcessLog> selected = selectPPFLogs(
+      nonRoutine, firstRoutine, lastRoutine, maxProvenanceRecords());
+    addYokogawaMeta(logPrefix, "EligibleDetailCount", result.logs.size());
+    addYokogawaMeta(logPrefix, "EmittedDetailCount", selected.size());
+    addYokogawaMeta(logPrefix, "OmittedDetailCount",
+      result.logs.size() - selected.size());
+    addYokogawaMeta(logPrefix, "DetailTruncated",
+      selected.size() < result.logs.size());
+    addYokogawaMeta(rootPrefix, "EmittedLogDetailCount", selected.size());
+    addYokogawaMeta(rootPrefix, "OmittedLogDetailCount",
+      result.logs.size() - selected.size());
+    for (int i=0; i<selected.size(); i++) {
+      PostProcessLog log = selected.get(i);
+      String prefix = "Yokogawa PPF Log " + (i + 1) + " ";
+      addYokogawaMeta(prefix, "DocumentIndex", log.documentIndex);
+      addYokogawaMeta(prefix, "Time", log.timestamp);
+      addYokogawaMeta(prefix, "Level", log.level);
+      addYokogawaMeta(prefix, "Title", log.title);
+      addYokogawaMeta(prefix, "Message", sanitizePPFText(log.message));
+    }
+  }
+
+  private ArrayList<PostProcessLog> selectPPFLogs(
+    ArrayList<PostProcessLog> nonRoutine, PostProcessLog firstRoutine,
+    PostProcessLog lastRoutine, int limit)
+  {
+    ArrayList<PostProcessLog> selected = new ArrayList<PostProcessLog>();
+    for (PostProcessLog log : nonRoutine) {
+      if (selected.size() >= limit) {
+        return selected;
+      }
+      selected.add(log);
+    }
+    if (selected.size() < limit && firstRoutine != null) {
+      selected.add(firstRoutine);
+    }
+    if (selected.size() < limit && lastRoutine != null &&
+      lastRoutine != firstRoutine)
+    {
+      selected.add(lastRoutine);
+    }
+    return selected;
+  }
+
+  private boolean isRoutinePPFLog(PostProcessLog log) {
+    String level = log == null ? null : clean(log.level);
+    return level != null && (level.equalsIgnoreCase("Information") ||
+      level.equalsIgnoreCase("Info") || level.equalsIgnoreCase("Debug") ||
+      level.equalsIgnoreCase("Trace"));
+  }
+
+  private void addSanitizedPPFAttributes(String prefix,
+    LinkedHashMap<String, String> attributes)
+  {
+    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+      String name = entry.getKey();
+      String value = entry.getValue();
+      if (name.endsWith("Path")) {
+        if (name.equals("ParameterPath")) {
+          name = "ParameterFile";
+        }
+        else {
+          name = name.substring(0, name.length() - 4) + "Name";
+        }
+        value = getPortableFileName(value);
+      }
+      else if (name.equals("LastErrorMessage")) {
+        value = sanitizePPFText(value);
+      }
+      addYokogawaMeta(prefix, name, value);
+    }
+  }
+
+  private String sanitizePPFText(String value) {
+    String text = clean(value);
+    if (text != null && (text.indexOf('\\') >= 0 || text.indexOf('/') >= 0)) {
+      return getPortableFileName(text);
+    }
+    return text;
+  }
+
+  private String getPortableFileName(String path) {
+    String value = clean(path);
+    if (value == null) {
+      return null;
+    }
+    while (value.endsWith("/") || value.endsWith("\\")) {
+      value = value.substring(0, value.length() - 1);
+    }
+    int slash = Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+    return slash < 0 ? value : value.substring(slash + 1);
+  }
+
+  private String firstNonNull(String first, String second) {
+    return first == null ? second : first;
   }
 
   private void addMeasurementDataOriginalMetadata() {
@@ -2377,26 +2602,98 @@ public class CV7000Reader extends FormatReader {
 
     try {
       SidecarSummary summary = summarizeSidecar(measurementPath);
-      addYokogawaMeta("Yokogawa MLF ", "File", new Location(measurementPath).getName());
-      addYokogawaMeta("Yokogawa MLF ", "Encoding", "UTF-8");
-      addYokogawaMeta("Yokogawa MLF ", "ByteLength", summary.byteLength);
-      addYokogawaMeta("Yokogawa MLF ", "SHA-256", summary.sha256);
+      String prefix = "Yokogawa MLF MeasurementData ";
+      addYokogawaMeta(prefix, "File", new Location(measurementPath).getName());
+      addYokogawaMeta(prefix, "Encoding", "UTF-8");
+      addYokogawaMeta(prefix, "ByteLength", summary.byteLength);
+      addYokogawaMeta(prefix, "SHA-256", summary.sha256);
     }
     catch (IOException e) {
       LOGGER.debug("Could not summarize CV7000 measurement data {}", measurementPath, e);
     }
 
     if (measurementDataSummary != null) {
-      addYokogawaMeta("Yokogawa MLF ", "IMGRecordCount",
+      String prefix = "Yokogawa MLF MeasurementData ";
+      addYokogawaMeta(prefix, "Version", measurementDataSummary.version);
+      addYokogawaMeta(prefix, "TotalRecordCount",
+        measurementDataSummary.totalRecordCount);
+      addYokogawaMeta(prefix, "IMGRecordCount",
         measurementDataSummary.imageRecordCount);
-      addYokogawaMeta("Yokogawa MLF ", "FirstPlaneTime",
+      addYokogawaMeta(prefix, "ERRRecordCount",
+        measurementDataSummary.errorRecordCount);
+      addYokogawaMeta(prefix, "UnknownRecordCount",
+        getUnknownMLFRecordCount(measurementDataSummary));
+      addYokogawaMeta(prefix, "MissingTypeCount",
+        measurementDataSummary.missingTypeCount);
+      addYokogawaMeta(prefix, "FirstPlaneTime",
         measurementDataSummary.firstTimestamp);
-      addYokogawaMeta("Yokogawa MLF ", "LastPlaneTime",
+      addYokogawaMeta(prefix, "LastPlaneTime",
         measurementDataSummary.lastTimestamp);
-      addYokogawaMeta("Yokogawa MLF ", "FirstPlaneAction",
+      addYokogawaMeta(prefix, "FirstPlaneAction",
         measurementDataSummary.firstAction);
-      addYokogawaMeta("Yokogawa MLF ", "LastPlaneAction",
+      addYokogawaMeta(prefix, "LastPlaneAction",
         measurementDataSummary.lastAction);
+      addYokogawaMeta(prefix, "FirstErrorTime",
+        measurementDataSummary.firstErrorTimestamp);
+      addYokogawaMeta(prefix, "LastErrorTime",
+        measurementDataSummary.lastErrorTimestamp);
+      addMLFProvenanceMetadata(measurementDataSummary, prefix);
+    }
+  }
+
+  private int getUnknownMLFRecordCount(MeasurementDataSummary summary) {
+    return summary.totalRecordCount - summary.imageRecordCount -
+      summary.errorRecordCount - summary.missingTypeCount;
+  }
+
+  private void addMLFProvenanceMetadata(MeasurementDataSummary summary,
+    String measurementPrefix)
+  {
+    for (Map.Entry<String, Integer> entry : summary.recordTypeCounts.entrySet()) {
+      addYokogawaMeta("Yokogawa MLF Record Types ", entry.getKey() + "Count",
+        entry.getValue());
+    }
+    for (Map.Entry<String, Integer> entry : summary.errorClassCounts.entrySet()) {
+      addYokogawaMeta("Yokogawa MLF Error Summary ",
+        "Class " + entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, Integer> entry : summary.errorWellCounts.entrySet()) {
+      addYokogawaMeta("Yokogawa MLF Error Summary ",
+        "Well " + entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, Integer> entry :
+      summary.errorWellFieldCounts.entrySet())
+    {
+      addYokogawaMeta("Yokogawa MLF Error Summary ", entry.getKey(),
+        entry.getValue());
+    }
+
+    int eligible = summary.nonImageRecords.size();
+    int emitted = Math.min(eligible, maxProvenanceRecords());
+    addYokogawaMeta(measurementPrefix, "EligibleDetailCount", eligible);
+    addYokogawaMeta(measurementPrefix, "EmittedDetailCount", emitted);
+    addYokogawaMeta(measurementPrefix, "OmittedDetailCount", eligible - emitted);
+    addYokogawaMeta(measurementPrefix, "DetailTruncated", emitted < eligible);
+    for (int i=0; i<emitted; i++) {
+      MeasurementRecord record = summary.nonImageRecords.get(i);
+      String scope = "Yokogawa MLF Record " + (i + 1);
+      addYokogawaMeta(scope, "Type", record.type);
+      addYokogawaMeta(scope, "ErrorClass", record.errorClass);
+      addYokogawaMeta(scope, "Time", record.timestamp);
+      addYokogawaMeta(scope, "Well", getRecordWell(record));
+      addYokogawaMeta(scope, "Row", record.row);
+      addYokogawaMeta(scope, "Column", record.column);
+      addYokogawaMeta(scope, "FieldIndex", record.field);
+      addYokogawaMeta(scope, "TimePoint", record.timepoint);
+      addYokogawaMeta(scope, "TimelineIndex", record.timelineIndex);
+      addYokogawaMeta(scope, "ActionIndex", record.actionIndex);
+      addYokogawaMeta(scope, "Channel", record.channel);
+      addYokogawaMeta(scope, "ZIndex", record.zIndex);
+      addYokogawaMeta(scope, "X", record.x);
+      addYokogawaMeta(scope, "Y", record.y);
+      addYokogawaMeta(scope, "Z", record.z);
+      addYokogawaMeta(scope, "Action", record.action);
+      addYokogawaMeta(scope, "Message", record.message);
     }
   }
 
@@ -2457,6 +2754,12 @@ public class CV7000Reader extends FormatReader {
       return;
     }
 
+    if (scope != null && scope.startsWith("Yokogawa MLF Record ") &&
+      linkMLFRecordAnnotation(store, annotationID, scope, refs))
+    {
+      return;
+    }
+
     if (isPlaneProvenanceAnnotationScope(scope) &&
       linkPlaneProvenanceAnnotation(store, annotationID, scope, refs))
     {
@@ -2470,6 +2773,36 @@ public class CV7000Reader extends FormatReader {
     }
 
     store.setPlateAnnotationRef(annotationID, 0, refs.plate++);
+  }
+
+  private boolean linkMLFRecordAnnotation(MetadataStore store,
+    String annotationID, String scope, AnnotationRefIndexes refs)
+  {
+    Integer index = getIndexedScopeValue(scope, "Record");
+    if (index == null || measurementDataSummary == null ||
+      index.intValue() < 0 ||
+      index.intValue() >= measurementDataSummary.nonImageRecords.size())
+    {
+      return false;
+    }
+    MeasurementRecord record =
+      measurementDataSummary.nonImageRecords.get(index.intValue());
+    if (record.row == null || record.column == null || record.field == null ||
+      seriesLayout == null)
+    {
+      return false;
+    }
+    Field field = new Field();
+    field.row = record.row.intValue() - 1;
+    field.column = record.column.intValue() - 1;
+    field.field = record.field.intValue() - 1;
+    Integer series = seriesLayout.fieldToSeries.get(field);
+    if (series == null) {
+      return false;
+    }
+    store.setImageAnnotationRef(annotationID, series.intValue(),
+      refs.nextImage(series.intValue()));
+    return true;
   }
 
   private boolean isInstrumentAnnotationScope(String scope) {
@@ -2825,13 +3158,10 @@ public class CV7000Reader extends FormatReader {
       return;
     }
     for (int i=0; i<attributes.getLength(); i++) {
-      addYokogawaMeta(prefix, getYokogawaAttributeName(attributes.getQName(i)),
+      addYokogawaMeta(prefix,
+        parsing.getYokogawaAttributeName(attributes.getQName(i)),
         attributes.getValue(i));
     }
-  }
-
-  private String getYokogawaAttributeName(String qName) {
-    return parsing.getYokogawaAttributeName(qName);
   }
 
   private Integer getLinkedStandardLightSource(Channel channel) {
@@ -2862,8 +3192,30 @@ public class CV7000Reader extends FormatReader {
       channel.filterID, Integer.valueOf(channel.cameraNumber), channel.acquisition));
   }
 
-  private Integer parseInteger(String value) {
-    return parsing.parseInteger(value);
+  private <K> void incrementCount(LinkedHashMap<K, Integer> counts, K key) {
+    if (counts == null || key == null) {
+      return;
+    }
+    Integer count = counts.get(key);
+    counts.put(key, Integer.valueOf(count == null ? 1 : count.intValue() + 1));
+  }
+
+  private String getErrorClass(MeasurementRecord record) {
+    String message = record == null ? null : clean(record.message);
+    if (message != null && message.regionMatches(true, 0, "AF Error", 0, 8)) {
+      return "AF Error";
+    }
+    return "Other";
+  }
+
+  private String getRecordWell(MeasurementRecord record) {
+    if (record == null || record.row == null || record.column == null ||
+      record.row.intValue() <= 0 || record.column.intValue() <= 0)
+    {
+      return null;
+    }
+    return getRowName(record.row.intValue() - 1) +
+      String.format("%02d", record.column.intValue());
   }
 
   private Length getPhysicalSizeZ(int series) {
@@ -3285,11 +3637,32 @@ public class CV7000Reader extends FormatReader {
       return colon < 0 ? qName : qName.substring(colon + 1);
     }
 
+    public boolean isElement(String qName, String name) {
+      return name != null && name.equals(getYokogawaAttributeName(qName));
+    }
+
+    public boolean elementStartsWith(String qName, String prefix) {
+      return prefix != null &&
+        getYokogawaAttributeName(qName).startsWith(prefix);
+    }
+
     public Integer parseInteger(String value) {
       if (value == null || value.trim().length() == 0) {
         return null;
       }
       return Integer.valueOf(value.trim());
+    }
+
+    public int parseRequiredInteger(String value) {
+      Integer parsed = parseInteger(value);
+      if (parsed == null) {
+        throw new NumberFormatException("Missing required integer value");
+      }
+      return parsed.intValue();
+    }
+
+    public Double parseDouble(String value) {
+      return DataTools.parseDouble(value == null ? null : value.trim());
     }
 
     public Double parseYokogawaGain(String value) {
@@ -3323,7 +3696,7 @@ public class CV7000Reader extends FormatReader {
         }
         end++;
       }
-      return DataTools.parseDouble(trimmed.substring(start, end));
+      return parseDouble(trimmed.substring(start, end));
     }
 
     public DetectionFilter parseDetectionFilter(String acquisition) {
@@ -3335,8 +3708,8 @@ public class CV7000Reader extends FormatReader {
         if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
           String center = trimmed.substring(2, trimmed.indexOf("/"));
           String width = trimmed.substring(trimmed.indexOf("/") + 1);
-          Double parsedCenter = DataTools.parseDouble(center);
-          Double parsedWidth = DataTools.parseDouble(width);
+          Double parsedCenter = parseDouble(center);
+          Double parsedWidth = parseDouble(width);
           if (parsedCenter != null && parsedWidth != null) {
             return DetectionFilter.bandPass(parsedCenter, parsedWidth);
           }
@@ -3358,17 +3731,32 @@ public class CV7000Reader extends FormatReader {
       return binning + "x" + binning;
     }
 
-    public String getAttribute(Attributes attributes, String name) {
+    public String getRawAttribute(Attributes attributes, String name) {
       if (attributes == null || name == null) {
         return null;
       }
       for (int i=0; i<attributes.getLength(); i++) {
         if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
-          String value = attributes.getValue(i);
-          return clean(value);
+          return attributes.getValue(i);
         }
       }
       return null;
+    }
+
+    public String getAttribute(Attributes attributes, String name) {
+      return clean(getRawAttribute(attributes, name));
+    }
+
+    public void copyAttributes(Attributes attributes,
+      Map<String, String> values)
+    {
+      if (attributes == null || values == null) {
+        return;
+      }
+      for (int i=0; i<attributes.getLength(); i++) {
+        values.put(getYokogawaAttributeName(attributes.getQName(i)),
+          attributes.getValue(i));
+      }
     }
   }
 
@@ -3540,11 +3928,70 @@ public class CV7000Reader extends FormatReader {
   }
 
   public static class MeasurementDataSummary {
+    public String version;
+    public int totalRecordCount;
     public int imageRecordCount;
+    public int errorRecordCount;
+    public int missingTypeCount;
+    public LinkedHashMap<String, Integer> recordTypeCounts =
+      new LinkedHashMap<String, Integer>();
+    public LinkedHashMap<String, Integer> errorClassCounts =
+      new LinkedHashMap<String, Integer>();
+    public LinkedHashMap<String, Integer> errorWellCounts =
+      new LinkedHashMap<String, Integer>();
+    public LinkedHashMap<String, Integer> errorWellFieldCounts =
+      new LinkedHashMap<String, Integer>();
+    public ArrayList<MeasurementRecord> nonImageRecords =
+      new ArrayList<MeasurementRecord>();
     public String firstTimestamp;
     public String lastTimestamp;
     public String firstAction;
     public String lastAction;
+    public String firstErrorTimestamp;
+    public String lastErrorTimestamp;
+  }
+
+  public static class MeasurementRecord {
+    public String type;
+    public String timestamp;
+    public String action;
+    public String message;
+    public String errorClass;
+    public Integer row;
+    public Integer column;
+    public Integer field;
+    public Integer timepoint;
+    public Integer timelineIndex;
+    public Integer actionIndex;
+    public Integer channel;
+    public Integer zIndex;
+    public Double x;
+    public Double y;
+    public Double z;
+  }
+
+  private static class PostProcessResult {
+    public LinkedHashMap<String, String> root =
+      new LinkedHashMap<String, String>();
+    public ArrayList<PostProcessAction> actions =
+      new ArrayList<PostProcessAction>();
+    public ArrayList<PostProcessLog> logs = new ArrayList<PostProcessLog>();
+  }
+
+  private static class PostProcessAction {
+    public String type;
+    public LinkedHashMap<String, String> attributes =
+      new LinkedHashMap<String, String>();
+  }
+
+  private static class PostProcessLog {
+    public int documentIndex;
+    public String timestamp;
+    public String level;
+    public String title;
+    public String message;
+    public LinkedHashMap<String, String> attributes =
+      new LinkedHashMap<String, String>();
   }
 
   // ###############
@@ -3577,12 +4024,14 @@ public class CV7000Reader extends FormatReader {
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      if (qName.equals("bts:WellPlate")) {
+      if (parsing.isElement(qName, "WellPlate")) {
         addYokogawaAttributes("Yokogawa WPI WellPlate ", attributes);
-        name = attributes.getValue("bts:Name");
-        plateID = attributes.getValue("bts:ProductID");
-        plateRows = Integer.parseInt(attributes.getValue("bts:Rows"));
-        plateColumns = Integer.parseInt(attributes.getValue("bts:Columns"));
+        name = parsing.getRawAttribute(attributes, "Name");
+        plateID = parsing.getRawAttribute(attributes, "ProductID");
+        plateRows = parsing.parseRequiredInteger(
+          parsing.getRawAttribute(attributes, "Rows"));
+        plateColumns = parsing.parseRequiredInteger(
+          parsing.getRawAttribute(attributes, "Columns"));
       }
     }
 
@@ -3591,13 +4040,10 @@ public class CV7000Reader extends FormatReader {
   private class MeasurementDataHandler extends BaseHandler {
     private StringBuffer currentValue = new StringBuffer();
     private String btsType;
+    private MeasurementRecord currentRecord;
     private ArrayList<Plane> planes = new ArrayList<Plane>();
     private String parentDir;
-    private int imageRecordCount;
-    private String firstTimestamp;
-    private String lastTimestamp;
-    private String firstAction;
-    private String lastAction;
+    private MeasurementDataSummary summary = new MeasurementDataSummary();
 
     public MeasurementDataHandler(String parentDir) {
       super();
@@ -3609,12 +4055,6 @@ public class CV7000Reader extends FormatReader {
     }
 
     public MeasurementDataSummary getSummary() {
-      MeasurementDataSummary summary = new MeasurementDataSummary();
-      summary.imageRecordCount = imageRecordCount;
-      summary.firstTimestamp = firstTimestamp;
-      summary.lastTimestamp = lastTimestamp;
-      summary.firstAction = firstAction;
-      summary.lastAction = lastAction;
       return summary;
     }
 
@@ -3633,34 +4073,68 @@ public class CV7000Reader extends FormatReader {
       currentValue.setLength(0);
 
       try {
-        btsType = attributes.getValue("bts:Type");
-        if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG")) {
+        String element = parsing.getYokogawaAttributeName(qName);
+        if (parsing.isElement(qName, "MeasurementData")) {
+          summary.version = parsing.getAttribute(attributes, "Version");
+          return;
+        }
+        if (!element.equals("MeasurementRecord")) {
+          return;
+        }
+        btsType = parsing.getAttribute(attributes, "Type");
+        summary.totalRecordCount++;
+        if (btsType == null) {
+          summary.missingTypeCount++;
+          incrementCount(summary.recordTypeCounts, "Missing");
+          currentRecord = parseNonImageRecord(attributes, null);
+          return;
+        }
+        incrementCount(summary.recordTypeCounts, btsType);
+        if (btsType.equals("IMG")) {
           // When the instrument is recording an acquisition error the "type"
           // will be "ERR" so we can skip those.
           Plane p = new Plane();
           p.field = new Field();
-          p.field.row = Integer.parseInt(attributes.getValue("bts:Row")) - 1;
-          p.field.column = Integer.parseInt(attributes.getValue("bts:Column")) - 1;
-          p.timepoint = Integer.parseInt(attributes.getValue("bts:TimePoint")) - 1;
-          p.field.field = Integer.parseInt(attributes.getValue("bts:FieldIndex")) - 1;
-          p.z = Integer.parseInt(attributes.getValue("bts:ZIndex")) - 1;
-          p.channel = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
-          p.actionIndex = Integer.parseInt(attributes.getValue("bts:ActionIndex")) - 1;
-          p.timelineIndex = Integer.parseInt(attributes.getValue("bts:TimelineIndex")) - 1;
+          p.field.row = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "Row")) - 1;
+          p.field.column = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "Column")) - 1;
+          p.timepoint = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "TimePoint")) - 1;
+          p.field.field = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "FieldIndex")) - 1;
+          p.z = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "ZIndex")) - 1;
+          p.channel = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "Ch")) - 1;
+          p.actionIndex = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "ActionIndex")) - 1;
+          p.timelineIndex = parsing.parseRequiredInteger(
+            parsing.getRawAttribute(attributes, "TimelineIndex")) - 1;
 
-          p.xpos = DataTools.parseDouble(attributes.getValue("bts:X"));
-          p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
-          p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
-          p.timestamp = attributes.getValue("bts:Time");
-          p.actionName = attributes.getValue("bts:Action");
-          imageRecordCount++;
-          if (firstTimestamp == null) {
-            firstTimestamp = p.timestamp;
-            firstAction = p.actionName;
+          p.xpos = parsing.parseDouble(parsing.getRawAttribute(attributes, "X"));
+          p.ypos = parsing.parseDouble(parsing.getRawAttribute(attributes, "Y"));
+          p.zpos = parsing.parseDouble(parsing.getRawAttribute(attributes, "Z"));
+          p.timestamp = parsing.getRawAttribute(attributes, "Time");
+          p.actionName = parsing.getRawAttribute(attributes, "Action");
+          summary.imageRecordCount++;
+          if (summary.firstTimestamp == null) {
+            summary.firstTimestamp = p.timestamp;
+            summary.firstAction = p.actionName;
           }
-          lastTimestamp = p.timestamp;
-          lastAction = p.actionName;
+          summary.lastTimestamp = p.timestamp;
+          summary.lastAction = p.actionName;
           planes.add(p);
+        }
+        else {
+          currentRecord = parseNonImageRecord(attributes, btsType);
+          if (btsType.equals("ERR")) {
+            summary.errorRecordCount++;
+            if (summary.firstErrorTimestamp == null) {
+              summary.firstErrorTimestamp = currentRecord.timestamp;
+            }
+            summary.lastErrorTimestamp = currentRecord.timestamp;
+          }
         }
       }
       catch (RuntimeException e) {
@@ -3670,7 +4144,8 @@ public class CV7000Reader extends FormatReader {
             attributeMap.put(
                 attributes.getQName(i), attributes.getValue(i));
           }
-          LOGGER.error("Error parsing attributes: {}", attributeMap, e);
+          LOGGER.error("Could not parse CV7000 {} MeasurementRecord " +
+            "attributes: {}", MEASUREMENT_FILE, attributeMap, e);
         }
         throw e;
       }
@@ -3679,12 +4154,80 @@ public class CV7000Reader extends FormatReader {
     @Override
     public void endElement(String uri, String localName, String qName) {
       String value = currentValue.toString();
-      if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG") &&
+      if (!parsing.isElement(qName, "MeasurementRecord")) {
+        return;
+      }
+      if ("IMG".equals(btsType) &&
         value.trim().length() > 0) {
         Location imgFile = new Location(parentDir, value);
         if (imgFile.exists()) {
           planes.get(planes.size() - 1).file = imgFile.getAbsolutePath();
         }
+      }
+      else if (currentRecord != null) {
+        currentRecord.message = clean(value);
+        currentRecord.errorClass = getErrorClass(currentRecord);
+        summary.nonImageRecords.add(currentRecord);
+        if ("ERR".equals(currentRecord.type)) {
+          incrementCount(summary.errorClassCounts, currentRecord.errorClass);
+          String well = getRecordWell(currentRecord);
+          if (well != null) {
+            incrementCount(summary.errorWellCounts, well);
+            if (currentRecord.field != null) {
+              incrementCount(summary.errorWellFieldCounts,
+                well + "/Field " + currentRecord.field);
+            }
+          }
+        }
+      }
+      currentRecord = null;
+      btsType = null;
+    }
+
+    private MeasurementRecord parseNonImageRecord(Attributes attributes,
+      String type)
+    {
+      MeasurementRecord record = new MeasurementRecord();
+      record.type = type == null ? "Missing" : type;
+      record.timestamp = parsing.getAttribute(attributes, "Time");
+      record.action = parsing.getAttribute(attributes, "Action");
+      record.row = parseOptionalOneBasedInteger(attributes, "Row");
+      record.column = parseOptionalOneBasedInteger(attributes, "Column");
+      record.field = parseOptionalOneBasedInteger(attributes, "FieldIndex");
+      record.timepoint = parseOptionalOneBasedInteger(attributes, "TimePoint");
+      record.timelineIndex = parseOptionalOneBasedInteger(attributes, "TimelineIndex");
+      record.actionIndex = parseOptionalOneBasedInteger(attributes, "ActionIndex");
+      record.channel = parseOptionalOneBasedInteger(attributes, "Ch");
+      record.zIndex = parseOptionalOneBasedInteger(attributes, "ZIndex");
+      record.x = parseOptionalDouble(attributes, "X");
+      record.y = parseOptionalDouble(attributes, "Y");
+      record.z = parseOptionalDouble(attributes, "Z");
+      return record;
+    }
+
+    private Integer parseOptionalOneBasedInteger(Attributes attributes,
+      String name)
+    {
+      try {
+        Integer value = parsing.parseInteger(
+          parsing.getAttribute(attributes, name));
+        return value;
+      }
+      catch (RuntimeException e) {
+        LOGGER.debug("Ignoring invalid CV7000 MLF {} value {}", name,
+          parsing.getAttribute(attributes, name));
+        return null;
+      }
+    }
+
+    private Double parseOptionalDouble(Attributes attributes, String name) {
+      try {
+        return parsing.parseDouble(parsing.getAttribute(attributes, name));
+      }
+      catch (RuntimeException e) {
+        LOGGER.debug("Ignoring invalid CV7000 MLF {} value {}", name,
+          parsing.getAttribute(attributes, name));
+        return null;
       }
     }
 
@@ -3703,41 +4246,55 @@ public class CV7000Reader extends FormatReader {
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      if (qName.equals("bts:MeasurementSamplePlate")) {
+      if (parsing.isElement(qName, "MeasurementSamplePlate")) {
         addYokogawaAttributes("Yokogawa MRF MeasurementSamplePlate ", attributes);
-        result.wppPath = attributes.getValue("bts:WellPlateProductFileName");
+        result.wppPath = parsing.getRawAttribute(
+          attributes, "WellPlateProductFileName");
         if (result.wppPath != null && result.wppPath.trim().length() == 0) {
           result.wppPath = null;
         }
       }
-      else if (qName.equals("bts:MeasurementChannel")) {
+      else if (parsing.isElement(qName, "MeasurementChannel")) {
         Channel c = new Channel();
-        c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
+        c.index = parsing.parseRequiredInteger(
+          parsing.getRawAttribute(attributes, "Ch")) - 1;
         addYokogawaAttributes(
           "Yokogawa MRF Channel " + (c.index + 1) + " ", attributes);
-        c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
-        c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
-        c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
-        c.inputBitDepth = parseInteger(attributes.getValue("bts:InputBitDepth"));
-        c.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
-        c.horizontalPixels = parseInteger(attributes.getValue("bts:HorizontalPixels"));
-        c.verticalPixels = parseInteger(attributes.getValue("bts:VerticalPixels"));
-        c.filterWheelPosition = parseInteger(attributes.getValue("bts:FilterWheelPosition"));
-        c.filterPosition = parseInteger(attributes.getValue("bts:FilterPosition"));
-        c.correctionFile = attributes.getValue("bts:ShadingCorrectionSource");
+        c.xSize = parsing.parseDouble(parsing.getRawAttribute(
+          attributes, "HorizontalPixelDimension"));
+        c.ySize = parsing.parseDouble(parsing.getRawAttribute(
+          attributes, "VerticalPixelDimension"));
+        c.cameraNumber = parsing.parseRequiredInteger(
+          parsing.getRawAttribute(attributes, "CameraNumber"));
+        c.inputBitDepth = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "InputBitDepth"));
+        c.inputLevel = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "InputLevel"));
+        c.horizontalPixels = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "HorizontalPixels"));
+        c.verticalPixels = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "VerticalPixels"));
+        c.filterWheelPosition = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "FilterWheelPosition"));
+        c.filterPosition = parsing.parseInteger(
+          parsing.getRawAttribute(attributes, "FilterPosition"));
+        c.correctionFile = parsing.getRawAttribute(
+          attributes, "ShadingCorrectionSource");
         if (c.correctionFile != null && c.correctionFile.trim().length() == 0) {
           c.correctionFile = null;
         }
         result.channels.add(c);
       }
-      else if (qName.equals("bts:MeasurementDetail")) {
+      else if (parsing.isElement(qName, "MeasurementDetail")) {
         addYokogawaAttributes("Yokogawa MRF MeasurementDetail ", attributes);
-        result.startTime = attributes.getValue("bts:BeginTime");
-        result.endTime = attributes.getValue("bts:EndTime");
-        result.settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
-        result.measurementOperatorName = clean(attributes.getValue("bts:OperatorName"));
+        result.startTime = parsing.getRawAttribute(attributes, "BeginTime");
+        result.endTime = parsing.getRawAttribute(attributes, "EndTime");
+        result.settingsPath = parsing.getRawAttribute(
+          attributes, "MeasurementSettingFileName");
+        result.measurementOperatorName = parsing.getAttribute(
+          attributes, "OperatorName");
 
-        String system = attributes.getValue("bts:TargetSystem");
+        String system = parsing.getRawAttribute(attributes, "TargetSystem");
         result.targetSystem = clean(system);
         addYokogawaMeta(
           "Yokogawa MRF MeasurementDetail ", "AcquisitionSystem", system);
@@ -3758,7 +4315,7 @@ public class CV7000Reader extends FormatReader {
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      if (qName.equals("bts:WellPlateProduct")) {
+      if (parsing.isElement(qName, "WellPlateProduct")) {
         addYokogawaAttributes("Yokogawa WPP ", attributes);
       }
     }
@@ -3766,23 +4323,66 @@ public class CV7000Reader extends FormatReader {
   }
 
   private class PostProcessHandler extends BaseHandler {
-    private int actionIndex = -1;
+    private PostProcessResult result = new PostProcessResult();
+    private StringBuffer currentValue = new StringBuffer();
+    private PostProcessLog currentLog;
+    private int unknownElementCount;
+
+    @Override
+    public void characters(char[] ch, int start, int length) {
+      currentValue.append(ch, start, length);
+    }
 
     @Override
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      if (qName.equals("cvpp:PostProcess") || qName.equals("PostProcess")) {
-        addYokogawaAttributes("Yokogawa PPF PostProcess ", attributes);
+      currentValue.setLength(0);
+      String element = parsing.getYokogawaAttributeName(qName);
+      if (element.equals("PostProcess")) {
+        parsing.copyAttributes(attributes, result.root);
       }
-      else if (qName.equals("cvpp:PostProcessAction") ||
-        qName.equals("PostProcessAction"))
+      else if (element.endsWith("Action") && !element.endsWith("ActionList")) {
+        PostProcessAction action = new PostProcessAction();
+        action.type = element;
+        parsing.copyAttributes(attributes, action.attributes);
+        result.actions.add(action);
+      }
+      else if (element.equals("PostProcessLog")) {
+        currentLog = new PostProcessLog();
+        currentLog.documentIndex = result.logs.size() + 1;
+        parsing.copyAttributes(attributes, currentLog.attributes);
+        currentLog.timestamp = firstNonNull(
+          currentLog.attributes.get("DateTime"),
+          currentLog.attributes.get("Time"));
+        currentLog.level = currentLog.attributes.get("Level");
+        currentLog.title = currentLog.attributes.get("Title");
+        currentLog.message = currentLog.attributes.get("Message");
+      }
+      else if (!element.equals("PostProcessActionList") &&
+        !element.equals("PostProcessLogList"))
       {
-        actionIndex++;
-        addYokogawaAttributes(
-          "Yokogawa PPF PostProcessAction " + (actionIndex + 1) + " ",
-          attributes);
+        unknownElementCount++;
       }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+      if (parsing.isElement(qName, "PostProcessLog") &&
+        currentLog != null)
+      {
+        String text = clean(currentValue.toString());
+        if (currentLog.message == null) {
+          currentLog.message = text;
+        }
+        result.logs.add(currentLog);
+        currentLog = null;
+      }
+    }
+
+    @Override
+    public void endDocument() {
+      emitPostProcessMetadata(result, unknownElementCount);
     }
 
   }
@@ -3860,41 +4460,41 @@ public class CV7000Reader extends FormatReader {
       Attributes attributes)
     {
       currentValue.setLength(0);
-      if (qName.equals("bts:MeasurementSetting")) {
+      if (parsing.isElement(qName, "MeasurementSetting")) {
         addYokogawaAttributes("Yokogawa MES MeasurementSetting ", attributes);
       }
-      else if (qName.equals("bts:LightSource")) {
+      else if (parsing.isElement(qName, "LightSource")) {
         parseLightSource(attributes);
       }
-      else if (qName.equals("bts:Channel")) {
+      else if (parsing.isElement(qName, "Channel")) {
         parseChannelTemplate(attributes);
       }
-      else if (qName.equals("bts:Timeline")) {
+      else if (parsing.isElement(qName, "Timeline")) {
         startTimeline(attributes);
       }
-      else if (qName.equals("bts:TargetWell")) {
+      else if (parsing.isElement(qName, "TargetWell")) {
         startTargetWell(attributes);
       }
-      else if (qName.equals("bts:PointSequence")) {
+      else if (parsing.isElement(qName, "PointSequence")) {
         addYokogawaAttributes(
           "Yokogawa MES Timeline " + (timelineIndex + 1) +
           " PointSequence ", attributes);
       }
-      else if (qName.equals("bts:FixedPosition")) {
+      else if (parsing.isElement(qName, "FixedPosition")) {
         addYokogawaAttributes(
           "Yokogawa MES Timeline " + (timelineIndex + 1) +
           " FixedPosition ", attributes);
       }
-      else if (qName.equals("bts:Point")) {
+      else if (parsing.isElement(qName, "Point")) {
         pointIndex++;
         addYokogawaAttributes(
           "Yokogawa MES Timeline " + (timelineIndex + 1) +
           " Point " + (pointIndex + 1) + " ", attributes);
       }
-      else if (qName.equals("bts:ActionList")) {
+      else if (parsing.isElement(qName, "ActionList")) {
         startActionList(attributes);
       }
-      else if (qName.startsWith("bts:ActionAcquire")) {
+      else if (parsing.elementStartsWith(qName, "ActionAcquire")) {
         startActionAcquire(qName, attributes);
       }
     }
@@ -3903,7 +4503,9 @@ public class CV7000Reader extends FormatReader {
     public void endElement(String uri, String localName, String qName) {
       String value = currentValue.toString();
 
-      if (qName.equals("bts:LightSourceName") && currentChannelIndex >= 0) {
+      if (parsing.isElement(qName, "LightSourceName") &&
+        currentChannelIndex >= 0)
+      {
         addYokogawaMeta(
           "Yokogawa MES Channel " + (currentChannelIndex + 1) + " ",
           "LightSourceName", value);
@@ -3920,30 +4522,30 @@ public class CV7000Reader extends FormatReader {
             currentChannelIndex, currentDefinitionOccurrence, index);
         }
       }
-      else if (qName.equals("bts:Channel")) {
+      else if (parsing.isElement(qName, "Channel")) {
         currentChannelIndex = -1;
         currentDefinitionOccurrence = -1;
       }
-      else if (qName.equals("bts:Ch")) {
+      else if (parsing.isElement(qName, "Ch")) {
         assignActionChannel(value);
       }
-      else if (qName.startsWith("bts:ActionAcquire")) {
+      else if (parsing.elementStartsWith(qName, "ActionAcquire")) {
         clearActionAcquireState();
       }
     }
 
     private void parseLightSource(Attributes attributes) {
       LightSource lightSource = new LightSource();
-      lightSource.name = attributes.getValue("bts:Name");
-      lightSource.type = attributes.getValue("bts:Type");
+      lightSource.name = parsing.getRawAttribute(attributes, "Name");
+      lightSource.type = parsing.getRawAttribute(attributes, "Type");
       addYokogawaAttributes(
         "Yokogawa MES LightSource " + lightSource.name + " ", attributes);
 
-      String wavelength = attributes.getValue("bts:WaveLength");
-      String power = attributes.getValue("bts:Power");
+      String wavelength = parsing.getRawAttribute(attributes, "WaveLength");
+      String power = parsing.getRawAttribute(attributes, "Power");
 
-      lightSource.wavelength = DataTools.parseDouble(wavelength);
-      lightSource.attenuation = DataTools.parseDouble(power);
+      lightSource.wavelength = parsing.parseDouble(wavelength);
+      lightSource.attenuation = parsing.parseDouble(power);
 
       result.lightSources.add(lightSource);
     }
@@ -3951,12 +4553,12 @@ public class CV7000Reader extends FormatReader {
     private void parseChannelTemplate(Attributes attributes) {
       currentChannelIndex = -1;
       currentDefinitionOccurrence = -1;
-      String ch = attributes.getValue("bts:Ch");
+      String ch = parsing.getRawAttribute(attributes, "Ch");
       if (ch == null) {
         return;
       }
 
-      int index = Integer.parseInt(ch) - 1;
+      int index = parsing.parseRequiredInteger(ch) - 1;
       if (index < 0) {
         return;
       }
@@ -3967,36 +4569,39 @@ public class CV7000Reader extends FormatReader {
 
       Channel template = new Channel();
       template.index = index;
-      template.target = attributes.getValue("bts:Target");
+      template.target = parsing.getRawAttribute(attributes, "Target");
       addYokogawaAttributes(
         "Yokogawa MES Channel " + (template.index + 1) + " ", attributes);
-      template.objectiveID = attributes.getValue("bts:ObjectiveID");
-      template.objective = attributes.getValue("bts:Objective");
-      template.binning = attributes.getValue("bts:Binning");
-      template.methodID = attributes.getValue("bts:MethodID");
-      template.method = attributes.getValue("bts:Method");
-      template.filterID = attributes.getValue("bts:FilterID");
-      template.kind = attributes.getValue("bts:Kind");
-      template.andorParameterID = attributes.getValue("bts:AndorParameterID");
-      template.andorParameter = attributes.getValue("bts:AndorParameter");
+      template.objectiveID = parsing.getRawAttribute(attributes, "ObjectiveID");
+      template.objective = parsing.getRawAttribute(attributes, "Objective");
+      template.binning = parsing.getRawAttribute(attributes, "Binning");
+      template.methodID = parsing.getRawAttribute(attributes, "MethodID");
+      template.method = parsing.getRawAttribute(attributes, "Method");
+      template.filterID = parsing.getRawAttribute(attributes, "FilterID");
+      template.kind = parsing.getRawAttribute(attributes, "Kind");
+      template.andorParameterID = parsing.getRawAttribute(
+        attributes, "AndorParameterID");
+      template.andorParameter = parsing.getRawAttribute(
+        attributes, "AndorParameter");
       template.detectorGain = parsing.parseYokogawaGain(template.andorParameter);
-      template.cameraType = attributes.getValue("bts:CameraType");
-      template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
+      template.cameraType = parsing.getRawAttribute(attributes, "CameraType");
+      template.inputLevel = parsing.parseInteger(
+        parsing.getRawAttribute(attributes, "InputLevel"));
 
-      String mag = attributes.getValue("bts:Magnification");
-      template.magnification = DataTools.parseDouble(mag);
+      String mag = parsing.getRawAttribute(attributes, "Magnification");
+      template.magnification = parsing.parseDouble(mag);
 
-      String exposure = attributes.getValue("bts:ExposureTime");
-      template.exposureTime = DataTools.parseDouble(exposure);
+      String exposure = parsing.getRawAttribute(attributes, "ExposureTime");
+      template.exposureTime = parsing.parseDouble(exposure);
 
-      populateChannelColor(template, attributes.getValue("bts:Color"));
+      populateChannelColor(template, parsing.getRawAttribute(attributes, "Color"));
 
-      template.acquisition = attributes.getValue("bts:Acquisition");
+      template.acquisition = parsing.getRawAttribute(attributes, "Acquisition");
       // Yokogawa Acquisition values such as BP676/29 identify detection
       // filters.  Excitation comes from the LightSourceName link.
       template.detectionFilter = parsing.parseDetectionFilter(template.acquisition);
 
-      template.fluor = attributes.getValue("bts:Fluorophore");
+      template.fluor = parsing.getRawAttribute(attributes, "Fluorophore");
       applyChannelSettings(template, currentDefinitionOccurrence);
     }
 
@@ -4043,8 +4648,8 @@ public class CV7000Reader extends FormatReader {
     }
 
     private void startActionList(Attributes attributes) {
-      actionRunMode = attributes.getValue("bts:RunMode");
-      actionAFSearch = attributes.getValue("bts:AFSearch");
+      actionRunMode = parsing.getRawAttribute(attributes, "RunMode");
+      actionAFSearch = parsing.getRawAttribute(attributes, "AFSearch");
       addYokogawaAttributes(
         "Yokogawa MES Timeline " + (timelineIndex + 1) +
         " ActionList ", attributes);
@@ -4052,23 +4657,27 @@ public class CV7000Reader extends FormatReader {
 
     private void startActionAcquire(String qName, Attributes attributes) {
       actionIndex++;
-      currentActionType = getYokogawaAttributeName(qName);
-      currentActionXOffset = attributes.getValue("bts:XOffset");
-      currentActionYOffset = attributes.getValue("bts:YOffset");
-      currentActionAFShiftBase = attributes.getValue("bts:AFShiftBase");
-      currentActionTopDistance = attributes.getValue("bts:TopDistance");
-      currentActionBottomDistance = attributes.getValue("bts:BottomDistance");
-      currentActionSliceLength = attributes.getValue("bts:SliceLength");
-      currentActionUseSoftFocus = attributes.getValue("bts:UseSoftFocus");
+      currentActionType = parsing.getYokogawaAttributeName(qName);
+      currentActionXOffset = parsing.getRawAttribute(attributes, "XOffset");
+      currentActionYOffset = parsing.getRawAttribute(attributes, "YOffset");
+      currentActionAFShiftBase = parsing.getRawAttribute(
+        attributes, "AFShiftBase");
+      currentActionTopDistance = parsing.getRawAttribute(
+        attributes, "TopDistance");
+      currentActionBottomDistance = parsing.getRawAttribute(
+        attributes, "BottomDistance");
+      currentActionSliceLength = parsing.getRawAttribute(
+        attributes, "SliceLength");
+      currentActionUseSoftFocus = parsing.getRawAttribute(
+        attributes, "UseSoftFocus");
       addYokogawaAttributes(
         "Yokogawa MES Timeline " + (timelineIndex + 1) +
         " Action " + (actionIndex + 1) + " ", attributes);
-      currentPhysicalSizeZ = DataTools.parseDouble(
-        attributes.getValue("bts:SliceLength"));
+      currentPhysicalSizeZ = parsing.parseDouble(currentActionSliceLength);
     }
 
     private void assignActionChannel(String value) {
-      int channelIndex = Integer.parseInt(value) - 1;
+      int channelIndex = parsing.parseRequiredInteger(value) - 1;
       if (channelIndex < 0) {
         return;
       }
@@ -4193,18 +4802,18 @@ public class CV7000Reader extends FormatReader {
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      String name = getYokogawaAttributeName(qName);
+      String name = parsing.getYokogawaAttributeName(qName);
       if ("EMFilter".equals(name)) {
         currentFilter = new CrosstalkFilter();
         currentFilter.filterID = parsing.getAttribute(attributes, "FilterID");
-        currentFilter.cameraNumber = DataTools.parseInteger(
+        currentFilter.cameraNumber = parsing.parseInteger(
           parsing.getAttribute(attributes, "CameraID"));
         currentFilter.acquisition = parsing.getAttribute(attributes, "Acquisition");
-        currentFilter.averageTransmittance = DataTools.parseDouble(
+        currentFilter.averageTransmittance = parsing.parseDouble(
           parsing.getAttribute(attributes, "AverageTransmittance"));
-        currentFilter.minWaveLength = DataTools.parseDouble(
+        currentFilter.minWaveLength = parsing.parseDouble(
           parsing.getAttribute(attributes, "MinWaveLength"));
-        currentFilter.maxWaveLength = DataTools.parseDouble(
+        currentFilter.maxWaveLength = parsing.parseDouble(
           parsing.getAttribute(attributes, "MaxWaveLength"));
         parameters.addFilter(currentFilter);
       }
@@ -4213,7 +4822,7 @@ public class CV7000Reader extends FormatReader {
         dichroic.id = parsing.getAttribute(attributes, "ID");
         dichroic.name = parsing.getAttribute(attributes, "Name");
         dichroic.reflection = parsing.getAttribute(attributes, "Reflection");
-        dichroic.averageTransmittance = DataTools.parseDouble(
+        dichroic.averageTransmittance = parsing.parseDouble(
           parsing.getAttribute(attributes, "AverageTransmittance"));
         currentFilter.dichroics.add(dichroic);
       }
@@ -4226,7 +4835,7 @@ public class CV7000Reader extends FormatReader {
         CrosstalkFluorophoreIntensity intensity =
           new CrosstalkFluorophoreIntensity();
         intensity.filterID = parsing.getAttribute(attributes, "FilterID");
-        intensity.averageIntensity = DataTools.parseDouble(
+        intensity.averageIntensity = parsing.parseDouble(
           parsing.getAttribute(attributes, "AverageIntensity"));
         currentFluorophore.intensities.add(intensity);
       }
@@ -4234,7 +4843,7 @@ public class CV7000Reader extends FormatReader {
 
     @Override
     public void endElement(String uri, String localName, String qName) {
-      String name = getYokogawaAttributeName(qName);
+      String name = parsing.getYokogawaAttributeName(qName);
       if ("EMFilter".equals(name)) {
         currentFilter = null;
       }
@@ -4256,7 +4865,7 @@ public class CV7000Reader extends FormatReader {
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      String name = getYokogawaAttributeName(qName);
+      String name = parsing.getYokogawaAttributeName(qName);
       if ("GeometryParameter".equals(name)) {
         parameters.mode = parsing.getAttribute(attributes, "Mode");
         return;
@@ -4270,18 +4879,18 @@ public class CV7000Reader extends FormatReader {
       affine.method = parsing.getAttribute(attributes, "Method");
       affine.objectiveID = parsing.getAttribute(attributes, "ObjectiveID");
       affine.objective = parsing.getAttribute(attributes, "Objective");
-      affine.magnification = DataTools.parseDouble(
+      affine.magnification = parsing.parseDouble(
         parsing.getAttribute(attributes, "Magnification"));
       affine.filterID = parsing.getAttribute(attributes, "FilterID");
       affine.acquisition = parsing.getAttribute(attributes, "Acquisition");
       affine.use = parsing.getAttribute(attributes, "Use");
       affine.updateTime = parsing.getAttribute(attributes, "UpdateTime");
-      affine.a = DataTools.parseDouble(parsing.getAttribute(attributes, "A"));
-      affine.b = DataTools.parseDouble(parsing.getAttribute(attributes, "B"));
-      affine.c = DataTools.parseDouble(parsing.getAttribute(attributes, "C"));
-      affine.d = DataTools.parseDouble(parsing.getAttribute(attributes, "D"));
-      affine.e = DataTools.parseDouble(parsing.getAttribute(attributes, "E"));
-      affine.f = DataTools.parseDouble(parsing.getAttribute(attributes, "F"));
+      affine.a = parsing.parseDouble(parsing.getAttribute(attributes, "A"));
+      affine.b = parsing.parseDouble(parsing.getAttribute(attributes, "B"));
+      affine.c = parsing.parseDouble(parsing.getAttribute(attributes, "C"));
+      affine.d = parsing.parseDouble(parsing.getAttribute(attributes, "D"));
+      affine.e = parsing.parseDouble(parsing.getAttribute(attributes, "E"));
+      affine.f = parsing.parseDouble(parsing.getAttribute(attributes, "F"));
       parameters.addAffine(affine);
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -79,6 +79,7 @@ public class CV7000Reader extends FormatReader {
   private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
   private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
   private static final String POST_PROCESS = "PostProcess.ppf";
+  private static final String BRIGHTFIELD = "Brightfield";
 
   // -- Fields --
 
@@ -593,37 +594,28 @@ public class CV7000Reader extends FormatReader {
       store.setPlateExternalIdentifier(plate.getPlateID(), 0);
 
       String instrument = null;
+      HashMap<Integer, Integer> lightSourceIndexes = new HashMap<Integer, Integer>();
+      HashMap<Integer, Integer> detectorIndexes = new HashMap<Integer, Integer>();
+      HashMap<FilterKey, Integer> filterIndexes = new HashMap<FilterKey, Integer>();
       List<String> usedObjectiveIDs = new ArrayList<String>();
-      if (lightSources.size() > 0) {
+      if ((lightSources != null && lightSources.size() > 0) ||
+        (channels != null && channels.size() > 0))
+      {
         instrument = MetadataTools.createLSID("Instrument", 0);
 
         store.setInstrumentID(instrument, 0);
-
-        int nextLightSource = 0;
-        for (LightSource l : lightSources) {
-          if ("Laser".equals(l.type)) {
-            String laserID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
-            store.setLaserID(laserID, 0, nextLightSource);
-            store.setLaserWavelength(
-              new Length(l.wavelength, UNITS.NANOMETER), 0, nextLightSource);
-            store.setLaserPower(new Power(l.power, UNITS.MILLIWATT), 0, nextLightSource);
-            nextLightSource++;
-          }
-        }
-
-        for (Channel c : channels) {
-          if (c.objectiveID != null && !usedObjectiveIDs.contains(c.objectiveID)) {
-            int index = usedObjectiveIDs.size();
-            String objectiveID = MetadataTools.createLSID("Objective", 0, index);
-            store.setObjectiveID(objectiveID, 0, index);
-            store.setObjectiveModel(c.objective, 0, index);
-            usedObjectiveIDs.add(c.objectiveID);
-          }
-        }
+        populateLightSources(store, lightSourceIndexes);
+        populateObjectives(store, usedObjectiveIDs);
+        populateDetectors(store, detectorIndexes);
+        populateFilters(store, filterIndexes);
+        addYokogawaOriginalMetadata();
       }
 
       for (int i=0; i<getSeriesCount(); i++) {
         setSeries(i);
+        if (instrument != null) {
+          store.setImageInstrumentRef(instrument, i);
+        }
         if (channels != null) {
           Length physicalSizeZ = getPhysicalSizeZ(i);
           if (physicalSizeZ != null) {
@@ -674,21 +666,44 @@ public class CV7000Reader extends FormatReader {
               store.setChannelFluor(channel.fluor, i, c);
             }
 
-            if (channel.excitation != null && channel.lightSourceRefs != null) {
-              int index = -1;
-              for (int ref=0; ref<channel.lightSourceRefs.size(); ref++) {
-                int lightSource = channel.lightSourceRefs.get(ref);
-                if ("Laser".equals(lightSources.get(lightSource).type) &&
-                  lightSources.get(lightSource).wavelength < channel.excitation)
-                {
-                  index = lightSource;
-                }
-              }
-              if (index >= 0) {
+            Integer lightSource = getLinkedLaser(channel);
+            if (lightSource != null && lightSourceIndexes.containsKey(lightSource)) {
+              LightSource source = lightSources.get(lightSource);
+              if (source.wavelength != null && source.wavelength > 0) {
+                int index = lightSourceIndexes.get(lightSource);
                 store.setChannelLightSourceSettingsID(
                   MetadataTools.createLSID("LightSource", 0, index), i, c);
                 store.setChannelExcitationWavelength(
-                  new Length(channel.excitation, UNITS.NANOMETER), i, c);
+                  new Length(source.wavelength, UNITS.NANOMETER), i, c);
+              }
+            }
+
+            if (!channel.isBrightfield() && channel.detectionFilter != null &&
+              channel.detectionFilter.center != null)
+            {
+              store.setChannelEmissionWavelength(
+                new Length(channel.detectionFilter.center, UNITS.NANOMETER), i, c);
+            }
+
+            FilterKey filter = new FilterKey(channel);
+            if (filterIndexes.containsKey(filter)) {
+              store.setLightPathEmissionFilterRef(
+                MetadataTools.createLSID("Filter", 0, filterIndexes.get(filter)), i, c, 0);
+            }
+
+            if (detectorIndexes.containsKey(channel.cameraNumber)) {
+              String detectorID = MetadataTools.createLSID(
+                "Detector", 0, detectorIndexes.get(channel.cameraNumber));
+              store.setDetectorSettingsID(detectorID, i, c);
+              String binning = getBinningValue(channel.binning);
+              if (binning != null) {
+                try {
+                  store.setDetectorSettingsBinning(
+                    MetadataTools.getBinning(binning), i, c);
+                }
+                catch (FormatException e) {
+                  LOGGER.debug("Ignoring invalid CV7000 binning value {}", binning, e);
+                }
               }
             }
 
@@ -716,6 +731,215 @@ public class CV7000Reader extends FormatReader {
       }
       setSeries(0);
     }
+  }
+
+  private void populateLightSources(MetadataStore store,
+    HashMap<Integer, Integer> lightSourceIndexes)
+  {
+    if (lightSources == null) {
+      return;
+    }
+    int nextLightSource = 0;
+    for (int i=0; i<lightSources.size(); i++) {
+      LightSource l = lightSources.get(i);
+      if ("Laser".equals(l.type)) {
+        String laserID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
+        store.setLaserID(laserID, 0, nextLightSource);
+        if (l.wavelength != null) {
+          store.setLaserWavelength(
+            new Length(l.wavelength, UNITS.NANOMETER), 0, nextLightSource);
+        }
+        if (l.power != null) {
+          store.setLaserPower(new Power(l.power, UNITS.MILLIWATT), 0, nextLightSource);
+        }
+        lightSourceIndexes.put(i, nextLightSource);
+        nextLightSource++;
+      }
+    }
+  }
+
+  private void populateObjectives(MetadataStore store, List<String> usedObjectiveIDs) {
+    if (channels == null) {
+      return;
+    }
+    for (Channel c : channels) {
+      if (c.objectiveID != null && !usedObjectiveIDs.contains(c.objectiveID)) {
+        int index = usedObjectiveIDs.size();
+        String objectiveID = MetadataTools.createLSID("Objective", 0, index);
+        store.setObjectiveID(objectiveID, 0, index);
+        store.setObjectiveModel(c.objective, 0, index);
+        usedObjectiveIDs.add(c.objectiveID);
+      }
+    }
+  }
+
+  private void populateDetectors(MetadataStore store,
+    HashMap<Integer, Integer> detectorIndexes)
+    throws FormatException
+  {
+    if (channels == null) {
+      return;
+    }
+    for (Channel c : channels) {
+      if (!detectorIndexes.containsKey(c.cameraNumber)) {
+        int detector = detectorIndexes.size();
+        detectorIndexes.put(c.cameraNumber, detector);
+        String detectorID = MetadataTools.createLSID("Detector", 0, detector);
+        store.setDetectorID(detectorID, 0, detector);
+        if (c.cameraType != null && c.cameraType.trim().length() > 0) {
+          store.setDetectorModel(c.cameraType, 0, detector);
+        }
+        store.setDetectorType(MetadataTools.getDetectorType("Other"), 0, detector);
+      }
+    }
+  }
+
+  private void populateFilters(MetadataStore store,
+    HashMap<FilterKey, Integer> filterIndexes)
+    throws FormatException
+  {
+    if (channels == null) {
+      return;
+    }
+    for (Channel c : channels) {
+      FilterKey key = new FilterKey(c);
+      if (!key.isValid() || filterIndexes.containsKey(key)) {
+        continue;
+      }
+      int filter = filterIndexes.size();
+      filterIndexes.put(key, filter);
+      String filterID = MetadataTools.createLSID("Filter", 0, filter);
+      store.setFilterID(filterID, 0, filter);
+      store.setFilterModel(key.acquisition, 0, filter);
+      store.setFilterType(MetadataTools.getFilterType(key.detectionFilter.filterType), 0, filter);
+      if (key.detectionFilter != null) {
+        Length cutIn = key.detectionFilter.cutIn == null ?
+          null : FormatTools.getCutIn(key.detectionFilter.cutIn);
+        Length cutOut = key.detectionFilter.cutOut == null ?
+          null : FormatTools.getCutOut(key.detectionFilter.cutOut);
+        if (cutIn != null) {
+          store.setTransmittanceRangeCutIn(cutIn, 0, filter);
+        }
+        if (cutOut != null) {
+          store.setTransmittanceRangeCutOut(cutOut, 0, filter);
+        }
+      }
+    }
+  }
+
+  private void addYokogawaOriginalMetadata() {
+    if (lightSources != null) {
+      for (LightSource source : lightSources) {
+        String prefix = "Yokogawa LightSource " + source.name + " ";
+        addGlobalMeta(prefix + "Type", source.type);
+        addGlobalMeta(prefix + "WaveLength", source.wavelength);
+        addGlobalMeta(prefix + "Power", source.power);
+      }
+    }
+    if (channels == null) {
+      return;
+    }
+    HashSet<String> seen = new HashSet<String>();
+    for (Channel c : channels) {
+      String key = c.timelineIndex + ":" + c.actionIndex + ":" + c.index;
+      if (!seen.add(key)) {
+        continue;
+      }
+      String prefix = "Yokogawa Timeline " + (c.timelineIndex + 1) +
+        " Action " + (c.actionIndex + 1) + " Channel " + (c.index + 1) + " ";
+      addGlobalMeta(prefix + "Target", c.target);
+      addGlobalMeta(prefix + "Kind", c.kind);
+      addGlobalMeta(prefix + "MethodID", c.methodID);
+      addGlobalMeta(prefix + "Method", c.method);
+      addGlobalMeta(prefix + "FilterID", c.filterID);
+      addGlobalMeta(prefix + "Acquisition", c.acquisition);
+      if (c.detectionFilter != null) {
+        addGlobalMeta(prefix + "DetectionFilterType", c.detectionFilter.filterType);
+        addGlobalMeta(prefix + "DetectionFilterCenter", c.detectionFilter.center);
+        addGlobalMeta(prefix + "DetectionFilterWidth", c.detectionFilter.width);
+        addGlobalMeta(prefix + "DetectionFilterCutIn", c.detectionFilter.cutIn);
+        addGlobalMeta(prefix + "DetectionFilterCutOut", c.detectionFilter.cutOut);
+      }
+      addGlobalMeta(prefix + "CameraNumber", c.cameraNumber);
+      addGlobalMeta(prefix + "CameraType", c.cameraType);
+      addGlobalMeta(prefix + "Binning", c.binning);
+      addGlobalMeta(prefix + "AndorParameterID", c.andorParameterID);
+      addGlobalMeta(prefix + "AndorParameter", c.andorParameter);
+      addGlobalMeta(prefix + "InputBitDepth", c.inputBitDepth);
+      addGlobalMeta(prefix + "InputLevel", c.inputLevel);
+      addGlobalMeta(prefix + "HorizontalPixels", c.horizontalPixels);
+      addGlobalMeta(prefix + "VerticalPixels", c.verticalPixels);
+      addGlobalMeta(prefix + "FilterWheelPosition", c.filterWheelPosition);
+      addGlobalMeta(prefix + "FilterPosition", c.filterPosition);
+      addGlobalMeta(prefix + "ShadingCorrectionSource", c.correctionFile);
+    }
+  }
+
+  private Integer getLinkedLaser(Channel channel) {
+    if (channel == null || channel.isBrightfield() ||
+      channel.lightSourceRefs == null || lightSources == null)
+    {
+      return null;
+    }
+    for (Integer lightSource : channel.lightSourceRefs) {
+      if (lightSource != null && lightSource >= 0 && lightSource < lightSources.size() &&
+        "Laser".equals(lightSources.get(lightSource).type))
+      {
+        return lightSource;
+      }
+    }
+    return null;
+  }
+
+  private String getBinningValue(String binning) {
+    if (binning == null || binning.trim().length() == 0) {
+      return null;
+    }
+    if (binning.indexOf('x') >= 0 || binning.indexOf('X') >= 0) {
+      return binning;
+    }
+    return binning + "x" + binning;
+  }
+
+  private DetectionFilter parseDetectionFilter(String acquisition) {
+    if (acquisition == null) {
+      return null;
+    }
+    String trimmed = acquisition.trim();
+    try {
+      if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
+        String center = trimmed.substring(2, trimmed.indexOf("/"));
+        String width = trimmed.substring(trimmed.indexOf("/") + 1);
+        Double parsedCenter = DataTools.parseDouble(center);
+        Double parsedWidth = DataTools.parseDouble(width);
+        if (parsedCenter != null && parsedWidth != null) {
+          return DetectionFilter.bandPass(parsedCenter, parsedWidth);
+        }
+      }
+      else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
+        Double cutIn = DataTools.parseDouble(trimmed.substring(2));
+        if (cutIn != null) {
+          return DetectionFilter.longPass(cutIn);
+        }
+      }
+      else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
+        Double cutOut = DataTools.parseDouble(trimmed.substring(2));
+        if (cutOut != null) {
+          return DetectionFilter.shortPass(cutOut);
+        }
+      }
+    }
+    catch (RuntimeException e) {
+      LOGGER.debug("Ignoring invalid CV7000 detection filter value {}", acquisition, e);
+    }
+    return null;
+  }
+
+  private Integer parseInteger(String value) {
+    if (value == null || value.trim().length() == 0) {
+      return null;
+    }
+    return Integer.valueOf(value);
   }
 
   private int getChannelIndex(Plane p) {
@@ -990,6 +1214,12 @@ public class CV7000Reader extends FormatReader {
         c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
         c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
+        c.inputBitDepth = parseInteger(attributes.getValue("bts:InputBitDepth"));
+        c.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
+        c.horizontalPixels = parseInteger(attributes.getValue("bts:HorizontalPixels"));
+        c.verticalPixels = parseInteger(attributes.getValue("bts:VerticalPixels"));
+        c.filterWheelPosition = parseInteger(attributes.getValue("bts:FilterWheelPosition"));
+        c.filterPosition = parseInteger(attributes.getValue("bts:FilterPosition"));
         c.correctionFile = attributes.getValue("bts:ShadingCorrectionSource");
         if (c.correctionFile != null && c.correctionFile.trim().length() == 0) {
           c.correctionFile = null;
@@ -1054,9 +1284,18 @@ public class CV7000Reader extends FormatReader {
 
             Channel template = new Channel();
             template.index = index;
+            template.target = attributes.getValue("bts:Target");
             template.objectiveID = attributes.getValue("bts:ObjectiveID");
             template.objective = attributes.getValue("bts:Objective");
             template.binning = attributes.getValue("bts:Binning");
+            template.methodID = attributes.getValue("bts:MethodID");
+            template.method = attributes.getValue("bts:Method");
+            template.filterID = attributes.getValue("bts:FilterID");
+            template.kind = attributes.getValue("bts:Kind");
+            template.andorParameterID = attributes.getValue("bts:AndorParameterID");
+            template.andorParameter = attributes.getValue("bts:AndorParameter");
+            template.cameraType = attributes.getValue("bts:CameraType");
+            template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
 
             String mag = attributes.getValue("bts:Magnification");
             template.magnification = DataTools.parseDouble(mag);
@@ -1081,14 +1320,10 @@ public class CV7000Reader extends FormatReader {
               }
             }
 
-            String acquisition = attributes.getValue("bts:Acquisition");
-            if (acquisition != null) {
-              if (acquisition.indexOf("/") > 0) {
-                acquisition = acquisition.replaceAll("BP", "");
-                String wave = acquisition.substring(0, acquisition.indexOf("/"));
-                template.excitation = DataTools.parseDouble(wave);
-              }
-            }
+            template.acquisition = attributes.getValue("bts:Acquisition");
+            // Yokogawa Acquisition values such as BP676/29 identify detection
+            // filters.  Excitation comes from the LightSourceName link.
+            template.detectionFilter = parseDetectionFilter(template.acquisition);
 
             template.fluor = attributes.getValue("bts:Fluorophore");
             applyChannelSettings(template);
@@ -1180,6 +1415,89 @@ public class CV7000Reader extends FormatReader {
     public Double power;
   }
 
+  static class DetectionFilter {
+    public String filterType;
+    public Double center;
+    public Double width;
+    public Double cutIn;
+    public Double cutOut;
+
+    public static DetectionFilter bandPass(Double center, Double width) {
+      DetectionFilter filter = new DetectionFilter("BandPass");
+      filter.center = center;
+      filter.width = width;
+      filter.cutIn = center - (width / 2);
+      filter.cutOut = center + (width / 2);
+      return filter;
+    }
+
+    public static DetectionFilter longPass(Double cutIn) {
+      DetectionFilter filter = new DetectionFilter("LongPass");
+      filter.cutIn = cutIn;
+      return filter;
+    }
+
+    public static DetectionFilter shortPass(Double cutOut) {
+      DetectionFilter filter = new DetectionFilter("ShortPass");
+      filter.cutOut = cutOut;
+      return filter;
+    }
+
+    private DetectionFilter(String filterType) {
+      this.filterType = filterType;
+    }
+  }
+
+  class FilterKey {
+    public String filterID;
+    public String acquisition;
+    public Integer filterWheelPosition;
+    public Integer filterPosition;
+    public DetectionFilter detectionFilter;
+
+    public FilterKey(Channel ch) {
+      filterID = ch.filterID;
+      acquisition = ch.acquisition;
+      filterWheelPosition = ch.filterWheelPosition;
+      filterPosition = ch.filterPosition;
+      detectionFilter = ch.detectionFilter;
+    }
+
+    public boolean isValid() {
+      return acquisition != null && detectionFilter != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof FilterKey)) {
+        return false;
+      }
+      FilterKey key = (FilterKey) o;
+      return same(filterID, key.filterID) &&
+        same(acquisition, key.acquisition) &&
+        same(filterWheelPosition, key.filterWheelPosition) &&
+        same(filterPosition, key.filterPosition);
+    }
+
+    @Override
+    public int hashCode() {
+      int code = 17;
+      code = 31 * code + hash(filterID);
+      code = 31 * code + hash(acquisition);
+      code = 31 * code + hash(filterWheelPosition);
+      code = 31 * code + hash(filterPosition);
+      return code;
+    }
+
+    private boolean same(Object a, Object b) {
+      return a == null ? b == null : a.equals(b);
+    }
+
+    private int hash(Object value) {
+      return value == null ? 0 : value.hashCode();
+    }
+  }
+
   class Channel {
     public int timelineIndex = -1;
     public int actionIndex = -1;
@@ -1187,10 +1505,25 @@ public class CV7000Reader extends FormatReader {
     public double xSize;
     public double ySize;
     public int cameraNumber;
+    public Integer inputBitDepth;
+    public Integer inputLevel;
+    public Integer horizontalPixels;
+    public Integer verticalPixels;
+    public Integer filterWheelPosition;
+    public Integer filterPosition;
     public String correctionFile;
     public List<Integer> lightSourceRefs = new ArrayList<Integer>();
-    public Double excitation;
 
+    public String target;
+    public String methodID;
+    public String method;
+    public String filterID;
+    public String acquisition;
+    public DetectionFilter detectionFilter;
+    public String kind;
+    public String cameraType;
+    public String andorParameterID;
+    public String andorParameter;
     public String objectiveID;
     public String objective;
     public Double magnification;
@@ -1209,9 +1542,24 @@ public class CV7000Reader extends FormatReader {
       xSize = ch.xSize;
       ySize = ch.ySize;
       cameraNumber = ch.cameraNumber;
+      inputBitDepth = ch.inputBitDepth;
+      inputLevel = ch.inputLevel;
+      horizontalPixels = ch.horizontalPixels;
+      verticalPixels = ch.verticalPixels;
+      filterWheelPosition = ch.filterWheelPosition;
+      filterPosition = ch.filterPosition;
       correctionFile = ch.correctionFile;
       lightSourceRefs = new ArrayList<Integer>(ch.lightSourceRefs);
-      excitation = ch.excitation;
+      target = ch.target;
+      methodID = ch.methodID;
+      method = ch.method;
+      filterID = ch.filterID;
+      acquisition = ch.acquisition;
+      detectionFilter = ch.detectionFilter;
+      kind = ch.kind;
+      cameraType = ch.cameraType;
+      andorParameterID = ch.andorParameterID;
+      andorParameter = ch.andorParameter;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
       magnification = ch.magnification;
@@ -1223,7 +1571,17 @@ public class CV7000Reader extends FormatReader {
     }
 
     public void copyChannelSettings(Channel ch) {
-      excitation = ch.excitation;
+      target = ch.target;
+      methodID = ch.methodID;
+      method = ch.method;
+      filterID = ch.filterID;
+      acquisition = ch.acquisition;
+      detectionFilter = ch.detectionFilter;
+      kind = ch.kind;
+      cameraType = ch.cameraType;
+      andorParameterID = ch.andorParameterID;
+      andorParameter = ch.andorParameter;
+      inputLevel = ch.inputLevel;
       objectiveID = ch.objectiveID;
       objective = ch.objective;
       magnification = ch.magnification;
@@ -1236,8 +1594,13 @@ public class CV7000Reader extends FormatReader {
     public boolean hasChannelSettings() {
       return objectiveID != null || objective != null || magnification != null ||
         exposureTime != null || binning != null || color != null ||
-        excitation != null || fluor != null ||
+        acquisition != null || detectionFilter != null || fluor != null ||
         (lightSourceRefs != null && lightSourceRefs.size() > 0);
+    }
+
+    public boolean isBrightfield() {
+      return BRIGHTFIELD.equals(kind) ||
+        (method != null && BRIGHTFIELD.equalsIgnoreCase(method));
     }
 
     @Override

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -958,11 +958,11 @@ public class CV7000Reader extends FormatReader {
       if (plane == null) {
         continue;
       }
-      // MLF Z values match MES AFShiftBase + (ZIndex - 1) * SliceLength,
-      // where SliceLength is the physical Z spacing in micrometers. AFSearch
-      // indicates the reference is the autofocus/base surface, so this is an
-      // AF-relative stack coordinate, not a proven absolute stage Z.
-      store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.MICROMETER), series, p);
+      // MLF Z values match MES AFShiftBase + (ZIndex - 1) * SliceLength, but
+      // AFSearch indicates the reference is the autofocus/base surface. Keep
+      // per-plane Z as an AF-relative reference-frame coordinate; calibrated Z
+      // spacing is reported separately via Pixels.PhysicalSizeZ when available.
+      store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), series, p);
       Double deltaT = getPlaneDeltaTSeconds(plane, timing.startMillis);
       if (deltaT != null) {
         store.setPlaneDeltaT(new Time(deltaT, UNITS.SECOND), series, p);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1447,8 +1447,7 @@ public class CV7000Reader extends FormatReader {
           int index = usedObjectiveIDs.size();
           String objectiveID = MetadataTools.createLSID("Objective", 0, index);
           store.setObjectiveID(objectiveID, 0, index);
-          populateObjectiveModel(store, index, c.objectiveID, c.objective,
-            c.magnification);
+          populateObjectiveModel(store, index, c.objective, c.magnification);
           usedObjectiveIDs.add(c.objectiveID);
         }
       }
@@ -1464,8 +1463,8 @@ public class CV7000Reader extends FormatReader {
           int index = usedObjectiveIDs.size();
           String objectiveID = MetadataTools.createLSID("Objective", 0, index);
           store.setObjectiveID(objectiveID, 0, index);
-          populateObjectiveModel(store, index, objective.objectiveID,
-            objective.objective, objective.magnification);
+          populateObjectiveModel(store, index, objective.objective,
+            objective.magnification);
           usedObjectiveIDs.add(objective.objectiveID);
         }
       }
@@ -1473,7 +1472,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   private void populateObjectiveModel(MetadataStore store, int objectiveIndex,
-    String objectiveID, String model, Double magnification)
+    String model, Double magnification)
   {
     if (model != null) {
       store.setObjectiveModel(model, 0, objectiveIndex);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1999,6 +1999,7 @@ public class CV7000Reader extends FormatReader {
       store.setBinaryFileMIMEType(XML_MIME_TYPE, index);
       store.setBinaryFileSize(length, index);
       store.setBinaryFileBinData(bytes, index);
+      store.setBinaryFileBinDataBigEndian(Boolean.FALSE, index);
       store.setBinaryFileBinDataLength(length, index);
       return annotationID;
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -79,6 +79,8 @@ public class CV7000Reader extends FormatReader {
 
   public static final String DUPLICATE_PLANES_KEY = "cv7000.duplicate_missing_planes";
   public static final boolean DUPLICATE_PLANES_DEFAULT = false;
+  public static final String PRESERVE_RAW_SIDECARS_KEY = "cv7000.preserve_raw_sidecars";
+  public static final boolean PRESERVE_RAW_SIDECARS_DEFAULT = true;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
 
@@ -134,6 +136,15 @@ public class CV7000Reader extends FormatReader {
        DUPLICATE_PLANES_KEY, DUPLICATE_PLANES_DEFAULT);
     }
     return DUPLICATE_PLANES_DEFAULT;
+  }
+
+  public boolean preserveRawSidecars() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       PRESERVE_RAW_SIDECARS_KEY, PRESERVE_RAW_SIDECARS_DEFAULT);
+    }
+    return PRESERVE_RAW_SIDECARS_DEFAULT;
   }
 
   // -- IFormatReader API methods --
@@ -307,6 +318,7 @@ public class CV7000Reader extends FormatReader {
   protected ArrayList<String> getAvailableOptions() {
     ArrayList<String> optionsList = super.getAvailableOptions();
     optionsList.add(DUPLICATE_PLANES_KEY);
+    optionsList.add(PRESERVE_RAW_SIDECARS_KEY);
     return optionsList;
   }
 
@@ -999,7 +1011,7 @@ public class CV7000Reader extends FormatReader {
     if (channel.detectorGain != null) {
       store.setDetectorSettingsGain(channel.detectorGain, series, channelIndex);
     }
-    String binning = getBinningValue(channel.binning);
+    String binning = parsing.getBinningValue(channel.binning);
     if (binning != null) {
       try {
         store.setDetectorSettingsBinning(
@@ -1334,12 +1346,16 @@ public class CV7000Reader extends FormatReader {
     int plateAnnotationRef = 0;
     if (allFiles != null) {
       for (String file : allFiles) {
-        Location location = file == null ? null : new Location(file);
+        if (file == null) {
+          continue;
+        }
+        Location location = new Location(file);
+        String name = location.getName();
         CV7000FileRole role = classifyCV7000File(location);
-        if (file != null && isDatasetFile(role) && !isPixelFile(role)) {
+        if (isDatasetFile(role) && !isPixelFile(role)) {
           parseStructuredSidecarMetadata(file, role);
           addSidecarSummaryMetadata(file, role);
-          if (preserveRawSidecarAsFileAnnotation(role)) {
+          if (preserveRawSidecars() && preserveRawSidecarAsFileAnnotation(role)) {
             String annotationID = addRawSidecarFileAnnotation(
               store, file, rawSidecarAnnotation);
             if (annotationID != null) {
@@ -1348,8 +1364,9 @@ public class CV7000Reader extends FormatReader {
               plateAnnotationRef++;
             }
           }
-          addYokogawaMetaList("Yokogawa Sidecar ", "File",
-            location.getName());
+          if (name != null) {
+            addYokogawaMetaList("Yokogawa Sidecar ", "File", name);
+          }
         }
       }
     }
@@ -1884,18 +1901,6 @@ public class CV7000Reader extends FormatReader {
       channel.filterID, Integer.valueOf(channel.cameraNumber), channel.acquisition));
   }
 
-  private String getBinningValue(String binning) {
-    return parsing.getBinningValue(binning);
-  }
-
-  private DetectionFilter parseDetectionFilter(String acquisition) {
-    return parsing.parseDetectionFilter(acquisition);
-  }
-
-  private Double parseYokogawaGain(String value) {
-    return parsing.parseYokogawaGain(value);
-  }
-
   private Integer parseInteger(String value) {
     return parsing.parseInteger(value);
   }
@@ -2002,21 +2007,6 @@ public class CV7000Reader extends FormatReader {
 
   private String readSanitizedXML(String filename) throws IOException {
     return parsing.readSanitizedXML(filename);
-  }
-
-  private boolean isWellAcquired(int row, int col) {
-    String key = getWellKey(row, col);
-    if (seriesLayout != null && seriesLayout.acquiredWells.containsKey(key)) {
-      return seriesLayout.acquiredWells.get(key);
-    }
-    if (planeData != null) {
-      for (Plane p : planeData) {
-        if (p != null && p.file != null && p.field.row == row && p.field.column == col) {
-          return true;
-        }
-      }
-    }
-    return false;
   }
 
   private String getWellKey(int row, int column) {
@@ -2745,7 +2735,7 @@ public class CV7000Reader extends FormatReader {
             template.kind = attributes.getValue("bts:Kind");
             template.andorParameterID = attributes.getValue("bts:AndorParameterID");
             template.andorParameter = attributes.getValue("bts:AndorParameter");
-            template.detectorGain = parseYokogawaGain(template.andorParameter);
+            template.detectorGain = parsing.parseYokogawaGain(template.andorParameter);
             template.cameraType = attributes.getValue("bts:CameraType");
             template.inputLevel = parseInteger(attributes.getValue("bts:InputLevel"));
 
@@ -2775,7 +2765,7 @@ public class CV7000Reader extends FormatReader {
             template.acquisition = attributes.getValue("bts:Acquisition");
             // Yokogawa Acquisition values such as BP676/29 identify detection
             // filters.  Excitation comes from the LightSourceName link.
-            template.detectionFilter = parseDetectionFilter(template.acquisition);
+            template.detectionFilter = parsing.parseDetectionFilter(template.acquisition);
 
             template.fluor = attributes.getValue("bts:Fluorophore");
             applyChannelSettings(template);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +57,7 @@ import ome.units.quantity.Power;
 import ome.units.quantity.Time;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PercentFraction;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 import ome.xml.model.enums.AcquisitionMode;
@@ -94,6 +96,7 @@ public class CV7000Reader extends FormatReader {
   private String detailPath;
   private String measurementPath;
   private String settingsPath;
+  private DatasetPaths datasetPaths;
   private ArrayList<Plane> planeData;
   private int[][] reversePlaneLookup;
   private ArrayList<LightSource> lightSources;
@@ -101,6 +104,7 @@ public class CV7000Reader extends FormatReader {
   private String startTime, endTime;
   private ArrayList<String> extraFiles;
   private MeasurementDataHandler measurementHandler;
+  private CrosstalkParameters crosstalkParameters;
 
   private transient Map<String, Boolean> acquiredWells = new HashMap<String, Boolean>();
 
@@ -153,7 +157,9 @@ public class CV7000Reader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(new Location(currentId).getAbsolutePath());
     for (String file : allFiles) {
-      if (file != null && !files.contains(file) && (!noPixels || !isTiffFile(file))) {
+      if (file != null && !files.contains(file) &&
+        (!noPixels || !isPixelFile(classifyCV7000File(new Location(file)))))
+      {
         files.add(file);
       }
     }
@@ -197,9 +203,20 @@ public class CV7000Reader extends FormatReader {
         }
       }
     }
-    files.addAll(extraFiles);
+    if (extraFiles != null) {
+      for (String file : extraFiles) {
+        if (!noPixels ||
+          !isPixelFile(classifyCV7000File(new Location(file))))
+        {
+          files.add(file);
+        }
+      }
+    }
     for (String file : allFiles) {
-      if (file != null && !isTiffFile(file) && !(new Location(file).isDirectory())) {
+      Location location = file == null ? null : new Location(file);
+      if (location != null && !isPixelFile(classifyCV7000File(location)) &&
+        !location.isDirectory())
+      {
         files.add(file);
       }
     }
@@ -221,12 +238,14 @@ public class CV7000Reader extends FormatReader {
       detailPath = null;
       wppPath = null;
       settingsPath = null;
+      datasetPaths = null;
       planeData = null;
       lightSources = null;
       channels = null;
       startTime = null;
       endTime = null;
       measurementHandler = null;
+      crosstalkParameters = null;
       reversePlaneLookup = null;
       extraFiles = null;
       acquiredWells.clear();
@@ -288,6 +307,7 @@ public class CV7000Reader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
     DatasetPaths paths = getDatasetPaths(id);
+    datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
 
     parseMeasurementData(paths);
@@ -309,6 +329,9 @@ public class CV7000Reader extends FormatReader {
     paths.parent = wpi.getParentFile();
     paths.measurementData = new Location(paths.parent, MEASUREMENT_FILE);
     paths.measurementDetail = new Location(paths.parent, MEASUREMENT_DETAIL);
+    paths.postProcess = new Location(paths.parent, POST_PROCESS);
+    paths.otfCrosstalk = new Location(paths.parent, OTF_CROSSTALK_PARAMETER);
+    paths.otfGeometry = new Location(paths.parent, OTF_GEOMETRY_PARAMETER);
     return paths;
   }
 
@@ -325,7 +348,9 @@ public class CV7000Reader extends FormatReader {
     Arrays.sort(listedFiles);
     for (int i=0; i<listedFiles.length; i++) {
       Location file = new Location(parent, listedFiles[i]);
-      if (!file.isDirectory() && file.canRead() && isCV7000DatasetFile(file)) {
+      if (!file.isDirectory() && file.canRead() &&
+        isDatasetFile(classifyCV7000File(file)))
+      {
         allFiles.add(file.getAbsolutePath());
       }
     }
@@ -350,6 +375,7 @@ public class CV7000Reader extends FormatReader {
     parseMeasurementDetail(paths);
     parseWellPlateProduct();
     parseMeasurementSettings();
+    parseOTFCrosstalk(paths);
   }
 
   /** MeasurementDetail links the acquisition settings sidecars and seeds channels. */
@@ -387,6 +413,24 @@ public class CV7000Reader extends FormatReader {
       if (xml.length() > 0) {
         XMLTools.parseXML(xml, settingsHandler);
       }
+    }
+  }
+
+  /** OTF crosstalk stores exact emission filter bands and optional dichroics. */
+  private void parseOTFCrosstalk(DatasetPaths paths) {
+    Location crosstalk = paths.otfCrosstalk;
+    if (!crosstalk.exists()) {
+      return;
+    }
+
+    try {
+      CrosstalkParameterHandler handler = new CrosstalkParameterHandler();
+      XMLTools.parseXML(readSanitizedXML(crosstalk.getAbsolutePath()), handler);
+      crosstalkParameters = handler.getParameters();
+    }
+    catch (Exception e) {
+      crosstalkParameters = null;
+      LOGGER.warn("Could not parse CV7000 crosstalk sidecar {}", crosstalk.getAbsolutePath(), e);
     }
   }
 
@@ -597,7 +641,9 @@ public class CV7000Reader extends FormatReader {
 
       InstrumentMetadataIndexes indexes = populateInstrumentMetadata(store);
       populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
-        indexes.detectorIndexes, indexes.filterIndexes, indexes.usedObjectiveIDs, timings);
+        indexes.detectorIndexes, indexes.filterIndexes, indexes.dichroicIndexes,
+        indexes.usedObjectiveIDs, timings);
+      addYokogawaOriginalMetadata();
       setSeries(0);
     }
   }
@@ -616,8 +662,8 @@ public class CV7000Reader extends FormatReader {
       populateLightSources(store, indexes.lightSourceIndexes);
       populateObjectives(store, indexes.usedObjectiveIDs);
       populateDetectors(store, indexes.detectorIndexes);
+      populateDichroics(store, indexes.dichroicIndexes);
       populateFilters(store, indexes.filterIndexes);
-      addYokogawaOriginalMetadata();
     }
     return indexes;
   }
@@ -720,6 +766,7 @@ public class CV7000Reader extends FormatReader {
     HashMap<Integer, Integer> lightSourceIndexes,
     HashMap<Integer, Integer> detectorIndexes,
     HashMap<FilterKey, Integer> filterIndexes,
+    HashMap<String, Integer> dichroicIndexes,
     List<String> usedObjectiveIDs, SeriesTiming[] timings)
   {
     for (int i=0; i<getSeriesCount(); i++) {
@@ -728,7 +775,7 @@ public class CV7000Reader extends FormatReader {
         store.setImageInstrumentRef(instrument, i);
       }
       populateChannelMetadata(store, i, lightSourceIndexes, detectorIndexes,
-        filterIndexes, usedObjectiveIDs);
+        filterIndexes, dichroicIndexes, usedObjectiveIDs);
       populatePlaneMetadata(store, i, timings[i]);
     }
   }
@@ -737,6 +784,7 @@ public class CV7000Reader extends FormatReader {
     HashMap<Integer, Integer> lightSourceIndexes,
     HashMap<Integer, Integer> detectorIndexes,
     HashMap<FilterKey, Integer> filterIndexes,
+    HashMap<String, Integer> dichroicIndexes,
     List<String> usedObjectiveIDs)
   {
     if (channels == null) {
@@ -799,7 +847,7 @@ public class CV7000Reader extends FormatReader {
       }
 
       populateChannelLightSourceSettings(store, series, c, channel, lightSourceIndexes);
-      populateChannelFilterSettings(store, series, c, channel, filterIndexes);
+      populateChannelFilterSettings(store, series, c, channel, filterIndexes, dichroicIndexes);
       populateDetectorSettings(store, series, c, channel, detectorIndexes);
       populateExposureTime(store, series, c, channel);
     }
@@ -826,7 +874,8 @@ public class CV7000Reader extends FormatReader {
   }
 
   private void populateChannelFilterSettings(MetadataStore store, int series,
-    int channelIndex, Channel channel, HashMap<FilterKey, Integer> filterIndexes)
+    int channelIndex, Channel channel, HashMap<FilterKey, Integer> filterIndexes,
+    HashMap<String, Integer> dichroicIndexes)
   {
     if (!channel.isBrightfield() && channel.detectionFilter != null &&
       channel.detectionFilter.center != null)
@@ -840,6 +889,16 @@ public class CV7000Reader extends FormatReader {
       store.setLightPathEmissionFilterRef(
         MetadataTools.createLSID("Filter", 0, filterIndexes.get(filter)),
         series, channelIndex, 0);
+    }
+
+    CrosstalkFilter crosstalk = getCrosstalkFilter(channel);
+    if (crosstalk != null && crosstalk.dichroics.size() == 1 &&
+      dichroicIndexes.containsKey(crosstalk.dichroics.get(0).name))
+    {
+      store.setLightPathDichroicRef(
+        MetadataTools.createLSID(
+          "Dichroic", 0, dichroicIndexes.get(crosstalk.dichroics.get(0).name)),
+        series, channelIndex);
     }
   }
 
@@ -1039,6 +1098,29 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
+  private void populateDichroics(MetadataStore store,
+    HashMap<String, Integer> dichroicIndexes)
+  {
+    if (crosstalkParameters == null) {
+      return;
+    }
+
+    for (CrosstalkFilter filter : crosstalkParameters.filters.values()) {
+      for (CrosstalkDichroic dichroic : filter.dichroics) {
+        if (dichroic.name == null || dichroic.name.trim().length() == 0 ||
+          dichroicIndexes.containsKey(dichroic.name))
+        {
+          continue;
+        }
+        int index = dichroicIndexes.size();
+        dichroicIndexes.put(dichroic.name, index);
+        String dichroicID = MetadataTools.createLSID("Dichroic", 0, index);
+        store.setDichroicID(dichroicID, 0, index);
+        store.setDichroicModel(dichroic.name, 0, index);
+      }
+    }
+  }
+
   private void populateFilters(MetadataStore store,
     HashMap<FilterKey, Integer> filterIndexes)
     throws FormatException
@@ -1057,29 +1139,63 @@ public class CV7000Reader extends FormatReader {
       store.setFilterID(filterID, 0, filter);
       store.setFilterModel(key.acquisition, 0, filter);
       store.setFilterType(MetadataTools.getFilterType(key.detectionFilter.filterType), 0, filter);
+      CrosstalkFilter crosstalk = getCrosstalkFilter(c);
       if (key.detectionFilter != null) {
-        Length cutIn = key.detectionFilter.cutIn == null ?
-          null : FormatTools.getCutIn(key.detectionFilter.cutIn);
-        Length cutOut = key.detectionFilter.cutOut == null ?
-          null : FormatTools.getCutOut(key.detectionFilter.cutOut);
+        Length cutIn = getCrosstalkCutIn(crosstalk);
+        if (cutIn == null && key.detectionFilter.cutIn != null) {
+          cutIn = FormatTools.getCutIn(key.detectionFilter.cutIn);
+        }
+        Length cutOut = getCrosstalkCutOut(crosstalk);
+        if (cutOut == null && key.detectionFilter.cutOut != null) {
+          cutOut = FormatTools.getCutOut(key.detectionFilter.cutOut);
+        }
         if (cutIn != null) {
           store.setTransmittanceRangeCutIn(cutIn, 0, filter);
         }
         if (cutOut != null) {
           store.setTransmittanceRangeCutOut(cutOut, 0, filter);
         }
+        PercentFraction transmittance = getCrosstalkTransmittance(crosstalk);
+        if (transmittance != null) {
+          store.setTransmittanceRangeTransmittance(transmittance, 0, filter);
+        }
       }
     }
+  }
+
+  private Length getCrosstalkCutIn(CrosstalkFilter filter) {
+    return filter == null || filter.minWaveLength == null ?
+      null : FormatTools.getCutIn(filter.minWaveLength);
+  }
+
+  private Length getCrosstalkCutOut(CrosstalkFilter filter) {
+    return filter == null || filter.maxWaveLength == null ?
+      null : FormatTools.getCutOut(filter.maxWaveLength);
+  }
+
+  private PercentFraction getCrosstalkTransmittance(CrosstalkFilter filter) {
+    if (filter == null || filter.averageTransmittance == null) {
+      return null;
+    }
+    double fraction = filter.averageTransmittance / 100.0;
+    if (fraction < 0 || fraction > 1) {
+      LOGGER.debug("Ignoring invalid CV7000 OTF transmittance {}",
+        filter.averageTransmittance);
+      return null;
+    }
+    return new PercentFraction(Float.valueOf((float) fraction));
   }
 
   private void addYokogawaOriginalMetadata() {
     if (allFiles != null) {
       for (String file : allFiles) {
-        if (file != null && !isTiffFile(file)) {
-          addPostProcessOriginalMetadata(file);
-          addRawSidecarMetadata(file);
+        Location location = file == null ? null : new Location(file);
+        CV7000FileRole role = classifyCV7000File(location);
+        if (file != null && isDatasetFile(role) && !isPixelFile(role)) {
+          parseStructuredSidecarMetadata(file, role);
+          addRawSidecarMetadata(file, role);
           addYokogawaMetaList("Yokogawa Sidecar ", "File",
-            new Location(file).getName());
+            location.getName());
         }
       }
     }
@@ -1092,6 +1208,7 @@ public class CV7000Reader extends FormatReader {
         addYokogawaMeta(prefix, "Power", source.power);
       }
     }
+    addCrosstalkOriginalMetadata();
     if (channels == null) {
       return;
     }
@@ -1144,10 +1261,46 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private void addRawSidecarMetadata(String file) {
+  private void addCrosstalkOriginalMetadata() {
+    if (crosstalkParameters == null) {
+      return;
+    }
+
+    int filterIndex = 1;
+    for (CrosstalkFilter filter : crosstalkParameters.filters.values()) {
+      String prefix = "Yokogawa OTF Crosstalk EMFilter " + filterIndex + " ";
+      addYokogawaMeta(prefix, "FilterID", filter.filterID);
+      addYokogawaMeta(prefix, "CameraID", filter.cameraNumber);
+      addYokogawaMeta(prefix, "Acquisition", filter.acquisition);
+      addYokogawaMeta(prefix, "MinWaveLength", filter.minWaveLength);
+      addYokogawaMeta(prefix, "MaxWaveLength", filter.maxWaveLength);
+      addYokogawaMeta(prefix, "AverageTransmittance", filter.averageTransmittance);
+      for (int i=0; i<filter.dichroics.size(); i++) {
+        CrosstalkDichroic dichroic = filter.dichroics.get(i);
+        String dichroicPrefix = prefix + "ISDM " + (i + 1) + " ";
+        addYokogawaMeta(dichroicPrefix, "ID", dichroic.id);
+        addYokogawaMeta(dichroicPrefix, "Name", dichroic.name);
+        addYokogawaMeta(dichroicPrefix, "Reflection", dichroic.reflection);
+        addYokogawaMeta(
+          dichroicPrefix, "AverageTransmittance", dichroic.averageTransmittance);
+      }
+      filterIndex++;
+    }
+
+    for (CrosstalkFluorophore fluorophore : crosstalkParameters.fluorophores) {
+      String prefix = "Yokogawa OTF Crosstalk Fluorophore " +
+        fluorophore.name + " ";
+      for (CrosstalkFluorophoreIntensity intensity : fluorophore.intensities) {
+        addYokogawaMeta(prefix, "Filter " + intensity.filterID + " AverageIntensity",
+          intensity.averageIntensity);
+      }
+    }
+  }
+
+  private void addRawSidecarMetadata(String file, CV7000FileRole role) {
     Location location = new Location(file);
     String name = location.getName();
-    if (name == null || MEASUREMENT_FILE.equals(name) || !isRawXMLSidecar(location)) {
+    if (name == null || !preserveRawXML(role)) {
       return;
     }
 
@@ -1174,30 +1327,82 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private boolean isCV7000DatasetFile(Location file) {
+  private CV7000FileRole classifyCV7000File(Location file) {
+    if (file == null) {
+      return CV7000FileRole.UNKNOWN;
+    }
     String name = file.getName();
-    return name != null && (isTiffFile(name) || isKnownCV7000Sidecar(file));
+    if (name == null) {
+      return CV7000FileRole.UNKNOWN;
+    }
+    if (isTiffFile(name)) {
+      return CV7000FileRole.TIFF_PLANE;
+    }
+    if (isPath(file, currentId)) {
+      return CV7000FileRole.WPI;
+    }
+    if (isPath(file, measurementPath)) {
+      return CV7000FileRole.MEASUREMENT_DATA;
+    }
+    if (isPath(file, detailPath)) {
+      return CV7000FileRole.MEASUREMENT_DETAIL;
+    }
+    if (isPath(file, settingsPath)) {
+      return CV7000FileRole.MEASUREMENT_SETTINGS;
+    }
+    if (isPath(file, wppPath)) {
+      return CV7000FileRole.WELL_PLATE_PRODUCT;
+    }
+    if (datasetPaths != null) {
+      if (isPath(file, datasetPaths.wpiPath)) {
+        return CV7000FileRole.WPI;
+      }
+      if (isPath(file, datasetPaths.measurementData)) {
+        return CV7000FileRole.MEASUREMENT_DATA;
+      }
+      if (isPath(file, datasetPaths.measurementDetail)) {
+        return CV7000FileRole.MEASUREMENT_DETAIL;
+      }
+      if (isPath(file, datasetPaths.postProcess)) {
+        return CV7000FileRole.POST_PROCESS;
+      }
+      if (isPath(file, datasetPaths.otfCrosstalk)) {
+        return CV7000FileRole.OTF_CROSSTALK;
+      }
+      if (isPath(file, datasetPaths.otfGeometry)) {
+        return CV7000FileRole.OTF_GEOMETRY;
+      }
+    }
+    return CV7000FileRole.UNKNOWN;
   }
 
   private boolean isTiffFile(String name) {
     return name != null && checkSuffix(name, new String[] {"tif", "tiff"});
   }
 
-  private boolean isRawXMLSidecar(Location file) {
-    String name = file.getName();
-    return name != null && !MEASUREMENT_FILE.equals(name) &&
-      isKnownCV7000Sidecar(file);
+  private boolean isDatasetFile(CV7000FileRole role) {
+    return role != null && role != CV7000FileRole.UNKNOWN;
   }
 
-  private boolean isKnownCV7000Sidecar(Location file) {
-    String name = file.getName();
-    if (name == null) {
+  private boolean preserveRawXML(CV7000FileRole role) {
+    if (role == null) {
       return false;
     }
-    return isPath(file, currentId) || isPath(file, measurementPath) ||
-      isPath(file, detailPath) || isPath(file, settingsPath) ||
-      isPath(file, wppPath) || POST_PROCESS.equals(name) ||
-      OTF_CROSSTALK_PARAMETER.equals(name) || OTF_GEOMETRY_PARAMETER.equals(name);
+    switch (role) {
+      case WPI:
+      case MEASUREMENT_DETAIL:
+      case MEASUREMENT_SETTINGS:
+      case WELL_PLATE_PRODUCT:
+      case OTF_CROSSTALK:
+      case OTF_GEOMETRY:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private boolean isPixelFile(CV7000FileRole role) {
+    return role == CV7000FileRole.TIFF_PLANE;
   }
 
   private boolean isPath(Location file, String path) {
@@ -1207,11 +1412,20 @@ public class CV7000Reader extends FormatReader {
     return file.getAbsolutePath().equals(new Location(path).getAbsolutePath());
   }
 
-  private void addPostProcessOriginalMetadata(String file) {
-    Location location = new Location(file);
-    if (!POST_PROCESS.equals(location.getName())) {
-      return;
+  private boolean isPath(Location file, Location path) {
+    if (path == null) {
+      return false;
     }
+    return file.getAbsolutePath().equals(path.getAbsolutePath());
+  }
+
+  private void parseStructuredSidecarMetadata(String file, CV7000FileRole role) {
+    if (role == CV7000FileRole.POST_PROCESS) {
+      addPostProcessOriginalMetadata(file);
+    }
+  }
+
+  private void addPostProcessOriginalMetadata(String file) {
     try {
       String xml = readSanitizedXML(file);
       if (xml.length() > 0) {
@@ -1323,6 +1537,14 @@ public class CV7000Reader extends FormatReader {
     return null;
   }
 
+  private CrosstalkFilter getCrosstalkFilter(Channel channel) {
+    if (channel == null || crosstalkParameters == null) {
+      return null;
+    }
+    return crosstalkParameters.filters.get(new CrosstalkFilterKey(
+      channel.filterID, Integer.valueOf(channel.cameraNumber), channel.acquisition));
+  }
+
   private String getBinningValue(String binning) {
     if (binning == null || binning.trim().length() == 0) {
       return null;
@@ -1405,7 +1627,7 @@ public class CV7000Reader extends FormatReader {
     if (value == null || value.trim().length() == 0) {
       return null;
     }
-    return Integer.valueOf(value);
+    return Integer.valueOf(value.trim());
   }
 
   private int getChannelIndex(Plane p) {
@@ -1536,12 +1758,28 @@ public class CV7000Reader extends FormatReader {
 
   // -- Helper classes --
 
+  private enum CV7000FileRole {
+    TIFF_PLANE,
+    WPI,
+    MEASUREMENT_DATA,
+    MEASUREMENT_DETAIL,
+    MEASUREMENT_SETTINGS,
+    WELL_PLATE_PRODUCT,
+    POST_PROCESS,
+    OTF_CROSSTALK,
+    OTF_GEOMETRY,
+    UNKNOWN
+  }
+
   /** Resolved dataset paths used during the parsing phase. */
   class DatasetPaths {
     public Location parent;
     public String wpiPath;
     public Location measurementData;
     public Location measurementDetail;
+    public Location postProcess;
+    public Location otfCrosstalk;
+    public Location otfGeometry;
   }
 
   /** Intermediate layout data used to translate Yokogawa records into series. */
@@ -1563,6 +1801,8 @@ public class CV7000Reader extends FormatReader {
       new HashMap<Integer, Integer>();
     public HashMap<FilterKey, Integer> filterIndexes =
       new HashMap<FilterKey, Integer>();
+    public HashMap<String, Integer> dichroicIndexes =
+      new HashMap<String, Integer>();
     public List<String> usedObjectiveIDs = new ArrayList<String>();
   }
 
@@ -2067,6 +2307,166 @@ public class CV7000Reader extends FormatReader {
 
   }
 
+  class CrosstalkParameterHandler extends BaseHandler {
+    private CrosstalkParameters parameters = new CrosstalkParameters();
+    private CrosstalkFilter currentFilter;
+    private CrosstalkFluorophore currentFluorophore;
+
+    public CrosstalkParameters getParameters() {
+      return parameters;
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      String name = getYokogawaAttributeName(qName);
+      if ("EMFilter".equals(name)) {
+        currentFilter = new CrosstalkFilter();
+        currentFilter.filterID = getAttribute(attributes, "FilterID");
+        currentFilter.cameraNumber = DataTools.parseInteger(
+          getAttribute(attributes, "CameraID"));
+        currentFilter.acquisition = getAttribute(attributes, "Acquisition");
+        currentFilter.averageTransmittance = DataTools.parseDouble(
+          getAttribute(attributes, "AverageTransmittance"));
+        currentFilter.minWaveLength = DataTools.parseDouble(
+          getAttribute(attributes, "MinWaveLength"));
+        currentFilter.maxWaveLength = DataTools.parseDouble(
+          getAttribute(attributes, "MaxWaveLength"));
+        parameters.addFilter(currentFilter);
+      }
+      else if ("ISDM".equals(name) && currentFilter != null) {
+        CrosstalkDichroic dichroic = new CrosstalkDichroic();
+        dichroic.id = getAttribute(attributes, "ID");
+        dichroic.name = getAttribute(attributes, "Name");
+        dichroic.reflection = getAttribute(attributes, "Reflection");
+        dichroic.averageTransmittance = DataTools.parseDouble(
+          getAttribute(attributes, "AverageTransmittance"));
+        currentFilter.dichroics.add(dichroic);
+      }
+      else if ("Fluorophore".equals(name)) {
+        currentFluorophore = new CrosstalkFluorophore();
+        currentFluorophore.name = getAttribute(attributes, "Name");
+        parameters.fluorophores.add(currentFluorophore);
+      }
+      else if ("FluorophoreIntensity".equals(name) && currentFluorophore != null) {
+        CrosstalkFluorophoreIntensity intensity =
+          new CrosstalkFluorophoreIntensity();
+        intensity.filterID = getAttribute(attributes, "FilterID");
+        intensity.averageIntensity = DataTools.parseDouble(
+          getAttribute(attributes, "AverageIntensity"));
+        currentFluorophore.intensities.add(intensity);
+      }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+      String name = getYokogawaAttributeName(qName);
+      if ("EMFilter".equals(name)) {
+        currentFilter = null;
+      }
+      else if ("Fluorophore".equals(name)) {
+        currentFluorophore = null;
+      }
+    }
+
+    private String getAttribute(Attributes attributes, String name) {
+      if (attributes == null || name == null) {
+        return null;
+      }
+      for (int i=0; i<attributes.getLength(); i++) {
+        if (name.equals(getYokogawaAttributeName(attributes.getQName(i)))) {
+          String value = attributes.getValue(i);
+          return value == null || value.trim().length() == 0 ? null : value;
+        }
+      }
+      return null;
+    }
+  }
+
+  class CrosstalkParameters {
+    public LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter> filters =
+      new LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter>();
+    public ArrayList<CrosstalkFluorophore> fluorophores =
+      new ArrayList<CrosstalkFluorophore>();
+
+    public void addFilter(CrosstalkFilter filter) {
+      filters.put(new CrosstalkFilterKey(
+        filter.filterID, filter.cameraNumber, filter.acquisition), filter);
+    }
+  }
+
+  class CrosstalkFilter {
+    public String filterID;
+    public Integer cameraNumber;
+    public String acquisition;
+    public Double averageTransmittance;
+    public Double minWaveLength;
+    public Double maxWaveLength;
+    public ArrayList<CrosstalkDichroic> dichroics =
+      new ArrayList<CrosstalkDichroic>();
+  }
+
+  class CrosstalkDichroic {
+    public String id;
+    public String name;
+    public String reflection;
+    public Double averageTransmittance;
+  }
+
+  class CrosstalkFluorophore {
+    public String name;
+    public ArrayList<CrosstalkFluorophoreIntensity> intensities =
+      new ArrayList<CrosstalkFluorophoreIntensity>();
+  }
+
+  class CrosstalkFluorophoreIntensity {
+    public String filterID;
+    public Double averageIntensity;
+  }
+
+  class CrosstalkFilterKey {
+    public String filterID;
+    public Integer cameraNumber;
+    public String acquisition;
+
+    public CrosstalkFilterKey(String filterID, Integer cameraNumber,
+      String acquisition)
+    {
+      this.filterID = filterID;
+      this.cameraNumber = cameraNumber;
+      this.acquisition = acquisition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof CrosstalkFilterKey)) {
+        return false;
+      }
+      CrosstalkFilterKey key = (CrosstalkFilterKey) o;
+      return same(filterID, key.filterID) &&
+        same(cameraNumber, key.cameraNumber) &&
+        same(acquisition, key.acquisition);
+    }
+
+    @Override
+    public int hashCode() {
+      int code = 17;
+      code = 31 * code + hash(filterID);
+      code = 31 * code + hash(cameraNumber);
+      code = 31 * code + hash(acquisition);
+      return code;
+    }
+
+    private boolean same(Object a, Object b) {
+      return a == null ? b == null : a.equals(b);
+    }
+
+    private int hash(Object value) {
+      return value == null ? 0 : value.hashCode();
+    }
+  }
+
   class LightSource {
     public String name;
     public String type;
@@ -2110,6 +2510,7 @@ public class CV7000Reader extends FormatReader {
   class FilterKey {
     public String filterID;
     public String acquisition;
+    public int cameraNumber;
     public Integer filterWheelPosition;
     public Integer filterPosition;
     public DetectionFilter detectionFilter;
@@ -2117,6 +2518,7 @@ public class CV7000Reader extends FormatReader {
     public FilterKey(Channel ch) {
       filterID = ch.filterID;
       acquisition = ch.acquisition;
+      cameraNumber = ch.cameraNumber;
       filterWheelPosition = ch.filterWheelPosition;
       filterPosition = ch.filterPosition;
       detectionFilter = ch.detectionFilter;
@@ -2134,6 +2536,7 @@ public class CV7000Reader extends FormatReader {
       FilterKey key = (FilterKey) o;
       return same(filterID, key.filterID) &&
         same(acquisition, key.acquisition) &&
+        cameraNumber == key.cameraNumber &&
         same(filterWheelPosition, key.filterWheelPosition) &&
         same(filterPosition, key.filterPosition);
     }
@@ -2143,6 +2546,7 @@ public class CV7000Reader extends FormatReader {
       int code = 17;
       code = 31 * code + hash(filterID);
       code = 31 * code + hash(acquisition);
+      code = 31 * code + cameraNumber;
       code = 31 * code + hash(filterWheelPosition);
       code = 31 * code + hash(filterPosition);
       return code;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -625,6 +625,11 @@ public class CV7000Reader extends FormatReader {
       for (int i=0; i<getSeriesCount(); i++) {
         setSeries(i);
         if (channels != null) {
+          Length physicalSizeZ = getPhysicalSizeZ(i);
+          if (physicalSizeZ != null) {
+            store.setPixelsPhysicalSizeZ(physicalSizeZ, i);
+          }
+
           boolean physicalSizeSet = false;
           for (int c=0; c<getSizeC(); c++) {
             Plane p = lookupRepresentativePlane(i, c);
@@ -728,6 +733,29 @@ public class CV7000Reader extends FormatReader {
       }
     }
     return index;
+  }
+
+  private Length getPhysicalSizeZ(int series) {
+    Double physicalSizeZ = null;
+    boolean foundChannel = false;
+    for (int c=0; c<getSizeC(); c++) {
+      Plane p = lookupRepresentativePlane(series, c);
+      if (p == null) {
+        continue;
+      }
+      Channel channel = lookupChannel(p);
+      if (channel == null || channel.physicalSizeZ == null) {
+        return null;
+      }
+      foundChannel = true;
+      if (physicalSizeZ == null) {
+        physicalSizeZ = channel.physicalSizeZ;
+      }
+      else if (Math.abs(physicalSizeZ - channel.physicalSizeZ) > 0.000001) {
+        return null;
+      }
+    }
+    return foundChannel ? FormatTools.getPhysicalSizeZ(physicalSizeZ) : null;
   }
 
   private Channel lookupChannel(Plane p) {
@@ -988,6 +1016,7 @@ public class CV7000Reader extends FormatReader {
     private int currentChannelIndex = -1;
     private int timelineIndex = -1;
     private int actionIndex = -1;
+    private Double currentPhysicalSizeZ;
 
     // -- DefaultHandler API methods --
 
@@ -1069,9 +1098,12 @@ public class CV7000Reader extends FormatReader {
       else if (qName.equals("bts:Timeline")) {
         timelineIndex++;
         actionIndex = -1;
+        currentPhysicalSizeZ = null;
       }
       else if (qName.startsWith("bts:ActionAcquire")) {
         actionIndex++;
+        currentPhysicalSizeZ = DataTools.parseDouble(
+          attributes.getValue("bts:SliceLength"));
       }
     }
 
@@ -1105,14 +1137,19 @@ public class CV7000Reader extends FormatReader {
           if (ch.timelineIndex == -1 && ch.actionIndex == -1) {
             ch.timelineIndex = timelineIndex;
             ch.actionIndex = actionIndex;
+            ch.physicalSizeZ = currentPhysicalSizeZ;
           }
           else {
             Channel duplicate = new Channel(ch);
             duplicate.timelineIndex = timelineIndex;
             duplicate.actionIndex = actionIndex;
+            duplicate.physicalSizeZ = currentPhysicalSizeZ;
             channels.add(duplicate);
           }
         }
+      }
+      else if (qName.startsWith("bts:ActionAcquire")) {
+        currentPhysicalSizeZ = null;
       }
     }
 
@@ -1158,6 +1195,7 @@ public class CV7000Reader extends FormatReader {
     public String objective;
     public Double magnification;
     public Double exposureTime;
+    public Double physicalSizeZ;
     public String binning;
     public Color color;
 
@@ -1178,6 +1216,7 @@ public class CV7000Reader extends FormatReader {
       objective = ch.objective;
       magnification = ch.magnification;
       exposureTime = ch.exposureTime;
+      physicalSizeZ = ch.physicalSizeZ;
       binning = ch.binning;
       color = ch.color;
       fluor = ch.fluor;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -96,6 +96,19 @@ public class CV7000Reader extends FormatReader {
   private static final String YOKOGAWA_ANNOTATION_NAMESPACE =
     "openmicroscopy.org/OriginalMetadata/Yokogawa/CV7000";
   private static final String XML_MIME_TYPE = "application/xml";
+  // Manual objective table plus observed CV7000 objective labels in OTF geometry. These correctly resolve known objectives in local data and available data from public repositories.
+  private static final KnownObjectiveSpec[] KNOWN_OBJECTIVES =
+    new KnownObjectiveSpec[] {
+      new KnownObjectiveSpec(4, false, false, "Air", 0.16),
+      new KnownObjectiveSpec(10, false, false, "Air", 0.40),
+      new KnownObjectiveSpec(20, false, false, "Air", 0.75),
+      new KnownObjectiveSpec(40, false, false, "Air", 0.95),
+      new KnownObjectiveSpec(60, false, false, "Water", 1.2),
+      new KnownObjectiveSpec(20, false, true, "Air", 0.45),
+      new KnownObjectiveSpec(10, true, false, "Air", 0.30),
+      new KnownObjectiveSpec(20, true, false, "Air", 0.45),
+      new KnownObjectiveSpec(20, true, true, "Air", 0.45)
+    };
 
   // -- Fields --
 
@@ -339,8 +352,6 @@ public class CV7000Reader extends FormatReader {
     CV7000DatasetPaths paths = getDatasetPaths(id);
     datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
-    rawModel.paths = paths;
-    rawModel.plate = plate;
 
     parseMeasurementData(paths);
     parseOptionalSidecars(paths);
@@ -351,7 +362,7 @@ public class CV7000Reader extends FormatReader {
     seriesLayout = layout;
     initializeCoreMetadata(layout);
     populateReversePlaneLookup(layout);
-    new CV7000MetadataPopulator().populate(plate, layout);
+    populateMetadataStore(plate, layout);
     setSeries(0);
   }
 
@@ -385,7 +396,6 @@ public class CV7000Reader extends FormatReader {
         isDatasetFile(classifyCV7000File(file)))
       {
         allFiles.add(file.getAbsolutePath());
-        rawModel.addFile(file.getAbsolutePath());
       }
     }
   }
@@ -399,12 +409,9 @@ public class CV7000Reader extends FormatReader {
     }
 
     measurementPath = paths.measurementData.getAbsolutePath();
-    rawModel.measurementPath = measurementPath;
     measurementHandler = new MeasurementDataHandler(paths.parent.getAbsolutePath());
     XMLTools.parseXML(readSanitizedXML(measurementPath), measurementHandler);
     planeData = measurementHandler.getPlanes();
-    rawModel.measurementHandler = measurementHandler;
-    rawModel.planes = planeData;
   }
 
   /** Parse optional XML sidecars that enrich channel, instrument, and raw metadata. */
@@ -423,19 +430,22 @@ public class CV7000Reader extends FormatReader {
       return;
     }
 
-    channels = new ArrayList<Channel>();
-    rawModel.channels = channels;
     detailPath = paths.measurementDetail.getAbsolutePath();
-    rawModel.detailPath = detailPath;
     MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
     XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
+    MeasurementDetailResult result = detailHandler.getResult();
+    channels = result.channels;
+    startTime = result.startTime;
+    endTime = result.endTime;
+    measurementOperatorName = result.measurementOperatorName;
+    targetSystem = result.targetSystem;
+    wppPath = result.wppPath;
+    settingsPath = result.settingsPath;
     if (wppPath != null) {
       wppPath = new Location(paths.parent, wppPath).getAbsolutePath();
-      rawModel.wppPath = wppPath;
     }
     if (settingsPath != null) {
       settingsPath = new Location(paths.parent, settingsPath).getAbsolutePath();
-      rawModel.settingsPath = settingsPath;
     }
   }
 
@@ -449,13 +459,14 @@ public class CV7000Reader extends FormatReader {
   /** Measurement settings attach light sources, actions, filters, and channel modes. */
   private void parseMeasurementSettings() throws IOException {
     if (settingsPath != null && new Location(settingsPath).exists()) {
-      lightSources = new ArrayList<LightSource>();
-      rawModel.lightSources = lightSources;
-      MeasurementSettingsHandler settingsHandler = new MeasurementSettingsHandler();
+      MeasurementSettingsHandler settingsHandler =
+        new MeasurementSettingsHandler(channels);
       String xml = readSanitizedXML(settingsPath);
       if (xml.length() > 0) {
         XMLTools.parseXML(xml, settingsHandler);
       }
+      MeasurementSettingsResult result = settingsHandler.getResult();
+      lightSources = result.lightSources;
     }
   }
 
@@ -470,11 +481,9 @@ public class CV7000Reader extends FormatReader {
       OTFGeometryHandler handler = new OTFGeometryHandler();
       XMLTools.parseXML(readSanitizedXML(geometry.getAbsolutePath()), handler);
       otfGeometryParameters = handler.getParameters();
-      rawModel.otfGeometryParameters = otfGeometryParameters;
     }
     catch (Exception e) {
       otfGeometryParameters = null;
-      rawModel.otfGeometryParameters = null;
       LOGGER.warn("Could not parse CV7000 OTF geometry sidecar {}",
         geometry.getAbsolutePath(), e);
     }
@@ -491,11 +500,9 @@ public class CV7000Reader extends FormatReader {
       CrosstalkParameterHandler handler = new CrosstalkParameterHandler();
       XMLTools.parseXML(readSanitizedXML(crosstalk.getAbsolutePath()), handler);
       crosstalkParameters = handler.getParameters();
-      rawModel.crosstalkParameters = crosstalkParameters;
     }
     catch (Exception e) {
       crosstalkParameters = null;
-      rawModel.crosstalkParameters = null;
       LOGGER.warn("Could not parse CV7000 crosstalk sidecar {}", crosstalk.getAbsolutePath(), e);
     }
   }
@@ -506,7 +513,7 @@ public class CV7000Reader extends FormatReader {
       return;
     }
     sortChannelsByActionThenIndex();
-    rawModel.indexChannels();
+    rawModel.indexChannels(channels);
     resolveCorrectionFiles(parent);
   }
 
@@ -702,17 +709,17 @@ public class CV7000Reader extends FormatReader {
       if ((existing == null || existing.file == null) && p.file != null) {
         reversePlaneLookup[p.series][p.no] = planeIndex;
         layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
-          existing, existingIndex, p, "REPLACED_BY_TIFF"));
+          existing, p, "REPLACED_BY_TIFF"));
       }
       else if (p.file != null) {
         LOGGER.warn("Ignoring file {}", p.file);
         extraFiles.add(p.file);
         layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
-          p, planeIndex, existing, "IGNORED_TIFF_DUPLICATE"));
+          p, existing, "IGNORED_TIFF_DUPLICATE"));
       }
       else {
         layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
-          p, planeIndex, existing, "IGNORED_METADATA_ONLY_DUPLICATE"));
+          p, existing, "IGNORED_METADATA_ONLY_DUPLICATE"));
       }
     }
   }
@@ -739,7 +746,7 @@ public class CV7000Reader extends FormatReader {
       populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
         indexes.detectorIndexes, indexes.filterIndexes, indexes.dichroicIndexes,
         indexes.usedObjectiveIDs, experimenter, timings);
-      new CV7000OriginalMetadataPopulator().populate(store, indexes.instrument != null);
+      addYokogawaOriginalMetadata(store, indexes.instrument != null);
       setSeries(0);
     }
   }
@@ -1359,10 +1366,15 @@ public class CV7000Reader extends FormatReader {
     if (model != null) {
       store.setObjectiveModel(model, 0, objectiveIndex);
     }
-    if (magnification != null) {
-      store.setObjectiveNominalMagnification(magnification, 0, objectiveIndex);
+    CV7000ObjectiveSpec spec = getObjectiveSpec(model);
+    Double nominalMagnification = magnification;
+    if (nominalMagnification == null && spec != null) {
+      nominalMagnification = spec.magnification;
     }
-    CV7000ObjectiveSpec spec = getObjectiveSpec(objectiveID, model);
+    if (nominalMagnification != null) {
+      store.setObjectiveNominalMagnification(
+        nominalMagnification, 0, objectiveIndex);
+    }
     if (spec == null) {
       return;
     }
@@ -1381,40 +1393,19 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private CV7000ObjectiveSpec getObjectiveSpec(String objectiveID, String model) {
-    // CV7000 objective NA and immersion values come from the user manual,
-    // section 14, "MS Code" / "Objective Lens".
+  private CV7000ObjectiveSpec getObjectiveSpec(String model) {
     ObjectiveModelTokens tokens = parseObjectiveModel(model);
-    if (isObjectiveMagnification(tokens, 4) ||
-      (tokens.magnification == null && "4000".equals(objectiveID)))
-    {
-      return new CV7000ObjectiveSpec(0.16, "Air");
+
+    for (KnownObjectiveSpec known : KNOWN_OBJECTIVES) {
+      if (known.matches(tokens)) {
+        return known.toObjectiveSpec();
+      }
     }
-    if (isObjectiveMagnification(tokens, 10)) {
-      return new CV7000ObjectiveSpec(tokens.phase ? 0.30 : 0.40, "Air");
-    }
-    if (tokens.magnification == null && "10000".equals(objectiveID)) {
-      return new CV7000ObjectiveSpec(0.40, "Air");
-    }
-    if (isObjectiveMagnification(tokens, 20)) {
-      return new CV7000ObjectiveSpec(
-        tokens.phase || tokens.longWorkingDistance ? 0.45 : 0.75, "Air");
-    }
-    if (tokens.magnification == null && "20003".equals(objectiveID)) {
-      return new CV7000ObjectiveSpec(0.45, "Air");
-    }
-    if (tokens.magnification == null && "20000".equals(objectiveID)) {
-      return new CV7000ObjectiveSpec(0.75, "Air");
-    }
-    if (isObjectiveMagnification(tokens, 40) ||
-      (tokens.magnification == null && "40000".equals(objectiveID)))
-    {
-      return new CV7000ObjectiveSpec(0.95, "Air");
-    }
-    if (isObjectiveMagnification(tokens, 60) ||
-      (tokens.magnification == null && "60004".equals(objectiveID)))
-    {
-      return new CV7000ObjectiveSpec(1.2, "Water");
+
+    if (tokens.magnification != null || tokens.immersion != null) {
+      Double magnification = tokens.magnification == null ?
+        null : Double.valueOf(tokens.magnification.doubleValue());
+      return new CV7000ObjectiveSpec(magnification, null, tokens.immersion);
     }
     return null;
   }
@@ -1429,31 +1420,26 @@ public class CV7000Reader extends FormatReader {
     normalized = normalized.replaceAll("[^a-z0-9]+", " ").trim();
     normalized = normalized.replaceAll("\\s+", " ");
     String[] parts = normalized.split(" ");
-    for (String part : parts) {
+    for (int i=0; i<parts.length; i++) {
+      String part = parts[i];
       if (part.endsWith("x") && part.length() > 1) {
         tokens.magnification = parseInteger(part.substring(0, part.length() - 1));
       }
       if ("ph".equals(part) || "phase".equals(part)) {
         tokens.phase = true;
       }
-      if ("lwd".equals(part) || "long".equals(part)) {
+      if ("lwd".equals(part) || "wd".equals(part) || "long".equals(part)) {
         tokens.longWorkingDistance = true;
       }
-      if ("water".equals(part)) {
-        tokens.water = true;
+      if ("w".equals(part) && i + 1 < parts.length && "d".equals(parts[i + 1])) {
+        tokens.longWorkingDistance = true;
+        i++;
       }
-      if ("w".equals(part)) {
-        tokens.water = true;
+      else if ("w".equals(part)) {
+        tokens.immersion = "Water";
       }
     }
     return tokens;
-  }
-
-  private boolean isObjectiveMagnification(ObjectiveModelTokens tokens,
-    int magnification)
-  {
-    return tokens != null && tokens.magnification != null &&
-      tokens.magnification.intValue() == magnification;
   }
 
   private void populateDetectors(MetadataStore store,
@@ -1745,7 +1731,7 @@ public class CV7000Reader extends FormatReader {
       addYokogawaMeta(prefix, "Objective", objective.objective);
       addYokogawaMeta(prefix, "Magnification", objective.magnification);
       CV7000ObjectiveSpec spec =
-        getObjectiveSpec(objective.objectiveID, objective.objective);
+        getObjectiveSpec(objective.objective);
       if (spec != null) {
         addYokogawaMeta(prefix, "MappedLensNA", spec.lensNA);
         addYokogawaMeta(prefix, "MappedImmersion", spec.immersion);
@@ -1815,12 +1801,12 @@ public class CV7000Reader extends FormatReader {
     }
 
     try {
-      byte[] bytes = readSidecarBytes(file);
+      SidecarSummary summary = summarizeSidecar(file);
       String prefix = "Yokogawa Sidecar " + name + " ";
 
       addYokogawaMeta(prefix, "Role", role.name());
-      addYokogawaMeta(prefix, "ByteLength", bytes.length);
-      addYokogawaMeta(prefix, "SHA-256", sha256(bytes));
+      addYokogawaMeta(prefix, "ByteLength", summary.byteLength);
+      addYokogawaMeta(prefix, "SHA-256", summary.sha256);
     }
     catch (IOException e) {
       LOGGER.debug("Could not summarize CV7000 sidecar {}", file, e);
@@ -1856,6 +1842,26 @@ public class CV7000Reader extends FormatReader {
       LOGGER.debug("Could not preserve raw CV7000 sidecar {}", file, e);
     }
     return null;
+  }
+
+  private SidecarSummary summarizeSidecar(String file) throws IOException {
+    RandomAccessInputStream stream = new RandomAccessInputStream(file);
+    try {
+      long length = stream.length();
+      MessageDigest digest = createSHA256Digest();
+      byte[] buffer = new byte[8192];
+      long remaining = length;
+      while (remaining > 0) {
+        int count = (int) Math.min(buffer.length, remaining);
+        stream.readFully(buffer, 0, count);
+        digest.update(buffer, 0, count);
+        remaining -= count;
+      }
+      return new SidecarSummary(length, toHex(digest.digest()));
+    }
+    finally {
+      stream.close();
+    }
   }
 
   private byte[] readSidecarBytes(String file) throws IOException {
@@ -1990,11 +1996,11 @@ public class CV7000Reader extends FormatReader {
     }
 
     try {
-      byte[] bytes = readSidecarBytes(measurementPath);
+      SidecarSummary summary = summarizeSidecar(measurementPath);
       addYokogawaMeta("Yokogawa MLF ", "File", new Location(measurementPath).getName());
       addYokogawaMeta("Yokogawa MLF ", "Encoding", "UTF-8");
-      addYokogawaMeta("Yokogawa MLF ", "ByteLength", bytes.length);
-      addYokogawaMeta("Yokogawa MLF ", "SHA-256", sha256(bytes));
+      addYokogawaMeta("Yokogawa MLF ", "ByteLength", summary.byteLength);
+      addYokogawaMeta("Yokogawa MLF ", "SHA-256", summary.sha256);
     }
     catch (IOException e) {
       LOGGER.debug("Could not summarize CV7000 measurement data {}", measurementPath, e);
@@ -2014,23 +2020,25 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private String sha256(byte[] bytes) {
+  private MessageDigest createSHA256Digest() {
     try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(bytes);
-      StringBuilder hex = new StringBuilder(hash.length * 2);
-      for (byte b : hash) {
-        String value = Integer.toHexString(b & 0xff);
-        if (value.length() == 1) {
-          hex.append('0');
-        }
-        hex.append(value);
-      }
-      return hex.toString();
+      return MessageDigest.getInstance("SHA-256");
     }
     catch (NoSuchAlgorithmException e) {
       throw new RuntimeException("SHA-256 not available", e);
     }
+  }
+
+  private String toHex(byte[] bytes) {
+    StringBuilder hex = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      String value = Integer.toHexString(b & 0xff);
+      if (value.length() == 1) {
+        hex.append('0');
+      }
+      hex.append(value);
+    }
+    return hex.toString();
   }
 
   private void emitYokogawaMapAnnotations(MetadataStore store,
@@ -2581,7 +2589,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Resolved dataset paths used during the parsing phase. */
-  class CV7000DatasetPaths {
+  private static class CV7000DatasetPaths {
     public Location parent;
     public String wpiPath;
     public Location measurementData;
@@ -2592,38 +2600,14 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Parsed Yokogawa sidecars and reader-local provenance. */
-  class CV7000RawModel {
-    public CV7000DatasetPaths paths;
-    public WPIHandler plate;
-    public ArrayList<Plane> planes = new ArrayList<Plane>();
-    public ArrayList<LightSource> lightSources;
-    public ArrayList<Channel> channels;
-    public String startTime;
-    public String endTime;
-    public String wppPath;
-    public String detailPath;
-    public String measurementPath;
-    public String settingsPath;
-    public MeasurementDataHandler measurementHandler;
-    public CrosstalkParameters crosstalkParameters;
-    public OTFGeometryParameters otfGeometryParameters;
-    public ArrayList<String> allFiles = new ArrayList<String>();
+  private static class CV7000RawModel {
     public YokogawaOriginalMetadata originalMetadata =
       new YokogawaOriginalMetadata();
     private HashMap<ChannelKey, Channel> channelsByAcquisition =
       new HashMap<ChannelKey, Channel>();
-    private HashMap<Integer, ArrayList<Channel>> channelsByRawIndex =
-      new HashMap<Integer, ArrayList<Channel>>();
 
-    public void addFile(String file) {
-      if (file != null && !allFiles.contains(file)) {
-        allFiles.add(file);
-      }
-    }
-
-    public void indexChannels() {
+    public void indexChannels(ArrayList<Channel> channels) {
       channelsByAcquisition.clear();
-      channelsByRawIndex.clear();
       if (channels == null) {
         return;
       }
@@ -2633,13 +2617,6 @@ public class CV7000Reader extends FormatReader {
         if (!channelsByAcquisition.containsKey(key)) {
           channelsByAcquisition.put(key, channel);
         }
-        Integer rawIndex = Integer.valueOf(channel.index);
-        ArrayList<Channel> rawChannels = channelsByRawIndex.get(rawIndex);
-        if (rawChannels == null) {
-          rawChannels = new ArrayList<Channel>();
-          channelsByRawIndex.put(rawIndex, rawChannels);
-        }
-        rawChannels.add(channel);
       }
     }
 
@@ -2650,13 +2627,13 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Grouped Yokogawa metadata pending OME MapAnnotation emission. */
-  class YokogawaOriginalMetadata {
+  private static class YokogawaOriginalMetadata {
     public LinkedHashMap<String, YokogawaAnnotationGroup> groups =
       new LinkedHashMap<String, YokogawaAnnotationGroup>();
   }
 
   /** Intermediate layout data used to translate Yokogawa records into series. */
-  class CV7000SeriesLayout {
+  private static class CV7000SeriesLayout {
     public String firstFile;
     public ArrayList<Field> acquiredFields = new ArrayList<Field>();
     public HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
@@ -2700,23 +2677,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  /** Standard OME metadata population entrypoint. */
-  class CV7000MetadataPopulator {
-    public void populate(WPIHandler plate, CV7000SeriesLayout layout)
-      throws FormatException
-    {
-      populateMetadataStore(plate, layout);
-    }
-  }
-
-  /** Yokogawa-specific annotation and sidecar provenance entrypoint. */
-  class CV7000OriginalMetadataPopulator {
-    public void populate(MetadataStore store, boolean hasInstrument) {
-      addYokogawaOriginalMetadata(store, hasInstrument);
-    }
-  }
-
-  class ChannelKey {
+  private static class ChannelKey {
     public int timelineIndex;
     public int actionIndex;
     public int channelIndex;
@@ -2748,7 +2709,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Shared Yokogawa parsing and normalization helpers. */
-  class YokogawaParsing {
+  private static class YokogawaParsing {
     public String readSanitizedXML(String filename) throws IOException {
       String xml = DataTools.readFile(filename).trim();
       if (xml.endsWith(">>")) {
@@ -2848,7 +2809,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** OME instrument indexes shared by channel metadata population. */
-  class InstrumentMetadataIndexes {
+  private static class InstrumentMetadataIndexes {
     public String instrument;
     public HashMap<Integer, Integer> lightSourceIndexes =
       new HashMap<Integer, Integer>();
@@ -2861,7 +2822,7 @@ public class CV7000Reader extends FormatReader {
     public List<String> usedObjectiveIDs = new ArrayList<String>();
   }
 
-  class AnnotationRefIndexes {
+  private static class AnnotationRefIndexes {
     public int plate;
     public int instrument;
     private HashMap<Integer, Integer> imageRefs =
@@ -2886,7 +2847,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class PlaneProvenanceSummary {
+  private static class PlaneProvenanceSummary {
     public int planeCount;
     public int tiffBackedCount;
     public int filledCount;
@@ -2897,23 +2858,21 @@ public class CV7000Reader extends FormatReader {
     public ArrayList<String> anomalies = new ArrayList<String>();
   }
 
-  class DuplicatePlaneCandidate {
+  private static class DuplicatePlaneCandidate {
     public Plane candidate;
-    public int candidateIndex;
     public Plane selected;
     public String reason;
 
-    public DuplicatePlaneCandidate(Plane candidate, int candidateIndex,
-      Plane selected, String reason)
+    public DuplicatePlaneCandidate(Plane candidate, Plane selected,
+      String reason)
     {
       this.candidate = candidate;
-      this.candidateIndex = candidateIndex;
       this.selected = selected;
       this.reason = reason;
     }
   }
 
-  class YokogawaAnnotationGroup {
+  private static class YokogawaAnnotationGroup {
     public String scope;
     private LinkedHashMap<String, String> values =
       new LinkedHashMap<String, String>();
@@ -2929,7 +2888,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     public void put(String name, Object value) {
-      String key = clean(name);
+      String key = cleanText(name);
       String text = cleanValue(value);
       if (key == null || text == null) {
         return;
@@ -2943,7 +2902,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     public void putList(String name, Object value) {
-      String key = clean(name);
+      String key = cleanText(name);
       String text = cleanValue(value);
       if (key == null || text == null) {
         return;
@@ -2970,14 +2929,46 @@ public class CV7000Reader extends FormatReader {
       String text = String.valueOf(value);
       return text.trim().length() == 0 ? null : text;
     }
+
+    private String cleanText(String value) {
+      if (value == null) {
+        return null;
+      }
+      String trimmed = value.trim();
+      return trimmed.length() == 0 ? null : trimmed;
+    }
   }
 
-  class SeriesTiming {
+  private static class SeriesTiming {
     public Long startMillis;
     public String startTimestamp;
   }
 
-  class WPIHandler extends BaseHandler {
+  private static class SidecarSummary {
+    public long byteLength;
+    public String sha256;
+
+    public SidecarSummary(long byteLength, String sha256) {
+      this.byteLength = byteLength;
+      this.sha256 = sha256;
+    }
+  }
+
+  private static class MeasurementDetailResult {
+    public ArrayList<Channel> channels = new ArrayList<Channel>();
+    public String wppPath;
+    public String settingsPath;
+    public String startTime;
+    public String endTime;
+    public String measurementOperatorName;
+    public String targetSystem;
+  }
+
+  private static class MeasurementSettingsResult {
+    public ArrayList<LightSource> lightSources = new ArrayList<LightSource>();
+  }
+
+  private class WPIHandler extends BaseHandler {
     private int plateRows;
     private int plateColumns;
     private String name;
@@ -3019,7 +3010,7 @@ public class CV7000Reader extends FormatReader {
 
   }
 
-  class MeasurementDataHandler extends BaseHandler {
+  private class MeasurementDataHandler extends BaseHandler {
     private StringBuffer currentValue = new StringBuffer();
     private String btsType;
     private ArrayList<Plane> planes = new ArrayList<Plane>();
@@ -3029,8 +3020,6 @@ public class CV7000Reader extends FormatReader {
     private String lastTimestamp;
     private String firstAction;
     private String lastAction;
-
-    private int currentField = -1;
 
     public MeasurementDataHandler(String parentDir) {
       super();
@@ -3091,10 +3080,6 @@ public class CV7000Reader extends FormatReader {
           p.actionIndex = Integer.parseInt(attributes.getValue("bts:ActionIndex")) - 1;
           p.timelineIndex = Integer.parseInt(attributes.getValue("bts:TimelineIndex")) - 1;
 
-          if (p.field.field != currentField) {
-            currentField = p.field.field;
-          }
-
           p.xpos = DataTools.parseDouble(attributes.getValue("bts:X"));
           p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
           p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
@@ -3137,7 +3122,12 @@ public class CV7000Reader extends FormatReader {
 
   }
 
-  class MeasurementDetailHandler extends BaseHandler {
+  private class MeasurementDetailHandler extends BaseHandler {
+    private MeasurementDetailResult result = new MeasurementDetailResult();
+
+    public MeasurementDetailResult getResult() {
+      return result;
+    }
 
     // -- DefaultHandler API methods --
 
@@ -3147,11 +3137,10 @@ public class CV7000Reader extends FormatReader {
     {
       if (qName.equals("bts:MeasurementSamplePlate")) {
         addYokogawaAttributes("Yokogawa MRF MeasurementSamplePlate ", attributes);
-        wppPath = attributes.getValue("bts:WellPlateProductFileName");
-        if (wppPath != null && wppPath.trim().length() == 0) {
-          wppPath = null;
+        result.wppPath = attributes.getValue("bts:WellPlateProductFileName");
+        if (result.wppPath != null && result.wppPath.trim().length() == 0) {
+          result.wppPath = null;
         }
-        rawModel.wppPath = wppPath;
       }
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
@@ -3171,33 +3160,31 @@ public class CV7000Reader extends FormatReader {
         if (c.correctionFile != null && c.correctionFile.trim().length() == 0) {
           c.correctionFile = null;
         }
-        channels.add(c);
+        result.channels.add(c);
       }
       else if (qName.equals("bts:MeasurementDetail")) {
         addYokogawaAttributes("Yokogawa MRF MeasurementDetail ", attributes);
-        startTime = attributes.getValue("bts:BeginTime");
-        endTime = attributes.getValue("bts:EndTime");
-        rawModel.startTime = startTime;
-        rawModel.endTime = endTime;
-        settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
-        rawModel.settingsPath = settingsPath;
-        measurementOperatorName = clean(attributes.getValue("bts:OperatorName"));
+        result.startTime = attributes.getValue("bts:BeginTime");
+        result.endTime = attributes.getValue("bts:EndTime");
+        result.settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
+        result.measurementOperatorName = clean(attributes.getValue("bts:OperatorName"));
 
         String system = attributes.getValue("bts:TargetSystem");
-        targetSystem = clean(system);
+        result.targetSystem = clean(system);
         addYokogawaMeta(
           "Yokogawa MRF MeasurementDetail ", "AcquisitionSystem", system);
-        if (targetSystem != null &&
-          !targetSystem.toLowerCase().startsWith("cv7000"))
+        if (result.targetSystem != null &&
+          !result.targetSystem.toLowerCase().startsWith("cv7000"))
         {
-          LOGGER.warn("Found data from {}; this is not well-supported", targetSystem);
+          LOGGER.warn("Found data from {}; this is not well-supported",
+            result.targetSystem);
         }
       }
     }
 
   }
 
-  class WPPHandler extends BaseHandler {
+  private class WPPHandler extends BaseHandler {
 
     @Override
     public void startElement(String uri, String localName, String qName,
@@ -3210,7 +3197,7 @@ public class CV7000Reader extends FormatReader {
 
   }
 
-  class PostProcessHandler extends BaseHandler {
+  private class PostProcessHandler extends BaseHandler {
     private int actionIndex = -1;
 
     @Override
@@ -3232,7 +3219,9 @@ public class CV7000Reader extends FormatReader {
 
   }
 
-  class MeasurementSettingsHandler extends BaseHandler {
+  private class MeasurementSettingsHandler extends BaseHandler {
+    private MeasurementSettingsResult result = new MeasurementSettingsResult();
+    private ArrayList<Channel> parsedChannels;
     private StringBuffer currentValue = new StringBuffer();
     private int currentChannelIndex = -1;
     private int timelineIndex = -1;
@@ -3250,6 +3239,14 @@ public class CV7000Reader extends FormatReader {
     private String currentActionBottomDistance;
     private String currentActionSliceLength;
     private String currentActionUseSoftFocus;
+
+    public MeasurementSettingsHandler(ArrayList<Channel> channels) {
+      parsedChannels = channels;
+    }
+
+    public MeasurementSettingsResult getResult() {
+      return result;
+    }
 
     // -- DefaultHandler API methods --
 
@@ -3279,14 +3276,14 @@ public class CV7000Reader extends FormatReader {
         l.wavelength = DataTools.parseDouble(wavelength);
         l.power = DataTools.parseDouble(power);
 
-        lightSources.add(l);
+        result.lightSources.add(l);
       }
       else if (qName.equals("bts:Channel")) {
         currentChannelIndex = -1;
         String ch = attributes.getValue("bts:Ch");
         if (ch != null) {
           int index = Integer.parseInt(ch) - 1;
-          if (index >= 0 && index < channels.size()) {
+          if (index >= 0 && index < parsedChannels.size()) {
             currentChannelIndex = index;
 
             Channel template = new Channel();
@@ -3407,8 +3404,8 @@ public class CV7000Reader extends FormatReader {
           "Yokogawa MES Channel " + (currentChannelIndex + 1) + " ",
           "LightSourceName", value);
         int index = -1;
-        for (int i=0; i<lightSources.size(); i++) {
-          if (lightSources.get(i).name.equals(value)) {
+        for (int i=0; i<result.lightSources.size(); i++) {
+          if (result.lightSources.get(i).name.equals(value)) {
             index = i;
           }
         }
@@ -3421,13 +3418,13 @@ public class CV7000Reader extends FormatReader {
       }
       else if (qName.equals("bts:Ch")) {
         int channelIndex = Integer.parseInt(value) - 1;
-        if (channelIndex >= 0 && channelIndex < channels.size()) {
+        if (channelIndex >= 0 && channelIndex < parsedChannels.size()) {
           // the same channel may be acquired multiple times
           // if this is the first time the channel is acquired, set the indexes
           // if this is the second (or more) time the channel is acquired,
           // duplicate the channel so that each action has its own copy with
           // the correct indexes
-          Channel ch = channels.get(channelIndex);
+          Channel ch = parsedChannels.get(channelIndex);
           if (ch.timelineIndex == -1 && ch.actionIndex == -1) {
             ch.timelineIndex = timelineIndex;
             ch.actionIndex = actionIndex;
@@ -3446,7 +3443,7 @@ public class CV7000Reader extends FormatReader {
               currentActionXOffset, currentActionYOffset, currentActionAFShiftBase,
               currentActionTopDistance, currentActionBottomDistance,
               currentActionSliceLength, currentActionUseSoftFocus);
-            channels.add(duplicate);
+            parsedChannels.add(duplicate);
           }
         }
       }
@@ -3464,7 +3461,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     private void applyChannelSettings(Channel template) {
-      for (Channel ch : channels) {
+      for (Channel ch : parsedChannels) {
         if (ch.index == template.index) {
           ch.copyChannelSettings(template);
         }
@@ -3472,7 +3469,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     private void addLightSourceRef(int rawChannelIndex, int lightSourceIndex) {
-      for (Channel ch : channels) {
+      for (Channel ch : parsedChannels) {
         if (ch.index == rawChannelIndex &&
           !ch.lightSourceRefs.contains(lightSourceIndex))
         {
@@ -3483,7 +3480,7 @@ public class CV7000Reader extends FormatReader {
 
   }
 
-  class CrosstalkParameterHandler extends BaseHandler {
+  private class CrosstalkParameterHandler extends BaseHandler {
     private CrosstalkParameters parameters = new CrosstalkParameters();
     private CrosstalkFilter currentFilter;
     private CrosstalkFluorophore currentFluorophore;
@@ -3560,7 +3557,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class OTFGeometryHandler extends BaseHandler {
+  private class OTFGeometryHandler extends BaseHandler {
     private OTFGeometryParameters parameters = new OTFGeometryParameters();
 
     public OTFGeometryParameters getParameters() {
@@ -3614,7 +3611,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class OTFGeometryParameters {
+  private static class OTFGeometryParameters {
     public String mode;
     public LinkedHashMap<String, OTFGeometryObjective> objectivesByID =
       new LinkedHashMap<String, OTFGeometryObjective>();
@@ -3645,13 +3642,13 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class OTFGeometryObjective {
+  private static class OTFGeometryObjective {
     public String objectiveID;
     public String objective;
     public Double magnification;
   }
 
-  class OTFGeometryAffine {
+  private static class OTFGeometryAffine {
     public String methodID;
     public String method;
     public String objectiveID;
@@ -3669,7 +3666,7 @@ public class CV7000Reader extends FormatReader {
     public Double f;
   }
 
-  class CrosstalkParameters {
+  private static class CrosstalkParameters {
     public LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter> filters =
       new LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter>();
     public ArrayList<CrosstalkFluorophore> fluorophores =
@@ -3681,7 +3678,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class CrosstalkFilter {
+  private static class CrosstalkFilter {
     public String filterID;
     public Integer cameraNumber;
     public String acquisition;
@@ -3692,25 +3689,25 @@ public class CV7000Reader extends FormatReader {
       new ArrayList<CrosstalkDichroic>();
   }
 
-  class CrosstalkDichroic {
+  private static class CrosstalkDichroic {
     public String id;
     public String name;
     public String reflection;
     public Double averageTransmittance;
   }
 
-  class CrosstalkFluorophore {
+  private static class CrosstalkFluorophore {
     public String name;
     public ArrayList<CrosstalkFluorophoreIntensity> intensities =
       new ArrayList<CrosstalkFluorophoreIntensity>();
   }
 
-  class CrosstalkFluorophoreIntensity {
+  private static class CrosstalkFluorophoreIntensity {
     public String filterID;
     public Double averageIntensity;
   }
 
-  class CrosstalkFilterKey {
+  private static class CrosstalkFilterKey {
     public String filterID;
     public Integer cameraNumber;
     public String acquisition;
@@ -3752,31 +3749,76 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class LightSource {
+  private static class LightSource {
     public String name;
     public String type;
     public Double wavelength;
     public Double power;
   }
 
-  class CV7000ObjectiveSpec {
+  private static class CV7000ObjectiveSpec {
+    public Double magnification;
     public Double lensNA;
     public String immersion;
 
-    public CV7000ObjectiveSpec(Double lensNA, String immersion) {
+    public CV7000ObjectiveSpec(Double magnification, Double lensNA,
+      String immersion)
+    {
+      this.magnification = magnification;
       this.lensNA = lensNA;
       this.immersion = immersion;
     }
   }
 
-  class ObjectiveModelTokens {
+  private static class ObjectiveModelTokens {
     public Integer magnification;
     public boolean phase;
     public boolean longWorkingDistance;
-    public boolean water;
+    public String immersion;
   }
 
-  static class DetectionFilter {
+  private static class KnownObjectiveSpec {
+    public int magnification;
+    public boolean phase;
+    public boolean longWorkingDistance;
+    public String immersion;
+    public Double lensNA;
+
+    public KnownObjectiveSpec(int magnification, boolean phase,
+      boolean longWorkingDistance, String immersion, Double lensNA)
+    {
+      this.magnification = magnification;
+      this.phase = phase;
+      this.longWorkingDistance = longWorkingDistance;
+      this.immersion = immersion;
+      this.lensNA = lensNA;
+    }
+
+    public boolean matches(ObjectiveModelTokens tokens) {
+      if (tokens.magnification == null ||
+        tokens.magnification.intValue() != magnification)
+      {
+        return false;
+      }
+
+      if (tokens.phase != phase ||
+        tokens.longWorkingDistance != longWorkingDistance)
+      {
+        return false;
+      }
+      if (tokens.immersion != null) {
+        return immersion.equals(tokens.immersion);
+      }
+      return !"Water".equals(immersion);
+    }
+
+    public CV7000ObjectiveSpec toObjectiveSpec() {
+      return new CV7000ObjectiveSpec(
+        Double.valueOf(magnification), lensNA, immersion);
+    }
+  }
+
+  private static class DetectionFilter {
     public String filterType;
     public Double center;
     public Double width;
@@ -3797,7 +3839,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class FilterKey {
+  private static class FilterKey {
     public String filterID;
     public String acquisition;
     public int cameraNumber;
@@ -3851,7 +3893,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class Channel {
+  private static class Channel {
     public int timelineIndex = -1;
     public int actionIndex = -1;
     public int index;
@@ -4001,7 +4043,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class Plane {
+  private static class Plane {
     public String file;
     public String timestamp;
     public String actionName;
@@ -4021,7 +4063,7 @@ public class CV7000Reader extends FormatReader {
     public int timelineIndex;
   }
 
-  class Field {
+  private static class Field {
     public int row;
     public int column;
     public int field;
@@ -4042,7 +4084,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  class MinMax {
+  private static class MinMax {
     public int minZ = Integer.MAX_VALUE;
     public int maxZ = 0;
     public int minT = Integer.MAX_VALUE;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -38,6 +38,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -123,7 +124,7 @@ public class CV7000Reader extends FormatReader {
 
   // -- Fields --
 
-  private List<String> allFiles = new ArrayList<String>();
+  private LinkedHashSet<String> allFiles = new LinkedHashSet<String>();
   private MinimalTiffReader reader;
   private String wppPath;
   private String detailPath;
@@ -209,10 +210,10 @@ public class CV7000Reader extends FormatReader {
   /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
-    ArrayList<String> files = new ArrayList<String>();
+    LinkedHashSet<String> files = new LinkedHashSet<String>();
     files.add(new Location(currentId).getAbsolutePath());
     for (String file : allFiles) {
-      if (file != null && !files.contains(file) &&
+      if (file != null &&
         (!noPixels || !isPixelFile(classifyCV7000File(new Location(file)))))
       {
         files.add(file);
@@ -311,7 +312,7 @@ public class CV7000Reader extends FormatReader {
       if (allFiles != null) {
           allFiles.clear();
       } else {
-          allFiles = new ArrayList<String>();
+          allFiles = new LinkedHashSet<String>();
       }
     }
   }
@@ -332,20 +333,11 @@ public class CV7000Reader extends FormatReader {
       reader.setId(p.file);
       return reader.openBytes(0, buf, x, y, w, h);
     }
-    else if (duplicatePlanes() && no > 0) {
-      int[] zct = getLogicalZCTCoords(getSeries(), no);
-      // pick the first plane in the same channel
-      int dupPlane = getLogicalPlaneIndex(getSeries(), 0, zct[1], 0);
-
-      // very unlikely to happen, but catching the case
-      // where no is the first plane in the channel prevents
-      // a potential infinite loop
-      if (dupPlane == no) {
-        dupPlane = 0;
-      }
-      Plane duplicate = lookupPlane(getSeries(), dupPlane);
+    else if (duplicatePlanes()) {
+      Plane duplicate = getDuplicatePlane(getSeries(), no);
       if (duplicate != null && duplicate.file != null) {
-        return openBytes(dupPlane, buf, x, y, w, h);
+        reader.setId(duplicate.file);
+        return reader.openBytes(0, buf, x, y, w, h);
       }
     }
     return buf;
@@ -520,6 +512,7 @@ public class CV7000Reader extends FormatReader {
       }
       MeasurementSettingsResult result = settingsHandler.getResult();
       lightSources = result.lightSources;
+      channels = result.channels;
     }
   }
 
@@ -645,10 +638,12 @@ public class CV7000Reader extends FormatReader {
     determineChannelMappingMode(layout, acquiredFieldSet);
     sortAcquiredFields(layout.acquiredFields);
     indexAcquiredFields(layout);
+    assignLogicalChannelSlots(layout, acquiredFieldSet);
     collectPlaneExtents(layout, acquiredFieldSet);
-    layout.channelIndexes = layout.uniqueChannels.toArray(
-      new Integer[layout.uniqueChannels.size()]);
-    Arrays.sort(layout.channelIndexes);
+    layout.channelIndexes = new Integer[layout.channelSlots.size()];
+    for (int i=0; i<layout.channelIndexes.length; i++) {
+      layout.channelIndexes[i] = Integer.valueOf(i);
+    }
     return layout;
   }
 
@@ -657,9 +652,7 @@ public class CV7000Reader extends FormatReader {
     HashSet<Field> acquiredFieldSet = new HashSet<Field>();
     for (Plane p : planeData) {
       if (p != null && p.file != null) {
-        if (!allFiles.contains(p.file)) {
-          allFiles.add(p.file);
-        }
+        allFiles.add(p.file);
         if (layout.firstFile == null) {
           layout.firstFile = p.file;
         }
@@ -759,16 +752,122 @@ public class CV7000Reader extends FormatReader {
   private void collectPlaneExtents(CV7000SeriesLayout layout, HashSet<Field> acquiredFieldSet) {
     for (Plane p : planeData) {
       if (p != null && acquiredFieldSet.contains(p.field)) {
-        p.channelIndex = getLogicalChannelIndex(p, layout.channelMappingMode);
-
         if (!layout.minMax.containsKey(p.field)) {
           layout.minMax.put(p.field, new MinMax());
         }
         MinMax m = layout.minMax.get(p.field);
         m.update(p);
-        layout.uniqueChannels.add(p.channelIndex);
       }
     }
+  }
+
+  /** Assign stable channel slots and qualify only real cross-timeline collisions. */
+  private void assignLogicalChannelSlots(CV7000SeriesLayout layout,
+    HashSet<Field> acquiredFieldSet)
+  {
+    HashMap<String, HashSet<Integer>> timelinesByCoordinate =
+      new HashMap<String, HashSet<Integer>>();
+
+    for (Plane p : planeData) {
+      if (p == null || !acquiredFieldSet.contains(p.field)) {
+        continue;
+      }
+      ChannelSlotKey base = createBaseChannelSlot(p, layout.channelMappingMode);
+      String coordinate = getChannelCollisionCoordinate(p, base);
+      HashSet<Integer> timelines = timelinesByCoordinate.get(coordinate);
+      if (timelines == null) {
+        timelines = new HashSet<Integer>();
+        timelinesByCoordinate.put(coordinate, timelines);
+      }
+      timelines.add(Integer.valueOf(p.timelineIndex));
+    }
+
+    HashSet<String> qualifiedAcquisitions = new HashSet<String>();
+    for (Plane p : planeData) {
+      if (p == null || !acquiredFieldSet.contains(p.field)) {
+        continue;
+      }
+      ChannelSlotKey base = createBaseChannelSlot(p, layout.channelMappingMode);
+      HashSet<Integer> timelines = timelinesByCoordinate.get(
+        getChannelCollisionCoordinate(p, base));
+      if (timelines != null && timelines.size() > 1 &&
+        p.timelineIndex != Collections.min(timelines).intValue())
+      {
+        qualifiedAcquisitions.add(
+          base.identity() + "|timeline=" + p.timelineIndex);
+      }
+    }
+
+    HashSet<ChannelSlotKey> primarySlots = new HashSet<ChannelSlotKey>();
+    HashSet<ChannelSlotKey> qualifiedSlots = new HashSet<ChannelSlotKey>();
+    for (Plane p : planeData) {
+      if (p == null || !acquiredFieldSet.contains(p.field)) {
+        continue;
+      }
+      ChannelSlotKey base = createBaseChannelSlot(p, layout.channelMappingMode);
+      ChannelSlotKey slot = base;
+      if (qualifiedAcquisitions.contains(
+        base.identity() + "|timeline=" + p.timelineIndex))
+      {
+        slot = new ChannelSlotKey(base);
+        slot.timelineIndex = p.timelineIndex;
+        slot.timelineQualified = true;
+        qualifiedSlots.add(slot);
+      }
+      else {
+        primarySlots.add(slot);
+      }
+      p.channelSlot = slot;
+    }
+
+    ArrayList<ChannelSlotKey> primary =
+      new ArrayList<ChannelSlotKey>(primarySlots);
+    Collections.sort(primary);
+    layout.channelSlots.addAll(primary);
+
+    ArrayList<ChannelSlotKey> overflow =
+      new ArrayList<ChannelSlotKey>(qualifiedSlots);
+    Collections.sort(overflow, new Comparator<ChannelSlotKey>() {
+      @Override
+      public int compare(ChannelSlotKey a, ChannelSlotKey b) {
+        int timeline = Integer.compare(a.timelineIndex, b.timelineIndex);
+        return timeline == 0 ? a.compareBase(b) : timeline;
+      }
+    });
+    layout.channelSlots.addAll(overflow);
+    for (ChannelSlotKey slot : overflow) {
+      addYokogawaMetaList("Yokogawa Channel Mapping ",
+        "TimelineQualifiedSlot", slot.toString());
+    }
+
+    for (int i=0; i<layout.channelSlots.size(); i++) {
+      layout.channelSlotIndexes.put(layout.channelSlots.get(i), Integer.valueOf(i));
+    }
+    for (Plane p : planeData) {
+      if (p != null && p.channelSlot != null) {
+        p.channelIndex = layout.channelSlotIndexes.get(p.channelSlot).intValue();
+      }
+    }
+  }
+
+  private ChannelSlotKey createBaseChannelSlot(Plane plane,
+    CV7000ChannelMappingMode mode)
+  {
+    ChannelSlotKey key = new ChannelSlotKey();
+    key.mappingMode = mode;
+    key.actionIndex = plane.actionIndex;
+    key.rawChannel = plane.channel;
+    key.mappedIndex = mode == CV7000ChannelMappingMode.ACTION_MAPPED ?
+      getLogicalChannelIndex(plane, mode) : -1;
+    return key;
+  }
+
+  private String getChannelCollisionCoordinate(Plane plane,
+    ChannelSlotKey base)
+  {
+    return plane.field.row + ":" + plane.field.column + ":" +
+      plane.field.field + ":" + plane.z + ":" + plane.timepoint + "|" +
+      base.identity();
   }
 
   /** Initialize the Bio-Formats core metadata once the logical layout is known. */
@@ -812,14 +911,6 @@ public class CV7000Reader extends FormatReader {
       Integer series = layout.fieldToSeries.get(p.field);
       if (series == null) {
         continue;
-      }
-
-      // Reindex from Yokogawa's channel/action numbering into the compact
-      // channel list exposed by this reader for the current dataset.
-      p.channelIndex = Arrays.binarySearch(layout.channelIndexes, p.channelIndex);
-      if (p.channelIndex < 0) {
-        throw new FormatException("Could not map CV7000 channel " +
-          (p.channel + 1) + " to a compact reader channel index");
       }
 
       p.series = series.intValue();
@@ -1084,6 +1175,10 @@ public class CV7000Reader extends FormatReader {
       }
       Channel channel = lookupChannel(p);
       if (channel == null) {
+        continue;
+      }
+      if (channel.metadataAmbiguous) {
+        store.setChannelName(getChannelProvenance(channel, p), series, c);
         continue;
       }
 
@@ -1496,6 +1591,9 @@ public class CV7000Reader extends FormatReader {
   private void populateObjectives(MetadataStore store, List<String> usedObjectiveIDs) {
     if (channels != null) {
       for (Channel c : channels) {
+        if (c.metadataAmbiguous) {
+          continue;
+        }
         if (c.objectiveID != null && !usedObjectiveIDs.contains(c.objectiveID)) {
           int index = usedObjectiveIDs.size();
           String objectiveID = MetadataTools.createLSID("Objective", 0, index);
@@ -1614,6 +1712,9 @@ public class CV7000Reader extends FormatReader {
       return;
     }
     for (Channel c : channels) {
+      if (c.metadataAmbiguous) {
+        continue;
+      }
       if (!detectorIndexes.containsKey(c.cameraNumber)) {
         int detector = detectorIndexes.size();
         detectorIndexes.put(c.cameraNumber, detector);
@@ -1675,6 +1776,9 @@ public class CV7000Reader extends FormatReader {
       return;
     }
     for (Channel c : channels) {
+      if (c.metadataAmbiguous) {
+        continue;
+      }
       FilterKey key = new FilterKey(c);
       if (!key.isValid() || filterIndexes.containsKey(key)) {
         continue;
@@ -2488,17 +2592,52 @@ public class CV7000Reader extends FormatReader {
   }
 
   private Plane getDuplicatePlane(int series, int no) {
-    if (!duplicatePlanes() || no <= 0) {
+    if (!duplicatePlanes()) {
       return null;
     }
 
     int[] zct = getLogicalZCTCoords(series, no);
-    int dupPlane = getLogicalPlaneIndex(series, 0, zct[1], 0);
-    if (dupPlane == no) {
-      dupPlane = 0;
+    return findFirstBackedPlaneInChannel(
+      planeData, reversePlaneLookup[series], series, zct[1], no);
+  }
+
+  /** Select the lowest-index backed plane from one logical channel. */
+  static Plane findFirstBackedPlaneInChannel(ArrayList<Plane> planes,
+    int[] lookup, int series, int channel, int excludedPlane)
+  {
+    if (planes == null || lookup == null) {
+      return null;
     }
-    Plane duplicate = lookupPlane(series, dupPlane);
-    return duplicate != null && duplicate.file != null ? duplicate : null;
+    for (int no=0; no<lookup.length; no++) {
+      if (no == excludedPlane) {
+        continue;
+      }
+      int index = lookup[no];
+      if (index < 0 || index >= planes.size()) {
+        continue;
+      }
+      Plane plane = planes.get(index);
+      if (plane != null && plane.series == series && plane.no == no &&
+        plane.channelIndex == channel && plane.file != null)
+      {
+        return plane;
+      }
+    }
+    return null;
+  }
+
+  /** Match repeated raw-channel metadata by occurrence, reusing a sole row. */
+  static Channel selectChannelDefinition(List<Channel> definitions,
+    int occurrence)
+  {
+    if (definitions == null || definitions.size() == 0) {
+      return null;
+    }
+    if (definitions.size() == 1) {
+      return definitions.get(0);
+    }
+    return occurrence >= 0 && occurrence < definitions.size() ?
+      definitions.get(occurrence) : null;
   }
 
   private int getLogicalChannelCount(int series) {
@@ -2828,8 +2967,11 @@ public class CV7000Reader extends FormatReader {
     public String firstFile;
     public ArrayList<Field> acquiredFields = new ArrayList<Field>();
     public HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
-    public HashSet<Integer> uniqueChannels = new HashSet<Integer>();
     public Integer[] channelIndexes;
+    public ArrayList<ChannelSlotKey> channelSlots =
+      new ArrayList<ChannelSlotKey>();
+    public HashMap<ChannelSlotKey, Integer> channelSlotIndexes =
+      new HashMap<ChannelSlotKey, Integer>();
     public HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
     public int[][] reversePlaneLookup;
     public CV7000ChannelMappingMode channelMappingMode =
@@ -2867,6 +3009,88 @@ public class CV7000Reader extends FormatReader {
 
     private String getPlaneKey(int series, int channel) {
       return series + ":" + channel;
+    }
+  }
+
+  /** Logical channel identity, with an optional timeline collision qualifier. */
+  public static class ChannelSlotKey implements Comparable<ChannelSlotKey> {
+    public CV7000ChannelMappingMode mappingMode;
+    public int mappedIndex = -1;
+    public int actionIndex = -1;
+    public int rawChannel = -1;
+    public int timelineIndex = -1;
+    public boolean timelineQualified;
+
+    public ChannelSlotKey() {
+    }
+
+    public ChannelSlotKey(ChannelSlotKey key) {
+      mappingMode = key.mappingMode;
+      mappedIndex = key.mappedIndex;
+      actionIndex = key.actionIndex;
+      rawChannel = key.rawChannel;
+      timelineIndex = key.timelineIndex;
+      timelineQualified = key.timelineQualified;
+    }
+
+    public String identity() {
+      if (mappingMode == CV7000ChannelMappingMode.ACTION_MAPPED) {
+        return "mapped=" + mappedIndex;
+      }
+      return "action=" + actionIndex + ":raw=" + rawChannel;
+    }
+
+    public int compareBase(ChannelSlotKey other) {
+      if (mappingMode == CV7000ChannelMappingMode.ACTION_MAPPED &&
+        other.mappingMode == CV7000ChannelMappingMode.ACTION_MAPPED)
+      {
+        return Integer.compare(mappedIndex, other.mappedIndex);
+      }
+      int action = Integer.compare(actionIndex, other.actionIndex);
+      return action == 0 ? Integer.compare(rawChannel, other.rawChannel) : action;
+    }
+
+    @Override
+    public int compareTo(ChannelSlotKey other) {
+      return compareBase(other);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof ChannelSlotKey)) {
+        return false;
+      }
+      ChannelSlotKey key = (ChannelSlotKey) o;
+      if (mappingMode != key.mappingMode ||
+        timelineQualified != key.timelineQualified ||
+        timelineIndex != key.timelineIndex)
+      {
+        return false;
+      }
+      if (mappingMode == CV7000ChannelMappingMode.ACTION_MAPPED) {
+        return mappedIndex == key.mappedIndex;
+      }
+      return actionIndex == key.actionIndex && rawChannel == key.rawChannel;
+    }
+
+    @Override
+    public int hashCode() {
+      int code = mappingMode == null ? 0 : mappingMode.hashCode();
+      if (mappingMode == CV7000ChannelMappingMode.ACTION_MAPPED) {
+        code = 31 * code + mappedIndex;
+      }
+      else {
+        code = 31 * code + actionIndex;
+        code = 31 * code + rawChannel;
+      }
+      code = 31 * code + timelineIndex;
+      return 31 * code + (timelineQualified ? 1 : 0);
+    }
+
+    @Override
+    public String toString() {
+      String value = identity();
+      return timelineQualified ? value + ":timeline=" + timelineIndex : value;
     }
   }
 
@@ -3181,6 +3405,7 @@ public class CV7000Reader extends FormatReader {
 
   private static class MeasurementSettingsResult {
     public ArrayList<LightSource> lightSources = new ArrayList<LightSource>();
+    public ArrayList<Channel> channels = new ArrayList<Channel>();
   }
 
   public static class MeasurementDataSummary {
@@ -3434,8 +3659,17 @@ public class CV7000Reader extends FormatReader {
   private class MeasurementSettingsHandler extends BaseHandler {
     private MeasurementSettingsResult result = new MeasurementSettingsResult();
     private ArrayList<Channel> parsedChannels;
+    private HashMap<Integer, ArrayList<Channel>> baseChannelsByRaw =
+      new HashMap<Integer, ArrayList<Channel>>();
+    private ArrayList<Channel> resolvedChannels = new ArrayList<Channel>();
+    private HashSet<String> usedDefinitions = new HashSet<String>();
+    private HashMap<Integer, Integer> actionOccurrencesByRaw =
+      new HashMap<Integer, Integer>();
+    private HashMap<Integer, Integer> templateOccurrencesByRaw =
+      new HashMap<Integer, Integer>();
     private StringBuffer currentValue = new StringBuffer();
     private int currentChannelIndex = -1;
+    private int currentDefinitionOccurrence = -1;
     private int timelineIndex = -1;
     private int actionIndex = -1;
     private int targetWellIndex = -1;
@@ -3454,9 +3688,31 @@ public class CV7000Reader extends FormatReader {
 
     public MeasurementSettingsHandler(ArrayList<Channel> channels) {
       parsedChannels = channels;
+      for (Channel channel : parsedChannels) {
+        Integer raw = Integer.valueOf(channel.index);
+        ArrayList<Channel> definitions = baseChannelsByRaw.get(raw);
+        if (definitions == null) {
+          definitions = new ArrayList<Channel>();
+          baseChannelsByRaw.put(raw, definitions);
+        }
+        channel.definitionOccurrence = definitions.size();
+        definitions.add(channel);
+      }
     }
 
     public MeasurementSettingsResult getResult() {
+      result.channels.clear();
+      if (resolvedChannels.size() == 0) {
+        result.channels.addAll(parsedChannels);
+        return result;
+      }
+      result.channels.addAll(resolvedChannels);
+      for (Channel channel : parsedChannels) {
+        String key = getDefinitionKey(channel.index, channel.definitionOccurrence);
+        if (!usedDefinitions.contains(key)) {
+          result.channels.add(channel);
+        }
+      }
       return result;
     }
 
@@ -3522,16 +3778,20 @@ public class CV7000Reader extends FormatReader {
           "LightSourceName", value);
         int index = -1;
         for (int i=0; i<result.lightSources.size(); i++) {
-          if (result.lightSources.get(i).name.equals(value)) {
+          if (result.lightSources.get(i).name != null &&
+            result.lightSources.get(i).name.equals(value))
+          {
             index = i;
           }
         }
         if (index >= 0) {
-          addLightSourceRef(currentChannelIndex, index);
+          addLightSourceRef(
+            currentChannelIndex, currentDefinitionOccurrence, index);
         }
       }
       else if (qName.equals("bts:Channel")) {
         currentChannelIndex = -1;
+        currentDefinitionOccurrence = -1;
       }
       else if (qName.equals("bts:Ch")) {
         assignActionChannel(value);
@@ -3559,17 +3819,20 @@ public class CV7000Reader extends FormatReader {
 
     private void parseChannelTemplate(Attributes attributes) {
       currentChannelIndex = -1;
+      currentDefinitionOccurrence = -1;
       String ch = attributes.getValue("bts:Ch");
       if (ch == null) {
         return;
       }
 
       int index = Integer.parseInt(ch) - 1;
-      if (index < 0 || index >= parsedChannels.size()) {
+      if (index < 0) {
         return;
       }
 
       currentChannelIndex = index;
+      currentDefinitionOccurrence = nextOccurrence(
+        templateOccurrencesByRaw, index);
 
       Channel template = new Channel();
       template.index = index;
@@ -3603,7 +3866,7 @@ public class CV7000Reader extends FormatReader {
       template.detectionFilter = parsing.parseDetectionFilter(template.acquisition);
 
       template.fluor = attributes.getValue("bts:Fluorophore");
-      applyChannelSettings(template);
+      applyChannelSettings(template, currentDefinitionOccurrence);
     }
 
     private void populateChannelColor(Channel template, String color) {
@@ -3636,6 +3899,7 @@ public class CV7000Reader extends FormatReader {
       currentPhysicalSizeZ = null;
       actionRunMode = null;
       actionAFSearch = null;
+      actionOccurrencesByRaw.clear();
       addYokogawaAttributes(
         "Yokogawa MES Timeline " + (timelineIndex + 1) + " ", attributes);
     }
@@ -3674,21 +3938,29 @@ public class CV7000Reader extends FormatReader {
 
     private void assignActionChannel(String value) {
       int channelIndex = Integer.parseInt(value) - 1;
-      if (channelIndex < 0 || channelIndex >= parsedChannels.size()) {
+      if (channelIndex < 0) {
         return;
       }
-
-      // The same channel may be acquired multiple times. First occurrence
-      // receives the action indexes; later occurrences get action-specific copies.
-      Channel channel = parsedChannels.get(channelIndex);
-      if (channel.timelineIndex == -1 && channel.actionIndex == -1) {
-        assignActionSettings(channel);
+      int occurrence = nextOccurrence(actionOccurrencesByRaw, channelIndex);
+      Channel definition = getChannelDefinition(channelIndex, occurrence);
+      Channel channel;
+      if (definition == null) {
+        channel = new Channel();
+        channel.index = channelIndex;
+        channel.definitionOccurrence = -1;
+        channel.metadataAmbiguous = true;
+        LOGGER.warn("No unambiguous CV7000 MRF channel definition for " +
+          "timeline {}, action {}, raw channel {}, occurrence {}",
+          timelineIndex + 1, actionIndex + 1, channelIndex + 1, occurrence + 1);
       }
       else {
-        Channel duplicate = new Channel(channel);
-        assignActionSettings(duplicate);
-        parsedChannels.add(duplicate);
+        channel = new Channel(definition);
+        channel.definitionOccurrence = definition.definitionOccurrence;
+        usedDefinitions.add(getDefinitionKey(
+          channelIndex, definition.definitionOccurrence));
       }
+      assignActionSettings(channel);
+      resolvedChannels.add(channel);
     }
 
     private void assignActionSettings(Channel channel) {
@@ -3713,22 +3985,66 @@ public class CV7000Reader extends FormatReader {
       currentActionUseSoftFocus = null;
     }
 
-    private void applyChannelSettings(Channel template) {
-      for (Channel ch : parsedChannels) {
-        if (ch.index == template.index) {
-          ch.copyChannelSettings(template);
+    private void applyChannelSettings(Channel template, int occurrence) {
+      Channel definition = getChannelDefinition(template.index, occurrence);
+      if (definition != null) {
+        definition.copyChannelSettings(template);
+      }
+      else {
+        LOGGER.warn("No unambiguous CV7000 MRF channel definition for " +
+          "MES channel template {}, occurrence {}",
+          template.index + 1, occurrence + 1);
+        return;
+      }
+      int resolvedOccurrence = definition.definitionOccurrence;
+      for (Channel channel : resolvedChannels) {
+        if (channel.index == template.index &&
+          channel.definitionOccurrence == resolvedOccurrence)
+        {
+          channel.copyChannelSettings(template);
         }
       }
     }
 
-    private void addLightSourceRef(int rawChannelIndex, int lightSourceIndex) {
+    private void addLightSourceRef(int rawChannelIndex, int definitionOccurrence,
+      int lightSourceIndex)
+    {
       for (Channel ch : parsedChannels) {
         if (ch.index == rawChannelIndex &&
+          ch.definitionOccurrence == definitionOccurrence &&
           !ch.lightSourceRefs.contains(lightSourceIndex))
         {
           ch.lightSourceRefs.add(lightSourceIndex);
         }
       }
+      for (Channel ch : resolvedChannels) {
+        if (ch.index == rawChannelIndex &&
+          ch.definitionOccurrence == definitionOccurrence &&
+          !ch.lightSourceRefs.contains(lightSourceIndex))
+        {
+          ch.lightSourceRefs.add(lightSourceIndex);
+        }
+      }
+    }
+
+    private int nextOccurrence(HashMap<Integer, Integer> occurrences,
+      int rawChannel)
+    {
+      Integer raw = Integer.valueOf(rawChannel);
+      Integer next = occurrences.get(raw);
+      int occurrence = next == null ? 0 : next.intValue();
+      occurrences.put(raw, Integer.valueOf(occurrence + 1));
+      return occurrence;
+    }
+
+    private Channel getChannelDefinition(int rawChannel, int occurrence) {
+      ArrayList<Channel> definitions =
+        baseChannelsByRaw.get(Integer.valueOf(rawChannel));
+      return selectChannelDefinition(definitions, occurrence);
+    }
+
+    private String getDefinitionKey(int rawChannel, int occurrence) {
+      return rawChannel + ":" + occurrence;
     }
 
   }
@@ -4135,6 +4451,8 @@ public class CV7000Reader extends FormatReader {
     public int timelineIndex = -1;
     public int actionIndex = -1;
     public int index;
+    public int definitionOccurrence;
+    public boolean metadataAmbiguous;
     public double xSize;
     public double ySize;
     public int cameraNumber;
@@ -4184,6 +4502,8 @@ public class CV7000Reader extends FormatReader {
 
     public Channel(Channel ch) {
       index = ch.index;
+      definitionOccurrence = ch.definitionOccurrence;
+      metadataAmbiguous = ch.metadataAmbiguous;
       xSize = ch.xSize;
       ySize = ch.ySize;
       cameraNumber = ch.cameraNumber;
@@ -4294,6 +4614,7 @@ public class CV7000Reader extends FormatReader {
     public int channel;
     // this is the calculated index from 0 to getSizeC() - 1
     public int channelIndex;
+    public ChannelSlotKey channelSlot;
     public double xpos;
     public double ypos;
     public double zpos;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -81,6 +81,8 @@ public class CV7000Reader extends FormatReader {
   private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
   private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
   private static final String POST_PROCESS = "PostProcess.ppf";
+  private static final String OTF_CROSSTALK_PARAMETER = "OTF_crosstalk_parameter.xml";
+  private static final String OTF_GEOMETRY_PARAMETER = "OTF_geometry_parameter.xml";
   private static final String BRIGHTFIELD = "Brightfield";
   private static final int RAW_XML_CHUNK_SIZE = 7600;
 
@@ -151,7 +153,7 @@ public class CV7000Reader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(new Location(currentId).getAbsolutePath());
     for (String file : allFiles) {
-      if (file != null && !files.contains(file) && (!noPixels || !checkSuffix(file, "tif"))) {
+      if (file != null && !files.contains(file) && (!noPixels || !isTiffFile(file))) {
         files.add(file);
       }
     }
@@ -197,7 +199,7 @@ public class CV7000Reader extends FormatReader {
     }
     files.addAll(extraFiles);
     for (String file : allFiles) {
-      if (file != null && !checkSuffix(file, "tif") && !(new Location(file).isDirectory())) {
+      if (file != null && !isTiffFile(file) && !(new Location(file).isDirectory())) {
         files.add(file);
       }
     }
@@ -288,10 +290,10 @@ public class CV7000Reader extends FormatReader {
     DatasetPaths paths = getDatasetPaths(id);
     WPIHandler plate = parsePlate(paths.wpiPath);
 
-    collectDatasetFiles(paths.parent);
     parseMeasurementData(paths);
     parseOptionalSidecars(paths);
     normalizeChannels(paths.parent);
+    collectDatasetFiles(paths.parent);
 
     SeriesLayout layout = buildSeriesLayout();
     initializeCoreMetadata(layout);
@@ -323,7 +325,7 @@ public class CV7000Reader extends FormatReader {
     Arrays.sort(listedFiles);
     for (int i=0; i<listedFiles.length; i++) {
       Location file = new Location(parent, listedFiles[i]);
-      if (!file.isDirectory() && file.canRead()) {
+      if (!file.isDirectory() && file.canRead() && isCV7000DatasetFile(file)) {
         allFiles.add(file.getAbsolutePath());
       }
     }
@@ -1073,7 +1075,7 @@ public class CV7000Reader extends FormatReader {
   private void addYokogawaOriginalMetadata() {
     if (allFiles != null) {
       for (String file : allFiles) {
-        if (file != null && !checkSuffix(file, "tif")) {
+        if (file != null && !isTiffFile(file)) {
           addPostProcessOriginalMetadata(file);
           addRawSidecarMetadata(file);
           addYokogawaMetaList("Yokogawa Sidecar ", "File",
@@ -1145,7 +1147,7 @@ public class CV7000Reader extends FormatReader {
   private void addRawSidecarMetadata(String file) {
     Location location = new Location(file);
     String name = location.getName();
-    if (name == null || MEASUREMENT_FILE.equals(name) || !isRawXMLSidecar(file)) {
+    if (name == null || MEASUREMENT_FILE.equals(name) || !isRawXMLSidecar(location)) {
       return;
     }
 
@@ -1172,10 +1174,37 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private boolean isRawXMLSidecar(String file) {
-    return checkSuffix(file, "wpi") || checkSuffix(file, "mrf") ||
-      checkSuffix(file, "mes") || checkSuffix(file, "wpp") ||
-      checkSuffix(file, "ppf") || checkSuffix(file, "xml");
+  private boolean isCV7000DatasetFile(Location file) {
+    String name = file.getName();
+    return name != null && (isTiffFile(name) || isKnownCV7000Sidecar(file));
+  }
+
+  private boolean isTiffFile(String name) {
+    return name != null && checkSuffix(name, new String[] {"tif", "tiff"});
+  }
+
+  private boolean isRawXMLSidecar(Location file) {
+    String name = file.getName();
+    return name != null && !MEASUREMENT_FILE.equals(name) &&
+      isKnownCV7000Sidecar(file);
+  }
+
+  private boolean isKnownCV7000Sidecar(Location file) {
+    String name = file.getName();
+    if (name == null) {
+      return false;
+    }
+    return isPath(file, currentId) || isPath(file, measurementPath) ||
+      isPath(file, detailPath) || isPath(file, settingsPath) ||
+      isPath(file, wppPath) || POST_PROCESS.equals(name) ||
+      OTF_CROSSTALK_PARAMETER.equals(name) || OTF_GEOMETRY_PARAMETER.equals(name);
+  }
+
+  private boolean isPath(Location file, String path) {
+    if (path == null) {
+      return false;
+    }
+    return file.getAbsolutePath().equals(new Location(path).getAbsolutePath());
   }
 
   private void addPostProcessOriginalMetadata(String file) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -133,6 +133,8 @@ public class CV7000Reader extends FormatReader {
   // -- Fields --
 
   private LinkedHashSet<String> allFiles = new LinkedHashSet<String>();
+  private LinkedHashSet<String> planeFiles = new LinkedHashSet<String>();
+  private LinkedHashSet<String> correctionFiles = new LinkedHashSet<String>();
   private MinimalTiffReader reader;
   private String wppPath;
   private String detailPath;
@@ -352,6 +354,8 @@ public class CV7000Reader extends FormatReader {
       } else {
           allFiles = new LinkedHashSet<String>();
       }
+      planeFiles.clear();
+      correctionFiles.clear();
     }
   }
 
@@ -442,6 +446,8 @@ public class CV7000Reader extends FormatReader {
     measurementPath = null;
     settingsPath = null;
     allFiles.clear();
+    planeFiles.clear();
+    correctionFiles.clear();
   }
 
   private CV7000DatasetPaths getDatasetPaths(String id) {
@@ -645,6 +651,12 @@ public class CV7000Reader extends FormatReader {
           new Location(parentPath, ch.correctionFile).getAbsolutePath();
         ch.resolvedCorrectionFile = resolved;
         ch.correctionFile = getRelativePath(parentPath, resolved);
+        Location correction = new Location(resolved);
+        if (correction.exists() && correction.canRead() &&
+          !correction.isDirectory() && isTiffFile(correction.getName()))
+        {
+          correctionFiles.add(correction.getAbsolutePath());
+        }
       }
     }
   }
@@ -2311,9 +2323,6 @@ public class CV7000Reader extends FormatReader {
     if (name == null) {
       return CV7000FileRole.UNKNOWN;
     }
-    if (isTiffFile(name)) {
-      return CV7000FileRole.TIFF_PLANE;
-    }
     if (isPath(file, currentId)) {
       return CV7000FileRole.WPI;
     }
@@ -2348,6 +2357,12 @@ public class CV7000Reader extends FormatReader {
       if (isPath(file, datasetPaths.otfGeometryPath)) {
         return CV7000FileRole.OTF_GEOMETRY;
       }
+    }
+    if (planeFiles.contains(file.getAbsolutePath())) {
+      return CV7000FileRole.TIFF_PLANE;
+    }
+    if (correctionFiles.contains(file.getAbsolutePath())) {
+      return CV7000FileRole.SHADING_CORRECTION;
     }
     return CV7000FileRole.UNKNOWN;
   }
@@ -2384,7 +2399,8 @@ public class CV7000Reader extends FormatReader {
   }
 
   private boolean isPixelFile(CV7000FileRole role) {
-    return role == CV7000FileRole.TIFF_PLANE;
+    return role == CV7000FileRole.TIFF_PLANE ||
+      role == CV7000FileRole.SHADING_CORRECTION;
   }
 
   private boolean isPath(Location file, String path) {
@@ -3301,6 +3317,7 @@ public class CV7000Reader extends FormatReader {
 
   private enum CV7000FileRole {
     TIFF_PLANE,
+    SHADING_CORRECTION,
     WPI,
     MEASUREMENT_DATA,
     MEASUREMENT_DETAIL,
@@ -4160,8 +4177,12 @@ public class CV7000Reader extends FormatReader {
       if ("IMG".equals(btsType) &&
         value.trim().length() > 0) {
         Location imgFile = new Location(parentDir, value);
-        if (imgFile.exists()) {
-          planes.get(planes.size() - 1).file = imgFile.getAbsolutePath();
+        if (imgFile.exists() && imgFile.canRead() && !imgFile.isDirectory() &&
+          isTiffFile(imgFile.getName()))
+        {
+          String path = imgFile.getAbsolutePath();
+          planes.get(planes.size() - 1).file = path;
+          planeFiles.add(path);
         }
       }
       else if (currentRecord != null) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -878,7 +878,6 @@ public class CV7000Reader extends FormatReader {
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       store.setPlateName(plate.getPlateName(), 0);
-      store.setPlateDescription(plate.getPlateDescription(), 0);
       store.setPlateExternalIdentifier(plate.getPlateID(), 0);
 
       InstrumentMetadataIndexes indexes = populateInstrumentMetadata(store);
@@ -942,7 +941,6 @@ public class CV7000Reader extends FormatReader {
   {
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateName(plate.getPlateName(), 0);
-    store.setPlateDescription(plate.getPlateDescription(), 0);
     store.setPlateExternalIdentifier(plate.getPlateID(), 0);
     store.setPlateRows(new PositiveInteger(plate.getPlateRows()), 0);
     store.setPlateColumns(new PositiveInteger(plate.getPlateColumns()), 0);
@@ -3202,7 +3200,6 @@ public class CV7000Reader extends FormatReader {
     private int plateColumns;
     private String name;
     private String plateID;
-    private String description;
 
     public int getPlateRows() {
       return plateRows;
@@ -3218,10 +3215,6 @@ public class CV7000Reader extends FormatReader {
 
     public String getPlateID() {
       return plateID;
-    }
-
-    public String getPlateDescription() {
-      return description;
     }
 
     @Override
@@ -3267,26 +3260,6 @@ public class CV7000Reader extends FormatReader {
       summary.firstAction = firstAction;
       summary.lastAction = lastAction;
       return summary;
-    }
-
-    public int getImageRecordCount() {
-      return imageRecordCount;
-    }
-
-    public String getFirstTimestamp() {
-      return firstTimestamp;
-    }
-
-    public String getLastTimestamp() {
-      return lastTimestamp;
-    }
-
-    public String getFirstAction() {
-      return firstAction;
-    }
-
-    public String getLastAction() {
-      return lastAction;
     }
 
     // -- DefaultHandler API methods --

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -84,6 +84,9 @@ public class CV7000Reader extends FormatReader {
   public static final boolean DUPLICATE_PLANES_DEFAULT = false;
   public static final String PRESERVE_RAW_SIDECARS_KEY = "cv7000.preserve_raw_sidecars";
   public static final boolean PRESERVE_RAW_SIDECARS_DEFAULT = true;
+  public static final String INFER_OBJECTIVE_LENS_NA_KEY =
+    "cv7000.infer_objective_lens_na";
+  public static final boolean INFER_OBJECTIVE_LENS_NA_DEFAULT = false;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
   private static final CV7000ChannelMapper CHANNEL_MAPPER =
@@ -166,6 +169,15 @@ public class CV7000Reader extends FormatReader {
        PRESERVE_RAW_SIDECARS_KEY, PRESERVE_RAW_SIDECARS_DEFAULT);
     }
     return PRESERVE_RAW_SIDECARS_DEFAULT;
+  }
+
+  public boolean inferObjectiveLensNA() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       INFER_OBJECTIVE_LENS_NA_KEY, INFER_OBJECTIVE_LENS_NA_DEFAULT);
+    }
+    return INFER_OBJECTIVE_LENS_NA_DEFAULT;
   }
 
   // -- IFormatReader API methods --
@@ -345,6 +357,7 @@ public class CV7000Reader extends FormatReader {
     ArrayList<String> optionsList = super.getAvailableOptions();
     optionsList.add(DUPLICATE_PLANES_KEY);
     optionsList.add(PRESERVE_RAW_SIDECARS_KEY);
+    optionsList.add(INFER_OBJECTIVE_LENS_NA_KEY);
     return optionsList;
   }
 
@@ -1422,7 +1435,7 @@ public class CV7000Reader extends FormatReader {
     if (spec == null) {
       return;
     }
-    if (spec.lensNA != null) {
+    if (inferObjectiveLensNA() && spec.lensNA != null) {
       store.setObjectiveLensNA(spec.lensNA, 0, objectiveIndex);
     }
     if (spec.immersion != null) {
@@ -1781,7 +1794,9 @@ public class CV7000Reader extends FormatReader {
       CV7000ObjectiveSpec spec =
         getObjectiveSpec(objective.objective);
       if (spec != null) {
-        addYokogawaMeta(prefix, "MappedLensNA", spec.lensNA);
+        if (inferObjectiveLensNA()) {
+          addYokogawaMeta(prefix, "MappedLensNA", spec.lensNA);
+        }
         addYokogawaMeta(prefix, "MappedImmersion", spec.immersion);
       }
       objectiveIndex++;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -52,6 +52,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
+import loci.formats.codec.ZlibCodec;
 import loci.formats.meta.MetadataStore;
 
 import ome.units.UNITS;
@@ -65,6 +66,7 @@ import ome.xml.model.primitives.PercentFraction;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 import ome.xml.model.enums.AcquisitionMode;
+import ome.xml.model.enums.Compression;
 import ome.xml.model.enums.ContrastMethod;
 import ome.xml.model.enums.IlluminationType;
 import ome.xml.model.enums.NamingConvention;
@@ -87,6 +89,9 @@ public class CV7000Reader extends FormatReader {
   public static final boolean DUPLICATE_PLANES_DEFAULT = false;
   public static final String PRESERVE_RAW_SIDECARS_KEY = "cv7000.preserve_raw_sidecars";
   public static final boolean PRESERVE_RAW_SIDECARS_DEFAULT = true;
+  public static final String COMPRESS_RAW_SIDECARS_KEY =
+    "cv7000.compress_raw_sidecars";
+  public static final boolean COMPRESS_RAW_SIDECARS_DEFAULT = true;
   public static final String INFER_OBJECTIVE_LENS_NA_KEY =
     "cv7000.infer_objective_lens_na";
   public static final boolean INFER_OBJECTIVE_LENS_NA_DEFAULT = false;
@@ -174,6 +179,15 @@ public class CV7000Reader extends FormatReader {
        PRESERVE_RAW_SIDECARS_KEY, PRESERVE_RAW_SIDECARS_DEFAULT);
     }
     return PRESERVE_RAW_SIDECARS_DEFAULT;
+  }
+
+  public boolean compressRawSidecars() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       COMPRESS_RAW_SIDECARS_KEY, COMPRESS_RAW_SIDECARS_DEFAULT);
+    }
+    return COMPRESS_RAW_SIDECARS_DEFAULT;
   }
 
   public boolean inferObjectiveLensNA() {
@@ -353,6 +367,7 @@ public class CV7000Reader extends FormatReader {
     ArrayList<String> optionsList = super.getAvailableOptions();
     optionsList.add(DUPLICATE_PLANES_KEY);
     optionsList.add(PRESERVE_RAW_SIDECARS_KEY);
+    optionsList.add(COMPRESS_RAW_SIDECARS_KEY);
     optionsList.add(INFER_OBJECTIVE_LENS_NA_KEY);
     return optionsList;
   }
@@ -1935,7 +1950,7 @@ public class CV7000Reader extends FormatReader {
   // ###############
 
   private void addYokogawaOriginalMetadata(MetadataStore store,
-    boolean hasInstrument)
+    boolean hasInstrument) throws FormatException
   {
     int rawSidecarAnnotation = 0;
     int plateAnnotationRef = 0;
@@ -2169,7 +2184,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   private String addRawSidecarFileAnnotation(MetadataStore store, String file,
-    int index)
+    int index) throws FormatException
   {
     Location location = new Location(file);
     String name = location.getName();
@@ -2180,6 +2195,13 @@ public class CV7000Reader extends FormatReader {
     try {
       byte[] bytes = readSidecarBytes(file);
       NonNegativeLong length = new NonNegativeLong(Long.valueOf(bytes.length));
+      byte[] payload = bytes;
+      Compression compression = Compression.NONE;
+      if (compressRawSidecars()) {
+        payload = new ZlibCodec().compress(bytes, null);
+        compression = Compression.ZLIB;
+      }
+      long encodedLength = 4L * ((payload.length + 2L) / 3L);
       String annotationID = "Annotation:CV7000RawSidecar:" + index;
 
       store.setFileAnnotationID(annotationID, index);
@@ -2189,9 +2211,12 @@ public class CV7000Reader extends FormatReader {
       store.setBinaryFileFileName(name, index);
       store.setBinaryFileMIMEType(XML_MIME_TYPE, index);
       store.setBinaryFileSize(length, index);
-      store.setBinaryFileBinData(bytes, index);
+      store.setBinaryFileBinData(payload, index);
+      store.setBinaryFileBinDataCompression(compression, index);
+      // XML sidecars are opaque byte streams, so host byte order is irrelevant.
       store.setBinaryFileBinDataBigEndian(Boolean.FALSE, index);
-      store.setBinaryFileBinDataLength(length, index);
+      store.setBinaryFileBinDataLength(
+        new NonNegativeLong(Long.valueOf(encodedLength)), index);
       return annotationID;
     }
     catch (IOException e) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -102,7 +102,9 @@ public class CV7000Reader extends FormatReader {
   private String detailPath;
   private String measurementPath;
   private String settingsPath;
-  private DatasetPaths datasetPaths;
+  private CV7000RawModel rawModel = new CV7000RawModel();
+  private CV7000SeriesLayout seriesLayout;
+  private CV7000DatasetPaths datasetPaths;
   private ArrayList<Plane> planeData;
   private int[][] reversePlaneLookup;
   private ArrayList<LightSource> lightSources;
@@ -111,10 +113,7 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<String> extraFiles;
   private MeasurementDataHandler measurementHandler;
   private CrosstalkParameters crosstalkParameters;
-  private LinkedHashMap<String, YokogawaAnnotationGroup> yokogawaAnnotationGroups =
-    new LinkedHashMap<String, YokogawaAnnotationGroup>();
-
-  private transient Map<String, Boolean> acquiredWells = new HashMap<String, Boolean>();
+  private YokogawaParsing parsing = new YokogawaParsing();
 
   // -- Constructor --
 
@@ -254,10 +253,10 @@ public class CV7000Reader extends FormatReader {
       endTime = null;
       measurementHandler = null;
       crosstalkParameters = null;
-      yokogawaAnnotationGroups.clear();
       reversePlaneLookup = null;
       extraFiles = null;
-      acquiredWells.clear();
+      seriesLayout = null;
+      rawModel = new CV7000RawModel();
       if (allFiles != null) {
           allFiles.clear();
       } else {
@@ -315,25 +314,29 @@ public class CV7000Reader extends FormatReader {
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
-    yokogawaAnnotationGroups.clear();
-    DatasetPaths paths = getDatasetPaths(id);
+    rawModel = new CV7000RawModel();
+    seriesLayout = null;
+    CV7000DatasetPaths paths = getDatasetPaths(id);
     datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
+    rawModel.paths = paths;
+    rawModel.plate = plate;
 
     parseMeasurementData(paths);
     parseOptionalSidecars(paths);
     normalizeChannels(paths.parent);
     collectDatasetFiles(paths.parent);
 
-    SeriesLayout layout = buildSeriesLayout();
+    CV7000SeriesLayout layout = buildSeriesLayout();
+    seriesLayout = layout;
     initializeCoreMetadata(layout);
     populateReversePlaneLookup(layout);
-    populateMetadataStore(plate, layout);
+    new CV7000MetadataPopulator().populate(plate, layout);
     setSeries(0);
   }
 
-  private DatasetPaths getDatasetPaths(String id) {
-    DatasetPaths paths = new DatasetPaths();
+  private CV7000DatasetPaths getDatasetPaths(String id) {
+    CV7000DatasetPaths paths = new CV7000DatasetPaths();
     Location wpi = new Location(id).getAbsoluteFile();
     paths.wpiPath = wpi.getAbsolutePath();
     paths.parent = wpi.getParentFile();
@@ -362,12 +365,13 @@ public class CV7000Reader extends FormatReader {
         isDatasetFile(classifyCV7000File(file)))
       {
         allFiles.add(file.getAbsolutePath());
+        rawModel.addFile(file.getAbsolutePath());
       }
     }
   }
 
   /** Parse the required plane manifest and resolve readable TIFF plane paths. */
-  private void parseMeasurementData(DatasetPaths paths)
+  private void parseMeasurementData(CV7000DatasetPaths paths)
     throws FormatException, IOException
   {
     if (!paths.measurementData.exists()) {
@@ -375,13 +379,16 @@ public class CV7000Reader extends FormatReader {
     }
 
     measurementPath = paths.measurementData.getAbsolutePath();
+    rawModel.measurementPath = measurementPath;
     measurementHandler = new MeasurementDataHandler(paths.parent.getAbsolutePath());
     XMLTools.parseXML(readSanitizedXML(measurementPath), measurementHandler);
     planeData = measurementHandler.getPlanes();
+    rawModel.measurementHandler = measurementHandler;
+    rawModel.planes = planeData;
   }
 
   /** Parse optional XML sidecars that enrich channel, instrument, and raw metadata. */
-  private void parseOptionalSidecars(DatasetPaths paths) throws IOException {
+  private void parseOptionalSidecars(CV7000DatasetPaths paths) throws IOException {
     parseMeasurementDetail(paths);
     parseWellPlateProduct();
     parseMeasurementSettings();
@@ -389,21 +396,25 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** MeasurementDetail links the acquisition settings sidecars and seeds channels. */
-  private void parseMeasurementDetail(DatasetPaths paths) throws IOException {
+  private void parseMeasurementDetail(CV7000DatasetPaths paths) throws IOException {
     if (!paths.measurementDetail.exists()) {
       LOGGER.warn("Missing " + MEASUREMENT_DETAIL + " file");
       return;
     }
 
     channels = new ArrayList<Channel>();
+    rawModel.channels = channels;
     detailPath = paths.measurementDetail.getAbsolutePath();
+    rawModel.detailPath = detailPath;
     MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
     XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
     if (wppPath != null) {
       wppPath = new Location(paths.parent, wppPath).getAbsolutePath();
+      rawModel.wppPath = wppPath;
     }
     if (settingsPath != null) {
       settingsPath = new Location(paths.parent, settingsPath).getAbsolutePath();
+      rawModel.settingsPath = settingsPath;
     }
   }
 
@@ -418,6 +429,7 @@ public class CV7000Reader extends FormatReader {
   private void parseMeasurementSettings() throws IOException {
     if (settingsPath != null && new Location(settingsPath).exists()) {
       lightSources = new ArrayList<LightSource>();
+      rawModel.lightSources = lightSources;
       MeasurementSettingsHandler settingsHandler = new MeasurementSettingsHandler();
       String xml = readSanitizedXML(settingsPath);
       if (xml.length() > 0) {
@@ -427,7 +439,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** OTF crosstalk stores exact emission filter bands and optional dichroics. */
-  private void parseOTFCrosstalk(DatasetPaths paths) {
+  private void parseOTFCrosstalk(CV7000DatasetPaths paths) {
     Location crosstalk = paths.otfCrosstalk;
     if (!crosstalk.exists()) {
       return;
@@ -437,9 +449,11 @@ public class CV7000Reader extends FormatReader {
       CrosstalkParameterHandler handler = new CrosstalkParameterHandler();
       XMLTools.parseXML(readSanitizedXML(crosstalk.getAbsolutePath()), handler);
       crosstalkParameters = handler.getParameters();
+      rawModel.crosstalkParameters = crosstalkParameters;
     }
     catch (Exception e) {
       crosstalkParameters = null;
+      rawModel.crosstalkParameters = null;
       LOGGER.warn("Could not parse CV7000 crosstalk sidecar {}", crosstalk.getAbsolutePath(), e);
     }
   }
@@ -450,6 +464,7 @@ public class CV7000Reader extends FormatReader {
       return;
     }
     sortChannelsByActionThenIndex();
+    rawModel.indexChannels();
     resolveCorrectionFiles(parent);
   }
 
@@ -479,8 +494,8 @@ public class CV7000Reader extends FormatReader {
    * Build the field/channel/time/z layout before touching Bio-Formats core
    * metadata.  This keeps Yokogawa indexing separate from reader indexing.
    */
-  private SeriesLayout buildSeriesLayout() throws FormatException {
-    SeriesLayout layout = new SeriesLayout();
+  private CV7000SeriesLayout buildSeriesLayout() throws FormatException {
+    CV7000SeriesLayout layout = new CV7000SeriesLayout();
     HashSet<Field> acquiredFieldSet = collectAcquiredFields(layout);
 
     if (layout.firstFile == null) {
@@ -488,6 +503,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     sortAcquiredFields(layout.acquiredFields);
+    indexAcquiredFields(layout);
     collectPlaneExtents(layout, acquiredFieldSet);
     layout.channelIndexes = layout.uniqueChannels.toArray(
       new Integer[layout.uniqueChannels.size()]);
@@ -496,7 +512,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Only fields with at least one readable plane become Bio-Formats series. */
-  private HashSet<Field> collectAcquiredFields(SeriesLayout layout) {
+  private HashSet<Field> collectAcquiredFields(CV7000SeriesLayout layout) {
     HashSet<Field> acquiredFieldSet = new HashSet<Field>();
     for (Plane p : planeData) {
       if (p != null && p.file != null) {
@@ -530,8 +546,22 @@ public class CV7000Reader extends FormatReader {
     });
   }
 
+  /** Pre-index acquired wells and fields for plate metadata population. */
+  private void indexAcquiredFields(CV7000SeriesLayout layout) {
+    for (Field field : layout.acquiredFields) {
+      String key = getWellKey(field.row, field.column);
+      layout.acquiredWells.put(key, Boolean.TRUE);
+      ArrayList<Field> fields = layout.fieldsByWell.get(key);
+      if (fields == null) {
+        fields = new ArrayList<Field>();
+        layout.fieldsByWell.put(key, fields);
+      }
+      fields.add(field);
+    }
+  }
+
   /** Determine SizeZ/SizeT/channel coverage for every acquired field. */
-  private void collectPlaneExtents(SeriesLayout layout, HashSet<Field> acquiredFieldSet) {
+  private void collectPlaneExtents(CV7000SeriesLayout layout, HashSet<Field> acquiredFieldSet) {
     for (Plane p : planeData) {
       if (p != null && acquiredFieldSet.contains(p.field)) {
         p.channelIndex = getLogicalChannelIndex(p);
@@ -555,14 +585,15 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Initialize the Bio-Formats core metadata once the logical layout is known. */
-  private void initializeCoreMetadata(SeriesLayout layout) throws FormatException, IOException {
+  private void initializeCoreMetadata(CV7000SeriesLayout layout) throws FormatException, IOException {
     reader = new MinimalTiffReader();
     reader.setId(layout.firstFile);
     core.clear();
     core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));
 
     core.get(0).dimensionOrder = "XYCZT";
-    reversePlaneLookup = new int[layout.acquiredFields.size()][];
+    layout.reversePlaneLookup = new int[layout.acquiredFields.size()][];
+    reversePlaneLookup = layout.reversePlaneLookup;
 
     for (int i=0; i<layout.acquiredFields.size(); i++) {
       if (i > 0) {
@@ -583,7 +614,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Map each Yokogawa plane record to the reader's series and plane index. */
-  private void populateReversePlaneLookup(SeriesLayout layout) {
+  private void populateReversePlaneLookup(CV7000SeriesLayout layout) {
     int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
 
     extraFiles = new ArrayList<String>();
@@ -612,6 +643,7 @@ public class CV7000Reader extends FormatReader {
       p.no = FormatTools.positionToRaster(planeLengths,
         new int[] {p.channelIndex, p.z - m.minZ, p.timepoint - m.minT});
       assignPlaneLookup(i, p);
+      layout.indexPlane(p);
     }
   }
 
@@ -633,7 +665,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Populate OME metadata after core metadata and plane lookup are complete. */
-  private void populateMetadataStore(WPIHandler plate, SeriesLayout layout)
+  private void populateMetadataStore(WPIHandler plate, CV7000SeriesLayout layout)
     throws FormatException
   {
     SeriesTiming[] timings = buildSeriesTimings();
@@ -641,7 +673,7 @@ public class CV7000Reader extends FormatReader {
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 
-    populatePlateMetadata(store, plate, layout.acquiredFields, timings);
+    populatePlateMetadata(store, plate, layout, timings);
     setSeries(0);
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
@@ -653,7 +685,7 @@ public class CV7000Reader extends FormatReader {
       populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
         indexes.detectorIndexes, indexes.filterIndexes, indexes.dichroicIndexes,
         indexes.usedObjectiveIDs, timings);
-      addYokogawaOriginalMetadata(store, indexes.instrument != null);
+      new CV7000OriginalMetadataPopulator().populate(store, indexes.instrument != null);
       setSeries(0);
     }
   }
@@ -679,7 +711,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   private void populatePlateMetadata(MetadataStore store, WPIHandler plate,
-    ArrayList<Field> acquiredFields, SeriesTiming[] timings)
+    CV7000SeriesLayout layout, SeriesTiming[] timings)
   {
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateName(plate.getPlateName(), 0);
@@ -697,7 +729,7 @@ public class CV7000Reader extends FormatReader {
 
     HashMap<Integer, Integer> wellFieldCounts = new HashMap<Integer, Integer>();
     int maxFieldCount = 0;
-    for (Field field : acquiredFields) {
+    for (Field field : layout.acquiredFields) {
       int wellIndex = field.row * plate.getPlateColumns() + field.column;
       Integer count = wellFieldCounts.get(wellIndex);
       count = count == null ? 1 : count + 1;
@@ -727,17 +759,14 @@ public class CV7000Reader extends FormatReader {
         store.setWellRow(new NonNegativeInteger(row), 0, nextWell);
         store.setWellColumn(new NonNegativeInteger(col), 0, nextWell);
 
-        if (!isWellAcquired(row, col)) {
+        ArrayList<Field> wellFields = layout.fieldsByWell.get(getWellKey(row, col));
+        if (wellFields == null || wellFields.size() == 0) {
           nextWell++;
           continue;
         }
 
         int wellSample = 0;
-        for (Field field : acquiredFields) {
-          if (field.row != row || field.column != col) {
-            continue;
-          }
-
+        for (Field field : wellFields) {
           String wellSampleID =
             MetadataTools.createLSID("WellSample", 0, nextWell, wellSample);
           store.setWellSampleID(wellSampleID, 0, nextWell, wellSample);
@@ -904,11 +933,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   private String clean(String value) {
-    if (value == null) {
-      return null;
-    }
-    String trimmed = value.trim();
-    return trimmed.length() == 0 ? null : trimmed;
+    return parsing.clean(value);
   }
 
   private void populateChannelLightSourceSettings(MetadataStore store, int series,
@@ -1606,7 +1631,7 @@ public class CV7000Reader extends FormatReader {
     refs.plate = plateAnnotationRefStart;
 
     int mapAnnotationIndex = 0;
-    for (YokogawaAnnotationGroup group : yokogawaAnnotationGroups.values()) {
+    for (YokogawaAnnotationGroup group : rawModel.originalMetadata.groups.values()) {
       if (group.isEmpty()) {
         continue;
       }
@@ -1753,10 +1778,10 @@ public class CV7000Reader extends FormatReader {
     if (scope == null) {
       scope = "Yokogawa";
     }
-    YokogawaAnnotationGroup group = yokogawaAnnotationGroups.get(scope);
+    YokogawaAnnotationGroup group = rawModel.originalMetadata.groups.get(scope);
     if (group == null) {
       group = new YokogawaAnnotationGroup(scope);
-      yokogawaAnnotationGroups.put(scope, group);
+      rawModel.originalMetadata.groups.put(scope, group);
     }
     return group;
   }
@@ -1772,11 +1797,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   private String getYokogawaAttributeName(String qName) {
-    if (qName == null) {
-      return "";
-    }
-    int colon = qName.indexOf(":");
-    return colon < 0 ? qName : qName.substring(colon + 1);
+    return parsing.getYokogawaAttributeName(qName);
   }
 
   private Integer getLinkedLaser(Channel channel) {
@@ -1804,88 +1825,19 @@ public class CV7000Reader extends FormatReader {
   }
 
   private String getBinningValue(String binning) {
-    if (binning == null || binning.trim().length() == 0) {
-      return null;
-    }
-    if (binning.indexOf('x') >= 0 || binning.indexOf('X') >= 0) {
-      return binning;
-    }
-    return binning + "x" + binning;
+    return parsing.getBinningValue(binning);
   }
 
   private DetectionFilter parseDetectionFilter(String acquisition) {
-    if (acquisition == null) {
-      return null;
-    }
-    String trimmed = acquisition.trim();
-    try {
-      if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
-        String center = trimmed.substring(2, trimmed.indexOf("/"));
-        String width = trimmed.substring(trimmed.indexOf("/") + 1);
-        Double parsedCenter = DataTools.parseDouble(center);
-        Double parsedWidth = DataTools.parseDouble(width);
-        if (parsedCenter != null && parsedWidth != null) {
-          return DetectionFilter.bandPass(parsedCenter, parsedWidth);
-        }
-      }
-      else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
-        Double cutIn = DataTools.parseDouble(trimmed.substring(2));
-        if (cutIn != null) {
-          return DetectionFilter.longPass(cutIn);
-        }
-      }
-      else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
-        Double cutOut = DataTools.parseDouble(trimmed.substring(2));
-        if (cutOut != null) {
-          return DetectionFilter.shortPass(cutOut);
-        }
-      }
-    }
-    catch (RuntimeException e) {
-      LOGGER.debug("Ignoring invalid CV7000 detection filter value {}", acquisition, e);
-    }
-    return null;
+    return parsing.parseDetectionFilter(acquisition);
   }
 
   private Double parseYokogawaGain(String value) {
-    if (value == null) {
-      return null;
-    }
-    String trimmed = value.trim();
-    if (!trimmed.regionMatches(true, 0, "gain", 0, 4)) {
-      return null;
-    }
-    int start = -1;
-    for (int i=4; i<trimmed.length(); i++) {
-      char ch = trimmed.charAt(i);
-      if (Character.isDigit(ch) || ch == '+' || ch == '-' ||
-        ch == '.' || ch == ',')
-      {
-        start = i;
-        break;
-      }
-    }
-    if (start < 0) {
-      return null;
-    }
-    int end = start + 1;
-    while (end < trimmed.length()) {
-      char ch = trimmed.charAt(end);
-      if (!(Character.isDigit(ch) || ch == '+' || ch == '-' ||
-        ch == '.' || ch == ',' || ch == 'e' || ch == 'E'))
-      {
-        break;
-      }
-      end++;
-    }
-    return DataTools.parseDouble(trimmed.substring(start, end));
+    return parsing.parseYokogawaGain(value);
   }
 
   private Integer parseInteger(String value) {
-    if (value == null || value.trim().length() == 0) {
-      return null;
-    }
-    return Integer.valueOf(value.trim());
+    return parsing.parseInteger(value);
   }
 
   private int getChannelIndex(Plane p) {
@@ -1931,6 +1883,11 @@ public class CV7000Reader extends FormatReader {
   }
 
   private Channel lookupChannel(Plane p) {
+    Channel matched = rawModel.getChannel(p.timelineIndex, p.actionIndex, p.channel);
+    if (matched != null) {
+      return matched;
+    }
+
     Channel rawChannel = null;
     Channel populatedRawChannel = null;
     for (Channel ch : channels) {
@@ -1963,6 +1920,13 @@ public class CV7000Reader extends FormatReader {
   }
 
   private Plane lookupRepresentativePlane(int series, int channel) {
+    if (seriesLayout != null) {
+      Plane indexed = seriesLayout.getRepresentativePlane(series, channel);
+      if (indexed != null) {
+        return indexed;
+      }
+    }
+
     Plane metadataPlane = null;
     for (int no=0; no<reversePlaneLookup[series].length; no++) {
       Plane p = lookupPlane(series, no);
@@ -1977,28 +1941,26 @@ public class CV7000Reader extends FormatReader {
   }
 
   private String readSanitizedXML(String filename) throws IOException {
-    String xml = DataTools.readFile(filename).trim();
-    if (xml.endsWith(">>")) {
-      xml = xml.substring(0, xml.length() - 1);
-    }
-    return xml;
+    return parsing.readSanitizedXML(filename);
   }
 
   private boolean isWellAcquired(int row, int col) {
-    String key = row + "-" + col;
-    if (acquiredWells.containsKey(key)) {
-      return acquiredWells.get(key);
+    String key = getWellKey(row, col);
+    if (seriesLayout != null && seriesLayout.acquiredWells.containsKey(key)) {
+      return seriesLayout.acquiredWells.get(key);
     }
     if (planeData != null) {
       for (Plane p : planeData) {
         if (p != null && p.file != null && p.field.row == row && p.field.column == col) {
-          acquiredWells.put(key, true);
           return true;
         }
       }
     }
-    acquiredWells.put(key, false);
     return false;
+  }
+
+  private String getWellKey(int row, int column) {
+    return row + "-" + column;
   }
 
   private Plane lookupPlane(int series, int no) {
@@ -2030,7 +1992,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Resolved dataset paths used during the parsing phase. */
-  class DatasetPaths {
+  class CV7000DatasetPaths {
     public Location parent;
     public String wpiPath;
     public Location measurementData;
@@ -2040,14 +2002,262 @@ public class CV7000Reader extends FormatReader {
     public Location otfGeometry;
   }
 
+  /** Parsed Yokogawa sidecars and reader-local provenance. */
+  class CV7000RawModel {
+    public CV7000DatasetPaths paths;
+    public WPIHandler plate;
+    public ArrayList<Plane> planes = new ArrayList<Plane>();
+    public ArrayList<LightSource> lightSources;
+    public ArrayList<Channel> channels;
+    public String startTime;
+    public String endTime;
+    public String wppPath;
+    public String detailPath;
+    public String measurementPath;
+    public String settingsPath;
+    public MeasurementDataHandler measurementHandler;
+    public CrosstalkParameters crosstalkParameters;
+    public ArrayList<String> allFiles = new ArrayList<String>();
+    public YokogawaOriginalMetadata originalMetadata =
+      new YokogawaOriginalMetadata();
+    private HashMap<ChannelKey, Channel> channelsByAcquisition =
+      new HashMap<ChannelKey, Channel>();
+    private HashMap<Integer, ArrayList<Channel>> channelsByRawIndex =
+      new HashMap<Integer, ArrayList<Channel>>();
+
+    public void addFile(String file) {
+      if (file != null && !allFiles.contains(file)) {
+        allFiles.add(file);
+      }
+    }
+
+    public void indexChannels() {
+      channelsByAcquisition.clear();
+      channelsByRawIndex.clear();
+      if (channels == null) {
+        return;
+      }
+      for (Channel channel : channels) {
+        ChannelKey key = new ChannelKey(
+          channel.timelineIndex, channel.actionIndex, channel.index);
+        if (!channelsByAcquisition.containsKey(key)) {
+          channelsByAcquisition.put(key, channel);
+        }
+        Integer rawIndex = Integer.valueOf(channel.index);
+        ArrayList<Channel> rawChannels = channelsByRawIndex.get(rawIndex);
+        if (rawChannels == null) {
+          rawChannels = new ArrayList<Channel>();
+          channelsByRawIndex.put(rawIndex, rawChannels);
+        }
+        rawChannels.add(channel);
+      }
+    }
+
+    public Channel getChannel(int timelineIndex, int actionIndex, int rawChannel) {
+      return channelsByAcquisition.get(
+        new ChannelKey(timelineIndex, actionIndex, rawChannel));
+    }
+  }
+
+  /** Grouped Yokogawa metadata pending OME MapAnnotation emission. */
+  class YokogawaOriginalMetadata {
+    public LinkedHashMap<String, YokogawaAnnotationGroup> groups =
+      new LinkedHashMap<String, YokogawaAnnotationGroup>();
+  }
+
   /** Intermediate layout data used to translate Yokogawa records into series. */
-  class SeriesLayout {
+  class CV7000SeriesLayout {
     public String firstFile;
     public ArrayList<Field> acquiredFields = new ArrayList<Field>();
     public HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
     public HashSet<Integer> uniqueChannels = new HashSet<Integer>();
     public Integer[] channelIndexes;
     public HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
+    public int[][] reversePlaneLookup;
+    public LinkedHashMap<String, ArrayList<Field>> fieldsByWell =
+      new LinkedHashMap<String, ArrayList<Field>>();
+    public HashMap<String, Boolean> acquiredWells =
+      new HashMap<String, Boolean>();
+    private HashMap<String, Plane> representativePlanes =
+      new HashMap<String, Plane>();
+
+    public void indexPlane(Plane plane) {
+      if (plane == null) {
+        return;
+      }
+      String key = getPlaneKey(plane.series, plane.channelIndex);
+      Plane existing = representativePlanes.get(key);
+      if (existing == null || (existing.file == null && plane.file != null)) {
+        representativePlanes.put(key, plane);
+      }
+    }
+
+    public Plane getRepresentativePlane(int series, int channel) {
+      return representativePlanes.get(getPlaneKey(series, channel));
+    }
+
+    private String getPlaneKey(int series, int channel) {
+      return series + ":" + channel;
+    }
+  }
+
+  /** Standard OME metadata population entrypoint. */
+  class CV7000MetadataPopulator {
+    public void populate(WPIHandler plate, CV7000SeriesLayout layout)
+      throws FormatException
+    {
+      populateMetadataStore(plate, layout);
+    }
+  }
+
+  /** Yokogawa-specific annotation and sidecar provenance entrypoint. */
+  class CV7000OriginalMetadataPopulator {
+    public void populate(MetadataStore store, boolean hasInstrument) {
+      addYokogawaOriginalMetadata(store, hasInstrument);
+    }
+  }
+
+  class ChannelKey {
+    public int timelineIndex;
+    public int actionIndex;
+    public int channelIndex;
+
+    public ChannelKey(int timelineIndex, int actionIndex, int channelIndex) {
+      this.timelineIndex = timelineIndex;
+      this.actionIndex = actionIndex;
+      this.channelIndex = channelIndex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof ChannelKey)) {
+        return false;
+      }
+      ChannelKey key = (ChannelKey) o;
+      return timelineIndex == key.timelineIndex &&
+        actionIndex == key.actionIndex && channelIndex == key.channelIndex;
+    }
+
+    @Override
+    public int hashCode() {
+      int code = 17;
+      code = 31 * code + timelineIndex;
+      code = 31 * code + actionIndex;
+      code = 31 * code + channelIndex;
+      return code;
+    }
+  }
+
+  /** Shared Yokogawa parsing and normalization helpers. */
+  class YokogawaParsing {
+    public String readSanitizedXML(String filename) throws IOException {
+      String xml = DataTools.readFile(filename).trim();
+      if (xml.endsWith(">>")) {
+        xml = xml.substring(0, xml.length() - 1);
+      }
+      return xml;
+    }
+
+    public String clean(String value) {
+      if (value == null) {
+        return null;
+      }
+      String trimmed = value.trim();
+      return trimmed.length() == 0 ? null : trimmed;
+    }
+
+    public String getYokogawaAttributeName(String qName) {
+      if (qName == null) {
+        return "";
+      }
+      int colon = qName.indexOf(":");
+      return colon < 0 ? qName : qName.substring(colon + 1);
+    }
+
+    public Integer parseInteger(String value) {
+      if (value == null || value.trim().length() == 0) {
+        return null;
+      }
+      return Integer.valueOf(value.trim());
+    }
+
+    public Double parseYokogawaGain(String value) {
+      if (value == null) {
+        return null;
+      }
+      String trimmed = value.trim();
+      if (!trimmed.regionMatches(true, 0, "gain", 0, 4)) {
+        return null;
+      }
+      int start = -1;
+      for (int i=4; i<trimmed.length(); i++) {
+        char ch = trimmed.charAt(i);
+        if (Character.isDigit(ch) || ch == '+' || ch == '-' ||
+          ch == '.' || ch == ',')
+        {
+          start = i;
+          break;
+        }
+      }
+      if (start < 0) {
+        return null;
+      }
+      int end = start + 1;
+      while (end < trimmed.length()) {
+        char ch = trimmed.charAt(end);
+        if (!(Character.isDigit(ch) || ch == '+' || ch == '-' ||
+          ch == '.' || ch == ',' || ch == 'e' || ch == 'E'))
+        {
+          break;
+        }
+        end++;
+      }
+      return DataTools.parseDouble(trimmed.substring(start, end));
+    }
+
+    public DetectionFilter parseDetectionFilter(String acquisition) {
+      if (acquisition == null) {
+        return null;
+      }
+      String trimmed = acquisition.trim();
+      try {
+        if (trimmed.startsWith("BP") && trimmed.indexOf("/") > 2) {
+          String center = trimmed.substring(2, trimmed.indexOf("/"));
+          String width = trimmed.substring(trimmed.indexOf("/") + 1);
+          Double parsedCenter = DataTools.parseDouble(center);
+          Double parsedWidth = DataTools.parseDouble(width);
+          if (parsedCenter != null && parsedWidth != null) {
+            return DetectionFilter.bandPass(parsedCenter, parsedWidth);
+          }
+        }
+        else if (trimmed.startsWith("LP") && trimmed.length() > 2) {
+          Double cutIn = DataTools.parseDouble(trimmed.substring(2));
+          if (cutIn != null) {
+            return DetectionFilter.longPass(cutIn);
+          }
+        }
+        else if (trimmed.startsWith("SP") && trimmed.length() > 2) {
+          Double cutOut = DataTools.parseDouble(trimmed.substring(2));
+          if (cutOut != null) {
+            return DetectionFilter.shortPass(cutOut);
+          }
+        }
+      }
+      catch (RuntimeException e) {
+        LOGGER.debug("Ignoring invalid CV7000 detection filter value {}", acquisition, e);
+      }
+      return null;
+    }
+
+    public String getBinningValue(String binning) {
+      if (binning == null || binning.trim().length() == 0) {
+        return null;
+      }
+      if (binning.indexOf('x') >= 0 || binning.indexOf('X') >= 0) {
+        return binning;
+      }
+      return binning + "x" + binning;
+    }
   }
 
   /** OME instrument indexes shared by channel metadata population. */
@@ -2327,6 +2537,7 @@ public class CV7000Reader extends FormatReader {
         if (wppPath != null && wppPath.trim().length() == 0) {
           wppPath = null;
         }
+        rawModel.wppPath = wppPath;
       }
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
@@ -2352,7 +2563,10 @@ public class CV7000Reader extends FormatReader {
         addYokogawaAttributes("Yokogawa MRF MeasurementDetail ", attributes);
         startTime = attributes.getValue("bts:BeginTime");
         endTime = attributes.getValue("bts:EndTime");
+        rawModel.startTime = startTime;
+        rawModel.endTime = endTime;
         settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
+        rawModel.settingsPath = settingsPath;
 
         String system = attributes.getValue("bts:TargetSystem");
         addYokogawaMeta(

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -26,12 +26,10 @@
 package loci.formats.in;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -42,6 +40,7 @@ import java.util.Map;
 
 import loci.common.DataTools;
 import loci.common.Location;
+import loci.common.RandomAccessInputStream;
 import loci.common.xml.BaseHandler;
 import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
@@ -55,8 +54,10 @@ import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.units.quantity.Power;
 import ome.units.quantity.Time;
+import ome.xml.model.MapPair;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.NonNegativeLong;
 import ome.xml.model.primitives.PercentFraction;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
@@ -87,7 +88,11 @@ public class CV7000Reader extends FormatReader {
   private static final String OTF_CROSSTALK_PARAMETER = "OTF_crosstalk_parameter.xml";
   private static final String OTF_GEOMETRY_PARAMETER = "OTF_geometry_parameter.xml";
   private static final String BRIGHTFIELD = "Brightfield";
-  private static final int RAW_XML_CHUNK_SIZE = 7600;
+  private static final String RAW_SIDECAR_ANNOTATION_NAMESPACE =
+    "openmicroscopy.org/OriginalMetadata/Yokogawa/CV7000/RawSidecar";
+  private static final String YOKOGAWA_ANNOTATION_NAMESPACE =
+    "openmicroscopy.org/OriginalMetadata/Yokogawa/CV7000";
+  private static final String XML_MIME_TYPE = "application/xml";
 
   // -- Fields --
 
@@ -106,6 +111,8 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<String> extraFiles;
   private MeasurementDataHandler measurementHandler;
   private CrosstalkParameters crosstalkParameters;
+  private LinkedHashMap<String, YokogawaAnnotationGroup> yokogawaAnnotationGroups =
+    new LinkedHashMap<String, YokogawaAnnotationGroup>();
 
   private transient Map<String, Boolean> acquiredWells = new HashMap<String, Boolean>();
 
@@ -247,6 +254,7 @@ public class CV7000Reader extends FormatReader {
       endTime = null;
       measurementHandler = null;
       crosstalkParameters = null;
+      yokogawaAnnotationGroups.clear();
       reversePlaneLookup = null;
       extraFiles = null;
       acquiredWells.clear();
@@ -307,6 +315,7 @@ public class CV7000Reader extends FormatReader {
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
+    yokogawaAnnotationGroups.clear();
     DatasetPaths paths = getDatasetPaths(id);
     datasetPaths = paths;
     WPIHandler plate = parsePlate(paths.wpiPath);
@@ -644,7 +653,7 @@ public class CV7000Reader extends FormatReader {
       populateSeriesMetadata(store, indexes.instrument, indexes.lightSourceIndexes,
         indexes.detectorIndexes, indexes.filterIndexes, indexes.dichroicIndexes,
         indexes.usedObjectiveIDs, timings);
-      addYokogawaOriginalMetadata();
+      addYokogawaOriginalMetadata(store, indexes.instrument != null);
       setSeries(0);
     }
   }
@@ -1237,14 +1246,27 @@ public class CV7000Reader extends FormatReader {
     return new PercentFraction(Float.valueOf((float) fraction));
   }
 
-  private void addYokogawaOriginalMetadata() {
+  private void addYokogawaOriginalMetadata(MetadataStore store,
+    boolean hasInstrument)
+  {
+    int rawSidecarAnnotation = 0;
+    int plateAnnotationRef = 0;
     if (allFiles != null) {
       for (String file : allFiles) {
         Location location = file == null ? null : new Location(file);
         CV7000FileRole role = classifyCV7000File(location);
         if (file != null && isDatasetFile(role) && !isPixelFile(role)) {
           parseStructuredSidecarMetadata(file, role);
-          addRawSidecarMetadata(file, role);
+          addSidecarSummaryMetadata(file, role);
+          if (preserveRawSidecarAsFileAnnotation(role)) {
+            String annotationID = addRawSidecarFileAnnotation(
+              store, file, rawSidecarAnnotation);
+            if (annotationID != null) {
+              store.setPlateAnnotationRef(annotationID, 0, plateAnnotationRef);
+              rawSidecarAnnotation++;
+              plateAnnotationRef++;
+            }
+          }
           addYokogawaMetaList("Yokogawa Sidecar ", "File",
             location.getName());
         }
@@ -1261,6 +1283,7 @@ public class CV7000Reader extends FormatReader {
     }
     addCrosstalkOriginalMetadata();
     if (channels == null) {
+      emitYokogawaMapAnnotations(store, plateAnnotationRef, hasInstrument);
       return;
     }
     HashSet<String> seen = new HashSet<String>();
@@ -1311,6 +1334,7 @@ public class CV7000Reader extends FormatReader {
       addYokogawaMeta(prefix, "FilterPosition", c.filterPosition);
       addYokogawaMeta(prefix, "ShadingCorrectionSource", c.correctionFile);
     }
+    emitYokogawaMapAnnotations(store, plateAnnotationRef, hasInstrument);
   }
 
   private void addCrosstalkOriginalMetadata() {
@@ -1349,33 +1373,70 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private void addRawSidecarMetadata(String file, CV7000FileRole role) {
+  private void addSidecarSummaryMetadata(String file, CV7000FileRole role) {
     Location location = new Location(file);
     String name = location.getName();
-    if (name == null || !preserveRawXML(role)) {
+    if (name == null) {
       return;
     }
 
     try {
-      String xml = DataTools.readFile(file);
-      byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
-      String encoded = Base64.getEncoder().encodeToString(bytes);
-      int chunkCount = (encoded.length() + RAW_XML_CHUNK_SIZE - 1) / RAW_XML_CHUNK_SIZE;
-      String prefix = "Yokogawa Raw XML " + name + " ";
+      byte[] bytes = readSidecarBytes(file);
+      String prefix = "Yokogawa Sidecar " + name + " ";
 
-      addYokogawaMeta(prefix, "Encoding", "base64; charset=UTF-8");
+      addYokogawaMeta(prefix, "Role", role.name());
       addYokogawaMeta(prefix, "ByteLength", bytes.length);
       addYokogawaMeta(prefix, "SHA-256", sha256(bytes));
-      addYokogawaMeta(prefix, "ChunkCount", chunkCount);
-      for (int chunk=0; chunk<chunkCount; chunk++) {
-        int start = chunk * RAW_XML_CHUNK_SIZE;
-        int end = Math.min(start + RAW_XML_CHUNK_SIZE, encoded.length());
-        addYokogawaMeta(prefix, "Chunk " + zeroPad(chunk + 1, 4),
-          encoded.substring(start, end));
-      }
+    }
+    catch (IOException e) {
+      LOGGER.debug("Could not summarize CV7000 sidecar {}", file, e);
+    }
+  }
+
+  private String addRawSidecarFileAnnotation(MetadataStore store, String file,
+    int index)
+  {
+    Location location = new Location(file);
+    String name = location.getName();
+    if (name == null) {
+      return null;
+    }
+
+    try {
+      byte[] bytes = readSidecarBytes(file);
+      NonNegativeLong length = new NonNegativeLong(Long.valueOf(bytes.length));
+      String annotationID = "Annotation:CV7000RawSidecar:" + index;
+
+      store.setFileAnnotationID(annotationID, index);
+      store.setFileAnnotationNamespace(RAW_SIDECAR_ANNOTATION_NAMESPACE, index);
+      store.setFileAnnotationDescription(
+        "Yokogawa CV7000 raw sidecar " + name, index);
+      store.setBinaryFileFileName(name, index);
+      store.setBinaryFileMIMEType(XML_MIME_TYPE, index);
+      store.setBinaryFileSize(length, index);
+      store.setBinaryFileBinData(bytes, index);
+      store.setBinaryFileBinDataLength(length, index);
+      return annotationID;
     }
     catch (IOException e) {
       LOGGER.debug("Could not preserve raw CV7000 sidecar {}", file, e);
+    }
+    return null;
+  }
+
+  private byte[] readSidecarBytes(String file) throws IOException {
+    RandomAccessInputStream stream = new RandomAccessInputStream(file);
+    try {
+      long length = stream.length();
+      if (length > Integer.MAX_VALUE) {
+        throw new IOException("CV7000 sidecar too large to embed: " + file);
+      }
+      byte[] bytes = new byte[(int) length];
+      stream.readFully(bytes);
+      return bytes;
+    }
+    finally {
+      stream.close();
     }
   }
 
@@ -1436,7 +1497,7 @@ public class CV7000Reader extends FormatReader {
     return role != null && role != CV7000FileRole.UNKNOWN;
   }
 
-  private boolean preserveRawXML(CV7000FileRole role) {
+  private boolean preserveRawSidecarAsFileAnnotation(CV7000FileRole role) {
     if (role == null) {
       return false;
     }
@@ -1495,8 +1556,7 @@ public class CV7000Reader extends FormatReader {
     }
 
     try {
-      String xml = DataTools.readFile(measurementPath);
-      byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
+      byte[] bytes = readSidecarBytes(measurementPath);
       addYokogawaMeta("Yokogawa MLF ", "File", new Location(measurementPath).getName());
       addYokogawaMeta("Yokogawa MLF ", "Encoding", "UTF-8");
       addYokogawaMeta("Yokogawa MLF ", "ByteLength", bytes.length);
@@ -1539,20 +1599,166 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private String zeroPad(int value, int width) {
-    String s = String.valueOf(value);
-    while (s.length() < width) {
-      s = "0" + s;
+  private void emitYokogawaMapAnnotations(MetadataStore store,
+    int plateAnnotationRefStart, boolean hasInstrument)
+  {
+    AnnotationRefIndexes refs = new AnnotationRefIndexes();
+    refs.plate = plateAnnotationRefStart;
+
+    int mapAnnotationIndex = 0;
+    for (YokogawaAnnotationGroup group : yokogawaAnnotationGroups.values()) {
+      if (group.isEmpty()) {
+        continue;
+      }
+      String annotationID = "Annotation:CV7000:YokogawaMap:" + mapAnnotationIndex;
+      store.setMapAnnotationID(annotationID, mapAnnotationIndex);
+      store.setMapAnnotationNamespace(YOKOGAWA_ANNOTATION_NAMESPACE, mapAnnotationIndex);
+      store.setMapAnnotationDescription(group.scope, mapAnnotationIndex);
+      store.setMapAnnotationValue(group.toMapPairs(), mapAnnotationIndex);
+      linkYokogawaMapAnnotation(store, annotationID, group.scope, refs,
+        hasInstrument);
+      mapAnnotationIndex++;
     }
-    return s;
+  }
+
+  private void linkYokogawaMapAnnotation(MetadataStore store,
+    String annotationID, String scope, AnnotationRefIndexes refs,
+    boolean hasInstrument)
+  {
+    if (isInstrumentAnnotationScope(scope)) {
+      if (hasInstrument) {
+        store.setInstrumentAnnotationRef(annotationID, 0, refs.instrument++);
+      }
+      else {
+        store.setPlateAnnotationRef(annotationID, 0, refs.plate++);
+      }
+      return;
+    }
+
+    if (isImageOrChannelAnnotationScope(scope) &&
+      linkToMatchingSeriesAndChannels(store, annotationID, scope, refs))
+    {
+      return;
+    }
+
+    store.setPlateAnnotationRef(annotationID, 0, refs.plate++);
+  }
+
+  private boolean isInstrumentAnnotationScope(String scope) {
+    return scope != null && (scope.startsWith("Yokogawa MES LightSource ") ||
+      scope.startsWith("Yokogawa LightSource ") ||
+      scope.startsWith("Yokogawa OTF "));
+  }
+
+  private boolean isImageOrChannelAnnotationScope(String scope) {
+    return scope != null && (scope.startsWith("Yokogawa MES Timeline ") ||
+      scope.startsWith("Yokogawa MES Channel ") ||
+      scope.startsWith("Yokogawa Timeline "));
+  }
+
+  private boolean linkToMatchingSeriesAndChannels(MetadataStore store,
+    String annotationID, String scope, AnnotationRefIndexes refs)
+  {
+    Integer timeline = getIndexedScopeValue(scope, "Timeline");
+    Integer action = getIndexedScopeValue(scope, "Action");
+    Integer channel = getIndexedScopeValue(scope, "Channel");
+    boolean channelScoped = channel != null;
+    boolean actionScoped = action != null;
+
+    if (!channelScoped && !actionScoped) {
+      return false;
+    }
+
+    HashSet<Integer> linkedImages = new HashSet<Integer>();
+    HashSet<String> linkedChannels = new HashSet<String>();
+
+    for (int series=0; series<getSeriesCount(); series++) {
+      if (reversePlaneLookup == null || series >= reversePlaneLookup.length) {
+        continue;
+      }
+      for (int no=0; no<reversePlaneLookup[series].length; no++) {
+        Plane plane = lookupPlane(series, no);
+        if (!matchesScope(plane, timeline, action, channel)) {
+          continue;
+        }
+        if (linkedImages.add(Integer.valueOf(series))) {
+          store.setImageAnnotationRef(annotationID, series,
+            refs.nextImage(series));
+        }
+        if (channelScoped) {
+          String key = series + ":" + plane.channelIndex;
+          if (linkedChannels.add(key)) {
+            store.setChannelAnnotationRef(annotationID, series,
+              plane.channelIndex, refs.nextChannel(series, plane.channelIndex));
+          }
+        }
+      }
+    }
+
+    return linkedImages.size() > 0 || linkedChannels.size() > 0;
+  }
+
+  private boolean matchesScope(Plane plane, Integer timeline, Integer action,
+    Integer channel)
+  {
+    if (plane == null) {
+      return false;
+    }
+    if (timeline != null && plane.timelineIndex != timeline.intValue()) {
+      return false;
+    }
+    if (action != null && plane.actionIndex != action.intValue()) {
+      return false;
+    }
+    return channel == null || plane.channel == channel.intValue();
+  }
+
+  private Integer getIndexedScopeValue(String scope, String label) {
+    if (scope == null || label == null) {
+      return null;
+    }
+    String token = label + " ";
+    int start = scope.indexOf(token);
+    if (start < 0) {
+      return null;
+    }
+    start += token.length();
+    int end = start;
+    while (end < scope.length() && Character.isDigit(scope.charAt(end))) {
+      end++;
+    }
+    if (end == start) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(Integer.parseInt(scope.substring(start, end)) - 1);
+    }
+    catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   private void addYokogawaMeta(String prefix, String name, Object value) {
-    addGlobalMeta(prefix + name, value);
+    YokogawaAnnotationGroup group = getYokogawaAnnotationGroup(prefix);
+    group.put(name, value);
   }
 
   private void addYokogawaMetaList(String prefix, String name, Object value) {
-    addGlobalMetaList(prefix + name, value);
+    YokogawaAnnotationGroup group = getYokogawaAnnotationGroup(prefix);
+    group.putList(name, value);
+  }
+
+  private YokogawaAnnotationGroup getYokogawaAnnotationGroup(String prefix) {
+    String scope = clean(prefix);
+    if (scope == null) {
+      scope = "Yokogawa";
+    }
+    YokogawaAnnotationGroup group = yokogawaAnnotationGroups.get(scope);
+    if (group == null) {
+      group = new YokogawaAnnotationGroup(scope);
+      yokogawaAnnotationGroups.put(scope, group);
+    }
+    return group;
   }
 
   private void addYokogawaAttributes(String prefix, Attributes attributes) {
@@ -1858,6 +2064,90 @@ public class CV7000Reader extends FormatReader {
     public List<String> usedObjectiveIDs = new ArrayList<String>();
   }
 
+  class AnnotationRefIndexes {
+    public int plate;
+    public int instrument;
+    private HashMap<Integer, Integer> imageRefs =
+      new HashMap<Integer, Integer>();
+    private HashMap<String, Integer> channelRefs =
+      new HashMap<String, Integer>();
+
+    public int nextImage(int series) {
+      Integer key = Integer.valueOf(series);
+      Integer next = imageRefs.get(key);
+      int value = next == null ? 0 : next.intValue();
+      imageRefs.put(key, Integer.valueOf(value + 1));
+      return value;
+    }
+
+    public int nextChannel(int series, int channel) {
+      String key = series + ":" + channel;
+      Integer next = channelRefs.get(key);
+      int value = next == null ? 0 : next.intValue();
+      channelRefs.put(key, Integer.valueOf(value + 1));
+      return value;
+    }
+  }
+
+  class YokogawaAnnotationGroup {
+    public String scope;
+    private LinkedHashMap<String, String> values =
+      new LinkedHashMap<String, String>();
+    private HashMap<String, Integer> listIndexes =
+      new HashMap<String, Integer>();
+
+    public YokogawaAnnotationGroup(String scope) {
+      this.scope = scope;
+    }
+
+    public boolean isEmpty() {
+      return values.isEmpty();
+    }
+
+    public void put(String name, Object value) {
+      String key = clean(name);
+      String text = cleanValue(value);
+      if (key == null || text == null) {
+        return;
+      }
+      if (values.containsKey(key)) {
+        putList(key, text);
+      }
+      else {
+        values.put(key, text);
+      }
+    }
+
+    public void putList(String name, Object value) {
+      String key = clean(name);
+      String text = cleanValue(value);
+      if (key == null || text == null) {
+        return;
+      }
+      Integer next = listIndexes.get(key);
+      int index = next == null ? 1 : next.intValue() + 1;
+      listIndexes.put(key, Integer.valueOf(index));
+      values.put(key + "[" + index + "]", text);
+    }
+
+    public List<MapPair> toMapPairs() {
+      List<MapPair> pairs = new ArrayList<MapPair>();
+      pairs.add(new MapPair("Source", scope));
+      for (Map.Entry<String, String> entry : values.entrySet()) {
+        pairs.add(new MapPair(entry.getKey(), entry.getValue()));
+      }
+      return pairs;
+    }
+
+    private String cleanValue(Object value) {
+      if (value == null) {
+        return null;
+      }
+      String text = String.valueOf(value);
+      return text.trim().length() == 0 ? null : text;
+    }
+  }
+
   class SeriesTiming {
     public Long startMillis;
     public String startTimestamp;
@@ -1895,6 +2185,7 @@ public class CV7000Reader extends FormatReader {
       Attributes attributes)
     {
       if (qName.equals("bts:WellPlate")) {
+        addYokogawaAttributes("Yokogawa WPI WellPlate ", attributes);
         name = attributes.getValue("bts:Name");
         plateID = attributes.getValue("bts:ProductID");
         plateRows = Integer.parseInt(attributes.getValue("bts:Rows"));
@@ -2064,8 +2355,9 @@ public class CV7000Reader extends FormatReader {
         settingsPath = attributes.getValue("bts:MeasurementSettingFileName");
 
         String system = attributes.getValue("bts:TargetSystem");
-        addGlobalMeta("Acquisition system", system);
-        if (!system.toLowerCase().startsWith("cv7000")) {
+        addYokogawaMeta(
+          "Yokogawa MRF MeasurementDetail ", "AcquisitionSystem", system);
+        if (system != null && !system.toLowerCase().startsWith("cv7000")) {
           LOGGER.warn("Found data from {}; this is not well-supported", system);
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -140,7 +140,7 @@ public class CV7000Reader extends FormatReader {
   private String measurementOperatorName;
   private String targetSystem;
   private ArrayList<String> extraFiles;
-  private MeasurementDataHandler measurementHandler;
+  private MeasurementDataSummary measurementDataSummary;
   private CrosstalkParameters crosstalkParameters;
   private OTFGeometryParameters otfGeometryParameters;
   private YokogawaParsing parsing = new YokogawaParsing();
@@ -301,7 +301,7 @@ public class CV7000Reader extends FormatReader {
       endTime = null;
       measurementOperatorName = null;
       targetSystem = null;
-      measurementHandler = null;
+      measurementDataSummary = null;
       crosstalkParameters = null;
       otfGeometryParameters = null;
       reversePlaneLookup = null;
@@ -376,8 +376,8 @@ public class CV7000Reader extends FormatReader {
 
     parseMeasurementData(paths);
     parseOptionalSidecars(paths);
-    normalizeChannels(paths.parent);
-    collectDatasetFiles(paths.parent);
+    normalizeChannels(paths.parentPath);
+    collectDatasetFiles(paths.parentPath);
 
     CV7000SeriesLayout layout = buildSeriesLayout();
     seriesLayout = layout;
@@ -401,7 +401,7 @@ public class CV7000Reader extends FormatReader {
     measurementOperatorName = null;
     targetSystem = null;
     extraFiles = null;
-    measurementHandler = null;
+    measurementDataSummary = null;
     crosstalkParameters = null;
     otfGeometryParameters = null;
     wppPath = null;
@@ -415,12 +415,17 @@ public class CV7000Reader extends FormatReader {
     CV7000DatasetPaths paths = new CV7000DatasetPaths();
     Location wpi = new Location(id).getAbsoluteFile();
     paths.wpiPath = wpi.getAbsolutePath();
-    paths.parent = wpi.getParentFile();
-    paths.measurementData = new Location(paths.parent, MEASUREMENT_FILE);
-    paths.measurementDetail = new Location(paths.parent, MEASUREMENT_DETAIL);
-    paths.postProcess = new Location(paths.parent, POST_PROCESS);
-    paths.otfCrosstalk = new Location(paths.parent, OTF_CROSSTALK_PARAMETER);
-    paths.otfGeometry = new Location(paths.parent, OTF_GEOMETRY_PARAMETER);
+    paths.parentPath = wpi.getParentFile().getAbsolutePath();
+    paths.measurementDataPath =
+      new Location(paths.parentPath, MEASUREMENT_FILE).getAbsolutePath();
+    paths.measurementDetailPath =
+      new Location(paths.parentPath, MEASUREMENT_DETAIL).getAbsolutePath();
+    paths.postProcessPath =
+      new Location(paths.parentPath, POST_PROCESS).getAbsolutePath();
+    paths.otfCrosstalkPath =
+      new Location(paths.parentPath, OTF_CROSSTALK_PARAMETER).getAbsolutePath();
+    paths.otfGeometryPath =
+      new Location(paths.parentPath, OTF_GEOMETRY_PARAMETER).getAbsolutePath();
     return paths;
   }
 
@@ -432,7 +437,8 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Keep a dataset-level inventory for getUsedFiles and original metadata. */
-  private void collectDatasetFiles(Location parent) {
+  private void collectDatasetFiles(String parentPath) {
+    Location parent = new Location(parentPath);
     String[] listedFiles = parent.list(true);
     Arrays.sort(listedFiles);
     for (int i=0; i<listedFiles.length; i++) {
@@ -449,14 +455,16 @@ public class CV7000Reader extends FormatReader {
   private void parseMeasurementData(CV7000DatasetPaths paths)
     throws FormatException, IOException
   {
-    if (!paths.measurementData.exists()) {
+    if (!new Location(paths.measurementDataPath).exists()) {
       throw new FormatException("Missing " + MEASUREMENT_FILE + " file");
     }
 
-    measurementPath = paths.measurementData.getAbsolutePath();
-    measurementHandler = new MeasurementDataHandler(paths.parent.getAbsolutePath());
+    measurementPath = paths.measurementDataPath;
+    MeasurementDataHandler measurementHandler =
+      new MeasurementDataHandler(paths.parentPath);
     XMLTools.parseXML(readSanitizedXML(measurementPath), measurementHandler);
     planeData = measurementHandler.getPlanes();
+    measurementDataSummary = measurementHandler.getSummary();
   }
 
   /** Parse optional XML sidecars that enrich channel, instrument, and raw metadata. */
@@ -470,12 +478,12 @@ public class CV7000Reader extends FormatReader {
 
   /** MeasurementDetail links the acquisition settings sidecars and seeds channels. */
   private void parseMeasurementDetail(CV7000DatasetPaths paths) throws IOException {
-    if (!paths.measurementDetail.exists()) {
+    if (!new Location(paths.measurementDetailPath).exists()) {
       LOGGER.warn("Missing " + MEASUREMENT_DETAIL + " file");
       return;
     }
 
-    detailPath = paths.measurementDetail.getAbsolutePath();
+    detailPath = paths.measurementDetailPath;
     MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
     XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
     MeasurementDetailResult result = detailHandler.getResult();
@@ -487,10 +495,10 @@ public class CV7000Reader extends FormatReader {
     wppPath = result.wppPath;
     settingsPath = result.settingsPath;
     if (wppPath != null) {
-      wppPath = new Location(paths.parent, wppPath).getAbsolutePath();
+      wppPath = new Location(paths.parentPath, wppPath).getAbsolutePath();
     }
     if (settingsPath != null) {
-      settingsPath = new Location(paths.parent, settingsPath).getAbsolutePath();
+      settingsPath = new Location(paths.parentPath, settingsPath).getAbsolutePath();
     }
   }
 
@@ -517,38 +525,38 @@ public class CV7000Reader extends FormatReader {
 
   /** OTF geometry stores objective catalog entries and affine calibration rows. */
   private void parseOTFGeometry(CV7000DatasetPaths paths) {
-    Location geometry = paths.otfGeometry;
-    if (!geometry.exists()) {
+    String geometry = paths.otfGeometryPath;
+    if (!new Location(geometry).exists()) {
       return;
     }
 
     try {
       OTFGeometryHandler handler = new OTFGeometryHandler();
-      XMLTools.parseXML(readSanitizedXML(geometry.getAbsolutePath()), handler);
+      XMLTools.parseXML(readSanitizedXML(geometry), handler);
       otfGeometryParameters = handler.getParameters();
     }
     catch (Exception e) {
       otfGeometryParameters = null;
       LOGGER.warn("Could not parse CV7000 OTF geometry sidecar {}",
-        geometry.getAbsolutePath(), e);
+        geometry, e);
     }
   }
 
   /** OTF crosstalk stores exact emission filter bands and optional dichroics. */
   private void parseOTFCrosstalk(CV7000DatasetPaths paths) {
-    Location crosstalk = paths.otfCrosstalk;
-    if (!crosstalk.exists()) {
+    String crosstalk = paths.otfCrosstalkPath;
+    if (!new Location(crosstalk).exists()) {
       return;
     }
 
     try {
       CrosstalkParameterHandler handler = new CrosstalkParameterHandler();
-      XMLTools.parseXML(readSanitizedXML(crosstalk.getAbsolutePath()), handler);
+      XMLTools.parseXML(readSanitizedXML(crosstalk), handler);
       crosstalkParameters = handler.getParameters();
     }
     catch (Exception e) {
       crosstalkParameters = null;
-      LOGGER.warn("Could not parse CV7000 crosstalk sidecar {}", crosstalk.getAbsolutePath(), e);
+      LOGGER.warn("Could not parse CV7000 crosstalk sidecar {}", crosstalk, e);
     }
   }
 
@@ -557,13 +565,13 @@ public class CV7000Reader extends FormatReader {
   // ###############
 
   /** Normalize channel order and paths after all optional channel sources are parsed. */
-  private void normalizeChannels(Location parent) {
+  private void normalizeChannels(String parentPath) {
     if (channels == null) {
       return;
     }
     sortChannelsByActionThenIndex();
     rawModel.indexChannels(channels);
-    resolveCorrectionFiles(parent);
+    resolveCorrectionFiles(parentPath);
   }
 
   /** Yokogawa logical channels are ordered by action first, then channel index. */
@@ -580,13 +588,13 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Shading correction paths are relative to the dataset directory in the XML. */
-  private void resolveCorrectionFiles(Location parent) {
+  private void resolveCorrectionFiles(String parentPath) {
     for (Channel ch : channels) {
       if (ch.correctionFile != null) {
         String resolved =
-          new Location(parent, ch.correctionFile).getAbsolutePath();
+          new Location(parentPath, ch.correctionFile).getAbsolutePath();
         ch.resolvedCorrectionFile = resolved;
-        ch.correctionFile = getRelativePath(parent, resolved);
+        ch.correctionFile = getRelativePath(parentPath, resolved);
       }
     }
   }
@@ -595,10 +603,10 @@ public class CV7000Reader extends FormatReader {
    * Return a path relative to the WPI directory,
    * preserving the input on failure.
    */
-  private String getRelativePath(Location parent, String path) {
+  private String getRelativePath(String parent, String path) {
     try {
       Path parentPath =
-        Paths.get(parent.getAbsolutePath()).toAbsolutePath().normalize();
+        Paths.get(parent).toAbsolutePath().normalize();
       Path filePath = Paths.get(path).toAbsolutePath().normalize();
       return parentPath.relativize(filePath).toString();
     }
@@ -2075,19 +2083,19 @@ public class CV7000Reader extends FormatReader {
       if (isPath(file, datasetPaths.wpiPath)) {
         return CV7000FileRole.WPI;
       }
-      if (isPath(file, datasetPaths.measurementData)) {
+      if (isPath(file, datasetPaths.measurementDataPath)) {
         return CV7000FileRole.MEASUREMENT_DATA;
       }
-      if (isPath(file, datasetPaths.measurementDetail)) {
+      if (isPath(file, datasetPaths.measurementDetailPath)) {
         return CV7000FileRole.MEASUREMENT_DETAIL;
       }
-      if (isPath(file, datasetPaths.postProcess)) {
+      if (isPath(file, datasetPaths.postProcessPath)) {
         return CV7000FileRole.POST_PROCESS;
       }
-      if (isPath(file, datasetPaths.otfCrosstalk)) {
+      if (isPath(file, datasetPaths.otfCrosstalkPath)) {
         return CV7000FileRole.OTF_CROSSTALK;
       }
-      if (isPath(file, datasetPaths.otfGeometry)) {
+      if (isPath(file, datasetPaths.otfGeometryPath)) {
         return CV7000FileRole.OTF_GEOMETRY;
       }
     }
@@ -2134,13 +2142,6 @@ public class CV7000Reader extends FormatReader {
     return file.getAbsolutePath().equals(new Location(path).getAbsolutePath());
   }
 
-  private boolean isPath(Location file, Location path) {
-    if (path == null) {
-      return false;
-    }
-    return file.getAbsolutePath().equals(path.getAbsolutePath());
-  }
-
   private void parseStructuredSidecarMetadata(String file, CV7000FileRole role) {
     if (role == CV7000FileRole.POST_PROCESS) {
       addPostProcessOriginalMetadata(file);
@@ -2175,17 +2176,17 @@ public class CV7000Reader extends FormatReader {
       LOGGER.debug("Could not summarize CV7000 measurement data {}", measurementPath, e);
     }
 
-    if (measurementHandler != null) {
+    if (measurementDataSummary != null) {
       addYokogawaMeta("Yokogawa MLF ", "IMGRecordCount",
-        measurementHandler.getImageRecordCount());
+        measurementDataSummary.imageRecordCount);
       addYokogawaMeta("Yokogawa MLF ", "FirstPlaneTime",
-        measurementHandler.getFirstTimestamp());
+        measurementDataSummary.firstTimestamp);
       addYokogawaMeta("Yokogawa MLF ", "LastPlaneTime",
-        measurementHandler.getLastTimestamp());
+        measurementDataSummary.lastTimestamp);
       addYokogawaMeta("Yokogawa MLF ", "FirstPlaneAction",
-        measurementHandler.getFirstAction());
+        measurementDataSummary.firstAction);
       addYokogawaMeta("Yokogawa MLF ", "LastPlaneAction",
-        measurementHandler.getLastAction());
+        measurementDataSummary.lastAction);
     }
   }
 
@@ -2714,7 +2715,7 @@ public class CV7000Reader extends FormatReader {
     UNKNOWN
   }
 
-  private enum CV7000ChannelMappingMode {
+  public enum CV7000ChannelMappingMode {
     ACTION_MAPPED,
     RAW_MLF
   }
@@ -2781,21 +2782,21 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Resolved dataset paths used during the parsing phase. */
-  private static class CV7000DatasetPaths {
-    public Location parent;
+  public static class CV7000DatasetPaths {
+    public String parentPath;
     public String wpiPath;
-    public Location measurementData;
-    public Location measurementDetail;
-    public Location postProcess;
-    public Location otfCrosstalk;
-    public Location otfGeometry;
+    public String measurementDataPath;
+    public String measurementDetailPath;
+    public String postProcessPath;
+    public String otfCrosstalkPath;
+    public String otfGeometryPath;
   }
 
   /** Parsed Yokogawa sidecars and reader-local provenance. */
-  private static class CV7000RawModel {
+  public static class CV7000RawModel {
     public YokogawaOriginalMetadata originalMetadata =
       new YokogawaOriginalMetadata();
-    private HashMap<ChannelKey, Channel> channelsByAcquisition =
+    public HashMap<ChannelKey, Channel> channelsByAcquisition =
       new HashMap<ChannelKey, Channel>();
 
     public void indexChannels(ArrayList<Channel> channels) {
@@ -2819,13 +2820,13 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Grouped Yokogawa metadata pending OME MapAnnotation emission. */
-  private static class YokogawaOriginalMetadata {
+  public static class YokogawaOriginalMetadata {
     public LinkedHashMap<String, YokogawaAnnotationGroup> groups =
       new LinkedHashMap<String, YokogawaAnnotationGroup>();
   }
 
   /** Intermediate layout data used to translate Yokogawa records into series. */
-  private static class CV7000SeriesLayout {
+  public static class CV7000SeriesLayout {
     public String firstFile;
     public ArrayList<Field> acquiredFields = new ArrayList<Field>();
     public HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
@@ -2841,7 +2842,7 @@ public class CV7000Reader extends FormatReader {
       new HashMap<String, Boolean>();
     public ArrayList<DuplicatePlaneCandidate> duplicateCandidates =
       new ArrayList<DuplicatePlaneCandidate>();
-    private HashMap<String, Plane> representativePlanes =
+    public HashMap<String, Plane> representativePlanes =
       new HashMap<String, Plane>();
 
     public void indexPlane(Plane plane) {
@@ -2871,10 +2872,13 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class ChannelKey {
+  public static class ChannelKey {
     public int timelineIndex;
     public int actionIndex;
     public int channelIndex;
+
+    public ChannelKey() {
+    }
 
     public ChannelKey(int timelineIndex, int actionIndex, int channelIndex) {
       this.timelineIndex = timelineIndex;
@@ -2903,7 +2907,7 @@ public class CV7000Reader extends FormatReader {
   }
 
   /** Shared Yokogawa parsing and normalization helpers. */
-  private static class YokogawaParsing {
+  public static class YokogawaParsing {
     public String readSanitizedXML(String filename) throws IOException {
       String xml = DataTools.readFile(filename).trim();
       if (xml.endsWith(">>")) {
@@ -3065,10 +3069,13 @@ public class CV7000Reader extends FormatReader {
     public ArrayList<String> anomalies = new ArrayList<String>();
   }
 
-  private static class DuplicatePlaneCandidate {
+  public static class DuplicatePlaneCandidate {
     public Plane candidate;
     public Plane selected;
     public String reason;
+
+    public DuplicatePlaneCandidate() {
+    }
 
     public DuplicatePlaneCandidate(Plane candidate, Plane selected,
       String reason)
@@ -3079,12 +3086,15 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class YokogawaAnnotationGroup {
+  public static class YokogawaAnnotationGroup {
     public String scope;
-    private LinkedHashMap<String, String> values =
+    public LinkedHashMap<String, String> values =
       new LinkedHashMap<String, String>();
-    private HashMap<String, Integer> listIndexes =
+    public HashMap<String, Integer> listIndexes =
       new HashMap<String, Integer>();
+
+    public YokogawaAnnotationGroup() {
+    }
 
     public YokogawaAnnotationGroup(String scope) {
       this.scope = scope;
@@ -3175,6 +3185,14 @@ public class CV7000Reader extends FormatReader {
     public ArrayList<LightSource> lightSources = new ArrayList<LightSource>();
   }
 
+  public static class MeasurementDataSummary {
+    public int imageRecordCount;
+    public String firstTimestamp;
+    public String lastTimestamp;
+    public String firstAction;
+    public String lastAction;
+  }
+
   // ###############
   // ## Module 11: SAX Sidecar Handlers
   // ###############
@@ -3239,6 +3257,16 @@ public class CV7000Reader extends FormatReader {
 
     public ArrayList<Plane> getPlanes() {
       return planes;
+    }
+
+    public MeasurementDataSummary getSummary() {
+      MeasurementDataSummary summary = new MeasurementDataSummary();
+      summary.imageRecordCount = imageRecordCount;
+      summary.firstTimestamp = firstTimestamp;
+      summary.lastTimestamp = lastTimestamp;
+      summary.firstAction = firstAction;
+      summary.lastAction = lastAction;
+      return summary;
     }
 
     public int getImageRecordCount() {
@@ -3842,7 +3870,7 @@ public class CV7000Reader extends FormatReader {
   // ## Module 12: OTF, Crosstalk, Objective, Channel, And Plane Models
   // ###############
 
-  private static class OTFGeometryParameters {
+  public static class OTFGeometryParameters {
     public String mode;
     public LinkedHashMap<String, OTFGeometryObjective> objectivesByID =
       new LinkedHashMap<String, OTFGeometryObjective>();
@@ -3873,13 +3901,13 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class OTFGeometryObjective {
+  public static class OTFGeometryObjective {
     public String objectiveID;
     public String objective;
     public Double magnification;
   }
 
-  private static class OTFGeometryAffine {
+  public static class OTFGeometryAffine {
     public String methodID;
     public String method;
     public String objectiveID;
@@ -3897,7 +3925,7 @@ public class CV7000Reader extends FormatReader {
     public Double f;
   }
 
-  private static class CrosstalkParameters {
+  public static class CrosstalkParameters {
     public LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter> filters =
       new LinkedHashMap<CrosstalkFilterKey, CrosstalkFilter>();
     public ArrayList<CrosstalkFluorophore> fluorophores =
@@ -3909,7 +3937,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class CrosstalkFilter {
+  public static class CrosstalkFilter {
     public String filterID;
     public Integer cameraNumber;
     public String acquisition;
@@ -3920,28 +3948,31 @@ public class CV7000Reader extends FormatReader {
       new ArrayList<CrosstalkDichroic>();
   }
 
-  private static class CrosstalkDichroic {
+  public static class CrosstalkDichroic {
     public String id;
     public String name;
     public String reflection;
     public Double averageTransmittance;
   }
 
-  private static class CrosstalkFluorophore {
+  public static class CrosstalkFluorophore {
     public String name;
     public ArrayList<CrosstalkFluorophoreIntensity> intensities =
       new ArrayList<CrosstalkFluorophoreIntensity>();
   }
 
-  private static class CrosstalkFluorophoreIntensity {
+  public static class CrosstalkFluorophoreIntensity {
     public String filterID;
     public Double averageIntensity;
   }
 
-  private static class CrosstalkFilterKey {
+  public static class CrosstalkFilterKey {
     public String filterID;
     public Integer cameraNumber;
     public String acquisition;
+
+    public CrosstalkFilterKey() {
+    }
 
     public CrosstalkFilterKey(String filterID, Integer cameraNumber,
       String acquisition)
@@ -3980,7 +4011,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class LightSource {
+  public static class LightSource {
     public String name;
     public String type;
     public Double wavelength;
@@ -4049,7 +4080,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class DetectionFilter {
+  public static class DetectionFilter {
     public String filterType;
     public Double center;
     public Double width;
@@ -4065,7 +4096,10 @@ public class CV7000Reader extends FormatReader {
       return filter;
     }
 
-    private DetectionFilter(String filterType) {
+    public DetectionFilter() {
+    }
+
+    public DetectionFilter(String filterType) {
       this.filterType = filterType;
     }
   }
@@ -4124,7 +4158,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class Channel {
+  public static class Channel {
     public int timelineIndex = -1;
     public int actionIndex = -1;
     public int index;
@@ -4276,7 +4310,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class Plane {
+  public static class Plane {
     public String file;
     public String timestamp;
     public String actionName;
@@ -4296,7 +4330,7 @@ public class CV7000Reader extends FormatReader {
     public int timelineIndex;
   }
 
-  private static class Field {
+  public static class Field {
     public int row;
     public int column;
     public int field;
@@ -4317,7 +4351,7 @@ public class CV7000Reader extends FormatReader {
     }
   }
 
-  private static class MinMax {
+  public static class MinMax {
     public int minZ = Integer.MAX_VALUE;
     public int maxZ = 0;
     public int minT = Integer.MAX_VALUE;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,7 +72,7 @@ public class CV7000Reader extends FormatReader {
   // -- Constants --
 
   public static final String DUPLICATE_PLANES_KEY = "cv7000.duplicate_missing_planes";
-  public static final boolean DUPLICATE_PLANES_DEFAULT = true;
+  public static final boolean DUPLICATE_PLANES_DEFAULT = false;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
 
@@ -91,7 +92,6 @@ public class CV7000Reader extends FormatReader {
   private int[][] reversePlaneLookup;
   private ArrayList<LightSource> lightSources;
   private ArrayList<Channel> channels;
-  private int fields;
   private String startTime, endTime;
   private ArrayList<String> extraFiles;
 
@@ -215,7 +215,6 @@ public class CV7000Reader extends FormatReader {
       wppPath = null;
       settingsPath = null;
       planeData = null;
-      fields = 0;
       lightSources = null;
       channels = null;
       startTime = null;
@@ -258,7 +257,10 @@ public class CV7000Reader extends FormatReader {
       if (dupPlane == no) {
         dupPlane = 0;
       }
-      return openBytes(dupPlane, buf, x, y, w, h);
+      Plane duplicate = lookupPlane(getSeries(), dupPlane);
+      if (duplicate != null && duplicate.file != null) {
+        return openBytes(dupPlane, buf, x, y, w, h);
+      }
     }
     return buf;
   }
@@ -345,32 +347,51 @@ public class CV7000Reader extends FormatReader {
     }
 
     String firstFile = null;
-    HashMap<Integer, MinMax> minMax = new HashMap<Integer, MinMax>();
+    HashMap<Field, MinMax> minMax = new HashMap<Field, MinMax>();
 
-    fields = 0;
-    HashSet<Integer> uniqueWells = new HashSet<Integer>();
+    ArrayList<Field> acquiredFields = new ArrayList<Field>();
+    HashSet<Field> acquiredFieldSet = new HashSet<Field>();
     HashSet<Integer> uniqueChannels = new HashSet<Integer>();
 
     for (Plane p : planeData) {
-      if (p != null) {
-        if (!isWellAcquired(p.field.row, p.field.column)) {
-          continue;
-        }
+      if (p != null && p.file != null) {
         if (!allFiles.contains(p.file)) {
           allFiles.add(p.file);
         }
-
-        p.channelIndex = getChannelIndex(p);
-
-        int wellIndex = p.field.row * plate.getPlateColumns() + p.field.column;
-        if (!minMax.containsKey(wellIndex)) {
-          minMax.put(wellIndex, new MinMax());
-        }
-        MinMax m = minMax.get(wellIndex);
-
-        if (p.file != null && firstFile == null) {
+        if (firstFile == null) {
           firstFile = p.file;
         }
+        if (acquiredFieldSet.add(p.field)) {
+          acquiredFields.add(p.field);
+        }
+      }
+    }
+
+    if (firstFile == null) {
+      throw new FormatException("No readable TIFF planes found in " + measurementPath);
+    }
+
+    Collections.sort(acquiredFields, new Comparator<Field>() {
+      @Override
+      public int compare(Field f1, Field f2) {
+        if (f1.row != f2.row) {
+          return f1.row - f2.row;
+        }
+        if (f1.column != f2.column) {
+          return f1.column - f2.column;
+        }
+        return f1.field - f2.field;
+      }
+    });
+
+    for (Plane p : planeData) {
+      if (p != null && acquiredFieldSet.contains(p.field)) {
+        p.channelIndex = getChannelIndex(p);
+
+        if (!minMax.containsKey(p.field)) {
+          minMax.put(p.field, new MinMax());
+        }
+        MinMax m = minMax.get(p.field);
 
         if (p.timepoint > m.maxT) {
           m.maxT = p.timepoint;
@@ -395,12 +416,6 @@ public class CV7000Reader extends FormatReader {
           m.minC = p.channelIndex;
         }
         uniqueChannels.add(p.channelIndex);
-
-        if (p.field.field >= fields) {
-          fields = p.field.field + 1;
-        }
-
-        uniqueWells.add(wellIndex);
       }
     }
 
@@ -411,21 +426,20 @@ public class CV7000Reader extends FormatReader {
 
     core.get(0).dimensionOrder = "XYCZT";
 
-    int realWells = uniqueWells.size();
-    Integer[] wells = uniqueWells.toArray(new Integer[realWells]);
-    Arrays.sort(wells);
-    reversePlaneLookup = new int[realWells * fields][];
+    reversePlaneLookup = new int[acquiredFields.size()][];
 
     Integer[] channelIndexes = uniqueChannels.toArray(new Integer[uniqueChannels.size()]);
     Arrays.sort(channelIndexes);
 
-    for (int i=0; i<realWells * fields; i++) {
+    HashMap<Field, Integer> fieldToSeries = new HashMap<Field, Integer>();
+    for (int i=0; i<acquiredFields.size(); i++) {
       if (i > 0) {
         core.add(new CoreMetadata(core.get(0)));
       }
 
-      int wellIndex = wells[i / fields];
-      MinMax m = minMax.get(wellIndex);
+      Field field = acquiredFields.get(i);
+      fieldToSeries.put(field, i);
+      MinMax m = minMax.get(field);
       core.get(i).sizeZ = (m.maxZ - m.minZ) + 1;
       core.get(i).sizeT = (m.maxT - m.minT) + 1;
       core.get(i).sizeC = reader.getSizeC() * uniqueChannels.size();
@@ -435,12 +449,19 @@ public class CV7000Reader extends FormatReader {
       Arrays.fill(reversePlaneLookup[i], -1);
     }
 
-    int[] seriesLengths = new int[] {fields, realWells};
     int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
 
     extraFiles = new ArrayList<String>();
     for (int i=0; i<planeData.size(); i++) {
       Plane p = planeData.get(i);
+      if (p == null) {
+        continue;
+      }
+
+      Integer series = fieldToSeries.get(p.field);
+      if (series == null) {
+        continue;
+      }
 
       // reindex so that the plane's channel index is into
       // the list of unique acquired channels, not the list of all channels
@@ -448,15 +469,8 @@ public class CV7000Reader extends FormatReader {
       // this eliminates the need to correct for the minimum C index later on
       p.channelIndex = Arrays.binarySearch(channelIndexes, p.channelIndex);
 
-      Field f = p.field;
-      if (!isWellAcquired(f.row, f.column)) {
-        continue;
-      }
-      int wellNumber = f.row * plate.getPlateColumns() + f.column;
-      int wellIndex = Arrays.binarySearch(wells, wellNumber);
-      p.series = FormatTools.positionToRaster(seriesLengths,
-        new int[] {f.field, wellIndex});
-      MinMax m = minMax.get(wellNumber);
+      p.series = series.intValue();
+      MinMax m = minMax.get(p.field);
 
       planeLengths[0] = core.get(p.series).sizeC / reader.getSizeC();
       planeLengths[1] = core.get(p.series).sizeZ;
@@ -469,8 +483,14 @@ public class CV7000Reader extends FormatReader {
         reversePlaneLookup[p.series][p.no] = i;
       }
       else {
-        LOGGER.warn("Ignoring file {}", p.file);
-        extraFiles.add(p.file);
+        Plane existing = planeData.get(reversePlaneLookup[p.series][p.no]);
+        if ((existing == null || existing.file == null) && p.file != null) {
+          reversePlaneLookup[p.series][p.no] = i;
+        }
+        else if (p.file != null) {
+          LOGGER.warn("Ignoring file {}", p.file);
+          extraFiles.add(p.file);
+        }
       }
     }
 
@@ -489,7 +509,19 @@ public class CV7000Reader extends FormatReader {
     String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, 0);
     store.setPlateAcquisitionID(plateAcqID, 0, 0);
 
-    PositiveInteger fieldCount = FormatTools.getMaxFieldCount(fields);
+    HashMap<Integer, Integer> wellFieldCounts = new HashMap<Integer, Integer>();
+    int maxFieldCount = 0;
+    for (Field field : acquiredFields) {
+      int wellIndex = field.row * plate.getPlateColumns() + field.column;
+      Integer count = wellFieldCounts.get(wellIndex);
+      count = count == null ? 1 : count + 1;
+      wellFieldCounts.put(wellIndex, count);
+      if (count > maxFieldCount) {
+        maxFieldCount = count;
+      }
+    }
+
+    PositiveInteger fieldCount = FormatTools.getMaxFieldCount(maxFieldCount);
     if (fieldCount != null) {
       store.setPlateAcquisitionMaximumFieldCount(fieldCount, 0, 0);
     }
@@ -514,18 +546,23 @@ public class CV7000Reader extends FormatReader {
           continue;
         }
 
-        for (int field=0; field<fields; field++) {
+        int wellSample = 0;
+        for (Field field : acquiredFields) {
+          if (field.row != row || field.column != col) {
+            continue;
+          }
+
           String wellSampleID =
-            MetadataTools.createLSID("WellSample", 0, nextWell, field);
-          store.setWellSampleID(wellSampleID, 0, nextWell, field);
+            MetadataTools.createLSID("WellSample", 0, nextWell, wellSample);
+          store.setWellSampleID(wellSampleID, 0, nextWell, wellSample);
           store.setWellSampleIndex(
-            new NonNegativeInteger(nextImage), 0, nextWell, field);
+            new NonNegativeInteger(nextImage), 0, nextWell, wellSample);
           String imageID = MetadataTools.createLSID("Image", nextImage);
           store.setImageID(imageID, nextImage);
-          store.setWellSampleImageRef(imageID, 0, nextWell, field);
+          store.setWellSampleImageRef(imageID, 0, nextWell, wellSample);
 
           String name = "Well " + FormatTools.getWellRowName(row) +
-            (col + 1) + ", Field " + (field + 1);
+            (col + 1) + ", Field " + (field.field + 1);
           store.setImageName(name, nextImage);
           store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
 
@@ -540,13 +577,14 @@ public class CV7000Reader extends FormatReader {
           if (p != null) {
             store.setWellSamplePositionX(
               FormatTools.createLength(p.xpos, UNITS.REFERENCEFRAME),
-              0, nextWell, field);
+              0, nextWell, wellSample);
             store.setWellSamplePositionY(
               FormatTools.createLength(p.ypos, UNITS.REFERENCEFRAME),
-              0, nextWell, field);
+              0, nextWell, wellSample);
           }
 
           nextImage++;
+          wellSample++;
         }
         nextWell++;
       }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -630,10 +630,10 @@ public class CV7000Reader extends FormatReader {
         setSeries(i);
         if (channels != null) {
           for (int c=0; c<getSizeC(); c++) {
-            Plane p = lookupPlane(i, c);
+            Plane p = lookupRepresentativePlane(i, c);
             if (p == null) {
               // There was likely an error during acquisition for this
-              // particular plane.  Skip it.
+              // particular channel.  Skip it.
               continue;
             }
             Channel channel = lookupChannel(p);
@@ -703,7 +703,7 @@ public class CV7000Reader extends FormatReader {
 
         for (int p=0; p<getImageCount(); p++) {
           Plane plane = lookupPlane(i, p);
-          if (plane == null) {
+          if (plane == null || plane.file == null) {
             continue;
           }
           store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), i, p);
@@ -733,9 +733,30 @@ public class CV7000Reader extends FormatReader {
   }
 
   private Channel lookupChannel(Plane p) {
+    Channel rawChannel = null;
+    boolean ambiguousRawChannel = false;
     for (Channel ch : channels) {
-      if (ch.index == p.channel) {
+      if (ch.index == p.channel &&
+        ch.timelineIndex == p.timelineIndex &&
+        ch.actionIndex == p.actionIndex)
+      {
         return ch;
+      }
+      if (ch.index == p.channel) {
+        if (rawChannel != null) {
+          ambiguousRawChannel = true;
+        }
+        rawChannel = ch;
+      }
+    }
+    return ambiguousRawChannel ? null : rawChannel;
+  }
+
+  private Plane lookupRepresentativePlane(int series, int channel) {
+    for (int no=0; no<reversePlaneLookup[series].length; no++) {
+      Plane p = lookupPlane(series, no);
+      if (p != null && p.file != null && p.channelIndex == channel) {
+        return p;
       }
     }
     return null;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -939,16 +939,17 @@ public class CV7000Reader extends FormatReader {
   private void populateChannelLightSourceSettings(MetadataStore store, int series,
     int channelIndex, Channel channel, HashMap<Integer, Integer> lightSourceIndexes)
   {
-    Integer lightSource = getLinkedLaser(channel);
+    Integer lightSource = getLinkedStandardLightSource(channel);
     if (lightSource == null || !lightSourceIndexes.containsKey(lightSource)) {
       return;
     }
 
     LightSource source = lightSources.get(lightSource);
-    if (source.wavelength != null && source.wavelength > 0) {
-      int index = lightSourceIndexes.get(lightSource);
-      store.setChannelLightSourceSettingsID(
-        MetadataTools.createLSID("LightSource", 0, index), series, channelIndex);
+    int index = lightSourceIndexes.get(lightSource);
+    store.setChannelLightSourceSettingsID(
+      MetadataTools.createLSID("LightSource", 0, index), series, channelIndex);
+
+    if (isLaser(source) && source.wavelength != null && source.wavelength > 0) {
       // Yokogawa BP labels are detection filters; excitation comes from the
       // linked laser light-source wavelength.
       store.setChannelExcitationWavelength(
@@ -1124,6 +1125,7 @@ public class CV7000Reader extends FormatReader {
 
   private void populateLightSources(MetadataStore store,
     HashMap<Integer, Integer> lightSourceIndexes)
+    throws FormatException
   {
     if (lightSources == null) {
       return;
@@ -1131,7 +1133,7 @@ public class CV7000Reader extends FormatReader {
     int nextLightSource = 0;
     for (int i=0; i<lightSources.size(); i++) {
       LightSource l = lightSources.get(i);
-      if ("Laser".equals(l.type)) {
+      if (isLaser(l)) {
         String laserID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
         store.setLaserID(laserID, 0, nextLightSource);
         if (l.wavelength != null) {
@@ -1144,7 +1146,34 @@ public class CV7000Reader extends FormatReader {
         lightSourceIndexes.put(i, nextLightSource);
         nextLightSource++;
       }
+      else if (isLamp(l)) {
+        String filamentID = MetadataTools.createLSID("LightSource", 0, nextLightSource);
+        store.setFilamentID(filamentID, 0, nextLightSource);
+        store.setFilamentModel(getLightSourceModel(l), 0, nextLightSource);
+        // The CV7000 user manual identifies white-light illumination as a
+        // 100 W halogen lamp; MES fixtures expose only generic Type="Lamp".
+        store.setFilamentType(MetadataTools.getFilamentType("Halogen"),
+          0, nextLightSource);
+        lightSourceIndexes.put(i, nextLightSource);
+        nextLightSource++;
+      }
     }
+  }
+
+  private boolean isLaser(LightSource source) {
+    return source != null && "Laser".equalsIgnoreCase(source.type);
+  }
+
+  private boolean isLamp(LightSource source) {
+    return source != null && "Lamp".equalsIgnoreCase(source.type);
+  }
+
+  private String getLightSourceModel(LightSource source) {
+    String model = clean(source.name);
+    if (model == null) {
+      model = clean(source.type);
+    }
+    return model;
   }
 
   private void populateObjectives(MetadataStore store, List<String> usedObjectiveIDs) {
@@ -1175,11 +1204,24 @@ public class CV7000Reader extends FormatReader {
         detectorIndexes.put(c.cameraNumber, detector);
         String detectorID = MetadataTools.createLSID("Detector", 0, detector);
         store.setDetectorID(detectorID, 0, detector);
-        if (c.cameraType != null && c.cameraType.trim().length() > 0) {
-          store.setDetectorModel(c.cameraType, 0, detector);
-        }
+        populateDetectorCameraType(store, detector, c.cameraType);
         store.setDetectorType(MetadataTools.getDetectorType("Other"), 0, detector);
       }
+    }
+  }
+
+  private void populateDetectorCameraType(MetadataStore store, int detector,
+    String cameraType)
+  {
+    String type = clean(cameraType);
+    if (type == null) {
+      return;
+    }
+    if ("Andor".equalsIgnoreCase(type)) {
+      store.setDetectorManufacturer("Andor", 0, detector);
+    }
+    else {
+      store.setDetectorModel(type, 0, detector);
     }
   }
 
@@ -1224,6 +1266,10 @@ public class CV7000Reader extends FormatReader {
       store.setFilterID(filterID, 0, filter);
       store.setFilterModel(key.acquisition, 0, filter);
       store.setFilterType(MetadataTools.getFilterType(key.detectionFilter.filterType), 0, filter);
+      String wheel = getYokogawaFilterWheelLabel(key);
+      if (wheel != null) {
+        store.setFilterFilterWheel(wheel, 0, filter);
+      }
       CrosstalkFilter crosstalk = getCrosstalkFilter(c);
       if (key.detectionFilter != null) {
         Length cutIn = getCrosstalkCutIn(crosstalk);
@@ -1246,6 +1292,15 @@ public class CV7000Reader extends FormatReader {
         }
       }
     }
+  }
+
+  private String getYokogawaFilterWheelLabel(FilterKey key) {
+    if (key == null || key.filterWheelPosition == null ||
+      key.filterWheelPosition <= 0)
+    {
+      return null;
+    }
+    return "Yokogawa wheel " + key.filterWheelPosition;
   }
 
   private Length getCrosstalkCutIn(CrosstalkFilter filter) {
@@ -1800,15 +1855,19 @@ public class CV7000Reader extends FormatReader {
     return parsing.getYokogawaAttributeName(qName);
   }
 
-  private Integer getLinkedLaser(Channel channel) {
-    if (channel == null || channel.isBrightfield() ||
+  private Integer getLinkedStandardLightSource(Channel channel) {
+    if (channel == null ||
       channel.lightSourceRefs == null || lightSources == null)
     {
       return null;
     }
     for (Integer lightSource : channel.lightSourceRefs) {
-      if (lightSource != null && lightSource >= 0 && lightSource < lightSources.size() &&
-        "Laser".equals(lightSources.get(lightSource).type))
+      if (lightSource == null || lightSource < 0 || lightSource >= lightSources.size()) {
+        continue;
+      }
+      LightSource source = lightSources.get(lightSource);
+      if ((!channel.isBrightfield() && isLaser(source)) ||
+        (channel.isBrightfield() && isLamp(source)))
       {
         return lightSource;
       }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -26,6 +26,9 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -248,10 +251,10 @@ public class CV7000Reader extends FormatReader {
     }
     if (!noPixels && channels != null) {
       for (Channel c : channels) {
-        if (c != null && c.correctionFile != null &&
-          new Location(c.correctionFile).exists())
+        if (c != null && c.resolvedCorrectionFile != null &&
+          new Location(c.resolvedCorrectionFile).exists())
         {
-          files.add(c.correctionFile);
+          files.add(c.resolvedCorrectionFile);
         }
       }
     }
@@ -580,8 +583,30 @@ public class CV7000Reader extends FormatReader {
   private void resolveCorrectionFiles(Location parent) {
     for (Channel ch : channels) {
       if (ch.correctionFile != null) {
-        ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
+        String resolved =
+          new Location(parent, ch.correctionFile).getAbsolutePath();
+        ch.resolvedCorrectionFile = resolved;
+        ch.correctionFile = getRelativePath(parent, resolved);
       }
+    }
+  }
+
+  /**
+   * Return a path relative to the WPI directory,
+   * preserving the input on failure.
+   */
+  private String getRelativePath(Location parent, String path) {
+    try {
+      Path parentPath =
+        Paths.get(parent.getAbsolutePath()).toAbsolutePath().normalize();
+      Path filePath = Paths.get(path).toAbsolutePath().normalize();
+      return parentPath.relativize(filePath).toString();
+    }
+    catch (InvalidPathException e) {
+      return path;
+    }
+    catch (IllegalArgumentException e) {
+      return path;
     }
   }
 
@@ -4112,6 +4137,7 @@ public class CV7000Reader extends FormatReader {
     public Integer filterWheelPosition;
     public Integer filterPosition;
     public String correctionFile;
+    public String resolvedCorrectionFile;
     public List<Integer> lightSourceRefs = new ArrayList<Integer>();
 
     public String target;
@@ -4160,6 +4186,7 @@ public class CV7000Reader extends FormatReader {
       filterWheelPosition = ch.filterWheelPosition;
       filterPosition = ch.filterPosition;
       correctionFile = ch.correctionFile;
+      resolvedCorrectionFile = ch.resolvedCorrectionFile;
       lightSourceRefs = new ArrayList<Integer>(ch.lightSourceRefs);
       target = ch.target;
       methodID = ch.methodID;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -375,6 +375,7 @@ public class CV7000Reader extends FormatReader {
     seriesLayout = layout;
     initializeCoreMetadata(layout);
     populateReversePlaneLookup(layout);
+    applyInputBitDepths();
     populateMetadataStore(plate, layout);
     setSeries(0);
   }
@@ -947,6 +948,84 @@ public class CV7000Reader extends FormatReader {
       else {
         layout.duplicateCandidates.add(new DuplicatePlaneCandidate(
           p, existing, "IGNORED_METADATA_ONLY_DUPLICATE"));
+      }
+    }
+  }
+
+  /** Prefer consistent Yokogawa significant-bit metadata over TIFF defaults. */
+  private void applyInputBitDepths() {
+    for (int series=0; series<core.size(); series++) {
+      CoreMetadata metadata = core.get(series);
+      int tiffBits = metadata.bitsPerPixel;
+      int storageBits = FormatTools.getBytesPerPixel(metadata.pixelType) * 8;
+      LinkedHashSet<Integer> inputBitDepths = new LinkedHashSet<Integer>();
+      String fallbackReason = null;
+      boolean representedChannelFound = false;
+
+      for (int channelIndex=0; channelIndex<metadata.sizeC; channelIndex++) {
+        Plane plane = lookupRepresentativePlane(series, channelIndex);
+        if (plane == null) {
+          continue;
+        }
+        representedChannelFound = true;
+
+        Channel channel = lookupChannel(plane);
+        if (channel == null) {
+          if (fallbackReason == null) {
+            fallbackReason = "no matching channel metadata for logical channel " +
+              channelIndex;
+          }
+          continue;
+        }
+        if (channel.metadataAmbiguous) {
+          if (fallbackReason == null) {
+            fallbackReason = "ambiguous channel metadata for logical channel " +
+              channelIndex;
+          }
+          continue;
+        }
+
+        Integer inputBitDepth = channel.inputBitDepth;
+        if (inputBitDepth == null) {
+          if (fallbackReason == null) {
+            fallbackReason = "missing InputBitDepth for logical channel " +
+              channelIndex;
+          }
+        }
+        else if (inputBitDepth.intValue() <= 0) {
+          if (fallbackReason == null) {
+            fallbackReason = "invalid InputBitDepth " + inputBitDepth +
+              " for logical channel " + channelIndex;
+          }
+        }
+        else if (inputBitDepth.intValue() > storageBits) {
+          if (fallbackReason == null) {
+            fallbackReason = "InputBitDepth " + inputBitDepth +
+              " exceeds the " + storageBits + "-bit storage width for logical channel " +
+              channelIndex;
+          }
+        }
+        else {
+          inputBitDepths.add(inputBitDepth);
+        }
+      }
+
+      if (!representedChannelFound) {
+        fallbackReason = "no represented channels have Yokogawa metadata";
+      }
+      else if (fallbackReason == null && inputBitDepths.size() > 1) {
+        fallbackReason = "conflicting InputBitDepth values " + inputBitDepths;
+      }
+      else if (fallbackReason == null && inputBitDepths.isEmpty()) {
+        fallbackReason = "no usable InputBitDepth values";
+      }
+
+      if (fallbackReason == null) {
+        metadata.bitsPerPixel = inputBitDepths.iterator().next().intValue();
+      }
+      else {
+        LOGGER.warn("Falling back to TIFF-derived bit depth {} for CV7000 " +
+          "series {}: {}", tiffBits, series, fallbackReason);
       }
     }
   }


### PR DESCRIPTION
Hej everyone,

I was doing some conversions of some CV7000 data and found some weird behavior in the metadata construction etc. related to sparse acquisitions and timeline/action-specific channel metadata.

The reader previously assumed dense well/field layouts and often derived metadata from fixed plane positions, which broke when datasets had missing TIFFs, skipped fields, or timeline-specific channel instances.
The changes make series allocation, plane lookup, SPW metadata, channel metadata, physical pixel sizes, and missing-plane handling derive from actually acquired/readable planes where appropriate, while preserving parsed metadata-only plane records for fallbacks.

**Problems Found**
- CV7000 sparse acquisitions were expanded as if every acquired well contained every field up to the global maximum field index. This created extra series for fields that were never acquired.
- Missing TIFF planes could be treated as normal backing planes during metadata lookup. That caused WellSample positions and other per-plane metadata to be populated from planes without actual pixel data.
- Channel metadata lookup assumed that the first logical plane for a channel existed. In sparse datasets, channel 0 or the expected first plane may be absent, so objective, exposure, color, light source, and physical pixel metadata could be skipped or attached incorrectly.
- Timeline/action-specific channel instances were created before the global ChannelList metadata was parsed. Exact channel matching by raw channel plus timeline/action then found instances that existed but did not yet contain optical metadata.
- Missing-plane duplication was enabled by default, which could silently duplicate neighboring planes instead of returning fill pixels for absent image data creating false data.
- Duplicate logical plane slots could prefer metadata-only records over later TIFF-backed records.

**Fixes**
- Series are now built only from acquired well/field pairs that have readable TIFF planes. This prevents creation of empty field series for sparse acquisitions.
- SPW metadata now emits Image, WellSample, and PlateAcquisition references only for acquired fields, using compact per-well sample indexes.
- PlateAcquisition MaximumFieldCount is now computed from the maximum number of acquired fields per well, not from the global maximum field index.
- Missing-plane duplication is now opt-in by default. Missing planes return fill pixels unless cv7000.duplicate_missing_planes is explicitly enabled.
- Plane lookup now prefers TIFF-backed planes where pixel data is required, such as WellSample position metadata and duplicate-plane reads.
- Per-plane parsed metadata is still preserved for mapped MLF IMG records even when the referenced TIFF is missing, allowing logical missing planes to retain their own X/Y/Z metadata where useful.
- Channel metadata is now populated from representative planes instead of assuming fixed plane indexes exist. TIFF-backed planes are preferred, with metadata-only planes used as fallback when needed.
- Physical pixel sizes are set from the first channel in a series that has resolvable backed channel metadata, instead of requiring channel 0 to be present.
- Channel lookup now matches exact raw channel plus timeline/action first, then falls back to raw-channel metadata when needed.
- ChannelList settings are propagated to all timeline/action channel instances with the same raw channel index, restoring objective, exposure, color, fluorophore, excitation, and light source metadata across timeline-specific channels.
- Light source references are added to all matching channel instances without duplicates, and duplicated channels now deep-copy light source reference lists to avoid accidental shared mutable state.

I had a bit of a problem with plane duplication being enabled by default. According to 5cd0ea514 this was added a a better visualization option, but left enabled by default. From where I stand, the default behavior should never create false data.
I did a small top level search throughout and also found similar behavior in the InCell reader. If you want I can also revert this behavior there to disabled by default.

After the fixes, on my test data, the conversion now creates the proper number of files associated with the actual number of planes captured as described by the Yokogawa metadata with correctly populated metadata.

All the best!
Kilian
