### PR TITLE
Add reader for PreciPoint .vmic whole-slide images

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -8,6 +8,7 @@ loci.formats.in.URLReader[type=external] # urlreader
 
 # readers for compressed/archive files
 loci.formats.in.ZipReader             # zip
+loci.formats.in.VmicReader            # vmic
 
 # javax.imageio readers
 loci.formats.in.APNGReader            # png [javax.imageio]

--- a/components/formats-gpl/src/loci/formats/in/VmicReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VmicReader.java
@@ -1,0 +1,564 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+
+package loci.formats.in;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import loci.common.Location;
+import loci.common.xml.XMLTools;
+import loci.formats.*;
+import loci.formats.gui.AWTImageTools;
+import loci.formats.meta.MetadataStore;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * Reader for PreciPoint .vmic WSI files
+ *
+ * @author Kai Wiechen kai.wiechen at pathologie-worms.de
+ *
+ * contains a lot of code from:
+ * https://github.com/usnistgov/pyramidio
+ * DZI pyramid reader. Thread safe.
+ * @author Antoine Vandecreme
+ *
+ * .vmic format information from:
+ * https://github.com/openslide/openslide/issues/168
+ * https://lists.andrew.cmu.edu/pipermail/openslide-users/2015-December/001164.html
+ */
+
+public class VmicReader extends SubResolutionFormatReader {
+    private static final String INNER_CONTAINER = "Image.vmici";
+    public static final String DZI_FILE = "dzc_output.xml";
+    private static final String EXTENDED_METADATA = "VMCF/config.osc";
+    public static final String DZI_FILES = "dzc_output_files";
+
+    private File filesFolder;
+    private int tileSize;
+    private int overlap;
+    private String format;
+    private int width;
+    private int height;
+    private int maxLevel;
+
+    private FileSystem inner_zipfs;
+    private File innerZipFile;
+    boolean unzippedOuterZip = false;
+
+    // -- Constructor --
+
+    public VmicReader() {
+        super("vmic", new String[]{"vmic"});
+        domains = new String[]{FormatTools.GRAPHICS_DOMAIN};
+        suffixNecessary = true;
+        suffixSufficient = true;
+    }
+
+    /* (non-Javadoc)
+     * @see loci.formats.FormatReader#isThisType(java.lang.String, boolean)
+     */
+    @Override
+    public boolean isThisType(String name, boolean open) {
+        boolean isThisType = super.isThisType(name, open);
+        if (isThisType && open) {
+            try (ZipFile outerZipFile = new ZipFile(name)) {
+                ZipEntry innerZipEntry = outerZipFile.getEntry(INNER_CONTAINER);
+                if (innerZipEntry == null) {
+                    return false;
+                }
+                try (InputStream innerZip = outerZipFile.getInputStream(innerZipEntry)) {
+                    // check inner zip file magic numbers 0x50 0x4B
+                    byte[] bytes = new byte[2];
+                    int read = innerZip.read(bytes, 0, 2);
+                    return read == 2 && bytes[0] == 0x50 && bytes[1] == 0x4B;
+                }
+            } catch (IOException e) {
+                LOGGER.debug("I/O exception during isThisType() evaluation.", e);
+                return false;
+            }
+        }
+        return isThisType;
+    }
+
+    /**
+     * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+     */
+    @Override
+    public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+            throws FormatException, IOException {
+        FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+        Rectangle rect = new Rectangle(x, y, w, h);
+        BufferedImage image = readRegionOfLevel(rect, maxLevel - resolution);
+
+        byte[] t = AWTImageTools.getBytes(image, false);
+        System.arraycopy(t, 0, buf, 0, Math.min(t.length, buf.length));
+
+        return buf;
+    }
+
+    /* @see loci.formats.IFormatReader#close(boolean) */
+    @Override
+    public void close(boolean fileOnly) throws IOException {
+        super.close(fileOnly);
+
+        if (inner_zipfs != null) {
+            try {
+                inner_zipfs.close();
+            }
+            catch (IOException e) {
+                LOGGER.warn("Failed to close inner .vmici filesystem", e);
+            }
+            inner_zipfs = null;
+        }
+        if (unzippedOuterZip && innerZipFile != null) {
+            try {
+                Files.deleteIfExists(innerZipFile.toPath());
+            }
+            catch (IOException e) {
+                LOGGER.warn("Failed to delete temporary file {}", innerZipFile, e);
+            }
+        }
+        innerZipFile = null;
+        unzippedOuterZip = false;
+    }
+
+    /* @see IFormatReader#getResolutionCount() */
+    @Override
+    public int getResolutionCount() {
+        FormatTools.assertId(currentId, true, 1);
+        return core.get(0, 0).resolutionCount;
+    }
+
+    /* @see IFormatReader#setResolution(int) */
+    @Override
+    public void setResolution(int no) {
+        if (no < 0 || no >= getResolutionCount()) {
+            throw new IllegalArgumentException("Invalid resolution: " + no);
+        }
+
+        if (!hasFlattenedResolutions()) {
+            resolution = no;
+        }
+    }
+
+    /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+    @Override
+    public int getOptimalTileWidth() { return tileSize; }
+
+    /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+    @Override
+    public int getOptimalTileHeight() {
+        return tileSize;
+    }
+
+    /* @see loci.formats.FormatReader#getThumbSizeX() */
+    @Override
+    public int getThumbSizeX() {
+        return core.get(0, 0).thumbSizeX;
+    }
+
+    /* @see loci.formats.FormatReader#getThumbSizeY() */
+    @Override
+    public int getThumbSizeY() {
+        return core.get(0, 0).thumbSizeY;
+    }
+
+    /* @see loci.formats.FormatReader#initFile(String) */
+    @Override
+    public void initFile(String id) throws FormatException, IOException {
+        setFlattenedResolutions(false);
+        super.initFile(id);
+
+        filesFolder = new File(DZI_FILES);
+
+        // Extract the inner container (Image.vmici) to a temporary file and read it
+        // via a zip FileSystem backed by that file. Opening a zip FileSystem directly
+        // on an entry nested inside the outer zip would force the whole inner container
+        // (often > 1 GB) to be read into memory; streaming it to a temp file keeps the
+        // heap footprint low and works uniformly regardless of inner-container size.
+        try (ZipFile outerZipFile = new ZipFile(Location.getMappedId(id))) {
+            ZipEntry innerZipEntry = outerZipFile.getEntry(INNER_CONTAINER);
+            if (innerZipEntry == null) {
+                throw new FormatException(
+                    "Not a valid .vmic file: missing inner container " + INNER_CONTAINER);
+            }
+
+            innerZipFile = File.createTempFile("Image", ".vmici");
+            innerZipFile.deleteOnExit();
+            try (InputStream innerZip = outerZipFile.getInputStream(innerZipEntry);
+                 OutputStream out = new FileOutputStream(innerZipFile)) {
+                byte[] buffer = new byte[131072];
+                int len;
+                while ((len = innerZip.read(buffer)) > 0) {
+                    out.write(buffer, 0, len);
+                }
+            }
+            unzippedOuterZip = true;
+            inner_zipfs = FileSystems.newFileSystem(innerZipFile.toPath(), (ClassLoader) null);
+        }
+
+        initBasicMetadata();
+        initExtendedMetadata();
+    }
+
+    private void initBasicMetadata() throws FormatException, IOException {
+        Document doc;
+        try (InputStream is = Files.newInputStream(inner_zipfs.getPath(DZI_FILE))) {
+            doc = XMLTools.parseDOM(is);
+        } catch (ParserConfigurationException | SAXException ex) {
+            throw new FormatException("Failed to parse " + DZI_FILE, ex);
+        }
+
+        Element imageNode = doc.getDocumentElement();
+        if (!"Image".equals(imageNode.getNodeName())) {
+            throw new FormatException("Unsupported dzi file.");
+        }
+
+        tileSize = Integer.parseInt(imageNode.getAttribute("TileSize"));
+        overlap = Integer.parseInt(imageNode.getAttribute("Overlap"));
+        format = imageNode.getAttribute("Format");
+
+        NodeList childNodes = imageNode.getChildNodes();
+        int length = childNodes.getLength();
+        String w = null;
+        String h = null;
+        for (int i = 0; i < length; i++) {
+            Node node = childNodes.item(i);
+            if ("Size".equals(node.getNodeName())) {
+                NamedNodeMap attributes = node.getAttributes();
+                w = attributes.getNamedItem("Width").getNodeValue();
+                h = attributes.getNamedItem("Height").getNodeValue();
+            }
+        }
+        if (w == null || h == null) {
+            throw new FormatException("Missing image Size in " + DZI_FILE);
+        }
+        width = Integer.parseInt(w);
+        height = Integer.parseInt(h);
+
+        int maxDim = Math.max(width, height);
+        maxLevel = (int) Math.ceil(Math.log(maxDim) / Math.log(2));
+
+        CoreMetadata m0 = core.get(0, 0);
+
+        m0.interleaved = false;
+        m0.littleEndian = false;
+        m0.sizeX = width;
+        m0.sizeY = height;
+        m0.sizeZ = 1;
+        m0.sizeT = 1;
+        m0.sizeC = 3;
+        m0.rgb = getSizeC() > 1;
+        m0.imageCount = 1;
+        m0.pixelType = FormatTools.UINT8;
+        m0.dimensionOrder = "XYCZT";
+        m0.metadataComplete = true;
+        m0.indexed = false;
+
+        int maxResolutionLevels = maxLevel - 1;
+
+        m0.resolutionCount = 1;
+
+        // deepzoom pyramid subresolutions
+        for (int i = maxResolutionLevels; i >= 0; i--) {
+            CoreMetadata ms = new CoreMetadata(this, 0);
+            core.add(0, ms);
+            ms.sizeX = (int) Math.round(width * getZoomOfLevel(i));
+            ms.sizeY = (int) Math.round(height * getZoomOfLevel(i));
+            ms.sizeT = m0.sizeT;
+            ms.imageCount = m0.imageCount;
+            ms.thumbnail = true;
+            ms.resolutionCount = 1;
+
+            m0.resolutionCount += 1;
+
+            List<File> list_of_files = getFilesOfLevel(i);
+            if (list_of_files.size() == 1) {
+                m0.thumbSizeX = ms.sizeX;
+                m0.thumbSizeY = ms.sizeY;
+                break;
+            }
+        }
+    }
+
+    private void initExtendedMetadata() throws FormatException, IOException {
+        MetadataStore store = makeFilterMetadata();
+        MetadataTools.populatePixels(store, this);
+
+        // Extended metadata (physical pixel size, magnification, objective) is optional:
+        // if VMCF/config.osc is absent, the image still opens without those values.
+        Path entry = inner_zipfs.getPath(EXTENDED_METADATA);
+        if (!Files.exists(entry)) {
+            LOGGER.debug("No extended metadata ({}) present; skipping", EXTENDED_METADATA);
+            return;
+        }
+
+        HashMap<String, String> metaDataMap = new HashMap<>();
+        metaDataMap.put("ShortName", null);
+        metaDataMap.put("Magnification", null);
+        metaDataMap.put("PixelPerMicron", null);
+
+        Document doc;
+        try (InputStream is = Files.newInputStream(entry)) {
+            doc = XMLTools.parseDOM(is);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new FormatException("Failed to parse " + EXTENDED_METADATA, e);
+        }
+
+        Element imageNode = doc.getDocumentElement();
+        if (!imageNode.getNodeName().contains("ObjectScanConfig")) {
+            throw new FormatException("Unsupported config.osc file.");
+        }
+
+        NodeList outerChildNodes = imageNode.getChildNodes();
+        for (int i = 0; i < outerChildNodes.getLength(); i++) {
+            Node outerNode = outerChildNodes.item(i);
+            if (outerNode.getNodeName().contains("Objective") || outerNode.getNodeName().contains("CombinedOpticalConfig")) {
+                NodeList innerChildNodes = outerNode.getChildNodes();
+                for (int j = 0; j < innerChildNodes.getLength(); j++) {
+                    Node innerNode = innerChildNodes.item(j);
+                    String nn = innerNode.getNodeName().replace("ObjectScanConfig:", "");
+                    if (metaDataMap.containsKey(nn)) {
+                        metaDataMap.put(nn, innerNode.getTextContent());
+                    }
+                }
+            }
+        }
+
+        store.setInstrumentID("PreciPoint", 0);
+
+        String pixelPerMicron = metaDataMap.get("PixelPerMicron");
+        if (pixelPerMicron != null) {
+            Length pixelSize = FormatTools.createLength(
+                1 / Double.parseDouble(pixelPerMicron), UNITS.MICROMETER);
+            store.setPixelsPhysicalSizeX(pixelSize, 0);
+            store.setPixelsPhysicalSizeY(pixelSize, 0);
+        }
+
+        String shortName = metaDataMap.get("ShortName");
+        if (shortName != null) {
+            store.setObjectiveID(shortName, 0, 0);
+            store.setObjectiveSettingsID(shortName, 0);
+        }
+
+        String magnification = metaDataMap.get("Magnification");
+        if (magnification != null) {
+            store.setObjectiveNominalMagnification(Double.parseDouble(magnification), 0, 0);
+        }
+    }
+
+    private double getZoomOfLevel(int level) {
+        return Math.pow(2, level - maxLevel);
+    }
+
+    private List<File> getFilesOfLevel(int level) {
+        int widthOfLevel = 1;
+        int heightOfLevel = 1;
+
+        if (level != 0) {
+            widthOfLevel = (int) Math.round(width * getZoomOfLevel(level)); //Math.min(2 * level, width);
+            heightOfLevel = (int) Math.round(height * getZoomOfLevel(level)); //Math.min(2 * level, height);
+        }
+
+        int numColumns = (int) Math.ceil(widthOfLevel / (float) tileSize);
+        int numRows = (int) Math.ceil(heightOfLevel / (float) tileSize);
+
+        File levelFolder = new File(filesFolder, Integer.toString(level));
+        ArrayList<File> result = new ArrayList<>(numColumns * numRows);
+        for (int i = 0; i < numColumns; i++) {
+            for (int j = 0; j < numRows; j++) {
+                File file = new File(levelFolder, i + "_" + j + "." + format);
+                result.add(file);
+            }
+        }
+        return result;
+    }
+
+    private BufferedImage readRegionOfLevel(Rectangle region, int level)
+            throws IOException {
+        int firstTileColumn = region.x / tileSize;
+        if (tileSize * (firstTileColumn + 1) - overlap <= region.x) {
+            firstTileColumn++;
+        }
+        int firstTileRow = region.y / tileSize;
+        if (tileSize * (firstTileRow + 1) - overlap <= region.y) {
+            firstTileRow++;
+        }
+        int lastTileColumn = (region.x + region.width) / tileSize;
+        if (tileSize * lastTileColumn + overlap >= region.x + region.width
+                && lastTileColumn != 0) {
+            lastTileColumn--;
+        }
+        int lastTileRow = (region.y + region.height) / tileSize;
+        if (tileSize * lastTileRow + overlap >= region.y + region.height
+                && lastTileRow != 0) {
+            lastTileRow--;
+        }
+
+        BufferedImage result = null;
+        WritableRaster raster = null;
+        int dx = 0;
+        for (int i = firstTileColumn; i <= lastTileColumn; i++) {
+            int x;
+            int w;
+            if (i == firstTileColumn) {
+                x = region.x - firstTileColumn * tileSize;
+                if (i == lastTileColumn) {
+                    w = region.width;
+                } else {
+                    w = tileSize - x;
+                }
+                if (firstTileColumn != 0) {
+                    x += overlap;
+                }
+            } else {
+                x = overlap;
+                if (i == lastTileColumn) {
+                    w = region.width - dx;
+                } else {
+                    w = tileSize;
+                }
+            }
+
+            int dy = 0;
+            for (int j = firstTileRow; j <= lastTileRow; j++) {
+                int y;
+                int h;
+                if (j == firstTileRow) {
+                    y = region.y - firstTileRow * tileSize;
+                    if (j == lastTileRow) {
+                        h = region.height;
+                    } else {
+                        h = tileSize - y;
+                    }
+                    if (firstTileRow != 0) {
+                        y += overlap;
+                    }
+                } else {
+                    y = overlap;
+                    if (j == lastTileRow) {
+                        h = region.height - dy;
+                    } else {
+                        h = tileSize;
+                    }
+                }
+
+                Rectangle area = new Rectangle(x, y, w, h);
+                BufferedImage tile = readRegionOfTile(area, level, i, j);
+                if (i == firstTileColumn && j == firstTileRow) {
+                    result = createBufferedImage(region.width, region.height, tile);
+                    raster = result.getRaster();
+                }
+                raster.setRect(dx, dy, tile.getRaster());
+                tile.flush();
+                dy += h;
+            }
+            dx += w;
+        }
+        return result;
+    }
+
+    private BufferedImage readRegionOfTile(Rectangle region, int level,
+                                           int column, int row) throws IOException {
+        File levelFolder = new File(filesFolder, Integer.toString(level));
+        File tile = new File(levelFolder, column + "_" + row + "." + format);
+
+        String s = tile.getPath();
+        Path entry = inner_zipfs.getPath(s);
+
+        if (Files.exists(entry)) {
+            InputStream is = Files.newInputStream(entry);
+            try (ImageInputStream iis = ImageIO.createImageInputStream(is)) {
+                ImageReader reader = getImageReader(iis);
+                reader.setInput(iis);
+                ImageReadParam param = reader.getDefaultReadParam();
+                param.setSourceRegion(region);
+                return reader.read(0, param);
+            }
+
+        } else {
+            BufferedImage image = new BufferedImage(tileSize, tileSize, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2d = image.createGraphics();
+            g2d.setColor(Color.white);
+            g2d.fillRect(0, 0, tileSize, tileSize);
+            g2d.dispose();
+            return image;
+        }
+    }
+
+    private static ImageReader getImageReader(ImageInputStream iis)
+            throws IOException {
+        Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+        if (!readers.hasNext()) {
+            throw new IOException("No compatible image reader found.");
+        }
+        return readers.next();
+    }
+
+    /**
+     * Create a new buffered image with the same characteristics (color model,
+     * raster type, properties...) than the specified one.
+     *
+     * @param width the width
+     * @param height the height
+     * @param image an image with the same characteristics than the one which
+     * will be created.
+     */
+    private static BufferedImage createBufferedImage(int width, int height,
+                                                     BufferedImage image) {
+        Hashtable<String, Object> properties = null;
+        String[] propertyNames = image.getPropertyNames();
+        if (propertyNames != null) {
+            properties = new Hashtable<>(propertyNames.length);
+            for (String propertyName : propertyNames) {
+                properties.put(propertyName, image.getProperty(propertyName));
+            }
+        }
+        return new BufferedImage(
+                image.getColorModel(),
+                image.getRaster().createCompatibleWritableRaster(width, height),
+                image.isAlphaPremultiplied(),
+                properties);
+    }
+}

--- a/components/formats-gpl/test/loci/formats/utests/in/VmicReaderTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/in/VmicReaderTest.java
@@ -1,0 +1,244 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.utests.in;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.imageio.ImageIO;
+
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.in.VmicReader;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link loci.formats.in.VmicReader}.
+ *
+ * Every fixture is generated synthetically (a nested-zip Deep Zoom pyramid), so the
+ * test carries no proprietary sample data.
+ */
+public class VmicReaderTest {
+
+  private static final int TILE_SIZE = 256;
+
+  private VmicReader reader;
+  private OMEXMLMetadata metadata;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    reader = new VmicReader();
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    metadata = service.createOMEXMLMetadata();
+    reader.setMetadataStore(metadata);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    reader.close();
+  }
+
+  @Test
+  public void testCoreMetadataAndPyramid() throws Exception {
+    File vmic = createSyntheticVmic(1024, 1024, true);
+    reader.setId(vmic.getAbsolutePath());
+
+    assertEquals(reader.getSizeX(), 1024);
+    assertEquals(reader.getSizeY(), 1024);
+    assertEquals(reader.getSizeZ(), 1);
+    assertEquals(reader.getSizeT(), 1);
+    assertEquals(reader.getPixelType(), FormatTools.UINT8);
+    assertTrue(reader.isRGB());
+    assertEquals(reader.getSizeC(), 3);
+
+    // Deep Zoom pyramid should expose more than one resolution, each ~half the previous.
+    assertTrue(reader.getResolutionCount() > 1,
+      "expected a multi-resolution pyramid, got " + reader.getResolutionCount());
+    reader.setResolution(1);
+    assertTrue(reader.getSizeX() < 1024 && reader.getSizeX() >= 512,
+      "second resolution should be roughly half width, got " + reader.getSizeX());
+    reader.setResolution(0);
+  }
+
+  @Test
+  public void testTileReadSpanningTiles() throws Exception {
+    File vmic = createSyntheticVmic(1024, 1024, false);
+    reader.setId(vmic.getAbsolutePath());
+
+    // Read a 300x300 region straddling the 256px tile boundary.
+    int w = 300;
+    int h = 300;
+    byte[] buf = reader.openBytes(0, new byte[w * h * 3], 0, 0, w, h);
+    assertNotNull(buf);
+    assertEquals(buf.length, w * h * 3);
+    // Solid grey tiles: sampled channel byte should be near the fill value (JPEG-lossy).
+    int v = buf[0] & 0xff;
+    assertTrue(Math.abs(v - 128) <= 12, "unexpected pixel value " + v);
+  }
+
+  @Test
+  public void testPhysicalPixelSizeFromConfig() throws Exception {
+    File vmic = createSyntheticVmic(512, 512, true);
+    reader.setId(vmic.getAbsolutePath());
+
+    assertNotNull(metadata.getPixelsPhysicalSizeX(0));
+    // PixelPerMicron=4.0 -> 0.25 micron/pixel.
+    assertEquals(metadata.getPixelsPhysicalSizeX(0).value().doubleValue(), 0.25, 1e-6);
+    assertEquals(metadata.getObjectiveNominalMagnification(0, 0).doubleValue(), 40.0, 1e-6);
+  }
+
+  @Test
+  public void testMissingConfigStillOpens() throws Exception {
+    File vmic = createSyntheticVmic(512, 512, false);
+    reader.setId(vmic.getAbsolutePath());
+    assertEquals(reader.getSizeX(), 512);
+    // No config.osc -> physical size simply absent, not an error.
+    assertTrue(metadata.getPixelsPhysicalSizeX(0) == null);
+  }
+
+  @Test
+  public void testTemporaryFileCleanedUpOnClose() throws Exception {
+    File vmic = createSyntheticVmic(512, 512, false);
+    long before = countTempVmici();
+    reader.setId(vmic.getAbsolutePath());
+    reader.close();
+    long after = countTempVmici();
+    assertTrue(after <= before, "temporary .vmici file was not cleaned up on close");
+  }
+
+  @Test(expectedExceptions = {FormatException.class})
+  public void testRejectsZipWithoutInnerContainer() throws Exception {
+    File notVmic = File.createTempFile("bogus", ".vmic");
+    notVmic.deleteOnExit();
+    try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(notVmic))) {
+      zip.putNextEntry(new ZipEntry("something-else.txt"));
+      zip.write("not a vmic".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+    reader.setId(notVmic.getAbsolutePath());
+  }
+
+  // -- Helpers --
+
+  private long countTempVmici() {
+    File tmp = new File(System.getProperty("java.io.tmpdir"));
+    File[] matches = tmp.listFiles((d, name) ->
+      name.startsWith("Image") && name.endsWith(".vmici"));
+    return matches == null ? 0 : matches.length;
+  }
+
+  /**
+   * Build a synthetic .vmic: an outer zip whose sole entry {@code Image.vmici} is
+   * itself a zip holding a Deep Zoom descriptor, a full tile pyramid and (optionally)
+   * a PreciPoint config.osc.
+   */
+  private File createSyntheticVmic(int width, int height, boolean includeConfig)
+    throws Exception
+  {
+    ByteArrayOutputStream innerBytes = new ByteArrayOutputStream();
+    try (ZipOutputStream inner = new ZipOutputStream(innerBytes)) {
+      String dzi = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+        "<Image TileSize=\"" + TILE_SIZE + "\" Overlap=\"0\" Format=\"jpg\">\n" +
+        "  <Size Width=\"" + width + "\" Height=\"" + height + "\"/>\n" +
+        "</Image>";
+      writeEntry(inner, "dzc_output.xml", dzi.getBytes(StandardCharsets.UTF_8));
+
+      int maxLevel = (int) Math.ceil(Math.log(Math.max(width, height)) / Math.log(2));
+      for (int level = 0; level <= maxLevel; level++) {
+        double zoom = Math.pow(2, level - maxLevel);
+        int levelW = (int) Math.max(1, Math.round(width * zoom));
+        int levelH = (int) Math.max(1, Math.round(height * zoom));
+        int cols = (int) Math.ceil(levelW / (double) TILE_SIZE);
+        int rows = (int) Math.ceil(levelH / (double) TILE_SIZE);
+        for (int c = 0; c < cols; c++) {
+          for (int r = 0; r < rows; r++) {
+            int tw = Math.min(TILE_SIZE, levelW - c * TILE_SIZE);
+            int th = Math.min(TILE_SIZE, levelH - r * TILE_SIZE);
+            writeEntry(inner, "dzc_output_files/" + level + "/" + c + "_" + r + ".jpg",
+              solidJpeg(tw, th));
+          }
+        }
+      }
+
+      if (includeConfig) {
+        String osc = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+          "<ObjectScanConfig xmlns:ObjectScanConfig=\"urn:vmic\">\n" +
+          "  <Objective>\n" +
+          "    <ObjectScanConfig:ShortName>testobjective</ObjectScanConfig:ShortName>\n" +
+          "    <ObjectScanConfig:Magnification>40</ObjectScanConfig:Magnification>\n" +
+          "    <ObjectScanConfig:PixelPerMicron>4.0</ObjectScanConfig:PixelPerMicron>\n" +
+          "  </Objective>\n" +
+          "</ObjectScanConfig>";
+        writeEntry(inner, "VMCF/config.osc", osc.getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    File vmic = File.createTempFile("synthetic", ".vmic");
+    vmic.deleteOnExit();
+    try (ZipOutputStream outer = new ZipOutputStream(new FileOutputStream(vmic))) {
+      writeEntry(outer, "Image.vmici", innerBytes.toByteArray());
+    }
+    return vmic;
+  }
+
+  private static void writeEntry(ZipOutputStream zip, String name, byte[] data)
+    throws Exception
+  {
+    zip.putNextEntry(new ZipEntry(name));
+    zip.write(data);
+    zip.closeEntry();
+  }
+
+  private static byte[] solidJpeg(int w, int h) throws Exception {
+    BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+    Graphics2D g = img.createGraphics();
+    g.setColor(new Color(128, 128, 128));
+    g.fillRect(0, 0, w, h);
+    g.dispose();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(img, "jpg", out);
+    return out.toByteArray();
+  }
+}

--- a/components/formats-gpl/test/loci/formats/utests/testng.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng.xml
@@ -65,4 +65,9 @@
         <class name="loci.formats.utests.XMLAnnotationTest"/>
       </classes>
     </test>
+    <test name="VmicReaderTest">
+      <classes>
+        <class name="loci.formats.utests.in.VmicReaderTest"/>
+      </classes>
+    </test>
 </suite>


### PR DESCRIPTION
## Summary

Adds `VmicReader` for the PreciPoint `.vmic` whole-slide image format — the
long-standing format request tracked in openslide/openslide#168.

`.vmic` is an outer ZIP whose single `Image.vmici` entry is itself a ZIP containing a
Deep Zoom (DZI) pyramid of JPEG tiles (`dzc_output.xml` +
`dzc_output_files/<level>/<col>_<row>.jpg`) plus optional PreciPoint scan metadata
(`VMCF/config.osc`). The reader exposes it as a tiled, sub-resolution pyramid with
physical pixel size and objective magnification.

## Implementation

- Streams the inner `Image.vmici` container to a temporary file and reads it via a zip
  `FileSystem`, keeping heap usage low regardless of container size (these files are
  routinely > 1 GB).
- Parses `dzc_output.xml` and `config.osc` via `XMLTools`; `config.osc` (physical size /
  magnification) is optional.
- Decodes JPEG tiles with `ImageIO` and assembles requested regions across tile
  boundaries.
- Registered in `readers.txt` immediately after `ZipReader`.

## Testing

`VmicReaderTest` (TestNG, registered in the formats-gpl suite) runs entirely against a
**synthetically generated** nested-zip Deep Zoom fixture — no proprietary sample data.
It covers core metadata, pyramid resolutions, tile reads spanning tile boundaries,
optional-metadata handling, temp-file cleanup on close, and rejection of a ZIP lacking
the inner container. Also verified end-to-end by opening real PreciPoint `.vmic` slides
in QuPath through the Bio-Formats reader at modest heap.

## Attribution

The reader originated in @kwiechen's fork
(https://github.com/kwiechen/bioformats-vmic) and is credited as co-author. Opening
here to bring it upstream — happy to adjust attribution/approach per maintainer
preference, and to loop in the original author.

## Follow-ups

- Draft: opened for review before finalizing.
- A supported-formats documentation page will follow separately (the docs live outside
  this repository).
- Sample data: can provide a small synthetic `.vmic` if useful; production samples are
  patient-derived and cannot be shared.
