### PR TITLE
NDPI: Add writer support

### DIFF
--- a/components/formats-api/src/loci/formats/writers.txt
+++ b/components/formats-api/src/loci/formats/writers.txt
@@ -5,6 +5,7 @@
 loci.formats.out.OMEXMLWriter  	# ome
 loci.formats.out.PyramidOMETiffWriter # ome.tif, ome.tiff
 loci.formats.out.OMETiffWriter  # ome.tif, ome.tiff
+loci.formats.out.NDPIWriter     # ndpi
 loci.formats.out.TiffWriter     # tif, tiff
 loci.formats.out.JPEGWriter     # jpg, jpeg
 loci.formats.out.JPEG2000Writer # jp2

--- a/components/formats-bsd/test/loci/formats/utests/WriterDiscoveryTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/WriterDiscoveryTest.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2006 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import loci.formats.IFormatWriter;
+import loci.formats.ImageWriter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Asserts that {@link ImageWriter} discovery on a BSD-only classpath does
+ * not load the GPL Hamamatsu NDPI writer (loci.formats.out.NDPIWriter), and
+ * that BSD-only writers such as the TIFF writer are still discovered.
+ */
+public class WriterDiscoveryTest {
+
+  private static final String NDPI_WRITER_CLASS = "loci.formats.out.NDPIWriter";
+  private static final String TIFF_WRITER_CLASS = "loci.formats.out.TiffWriter";
+
+  @Test
+  public void testNDPIWriterUnavailableOnBSDClasspath() throws Exception {
+    ImageWriter writer = new ImageWriter();
+    try {
+      int ndpiWriterCount = 0;
+      for (IFormatWriter candidate : writer.getWriters()) {
+        if (candidate.getClass().getName().equals(NDPI_WRITER_CLASS)) {
+          ndpiWriterCount++;
+        }
+      }
+      Assert.assertEquals(ndpiWriterCount, 0,
+        "BSD-only writer discovery must not load the GPL NDPI writer");
+    }
+    finally {
+      writer.close();
+    }
+  }
+
+  @Test
+  public void testBSDWritersRemainDiscoverable() throws Exception {
+    ImageWriter writer = new ImageWriter();
+    try {
+      boolean foundTiffWriter = false;
+      for (IFormatWriter candidate : writer.getWriters()) {
+        if (candidate.getClass().getName().equals(TIFF_WRITER_CLASS)) {
+          foundTiffWriter = true;
+        }
+      }
+      Assert.assertTrue(foundTiffWriter,
+        "BSD-only writer discovery must retain available writers");
+    }
+    finally {
+      writer.close();
+    }
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -181,6 +181,12 @@
         <class name="loci.formats.utests.ConversionTest"/>
       </classes>
     </test>
+    <test name="WriterDiscoveryTest">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.WriterDiscoveryTest"/>
+      </classes>
+    </test>
     <test name="CompressDecompressTest">
       <groups/>
       <classes>

--- a/components/formats-gpl/src/loci/formats/out/NDPIClassicTiffWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/NDPIClassicTiffWriter.java
@@ -1,0 +1,370 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import loci.common.RandomAccessOutputStream;
+import loci.formats.FormatException;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.TiffRational;
+
+/**
+ * Writes little-endian classic TIFF directories with NDPI extensions.
+ *
+ * Value encoding, external-value writing and directory emission are separate
+ * steps, so that a directory can reference values written earlier in the
+ * file. Genuine Hamamatsu files place every value an IFD names, and the image
+ * payload the IFD describes, before the IFD itself, so those offsets point
+ * backwards while the next-IFD pointer may link forward.
+ *
+ * The header's first-IFD field and each directory's next-IFD field are 64
+ * bits wide and are left zero until the directory they name has been written,
+ * then filled in by patchOffset().
+ */
+final class NDPIClassicTiffWriter {
+
+  // -- Constants --
+
+  /** Header length; unlike classic TIFF the first-IFD pointer is 64 bits. */
+  static final int HEADER_LENGTH = 12;
+
+  /** Location of the header's 64-bit first-IFD pointer. */
+  static final long FIRST_IFD_POINTER = 4;
+
+  private static final int ASCII = 2;
+  private static final int SHORT = 3;
+  private static final int LONG = 4;
+  private static final int RATIONAL = 5;
+  private static final int SLONG = 9;
+  private static final int FLOAT = 11;
+
+  private static final Comparator<Entry> BY_TAG = new Comparator<Entry>() {
+    @Override
+    public int compare(Entry left, Entry right) {
+      return Integer.compare(left.value.tag, right.value.tag);
+    }
+  };
+
+  // -- Fields --
+
+  private final RandomAccessOutputStream out;
+
+  // -- Constructor --
+
+  NDPIClassicTiffWriter(RandomAccessOutputStream out) {
+    this.out = out;
+  }
+
+  // -- NDPIClassicTiffWriter API methods --
+
+  /**
+   * Writes the file header with an as yet unknown first directory.
+   * FIRST_IFD_POINTER is filled in once the first directory has been written.
+   */
+  void writeHeader() throws IOException {
+    out.seek(0);
+    out.order(true);
+    out.write('I');
+    out.write('I');
+    out.writeShort(42);
+    out.writeLong(0);
+  }
+
+  /**
+   * Prepares one directory entry, writing its value now when that value is
+   * too large to be stored inline.
+   *
+   * @param value the encoded value to prepare
+   * @return the entry, which may be used by any later directory
+   */
+  Entry entry(Value value) throws IOException {
+    if (!value.external()) return new Entry(value, -1);
+    align();
+    long offset = out.getFilePointer();
+    out.write(value.data);
+    return new Entry(value, offset);
+  }
+
+  /**
+   * Writes one completed directory at the current end of the stream. Every
+   * external value the entries name must already have been written, and the
+   * directory's next-IFD pointer is left zero.
+   *
+   * @param entries the directory's entries, in any order
+   * @return where the directory and its next-IFD pointer were written
+   */
+  Directory writeIFD(List<Entry> entries) throws IOException {
+    List<Entry> sorted = new ArrayList<Entry>(entries);
+    Collections.sort(sorted, BY_TAG);
+
+    align();
+    long offset = out.getFilePointer();
+    out.writeShort(sorted.size());
+    for (Entry entry : sorted) {
+      Value value = entry.value;
+      out.writeShort(value.tag);
+      out.writeShort(value.type);
+      out.writeInt(value.count);
+      if (value.external()) out.writeInt((int) entry.offset);
+      else writePadded(value.data);
+    }
+    long nextPointer = out.getFilePointer();
+    out.writeLong(0);
+    for (Entry entry : sorted) out.writeInt((int) entry.highWord());
+    return new Directory(offset, nextPointer);
+  }
+
+  /**
+   * Fills in one 64-bit offset already reserved in the output, leaving the
+   * stream where it was so that the caller can continue appending.
+   *
+   * @param location where the reserved offset begins
+   * @param offset the offset to store
+   */
+  void patchOffset(long location, long offset) throws IOException {
+    long end = out.getFilePointer();
+    out.seek(location);
+    out.writeLong(offset);
+    out.seek(end);
+  }
+
+  /** Encodes every value of the given directory, writing none of them. */
+  static List<Value> values(IFD ifd) throws FormatException {
+    List<Integer> tags = new ArrayList<Integer>(ifd.keySet());
+    tags.remove(Integer.valueOf(IFD.LITTLE_ENDIAN));
+    tags.remove(Integer.valueOf(IFD.BIG_TIFF));
+    Collections.sort(tags);
+    List<Value> values = new ArrayList<Value>();
+    for (Integer tag : tags) values.add(value(tag, ifd.get(tag)));
+    return values;
+  }
+
+  /** Encodes one TIFF value, writing nothing. */
+  static Value value(int tag, Object value) throws FormatException {
+    if (value instanceof String) {
+      byte[] text = (((String) value) + "\0")
+        .getBytes(StandardCharsets.US_ASCII);
+      return new Value(tag, ASCII, text.length, text, 0);
+    }
+    if (value instanceof TiffRational) {
+      TiffRational rational = (TiffRational) value;
+      return new Value(tag, RATIONAL, 1,
+        bytes(rational.getNumerator(), rational.getDenominator()), 0);
+    }
+    if (value instanceof Float) {
+      long bits = Float.floatToIntBits(((Float) value).floatValue()) &
+        0xffffffffL;
+      return new Value(tag, FLOAT, 1, bytes(bits), bits);
+    }
+    if (value instanceof Number) {
+      long number = ((Number) value).longValue();
+      int type = shortTag(tag) ? SHORT : signedLongTag(tag) ? SLONG : LONG;
+      return new Value(tag, type, 1,
+        type == SHORT ? shorts((int) number) : bytes(number), number);
+    }
+    if (value instanceof int[]) {
+      int[] values = (int[]) value;
+      int type = signedLongArrayTag(tag) ? SLONG : SHORT;
+      return new Value(tag, type, values.length,
+        type == SLONG ? signedBytes(values) : shorts(values), 0);
+    }
+    if (value instanceof long[]) {
+      long[] values = (long[]) value;
+      return new Value(tag, LONG, values.length, bytes(values),
+        values.length == 1 ? values[0] : 0);
+    }
+    throw new FormatException("Unsupported NDPI TIFF value for tag " + tag);
+  }
+
+  // -- Helper methods --
+
+  /** Aligns the stream so that the next structure begins on a TIFF word. */
+  private void align() throws IOException {
+    if ((out.getFilePointer() & 1) != 0) out.write(0);
+  }
+
+  private static boolean extendedScalarTag(int tag) {
+    return tag == IFD.STRIP_OFFSETS || tag == IFD.STRIP_BYTE_COUNTS;
+  }
+
+  private void writePadded(byte[] data) throws IOException {
+    out.write(data);
+    for (int i = data.length; i < 4; i++) out.write(0);
+  }
+
+  private static boolean shortTag(int tag) {
+    return tag == IFD.COMPRESSION ||
+      tag == IFD.PHOTOMETRIC_INTERPRETATION ||
+      tag == IFD.SAMPLES_PER_PIXEL ||
+      tag == IFD.PLANAR_CONFIGURATION ||
+      tag == IFD.RESOLUTION_UNIT ||
+      tag == NDPITags.VERSION;
+  }
+
+  private static boolean signedLongTag(int tag) {
+    return tag == NDPITags.X_POSITION || tag == NDPITags.Y_POSITION ||
+      tag == NDPITags.Z_POSITION || tag == NDPITags.REFOCUS_INTERVAL ||
+      tag == NDPITags.FOCUS_OFFSET;
+  }
+
+  private static boolean signedLongArrayTag(int tag) {
+    return tag == NDPITags.FOCUS_POINTS ||
+      tag == NDPITags.FOCUS_POINT_REGIONS;
+  }
+
+  private static byte[] signedBytes(int... values) {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    for (int value : values) {
+      bytes.write(value);
+      bytes.write(value >>> 8);
+      bytes.write(value >>> 16);
+      bytes.write(value >>> 24);
+    }
+    return bytes.toByteArray();
+  }
+
+  private static byte[] shorts(int... values) {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    for (int value : values) {
+      bytes.write(value);
+      bytes.write(value >>> 8);
+    }
+    return bytes.toByteArray();
+  }
+
+  private static byte[] bytes(long... values) {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    for (long value : values) {
+      bytes.write((int) value);
+      bytes.write((int) (value >>> 8));
+      bytes.write((int) (value >>> 16));
+      bytes.write((int) (value >>> 24));
+    }
+    return bytes.toByteArray();
+  }
+
+  // -- Helper classes --
+
+  /** One encoded TIFF value that has not yet been placed in the file. */
+  static final class Value {
+
+    private final int tag;
+    private final int type;
+    private final int count;
+    private final byte[] data;
+    private final long scalar;
+
+    private Value(int tag, int type, int count, byte[] data, long scalar) {
+      this.tag = tag;
+      this.type = type;
+      this.count = count;
+      this.data = data;
+      this.scalar = scalar;
+    }
+
+    int tag() {
+      return tag;
+    }
+
+    /**
+     * @return whether this value must be stored outside its directory entry.
+     *   Every ASCII value is stored externally, as genuine NDPI files do,
+     *   even when it would fit inline.
+     */
+    boolean external() {
+      return type == ASCII || data.length > 4;
+    }
+
+    /** @return a key identifying values whose emitted bytes are identical */
+    String key() {
+      StringBuilder key = new StringBuilder().append(type).append(':');
+      for (byte b : data) key.append(Integer.toHexString(b & 0xff)).append('.');
+      return key.toString();
+    }
+  }
+
+  /** One prepared directory entry, and where its value was written. */
+  static final class Entry {
+
+    private final Value value;
+    private final long offset;
+
+    private Entry(Value value, long offset) {
+      this.value = value;
+      this.offset = offset;
+    }
+
+    /** @return this entry with the same value written under another tag */
+    Entry retag(int tag) {
+      return new Entry(new Value(tag, value.type, value.count, value.data,
+        value.scalar), offset);
+    }
+
+    int tag() {
+      return value.tag;
+    }
+
+    /**
+     * @return the entry's NDPI 64-bit extension word, which carries the high
+     *   word of an external value's offset, or of the few scalars NDPI
+     *   deliberately extends past 32 bits. Every other entry, including a
+     *   negative SLONG, extends to zero.
+     */
+    private long highWord() {
+      if (value.external()) return offset >>> 32;
+      if (extendedScalarTag(value.tag)) return value.scalar >>> 32;
+      return 0;
+    }
+  }
+
+  /** Where a completed directory and its next-IFD pointer were written. */
+  static final class Directory {
+
+    private final long offset;
+    private final long nextPointer;
+
+    private Directory(long offset, long nextPointer) {
+      this.offset = offset;
+      this.nextPointer = nextPointer;
+    }
+
+    long offset() {
+      return offset;
+    }
+
+    /** @return where this directory's 64-bit next-IFD pointer begins */
+    long nextPointer() {
+      return nextPointer;
+    }
+  }
+}

--- a/components/formats-gpl/src/loci/formats/out/NDPIJPEGAssembler.java
+++ b/components/formats-gpl/src/loci/formats/out/NDPIJPEGAssembler.java
@@ -1,0 +1,558 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import loci.common.RandomAccessOutputStream;
+import loci.formats.FormatException;
+import loci.formats.codec.CodecOptions;
+import loci.formats.codec.JPEGCodec;
+
+/**
+ * Streams one continuous NDPI-style restart-marked JPEG assembled from
+ * independently compressed MCU-row regions.
+ *
+ * Input must be interleaved, unsigned 8-bit RGB rows supplied in
+ * top-to-bottom order; no other layout is accepted. Pixel buffering is
+ * limited to one eight-pixel-high MCU row.
+ */
+final class NDPIJPEGAssembler {
+
+  // -- Constants --
+
+  private static final int CHANNELS = 3;
+  private static final int MCU_SIZE = 8;
+  private static final int DRI = 0xffdd;
+  private static final int EOI = 0xffd9;
+  private static final int SOS = 0xffda;
+
+  // -- Fields --
+
+  private final RandomAccessOutputStream out;
+  private final int width;
+  private final int height;
+  private final int restartMCUs;
+  private final boolean indexed;
+  private final double quality;
+  private final int regionWidth;
+  private final byte[] rowBuffer;
+  private final byte[] imageBuffer;
+  private final long[] mcuStarts;
+  private final int[] captureRegions;
+  private final byte[][] capturedEntropy;
+
+  private ParsedJPEG template;
+  private int bufferedRows;
+  private int writtenRows;
+  private int regions;
+  private long jpegOffset = -1;
+  private boolean finished;
+
+  // -- Constructor --
+
+  /**
+   * Construct an assembler at the destination's current file position.
+   *
+   * @param out destination stream
+   * @param width complete image width
+   * @param height complete image height
+   * @param restartMCUs number of 8-by-8 MCUs in each restart interval;
+   *   ignored when not indexed
+   * @param indexed whether to emit a restart-marked, MCU-indexed JPEG rather
+   *   than one ordinary baseline JPEG buffered in full
+   * @param quality JPEG quality between 0.25 and 1
+   * @param captureRegions restart regions whose entropy data is retained for
+   *   AuthCode calculation, or null
+   */
+  NDPIJPEGAssembler(RandomAccessOutputStream out, int width, int height,
+    int restartMCUs, boolean indexed, double quality, int[] captureRegions)
+    throws FormatException
+  {
+    if (out == null) {
+      throw new IllegalArgumentException("Destination stream cannot be null");
+    }
+    if (width <= 0 || height <= 0) {
+      throw new FormatException("JPEG dimensions must be positive");
+    }
+    if (indexed && (restartMCUs <= 0 || restartMCUs > 0xffff)) {
+      throw new FormatException("JPEG restart interval must be 1..65535 MCUs");
+    }
+    if (!Double.isFinite(quality) || quality < 0.25 || quality > 1) {
+      throw new FormatException("JPEG quality must be between 0.25 and 1");
+    }
+    long mcuColumns = ((long) width + MCU_SIZE - 1) / MCU_SIZE;
+    if (indexed && mcuColumns % restartMCUs != 0) {
+      throw new FormatException("Padded JPEG width must contain a whole " +
+        "number of restart intervals");
+    }
+    long rowBytes = (long) width * CHANNELS;
+    long bufferBytes = rowBytes * MCU_SIZE;
+    if (bufferBytes > Integer.MAX_VALUE) {
+      throw new FormatException("One JPEG MCU row is too large to buffer");
+    }
+    this.out = out;
+    this.width = width;
+    this.height = height;
+    this.restartMCUs = restartMCUs;
+    this.indexed = indexed;
+    this.quality = quality;
+    this.regionWidth = indexed ? restartMCUs * MCU_SIZE : 0;
+    this.rowBuffer = indexed ? new byte[(int) bufferBytes] : null;
+    long imageBytes = rowBytes * height;
+    if (!indexed && imageBytes > Integer.MAX_VALUE) {
+      throw new FormatException(
+        "Non-indexed JPEG is too large to buffer as one image");
+    }
+    this.imageBuffer = indexed ? null : new byte[(int) imageBytes];
+    long regionRows = ((long) height + MCU_SIZE - 1) / MCU_SIZE;
+    long regionColumns = indexed ?
+      ((long) width + regionWidth - 1) / regionWidth : 0;
+    long regionCount = regionRows * regionColumns;
+    if (regionCount > Integer.MAX_VALUE) {
+      throw new FormatException("JPEG contains too many restart regions");
+    }
+    this.mcuStarts = indexed ?
+      new long[(int) regionCount] : new long[0];
+    this.captureRegions =
+      captureRegions == null ? new int[0] : captureRegions.clone();
+    if (!indexed && this.captureRegions.length > 0) {
+      throw new FormatException(
+        "Non-indexed JPEG cannot capture restart regions");
+    }
+    this.capturedEntropy = new byte[this.captureRegions.length][];
+    for (int region : this.captureRegions) {
+      if (region < 0 || region >= regionCount) {
+        throw new FormatException("Captured JPEG region is out of range");
+      }
+    }
+  }
+
+  // -- NDPIJPEGAssembler API methods --
+
+  /**
+   * Append one or more complete image rows.
+   */
+  void writeRows(byte[] pixels, int offset, int rows)
+    throws FormatException, IOException
+  {
+    ensureOpen();
+    if (pixels == null) {
+      throw new IllegalArgumentException("Pixel buffer cannot be null");
+    }
+    if (rows <= 0 || writtenRows + rows > height) {
+      throw new FormatException("Rows must be written once, top to bottom");
+    }
+    int rowBytes = width * CHANNELS;
+    long required = (long) rows * rowBytes;
+    if (offset < 0 || required > pixels.length - (long) offset) {
+      throw new FormatException("Pixel buffer does not contain " + rows +
+        " complete RGB rows");
+    }
+    if (!indexed) {
+      System.arraycopy(pixels, offset, imageBuffer, writtenRows * rowBytes,
+        (int) required);
+      writtenRows += rows;
+      return;
+    }
+
+    int source = offset;
+    int remaining = rows;
+    while (remaining > 0) {
+      int count = Math.min(remaining, MCU_SIZE - bufferedRows);
+      System.arraycopy(pixels, source, rowBuffer, bufferedRows * rowBytes,
+        count * rowBytes);
+      source += count * rowBytes;
+      bufferedRows += count;
+      writtenRows += count;
+      remaining -= count;
+      if (bufferedRows == MCU_SIZE) {
+        writeMCURow(bufferedRows);
+        bufferedRows = 0;
+      }
+    }
+  }
+
+  /**
+   * Finish the JPEG and return its location and restart-segment starts.
+   */
+  Result finish() throws FormatException, IOException {
+    ensureOpen();
+    if (writtenRows != height) {
+      throw new FormatException("Expected " + height + " rows but received " +
+        writtenRows);
+    }
+    if (!indexed) {
+      byte[] compressed = new JPEGCodec().compress(imageBuffer,
+        options(width, height, quality));
+      ParsedJPEG parsed = ParsedJPEG.parse(compressed);
+      parsed.assert444Sampling();
+      parsed.assertNoRestartMarkers();
+      jpegOffset = out.getFilePointer();
+      out.write(compressed);
+      finished = true;
+      return new Result(jpegOffset, compressed.length, new long[0],
+        new byte[0][]);
+    }
+    if (bufferedRows > 0) {
+      writeMCURow(bufferedRows);
+      bufferedRows = 0;
+    }
+    writeMarker(EOI);
+    finished = true;
+    return new Result(jpegOffset, out.getFilePointer() - jpegOffset,
+      mcuStarts.clone(), capturedEntropy.clone());
+  }
+
+  // -- Helper methods --
+
+  private void writeMCURow(int rows) throws FormatException, IOException {
+    for (int x = 0; x < width; x += regionWidth) {
+      int pieceWidth = Math.min(regionWidth, width - x);
+      byte[] piece = extractPiece(x, pieceWidth, rows);
+      byte[] compressed = new JPEGCodec().compress(piece,
+        options(pieceWidth, rows, quality));
+      ParsedJPEG parsed = ParsedJPEG.parse(compressed);
+
+      if (template == null) {
+        template = parsed;
+        template.assert444Sampling();
+        jpegOffset = out.getFilePointer();
+        byte[] header = Arrays.copyOf(template.header, template.header.length);
+        patchDimensions(header, template.sofOffset, width, height);
+        out.write(header, 0, template.sosOffset);
+        writeMarker(DRI);
+        out.write(0);
+        out.write(4);
+        out.write(restartMCUs >>> 8);
+        out.write(restartMCUs);
+        out.write(header, template.sosOffset,
+          header.length - template.sosOffset);
+      }
+      else {
+        template.assertCompatible(parsed);
+        writeMarker(0xffd0 + ((regions - 1) & 7));
+      }
+      mcuStarts[regions] = out.getFilePointer() - jpegOffset;
+      for (int i = 0; i < captureRegions.length; i++) {
+        if (captureRegions[i] == regions) {
+          capturedEntropy[i] = parsed.entropy;
+        }
+      }
+      out.write(parsed.entropy);
+      regions++;
+    }
+  }
+
+  private byte[] extractPiece(int x, int pieceWidth, int rows) {
+    int sourceRowBytes = width * CHANNELS;
+    int pieceRowBytes = pieceWidth * CHANNELS;
+    byte[] piece = new byte[pieceRowBytes * rows];
+    for (int row = 0; row < rows; row++) {
+      System.arraycopy(rowBuffer, row * sourceRowBytes + x * CHANNELS, piece,
+        row * pieceRowBytes, pieceRowBytes);
+    }
+    return piece;
+  }
+
+  private void writeMarker(int marker) throws IOException {
+    out.write(marker >>> 8);
+    out.write(marker);
+  }
+
+  private void ensureOpen() throws FormatException {
+    if (finished) {
+      throw new FormatException("JPEG assembly is already complete");
+    }
+  }
+
+  private static CodecOptions options(int width, int height, double quality) {
+    CodecOptions options = CodecOptions.getDefaultOptions();
+    options.width = width;
+    options.height = height;
+    options.channels = CHANNELS;
+    options.bitsPerSample = 8;
+    options.interleaved = true;
+    options.lossless = false;
+    options.quality = quality;
+    options.disableChromaSubsampling = true;
+    return options;
+  }
+
+  private static void patchDimensions(byte[] header, int sofOffset, int width,
+    int height)
+  {
+    int jpegWidth = width > 0xffff ? 0 : width;
+    int jpegHeight = height > 0xffff ? 0 : height;
+    header[sofOffset + 5] = (byte) (jpegHeight >>> 8);
+    header[sofOffset + 6] = (byte) jpegHeight;
+    header[sofOffset + 7] = (byte) (jpegWidth >>> 8);
+    header[sofOffset + 8] = (byte) jpegWidth;
+  }
+
+  /** Completed JPEG location information. */
+  static final class Result {
+
+    private final long jpegOffset;
+    private final long jpegLength;
+    private final long[] mcuStarts;
+    private final byte[][] capturedEntropy;
+
+    private Result(long jpegOffset, long jpegLength, long[] mcuStarts,
+      byte[][] capturedEntropy)
+    {
+      this.jpegOffset = jpegOffset;
+      this.jpegLength = jpegLength;
+      this.mcuStarts = mcuStarts;
+      this.capturedEntropy = capturedEntropy;
+    }
+
+    long getJPEGOffset() {
+      return jpegOffset;
+    }
+
+    long getJPEGLength() {
+      return jpegLength;
+    }
+
+    long[] getMCUStarts() {
+      return mcuStarts.clone();
+    }
+
+    byte[] getCapturedEntropy(int index) {
+      return capturedEntropy[index].clone();
+    }
+  }
+
+  /** A parsed baseline JPEG. */
+  static final class ParsedJPEG {
+
+    private final byte[] header;
+    private final byte[] entropy;
+    private final List<byte[]> quantizationTables;
+    private final List<byte[]> huffmanTables;
+    private final byte[] frameComponents;
+    private final byte[] scanComponents;
+    private final int sofOffset;
+    private final int sosOffset;
+    private final boolean hasDRI;
+
+    private ParsedJPEG(byte[] header, byte[] entropy,
+      List<byte[]> quantizationTables, List<byte[]> huffmanTables,
+      byte[] frameComponents, byte[] scanComponents, int sofOffset,
+      int sosOffset, boolean hasDRI)
+    {
+      this.header = header;
+      this.entropy = entropy;
+      this.quantizationTables = quantizationTables;
+      this.huffmanTables = huffmanTables;
+      this.frameComponents = frameComponents;
+      this.scanComponents = scanComponents;
+      this.sofOffset = sofOffset;
+      this.sosOffset = sosOffset;
+      this.hasDRI = hasDRI;
+    }
+
+    static ParsedJPEG parse(byte[] jpeg) throws FormatException {
+      if (jpeg.length < 4 || marker(jpeg, 0) != 0xffd8) {
+        throw new FormatException("JPEG piece does not begin with SOI");
+      }
+      List<byte[]> dqt = new ArrayList<byte[]>();
+      List<byte[]> dht = new ArrayList<byte[]>();
+      byte[] frame = null;
+      byte[] scan = null;
+      int sof = -1;
+      int sos = -1;
+      int entropyStart = -1;
+      int entropyEnd = -1;
+      boolean hasDRI = false;
+      int offset = 2;
+      while (offset + 1 < jpeg.length) {
+        if ((jpeg[offset] & 0xff) != 0xff) {
+          throw new FormatException("Expected JPEG marker at " + offset);
+        }
+        int code = marker(jpeg, offset);
+        if (code == EOI) break;
+        if (offset + 3 >= jpeg.length) {
+          throw new FormatException("Truncated JPEG marker");
+        }
+        int length = u16(jpeg, offset + 2);
+        if (length < 2 || offset + 2 + length > jpeg.length) {
+          throw new FormatException("Invalid JPEG marker length");
+        }
+        if (code == 0xffdb) {
+          dqt.add(slice(jpeg, offset + 4, offset + 2 + length));
+        }
+        else if (code == 0xffc4) {
+          dht.add(slice(jpeg, offset + 4, offset + 2 + length));
+        }
+        else if (code == 0xffc0) {
+          sof = offset;
+          int components = jpeg[offset + 9] & 0xff;
+          frame = slice(jpeg, offset + 9, offset + 10 + 3 * components);
+        }
+        else if (code == DRI) {
+          hasDRI = true;
+        }
+        else if (isSOF(code)) {
+          throw new FormatException("Only baseline sequential JPEG is " +
+            "supported, found SOF marker 0x" + Integer.toHexString(code));
+        }
+        else if (code == SOS) {
+          sos = offset;
+          int components = jpeg[offset + 4] & 0xff;
+          scan = slice(jpeg, offset + 4, offset + 5 + 2 * components);
+          entropyStart = offset + 2 + length;
+          entropyEnd = findEntropyEnd(jpeg, entropyStart);
+          break;
+        }
+        offset += 2 + length;
+      }
+      if (sof < 0 || sos < 0 || entropyStart < 0 || entropyEnd < 0) {
+        throw new FormatException("Incomplete JPEG marker structure");
+      }
+      return new ParsedJPEG(slice(jpeg, 0, entropyStart),
+        slice(jpeg, entropyStart, entropyEnd), dqt, dht, frame, scan, sof, sos,
+        hasDRI);
+    }
+
+    void assertCompatible(ParsedJPEG other) throws FormatException {
+      if (!byteListsEqual(quantizationTables, other.quantizationTables)) {
+        throw new FormatException("JPEG quantization tables differ between " +
+          "restart regions");
+      }
+      if (!byteListsEqual(huffmanTables, other.huffmanTables)) {
+        throw new FormatException("JPEG Huffman tables differ between " +
+          "restart regions");
+      }
+      if (!Arrays.equals(frameComponents, other.frameComponents)) {
+        throw new FormatException("JPEG frame components or sampling factors " +
+          "differ between restart regions");
+      }
+      if (!Arrays.equals(scanComponents, other.scanComponents)) {
+        throw new FormatException("JPEG scan components differ between " +
+          "restart regions");
+      }
+    }
+
+    void assert444Sampling() throws FormatException {
+      // parse() rejects any stream without an SOF0, and sets the frame
+      // components alongside it, so frameComponents is never null here.
+      if ((frameComponents[0] & 0xff) != CHANNELS) {
+        throw new FormatException("NDPI JPEG requires three components");
+      }
+      for (int i = 0; i < CHANNELS; i++) {
+        if ((frameComponents[2 + 3 * i] & 0xff) != 0x11) {
+          throw new FormatException("NDPI JPEG requires 4:4:4 sampling");
+        }
+      }
+    }
+
+    void assertNoRestartMarkers() throws FormatException {
+      if (hasDRI) {
+        throw new FormatException("Non-indexed JPEG must not contain DRI");
+      }
+      for (int i = 0; i + 1 < entropy.length; i++) {
+        if ((entropy[i] & 0xff) == 0xff) {
+          int next = entropy[i + 1] & 0xff;
+          if (next >= 0xd0 && next <= 0xd7) {
+            throw new FormatException(
+              "Non-indexed JPEG must not contain restart markers");
+          }
+        }
+      }
+    }
+
+    private static int findEntropyEnd(byte[] jpeg, int start)
+      throws FormatException
+    {
+      int offset = start;
+      while (offset + 1 < jpeg.length) {
+        if ((jpeg[offset] & 0xff) != 0xff) {
+          offset++;
+          continue;
+        }
+        int next = jpeg[offset + 1] & 0xff;
+        if (next == 0) {
+          offset += 2;
+          continue;
+        }
+        int markerOffset = offset;
+        while (next == 0xff) {
+          offset++;
+          if (offset + 1 >= jpeg.length) {
+            throw new FormatException("Truncated JPEG fill bytes");
+          }
+          next = jpeg[offset + 1] & 0xff;
+        }
+        if (next == 0xd9) return markerOffset;
+        if (next == 0xda) {
+          throw new FormatException("Multiple JPEG scans are not supported");
+        }
+        if (next == 0) {
+          throw new FormatException("Invalid fill before stuffed entropy byte");
+        }
+        if (next >= 0xd0 && next <= 0xd7) {
+          offset += 2;
+          continue;
+        }
+        throw new FormatException("Unexpected marker in JPEG entropy data");
+      }
+      throw new FormatException("JPEG entropy data has no EOI");
+    }
+
+    private static boolean byteListsEqual(List<byte[]> first,
+      List<byte[]> second)
+    {
+      if (first.size() != second.size()) return false;
+      for (int i = 0; i < first.size(); i++) {
+        if (!Arrays.equals(first.get(i), second.get(i))) return false;
+      }
+      return true;
+    }
+
+    private static boolean isSOF(int code) {
+      int low = code & 0xff;
+      return code >= 0xffc0 && code <= 0xffcf &&
+        low != 0xc4 && low != 0xc8 && low != 0xcc;
+    }
+
+    private static byte[] slice(byte[] bytes, int start, int end) {
+      return Arrays.copyOfRange(bytes, start, end);
+    }
+
+    private static int marker(byte[] bytes, int offset) {
+      return (bytes[offset] & 0xff) << 8 | bytes[offset + 1] & 0xff;
+    }
+
+    private static int u16(byte[] bytes, int offset) {
+      return (bytes[offset] & 0xff) << 8 | bytes[offset + 1] & 0xff;
+    }
+  }
+}

--- a/components/formats-gpl/src/loci/formats/out/NDPITags.java
+++ b/components/formats-gpl/src/loci/formats/out/NDPITags.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+/**
+ * The single definition of every private TIFF tag number the NDPI writer
+ * emits. Standard TIFF tags come from loci.formats.tiff.IFD.
+ */
+final class NDPITags {
+
+  // -- Constants --
+
+  /** NDPI format version; always 1. */
+  static final int VERSION = 65420;
+  /** Objective magnification scaled to the level, or -1/-2 for macro/map. */
+  static final int SOURCE_LENS = 65421;
+  /** Image-center X position in nanometers. */
+  static final int X_POSITION = 65422;
+  /** Image-center Y position in nanometers. */
+  static final int Y_POSITION = 65423;
+  /** Image-center Z position in nanometers. */
+  static final int Z_POSITION = 65424;
+  /** Index of the tissue region this image belongs to. */
+  static final int TISSUE_INDEX = 65425;
+  /** Low words of the restart-segment offsets into the JPEG stream. */
+  static final int MCU_STARTS = 65426;
+  /** Free-text slide reference. */
+  static final int REFERENCE = 65427;
+  /** Checksum over sampled entropy bytes of selected restart segments. */
+  static final int AUTH_CODE = 65428;
+  /** High words of the restart-segment offsets into the JPEG stream. */
+  static final int MCU_STARTS_HIGH_BYTES = 65432;
+  /** Exposure ratio. */
+  static final int EXPOSURE_RATIO = 65435;
+  /** Red gain multiplier. */
+  static final int RED_MULTIPLIER = 65436;
+  /** Green gain multiplier. */
+  static final int GREEN_MULTIPLIER = 65437;
+  /** Blue gain multiplier. */
+  static final int BLUE_MULTIPLIER = 65438;
+  /** Signed X/Y/Z focus-point triplets. */
+  static final int FOCUS_POINTS = 65439;
+  /** Signed focus-point region mappings. */
+  static final int FOCUS_POINT_REGIONS = 65440;
+  /** Capture mode; the RGB writer only emits brightfield (0). */
+  static final int CAPTURE_MODE = 65441;
+  /** Scanner serial number. */
+  static final int SERIAL_NUMBER = 65442;
+  /** JPEG quality as a percentage. */
+  static final int JPEG_QUALITY = 65444;
+  /** Refocus interval in minutes. */
+  static final int REFOCUS_INTERVAL = 65445;
+  /** Focus offset in nanometers. */
+  static final int FOCUS_OFFSET = 65446;
+  /** Scanner firmware version. */
+  static final int FIRMWARE_VERSION = 65448;
+  /** CRLF-separated scanner calibration property map. */
+  static final int CALIBRATION = 65449;
+  /** Macro-only flag indicating whether the label region is obscured. */
+  static final int LABEL_OBSCURED = 65450;
+  /** Emission wavelength in nanometers. */
+  static final int WAVELENGTH = 65451;
+  /** Lamp age in hours. */
+  static final int LAMP_AGE = 65453;
+  /** Exposure time in microseconds. */
+  static final int EXPOSURE_TIME = 65454;
+  /** Focus duration in seconds. */
+  static final int FOCUS_TIME = 65455;
+  /** Scan duration in seconds. */
+  static final int SCAN_TIME = 65456;
+  /** File-write duration in seconds. */
+  static final int WRITE_TIME = 65457;
+  /** Fully automatic focus flag. */
+  static final int FULLY_AUTO_FOCUS = 65458;
+  /** First of the eight consecutive barcode tags. */
+  static final int FIRST_BARCODE = 65468;
+  /** Last of the eight consecutive barcode tags. */
+  static final int LAST_BARCODE = 65475;
+  /** Medical-regulation string. */
+  static final int MEDICAL_REGULATION = 65476;
+
+  // -- Constructor --
+
+  private NDPITags() { }
+
+}

--- a/components/formats-gpl/src/loci/formats/out/NDPIWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/NDPIWriter.java
@@ -1223,7 +1223,11 @@ public class NDPIWriter extends FormatWriter {
 
   private Double objectiveMagnification() {
     MetadataRetrieve retrieve = getMetadataRetrieve();
-    String objectiveID = retrieve.getObjectiveSettingsID(0);
+    String objectiveID = null;
+    try {
+      objectiveID = retrieve.getObjectiveSettingsID(0);
+    }
+    catch (NullPointerException | IndexOutOfBoundsException e) { }
     for (int instrument = 0;
       instrument < retrieve.getInstrumentCount(); instrument++)
     {

--- a/components/formats-gpl/src/loci/formats/out/NDPIWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/NDPIWriter.java
@@ -1,0 +1,1346 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import loci.common.DateTools;
+import loci.common.Location;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.FormatWriter;
+import loci.formats.codec.CodecOptions;
+import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.MetadataOptions;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.PhotoInterp;
+import loci.formats.tiff.TiffCompression;
+import loci.formats.tiff.TiffRational;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.xml.model.primitives.Timestamp;
+
+/**
+ * Writes a narrow brightfield RGB subset of Hamamatsu NDPI.
+ *
+ * Each native pyramid resolution is supplied from largest to smallest as
+ * full-width, top-to-bottom row blocks.
+ *
+ * Output follows the physical layout genuine Hamamatsu files use: the
+ * header, the metadata every directory shares, then for each image its
+ * external values, its payload, its restart index where it has one, and its
+ * completed directory. The header's first-IFD pointer and each directory's
+ * next-IFD pointer are filled in with full 64-bit offsets once the directory
+ * they name exists.
+ */
+public class NDPIWriter extends FormatWriter {
+
+  // -- Constants --
+
+  /** Option for the free-text slide reference (ASCII). */
+  public static final String REFERENCE_KEY = "ndpi.reference";
+  /** Option for the image-center X position in nanometers. */
+  public static final String X_POSITION_KEY = "ndpi.position_x";
+  /** Option for the image-center Y position in nanometers. */
+  public static final String Y_POSITION_KEY = "ndpi.position_y";
+  /** Option for the image-center Z position in nanometers. */
+  public static final String Z_POSITION_KEY = "ndpi.position_z";
+  /** Option for the exposure ratio. */
+  public static final String EXPOSURE_RATIO_KEY = "ndpi.exposure_ratio";
+  /** Option for the red gain multiplier. */
+  public static final String RED_MULTIPLIER_KEY = "ndpi.red_multiplier";
+  /** Option for the green gain multiplier. */
+  public static final String GREEN_MULTIPLIER_KEY = "ndpi.green_multiplier";
+  /** Option for the blue gain multiplier. */
+  public static final String BLUE_MULTIPLIER_KEY = "ndpi.blue_multiplier";
+  /** Option for comma-separated signed X/Y/Z focus-point triplets. */
+  public static final String FOCUS_POINTS_KEY = "ndpi.focus_points";
+  /** Option for comma-separated signed focus-point region mappings. */
+  public static final String FOCUS_POINT_REGIONS_KEY =
+    "ndpi.focus_point_regions";
+  /** Option for the capture mode; the RGB writer accepts brightfield (0). */
+  public static final String CAPTURE_MODE_KEY = "ndpi.capture_mode";
+  /** Option for the scanner serial number (ASCII). */
+  public static final String SERIAL_NUMBER_KEY = "ndpi.scanner_serial_number";
+  /** Option for the scanner manufacturer used as TIFF Make (ASCII). */
+  public static final String SCANNER_MANUFACTURER_KEY =
+    "ndpi.scanner_manufacturer";
+  /** Option for the scanner model used as TIFF Model (ASCII). */
+  public static final String SCANNER_MODEL_KEY = "ndpi.scanner_model";
+  /** Option for the refocus interval in minutes. */
+  public static final String REFOCUS_INTERVAL_KEY = "ndpi.refocus_interval";
+  /** Option for the focus offset in nanometers. */
+  public static final String FOCUS_OFFSET_KEY = "ndpi.focus_offset";
+  /** Option for the scanner firmware version (ASCII). */
+  public static final String FIRMWARE_VERSION_KEY = "ndpi.firmware_version";
+  /** Option for CRLF-separated scanner calibration properties. */
+  public static final String CALIBRATION_KEY = "ndpi.calibration";
+  /** Option for the emission wavelength in nanometers. */
+  public static final String WAVELENGTH_KEY = "ndpi.wavelength";
+  /** Option for the lamp age in hours. */
+  public static final String LAMP_AGE_KEY = "ndpi.lamp_age";
+  /** Option for the exposure time in microseconds. */
+  public static final String EXPOSURE_TIME_KEY = "ndpi.exposure_time";
+  /** Option for the focus duration in seconds. */
+  public static final String FOCUS_TIME_KEY = "ndpi.focus_time";
+  /** Option for the scan duration in seconds. */
+  public static final String SCAN_TIME_KEY = "ndpi.scan_time";
+  /** Option for the file-write duration in seconds. */
+  public static final String WRITE_TIME_KEY = "ndpi.write_time";
+  /** Option for the fully automatic focus flag. */
+  public static final String FULLY_AUTO_FOCUS_KEY =
+    "ndpi.fully_automatic_focus";
+  /** Prefix for barcode options numbered zero through seven (ASCII). */
+  public static final String BARCODE_KEY_PREFIX = "ndpi.barcode.";
+  /** Option for the medical-regulation string (ASCII). */
+  public static final String MEDICAL_REGULATION_KEY =
+    "ndpi.medical_regulation";
+  /** Option overriding the base JPEG restart interval, in MCUs. */
+  public static final String RESTART_MCUS_KEY = "ndpi.restart_mcus";
+  /** Option identifying the optional macro/overview image series. */
+  public static final String MACRO_SERIES_KEY = "ndpi.macro_series";
+  /** Option identifying the optional single-channel tissue-map series. */
+  public static final String TISSUE_MAP_SERIES_KEY =
+    "ndpi.tissue_map_series";
+  /** Macro-only option indicating whether its label region is obscured. */
+  public static final String LABEL_OBSCURED_KEY = "ndpi.label_obscured";
+
+  private static final int CHANNELS = 3;
+  private static final double DEFAULT_JPEG_QUALITY = 0.8;
+  private static final int[] NOMINAL_RESTART_MCUS = {512, 480, 256, 240};
+  private static final int MINIMUM_MCU_STARTS = 44;
+  private static final String TIFF_DATE_FORMAT = "yyyy:MM:dd HH:mm:ss";
+
+  /** Fixed AuthCode restart-interval index and entropy-byte offset. */
+  private static final int AUTH_FIXED_OFFSET = 42;
+  /** Sample selector requesting AUTH_FIXED_OFFSET. */
+  private static final int AUTH_FIXED_SELECTOR = -1;
+  /** Constant key the sampled AuthCode bytes are combined with. */
+  private static final int AUTH_KEY = 0x1d6edb2a;
+  /**
+   * The four AuthCode samples, in the order they are combined. Each row is
+   * {restart-interval selector, entropy-byte selector}. AUTH_FIXED_SELECTOR
+   * means the fixed offset 42; any other value is a percentage, of the
+   * restart-interval count for the first column and of the selected
+   * interval's entropy length for the second.
+   */
+  private static final int[][] AUTH_SAMPLES = {
+    {AUTH_FIXED_SELECTOR, 72},
+    {72, AUTH_FIXED_SELECTOR},
+    {75, 80},
+    {80, 75}
+  };
+
+  // -- Fields --
+
+  private NDPIClassicTiffWriter saver;
+  /** Prepared entries every directory of this file repeats. */
+  private final Map<Integer, NDPIClassicTiffWriter.Entry> sharedEntries =
+    new LinkedHashMap<Integer, NDPIClassicTiffWriter.Entry>();
+  /** Shared external values already written, keyed by their emitted bytes. */
+  private final Map<String, NDPIClassicTiffWriter.Entry> sharedValues =
+    new HashMap<String, NDPIClassicTiffWriter.Entry>();
+  /** Prepared entries specific to the image currently being written. */
+  private final Map<Integer, NDPIClassicTiffWriter.Entry> imageEntries =
+    new LinkedHashMap<Integer, NDPIClassicTiffWriter.Entry>();
+  /** Where the pointer to the next completed directory belongs. */
+  private long nextIFDPointer;
+  private boolean imageStarted;
+  private NDPIJPEGAssembler assembler;
+  private int activeResolution = -1;
+  private int nextResolution;
+  private int nextRow;
+  private boolean chainComplete;
+  private Integer macroSeries;
+  private Integer tissueMapSeries;
+  private Boolean labelObscured;
+  private int expectedSeries;
+  private long rawOffset;
+  private long rawLength;
+  private String reference;
+  private Long xPosition;
+  private Long yPosition;
+  private Long zPosition;
+  private Long exposureRatio;
+  private Long redMultiplier;
+  private Long greenMultiplier;
+  private Long blueMultiplier;
+  private int[] focusPoints;
+  private int[] focusPointRegions;
+  private String scannerSerialNumber;
+  private String scannerManufacturer;
+  private String scannerModel;
+  private Long refocusInterval;
+  private Long focusOffset;
+  private String firmwareVersion;
+  private String calibration;
+  private Float wavelength;
+  private Long lampAge;
+  private Long exposureTime;
+  private Long focusTime;
+  private Long scanTime;
+  private Long writeTime;
+  private Boolean fullyAutomaticFocus;
+  private final String[] barcodes =
+    new String[NDPITags.LAST_BARCODE - NDPITags.FIRST_BARCODE + 1];
+  private String medicalRegulation;
+  private Integer restartMCUsOverride;
+  private double jpegQuality;
+  private int[] pyramidRestartMCUs;
+  private boolean[] indexedPyramidLevels;
+
+  // -- Constructor --
+
+  public NDPIWriter() {
+    super("Hamamatsu NDPI", "ndpi");
+    compressionTypes = new String[] {"JPEG"};
+    compression = compressionTypes[0];
+  }
+
+  // -- IFormatWriter API methods --
+
+  /* @see loci.formats.IFormatWriter#getPixelTypes(String) */
+  @Override
+  public int[] getPixelTypes(String codec) {
+    return new int[] {FormatTools.UINT8};
+  }
+
+  /* @see loci.formats.IFormatWriter#canDoStacks() */
+  @Override
+  public boolean canDoStacks() {
+    return false;
+  }
+
+  /* @see loci.formats.IFormatWriter#setCompression(String) */
+  @Override
+  public void setCompression(String compress) throws FormatException {
+    if (compress != null && !"JPEG".equals(compress)) {
+      throw new FormatException("NDPI supports only JPEG compression");
+    }
+    compression = "JPEG";
+  }
+
+  /* @see loci.formats.IFormatHandler#setId(String) */
+  @Override
+  public void setId(String id) throws FormatException, IOException {
+    if (id.equals(currentId)) {
+      return;
+    }
+    if (currentId != null) {
+      close();
+    }
+    readOptions();
+    jpegQuality = resolveJPEGQuality(options);
+    validateMetadata();
+    planRestartGeometry();
+    if (!sequential) {
+      throw new FormatException("NDPI requires sequential writing");
+    }
+    Location destination = new Location(id).getAbsoluteFile();
+    if (destination.exists() && !destination.delete()) {
+      throw new IOException("Could not truncate existing NDPI output: " + id);
+    }
+    super.setId(id);
+    sharedEntries.clear();
+    sharedValues.clear();
+    imageEntries.clear();
+    imageStarted = false;
+    assembler = null;
+    activeResolution = -1;
+    nextResolution = 0;
+    nextRow = 0;
+    expectedSeries = 0;
+    rawOffset = -1;
+    rawLength = 0;
+    chainComplete = false;
+
+    out.order(true);
+    saver = new NDPIClassicTiffWriter(out);
+    saver.writeHeader();
+    nextIFDPointer = NDPIClassicTiffWriter.FIRST_IFD_POINTER;
+    stageSharedValues();
+  }
+
+  /**
+   * Close the writer, discarding any incomplete output.
+   *
+   * An NDPI file whose directory chain was never completed is invalid, so it
+   * is removed. Incompleteness on its own is not reported as a failure,
+   * because close() usually runs from a finally block where throwing would
+   * mask the conversion error that caused it. Only a genuine close failure,
+   * or a failure to remove the invalid output, is thrown.
+   *
+   * @see loci.formats.FormatWriter#close()
+   */
+  @Override
+  public void close() throws IOException {
+    String output = currentId;
+    boolean incomplete = output != null && !chainComplete;
+    IOException closeFailure = null;
+    try {
+      super.close();
+    }
+    catch (IOException e) {
+      closeFailure = e;
+    }
+
+    IOException cleanupFailure = null;
+    if (incomplete) {
+      Location location = new Location(output);
+      if (location.delete() || !location.exists()) {
+        LOGGER.warn("Removed incomplete NDPI output {}", output);
+      }
+      else {
+        cleanupFailure = new IOException(
+          "Could not remove incomplete NDPI output: " + output);
+      }
+    }
+
+    if (closeFailure != null) {
+      if (cleanupFailure != null) closeFailure.addSuppressed(cleanupFailure);
+      throw closeFailure;
+    }
+    if (cleanupFailure != null) {
+      throw cleanupFailure;
+    }
+  }
+
+  /* @see loci.formats.IFormatWriter#setResolution(int) */
+  @Override
+  public void setResolution(int resolution) {
+    if (currentId != null) {
+      if (role(getSeries()) != ImageRole.PYRAMID) {
+        if (resolution != 0) {
+          throw new IllegalArgumentException(
+            "NDPI associated images support only resolution zero");
+        }
+      }
+      else if (resolution != activeResolution &&
+        resolution != nextResolution)
+      {
+        throw new IllegalArgumentException(
+          "NDPI resolutions must be written from largest to smallest");
+      }
+    }
+    super.setResolution(resolution);
+  }
+
+  /* @see loci.formats.IFormatWriter#setSeries(int) */
+  @Override
+  public void setSeries(int series) throws FormatException {
+    if (currentId != null && series != expectedSeries) {
+      throw new FormatException(
+        "NDPI series must be written as pyramid, macro, then tissue map");
+    }
+    super.setSeries(series);
+  }
+
+  /*
+   * @see loci.formats.IFormatWriter#saveBytes(int, byte[], int, int, int,
+   *   int)
+   */
+  @Override
+  public void saveBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    checkParams(no, buf, x, y, w, h);
+    if (chainComplete) {
+      throw new FormatException("NDPI writing is already complete");
+    }
+    if (no != 0) {
+      throw new FormatException("NDPI supports one plane per image");
+    }
+    if (x != 0 || w != getSizeX()) {
+      throw new FormatException("NDPI row blocks must span the full width");
+    }
+    if (y != nextRow) {
+      throw new FormatException(
+        "NDPI rows must be written once, top to bottom");
+    }
+    ImageRole role = role(getSeries());
+    if (role == ImageRole.PYRAMID && getResolution() != nextResolution &&
+      getResolution() != activeResolution)
+    {
+      throw new FormatException(
+        "NDPI resolutions must be written from largest to smallest");
+    }
+
+    if (!imageStarted) {
+      stageImageValues(getSizeX(), getSizeY(), role);
+      imageStarted = true;
+    }
+
+    if (role == ImageRole.TISSUE_MAP) {
+      if (rawOffset < 0) rawOffset = out.getFilePointer();
+      long requiredBytes = (long) w * h;
+      // Unreachable in practice: no caller whose buffer fits in a byte[] can
+      // hand over a single tissue-map row block larger than 2 GiB.
+      if (requiredBytes > Integer.MAX_VALUE) {
+        throw new FormatException(
+          "NDPI tissue-map row block is too large to write");
+      }
+      int byteCount = (int) requiredBytes;
+      out.write(buf, 0, byteCount);
+      rawLength += byteCount;
+      nextRow += h;
+      if (nextRow == getSizeY()) {
+        completeImage(new Level(rawOffset, rawLength, getSizeX(), getSizeY(),
+          ImageRole.TISSUE_MAP));
+        finishImageRole();
+      }
+      return;
+    }
+
+    if (assembler == null) {
+      activeResolution = getResolution();
+      int restartMCUs = role == ImageRole.PYRAMID ?
+        pyramidRestartMCUs[getResolution()] : 0;
+      boolean indexed = role == ImageRole.PYRAMID &&
+        indexedPyramidLevels[getResolution()];
+      if (!indexed) restartMCUs = 0;
+      int count = indexed ?
+        (int) mcuStartCount(getSizeX(), getSizeY(), restartMCUs) : 0;
+      assembler = new NDPIJPEGAssembler(out, getSizeX(), getSizeY(),
+        restartMCUs, indexed, jpegQuality,
+        indexed ? authSegments(count) : null);
+    }
+    byte[] rows = interleaved ? buf : interleaveRows(buf, w, h);
+    assembler.writeRows(rows, 0, h);
+    nextRow += h;
+
+    if (nextRow == getSizeY()) {
+      NDPIJPEGAssembler.Result jpeg = assembler.finish();
+      long[] starts = jpeg.getMCUStarts();
+      boolean indexed =
+        role == ImageRole.PYRAMID && starts.length >= MINIMUM_MCU_STARTS;
+      completeImage(new Level(jpeg, getSizeX(), getSizeY(), role,
+        role == ImageRole.PYRAMID ? sourceLens(getSizeX()) :
+        role == ImageRole.MACRO ? -1 : -2,
+        indexed ? Integer.valueOf(calculateAuthCode(jpeg, starts)) : null));
+      assembler = null;
+      activeResolution = -1;
+      nextRow = 0;
+      if (role == ImageRole.PYRAMID) nextResolution++;
+      if (role != ImageRole.PYRAMID ||
+        nextResolution == getResolutionCount()) finishImageRole();
+    }
+  }
+
+  // -- Helper methods --
+
+  private byte[] interleaveRows(byte[] planar, int width, int height) {
+    int plane = width * height;
+    byte[] interleavedRows = new byte[plane * CHANNELS];
+    for (int pixel = 0; pixel < plane; pixel++) {
+      for (int channel = 0; channel < CHANNELS; channel++) {
+        interleavedRows[pixel * CHANNELS + channel] =
+          planar[channel * plane + pixel];
+      }
+    }
+    return interleavedRows;
+  }
+
+  private void finishImageRole() {
+    nextRow = 0;
+    rawOffset = -1;
+    rawLength = 0;
+    if (expectedSeries == 0 && macroSeries != null) {
+      expectedSeries = macroSeries;
+    }
+    else if (expectedSeries != tissueMapSeriesValue() &&
+      tissueMapSeries != null)
+    {
+      expectedSeries = tissueMapSeries;
+    }
+    else {
+      chainComplete = true;
+    }
+  }
+
+  private int tissueMapSeriesValue() {
+    return tissueMapSeries == null ? -1 : tissueMapSeries.intValue();
+  }
+
+  private void validateMetadata() throws FormatException {
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+    validateAssociatedSeries(retrieve);
+    super.setSeries(0);
+    if (FormatTools.pixelTypeFromString(
+      retrieve.getPixelsType(0).toString()) != FormatTools.UINT8)
+    {
+      throw new FormatException("NDPI supports only unsigned 8-bit pixels");
+    }
+    if (retrieve.getPixelsSizeC(0).getValue().intValue() != CHANNELS ||
+      getSamplesPerPixel() != CHANNELS)
+    {
+      throw new FormatException("NDPI requires SizeC == 3 as one RGB plane");
+    }
+    if (getPlaneCount() != 1) {
+      throw new FormatException("NDPI supports one RGB plane");
+    }
+    Double magnification = objectiveMagnification();
+    if (magnification == null || magnification <= 0) {
+      throw new FormatException(
+        "NDPI requires a positive objective nominal magnification");
+    }
+    int previousWidth = Integer.MAX_VALUE;
+    int previousHeight = Integer.MAX_VALUE;
+    for (int r = 0; r < getResolutionCount(); r++) {
+      super.setResolution(r);
+      int width = getSizeX();
+      int height = getSizeY();
+      if (width > previousWidth || height > previousHeight) {
+        throw new FormatException(
+          "NDPI resolutions must be ordered largest to smallest");
+      }
+      previousWidth = width;
+      previousHeight = height;
+    }
+    super.setResolution(0);
+
+    if (macroSeries != null) {
+      validateSeriesLayout(retrieve, macroSeries, CHANNELS, "macro");
+    }
+    if (tissueMapSeries != null) {
+      validateSeriesLayout(retrieve, tissueMapSeries, 1, "tissue map");
+    }
+    super.setSeries(0);
+  }
+
+  private void validateAssociatedSeries(MetadataRetrieve retrieve)
+    throws FormatException
+  {
+    int imageCount = retrieve.getImageCount();
+    int expectedCount = 1 + (macroSeries == null ? 0 : 1) +
+      (tissueMapSeries == null ? 0 : 1);
+    if (imageCount != expectedCount) {
+      throw new FormatException("NDPI requires every non-pyramid series to " +
+        "be identified as macro or tissue map");
+    }
+    if (macroSeries != null) validateSeriesIndex(macroSeries, imageCount);
+    if (tissueMapSeries != null) validateSeriesIndex(tissueMapSeries,
+      imageCount);
+    if (macroSeries != null && macroSeries.equals(tissueMapSeries)) {
+      throw new FormatException(
+        "NDPI macro and tissue-map series must be different");
+    }
+    if (labelObscured != null && macroSeries == null) {
+      throw new FormatException(
+        "NDPI label-obscured option requires a macro series");
+    }
+    if (macroSeries != null && macroSeries.intValue() != 1) {
+      throw new FormatException("NDPI macro series must follow the pyramid");
+    }
+    // The tissue map needs no separate ordering check: the index-range and
+    // distinctness rules above leave it exactly one legal index, whether or
+    // not a macro series is present.
+  }
+
+  private static void validateSeriesIndex(Integer index, int imageCount)
+    throws FormatException
+  {
+    if (index.intValue() <= 0 || index.intValue() >= imageCount) {
+      throw new FormatException(
+        "NDPI associated-image series index is out of range");
+    }
+  }
+
+  private void validateSeriesLayout(MetadataRetrieve retrieve, int image,
+    int channels, String name) throws FormatException
+  {
+    super.setSeries(image);
+    if (FormatTools.pixelTypeFromString(
+      retrieve.getPixelsType(image).toString()) != FormatTools.UINT8)
+    {
+      throw new FormatException("NDPI " + name +
+        " supports only unsigned 8-bit pixels");
+    }
+    if (retrieve.getPixelsSizeC(image).getValue().intValue() != channels ||
+      getSamplesPerPixel() != channels)
+    {
+      throw new FormatException("NDPI " + name + " requires SizeC == " +
+        channels + " in one plane");
+    }
+    if (getPlaneCount() != 1 || getResolutionCount() != 1) {
+      throw new FormatException("NDPI " + name +
+        " requires exactly one image plane and resolution");
+    }
+  }
+
+  private void readOptions() throws FormatException {
+    clearOptions();
+    MetadataOptions metadataOptions = getMetadataOptions();
+    if (!(metadataOptions instanceof DynamicMetadataOptions)) return;
+    DynamicMetadataOptions options =
+      (DynamicMetadataOptions) metadataOptions;
+    try {
+      reference = ascii(options.get(REFERENCE_KEY), "slide reference");
+      xPosition = signedLong(options.getLong(X_POSITION_KEY), "X position");
+      yPosition = signedLong(options.getLong(Y_POSITION_KEY), "Y position");
+      zPosition = signedLong(options.getLong(Z_POSITION_KEY), "Z position");
+      exposureRatio = unsignedLong(options.getLong(EXPOSURE_RATIO_KEY),
+        "exposure ratio");
+      redMultiplier = unsignedLong(options.getLong(RED_MULTIPLIER_KEY),
+        "red multiplier");
+      greenMultiplier = unsignedLong(options.getLong(GREEN_MULTIPLIER_KEY),
+        "green multiplier");
+      blueMultiplier = unsignedLong(options.getLong(BLUE_MULTIPLIER_KEY),
+        "blue multiplier");
+      focusPoints = signedLongArray(options.get(FOCUS_POINTS_KEY),
+        "focus points", true);
+      focusPointRegions = signedLongArray(
+        options.get(FOCUS_POINT_REGIONS_KEY), "focus-point regions", false);
+      Long captureMode = unsignedLong(options.getLong(CAPTURE_MODE_KEY),
+        "capture mode");
+      if (captureMode != null && captureMode.longValue() != 0) {
+        throw new IllegalArgumentException(
+          "NDPI capture mode must be 0 for brightfield RGB");
+      }
+      scannerSerialNumber = ascii(options.get(SERIAL_NUMBER_KEY),
+        "scanner serial number");
+      scannerManufacturer = ascii(options.get(SCANNER_MANUFACTURER_KEY),
+        "scanner manufacturer");
+      scannerModel = ascii(options.get(SCANNER_MODEL_KEY), "scanner model");
+      refocusInterval = signedLong(options.getLong(REFOCUS_INTERVAL_KEY),
+        "refocus interval");
+      focusOffset = signedLong(options.getLong(FOCUS_OFFSET_KEY),
+        "focus offset");
+      firmwareVersion = ascii(options.get(FIRMWARE_VERSION_KEY),
+        "firmware version");
+      calibration = propertyMap(options.get(CALIBRATION_KEY));
+      wavelength = finiteNonNegative(options.getFloat(WAVELENGTH_KEY),
+        "wavelength");
+      lampAge = unsignedLong(options.getLong(LAMP_AGE_KEY), "lamp age");
+      exposureTime = unsignedLong(options.getLong(EXPOSURE_TIME_KEY),
+        "exposure time");
+      focusTime = unsignedLong(options.getLong(FOCUS_TIME_KEY), "focus time");
+      scanTime = unsignedLong(options.getLong(SCAN_TIME_KEY), "scan time");
+      writeTime = unsignedLong(options.getLong(WRITE_TIME_KEY), "write time");
+      fullyAutomaticFocus = options.getBoolean(FULLY_AUTO_FOCUS_KEY, null);
+      for (int i = 0; i < barcodes.length; i++) {
+        barcodes[i] = ascii(options.get(BARCODE_KEY_PREFIX + i), "barcode");
+      }
+      medicalRegulation = ascii(options.get(MEDICAL_REGULATION_KEY),
+        "medical regulation");
+      restartMCUsOverride = options.getInteger(RESTART_MCUS_KEY);
+      if (restartMCUsOverride != null && (restartMCUsOverride < 1 ||
+        restartMCUsOverride > 0xffff))
+      {
+        throw new IllegalArgumentException(
+          "NDPI restart interval must be between 1 and 65535 MCUs");
+      }
+      macroSeries = options.getInteger(MACRO_SERIES_KEY);
+      tissueMapSeries = options.getInteger(TISSUE_MAP_SERIES_KEY);
+      labelObscured = options.getBoolean(LABEL_OBSCURED_KEY, null);
+    }
+    catch (IllegalArgumentException e) {
+      throw new FormatException("Invalid NDPI writer option: " +
+        e.getMessage(), e);
+    }
+  }
+
+  private void clearOptions() {
+    reference = null;
+    xPosition = null;
+    yPosition = null;
+    zPosition = null;
+    exposureRatio = null;
+    redMultiplier = null;
+    greenMultiplier = null;
+    blueMultiplier = null;
+    focusPoints = null;
+    focusPointRegions = null;
+    scannerSerialNumber = null;
+    scannerManufacturer = null;
+    scannerModel = null;
+    refocusInterval = null;
+    focusOffset = null;
+    firmwareVersion = null;
+    calibration = null;
+    wavelength = null;
+    lampAge = null;
+    exposureTime = null;
+    focusTime = null;
+    scanTime = null;
+    writeTime = null;
+    fullyAutomaticFocus = null;
+    for (int i = 0; i < barcodes.length; i++) barcodes[i] = null;
+    medicalRegulation = null;
+    restartMCUsOverride = null;
+    macroSeries = null;
+    tissueMapSeries = null;
+    labelObscured = null;
+  }
+
+  /**
+   * Compute the AuthCode over four sampled entropy bytes.
+   *
+   * The constant key and the interval and byte selection below were derived
+   * from a corpus of scanner-written NDPI files and checked against the
+   * AuthCode values those files carry.
+   */
+  private int calculateAuthCode(NDPIJPEGAssembler.Result jpeg, long[] starts)
+    throws FormatException
+  {
+    int[] segments = authSegments(starts.length);
+    int[] samples = new int[segments.length];
+    for (int i = 0; i < segments.length; i++) {
+      long entropyLength =
+        starts[segments[i] + 1] - starts[segments[i]] - 2;
+      byte[] entropy = jpeg.getCapturedEntropy(i);
+      if (entropyLength <= 0 || entropy.length != entropyLength) {
+        throw new FormatException("NDPI JPEG contains an invalid MCU segment");
+      }
+      int selector = AUTH_SAMPLES[i][1];
+      long offset = selector == AUTH_FIXED_SELECTOR ? AUTH_FIXED_OFFSET :
+        selector * entropyLength / 100;
+      int index = (int) Math.min(entropyLength - 1, offset);
+      samples[i] = entropy[index] & 0xff;
+    }
+    return AUTH_KEY ^ samples[0] ^ (samples[2] << 8) ^
+      (samples[3] << 16) ^ (samples[1] << 24);
+  }
+
+  /** Select the restart intervals sampled by calculateAuthCode(). */
+  private static int[] authSegments(int count) {
+    int[] segments = new int[AUTH_SAMPLES.length];
+    for (int i = 0; i < segments.length; i++) {
+      int selector = AUTH_SAMPLES[i][0];
+      segments[i] = selector == AUTH_FIXED_SELECTOR ? AUTH_FIXED_OFFSET :
+        (int) ((long) selector * count / 100);
+    }
+    return segments;
+  }
+
+  /**
+   * Writes the external values every directory of this file shares, and
+   * prepares the entries that name them.
+   *
+   * The shared values sit immediately after the header, where genuine files
+   * keep them, so that every directory can point back to one copy.
+   */
+  private void stageSharedValues() throws FormatException, IOException {
+    for (NDPIClassicTiffWriter.Value value :
+      NDPIClassicTiffWriter.values(sharedIFD()))
+    {
+      sharedEntries.put(Integer.valueOf(value.tag()), stageShared(value));
+    }
+  }
+
+  /**
+   * Prepares one shared entry, writing its value unless another tag has
+   * already written the same bytes under the same TIFF type.
+   */
+  private NDPIClassicTiffWriter.Entry stageShared(
+    NDPIClassicTiffWriter.Value value) throws IOException
+  {
+    if (!value.external()) return saver.entry(value);
+    NDPIClassicTiffWriter.Entry written = sharedValues.get(value.key());
+    if (written != null) return written.retag(value.tag());
+    NDPIClassicTiffWriter.Entry entry = saver.entry(value);
+    sharedValues.put(value.key(), entry);
+    return entry;
+  }
+
+  /**
+   * Writes the external values of one image and prepares the entries that
+   * name them.
+   *
+   * These values depend only on the image's role and dimensions, so they are
+   * complete before any of its pixels are written and are placed immediately
+   * before its payload.
+   */
+  private void stageImageValues(int width, int height, ImageRole role)
+    throws FormatException, IOException
+  {
+    imageEntries.clear();
+    for (NDPIClassicTiffWriter.Value value :
+      NDPIClassicTiffWriter.values(imageIFD(width, height, role)))
+    {
+      stageImageValue(value);
+    }
+  }
+
+  private void stageImageValue(NDPIClassicTiffWriter.Value value)
+    throws IOException
+  {
+    imageEntries.put(Integer.valueOf(value.tag()), saver.entry(value));
+  }
+
+  /**
+   * Completes one image by writing its restart index where it has one, then
+   * its directory, then linking that directory into the chain.
+   */
+  private void completeImage(Level level)
+    throws FormatException, IOException
+  {
+    stageRestartIndex(level.mcuStarts);
+    List<NDPIClassicTiffWriter.Entry> entries =
+      new ArrayList<NDPIClassicTiffWriter.Entry>(sharedEntries.values());
+    entries.addAll(imageEntries.values());
+    for (NDPIClassicTiffWriter.Value value :
+      NDPIClassicTiffWriter.values(completedIFD(level)))
+    {
+      entries.add(saver.entry(value));
+    }
+    NDPIClassicTiffWriter.Directory directory = saver.writeIFD(entries);
+    saver.patchOffset(nextIFDPointer, directory.offset());
+    nextIFDPointer = directory.nextPointer();
+    imageEntries.clear();
+    imageStarted = false;
+  }
+
+  /** Writes the restart-offset arrays between an indexed JPEG and its IFD. */
+  private void stageRestartIndex(long[] mcuStarts)
+    throws FormatException, IOException
+  {
+    if (mcuStarts.length == 0) return;
+    stageImageValue(NDPIClassicTiffWriter.value(NDPITags.MCU_STARTS,
+      lowWords(mcuStarts)));
+    if (hasHighWords(mcuStarts)) {
+      stageImageValue(NDPIClassicTiffWriter.value(
+        NDPITags.MCU_STARTS_HIGH_BYTES, highWords(mcuStarts)));
+    }
+  }
+
+  /** The values every directory of one NDPI file repeats. */
+  private IFD sharedIFD() {
+    IFD ifd = new IFD();
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+    String make = scannerManufacturer == null ?
+      microscopeManufacturer(retrieve) : scannerManufacturer;
+    String model = scannerModel == null ?
+      microscopeModel(retrieve) : scannerModel;
+    if (make != null && !make.isEmpty()) ifd.putIFDValue(IFD.MAKE, make);
+    if (model != null && !model.isEmpty()) ifd.putIFDValue(IFD.MODEL, model);
+    ifd.putIFDValue(IFD.SOFTWARE, "Bio-Formats NDPIWriter");
+    String acquisitionDate = acquisitionDate(retrieve);
+    if (acquisitionDate != null) {
+      ifd.putIFDValue(IFD.DATE_TIME, acquisitionDate);
+    }
+    putFileWideOptionTags(ifd);
+    return ifd;
+  }
+
+  /** The values of one image that are known before its payload. */
+  private IFD imageIFD(int width, int height, ImageRole role) {
+    IFD ifd = new IFD();
+    boolean map = role == ImageRole.TISSUE_MAP;
+    ifd.put(IFD.BITS_PER_SAMPLE, map ? new int[] {8} : new int[] {8, 8, 8});
+    if (!map) {
+      ifd.put(IFD.Y_CB_CR_SUB_SAMPLING, new int[] {1, 1});
+      ifd.put(IFD.REFERENCE_BLACK_WHITE,
+        new long[] {0, 255, 128, 255, 128, 255});
+    }
+    addResolution(ifd, width, height, role);
+    return ifd;
+  }
+
+  /** The values of one image that are known only once it is complete. */
+  private IFD completedIFD(Level level) {
+    IFD ifd = new IFD();
+    ifd.putIFDValue(IFD.IMAGE_WIDTH, (long) level.width);
+    ifd.putIFDValue(IFD.IMAGE_LENGTH, (long) level.height);
+    boolean map = level.role == ImageRole.TISSUE_MAP;
+    ifd.putIFDValue(IFD.COMPRESSION, map ?
+      TiffCompression.UNCOMPRESSED.getCode() : TiffCompression.JPEG.getCode());
+    ifd.putIFDValue(IFD.PHOTOMETRIC_INTERPRETATION,
+      map ? PhotoInterp.BLACK_IS_ZERO.getCode() :
+      PhotoInterp.Y_CB_CR.getCode());
+    ifd.putIFDValue(IFD.SAMPLES_PER_PIXEL, map ? 1 : CHANNELS);
+    ifd.putIFDValue(IFD.ROWS_PER_STRIP, (long) level.height);
+    ifd.putIFDValue(IFD.PLANAR_CONFIGURATION, 1);
+    ifd.putIFDValue(NDPITags.VERSION, 1);
+    ifd.putIFDValue(NDPITags.SOURCE_LENS,
+      Float.valueOf((float) level.sourceLens));
+    if (level.role == ImageRole.PYRAMID) {
+      ifd.putIFDValue(NDPITags.X_POSITION, xPosition == null ? 0L : xPosition);
+      ifd.putIFDValue(NDPITags.Y_POSITION, yPosition == null ? 0L : yPosition);
+      Long levelZ = zPosition == null ? planeZ() : zPosition;
+      ifd.putIFDValue(NDPITags.Z_POSITION, levelZ == null ? 0L : levelZ);
+      ifd.putIFDValue(NDPITags.TISSUE_INDEX, 0L);
+      putPyramidOptionTags(ifd);
+    }
+    else {
+      ifd.putIFDValue(NDPITags.X_POSITION, 0L);
+      ifd.putIFDValue(NDPITags.Y_POSITION, 0L);
+      if (level.role == ImageRole.MACRO) {
+        ifd.putIFDValue(NDPITags.CAPTURE_MODE, 0L);
+        put(ifd, NDPITags.LABEL_OBSCURED, labelObscured == null ? null :
+          Long.valueOf(labelObscured.booleanValue() ? 1 : 0));
+      }
+    }
+    if (level.authCode != null) {
+      ifd.putIFDValue(NDPITags.AUTH_CODE,
+        level.authCode.intValue() & 0xffffffffL);
+    }
+    putStripTags(ifd, level.jpegOffset, level.jpegLength);
+    if (!map) {
+      ifd.putIFDValue(NDPITags.JPEG_QUALITY, Math.round(jpegQuality * 100));
+    }
+    return ifd;
+  }
+
+  private static String microscopeManufacturer(MetadataRetrieve retrieve) {
+    try {
+      return retrieve.getMicroscopeManufacturer(0);
+    }
+    catch (NullPointerException | IndexOutOfBoundsException e) {
+      // OMEXMLMetadata throws when Instrument exists without Microscope.
+      return null;
+    }
+  }
+
+  private static String microscopeModel(MetadataRetrieve retrieve) {
+    try {
+      return retrieve.getMicroscopeModel(0);
+    }
+    catch (NullPointerException | IndexOutOfBoundsException e) {
+      // OMEXMLMetadata throws when Instrument exists without Microscope.
+      return null;
+    }
+  }
+
+  private static String acquisitionDate(MetadataRetrieve retrieve) {
+    Timestamp timestamp = retrieve.getImageAcquisitionDate(0);
+    if (timestamp == null) return null;
+    return DateTools.convertDate(timestamp.asInstant().getMillis(),
+      DateTools.UNIX, TIFF_DATE_FORMAT);
+  }
+
+  private void putFileWideOptionTags(IFD ifd) {
+    if (reference != null) ifd.putIFDValue(NDPITags.REFERENCE, reference);
+    put(ifd, NDPITags.FOCUS_POINTS, focusPoints);
+    put(ifd, NDPITags.FOCUS_POINT_REGIONS, focusPointRegions);
+    put(ifd, NDPITags.SERIAL_NUMBER, scannerSerialNumber);
+    put(ifd, NDPITags.REFOCUS_INTERVAL, refocusInterval);
+    put(ifd, NDPITags.FOCUS_OFFSET, focusOffset);
+    put(ifd, NDPITags.FIRMWARE_VERSION, firmwareVersion);
+    put(ifd, NDPITags.CALIBRATION, calibration);
+    for (int i = 0; i < barcodes.length; i++) {
+      put(ifd, NDPITags.FIRST_BARCODE + i, barcodes[i]);
+    }
+    put(ifd, NDPITags.MEDICAL_REGULATION, medicalRegulation);
+  }
+
+  private void putPyramidOptionTags(IFD ifd) {
+    put(ifd, NDPITags.EXPOSURE_RATIO, exposureRatio);
+    put(ifd, NDPITags.RED_MULTIPLIER, redMultiplier);
+    put(ifd, NDPITags.GREEN_MULTIPLIER, greenMultiplier);
+    put(ifd, NDPITags.BLUE_MULTIPLIER, blueMultiplier);
+    ifd.putIFDValue(NDPITags.CAPTURE_MODE, 0L);
+    put(ifd, NDPITags.WAVELENGTH, wavelength);
+    put(ifd, NDPITags.LAMP_AGE, lampAge);
+    put(ifd, NDPITags.EXPOSURE_TIME, exposureTime);
+    put(ifd, NDPITags.FOCUS_TIME, focusTime);
+    put(ifd, NDPITags.SCAN_TIME, scanTime);
+    put(ifd, NDPITags.WRITE_TIME, writeTime);
+    put(ifd, NDPITags.FULLY_AUTO_FOCUS, fullyAutomaticFocus == null ? null :
+      Long.valueOf(fullyAutomaticFocus ? 1 : 0));
+  }
+
+  private static void put(IFD ifd, int tag, Object value) {
+    if (value != null) ifd.putIFDValue(tag, value);
+  }
+
+  private ImageRole role(int image) {
+    if (macroSeries != null && image == macroSeries.intValue()) {
+      return ImageRole.MACRO;
+    }
+    if (tissueMapSeries != null && image == tissueMapSeries.intValue()) {
+      return ImageRole.TISSUE_MAP;
+    }
+    return ImageRole.PYRAMID;
+  }
+
+  private Long planeZ() {
+    Length z;
+    try {
+      z = getMetadataRetrieve().getPlanePositionZ(0, 0);
+    }
+    catch (NullPointerException | IndexOutOfBoundsException e) {
+      return null;
+    }
+    if (z == null) return null;
+    Number nanometers = z.value(UNITS.NANOMETER);
+    if (nanometers == null) return null;
+    return signedLong(Long.valueOf(Math.round(nanometers.doubleValue())),
+      "plane Z position");
+  }
+
+  private static String ascii(String value, String name) {
+    if (value == null || value.isEmpty()) return null;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < 0x20 || c > 0x7e) {
+        throw new IllegalArgumentException(
+          "NDPI " + name + " must contain printable ASCII");
+      }
+    }
+    return value;
+  }
+
+  private static String propertyMap(String value) {
+    if (value == null || value.isEmpty()) return null;
+    // A non-empty value always splits into at least one non-empty record, so
+    // dropping an optional trailing CRLF cannot empty the record list.
+    String[] records = value.split("\r\n", -1);
+    int recordCount = records.length;
+    if (records[recordCount - 1].isEmpty()) recordCount--;
+    for (int record = 0; record < recordCount; record++) {
+      String line = records[record];
+      int equals = line.indexOf('=');
+      if (equals <= 0) {
+        throw new IllegalArgumentException(
+          "NDPI calibration metadata must contain key=value records");
+      }
+      for (int i = 0; i < line.length(); i++) {
+        char c = line.charAt(i);
+        if (c < 0x20 || c > 0x7e) {
+          throw new IllegalArgumentException(
+            "NDPI calibration metadata must use printable ASCII and CRLF");
+        }
+      }
+    }
+    // No further newline check is needed: splitting on CRLF leaves every
+    // stray CR or LF inside a record, where the printable-ASCII scan above
+    // rejects it.
+    return value;
+  }
+
+  private static Float finiteNonNegative(Float value, String name) {
+    if (value == null) return null;
+    if (!Float.isFinite(value.floatValue()) || value.floatValue() < 0) {
+      throw new IllegalArgumentException(
+        "NDPI " + name + " must be finite and non-negative");
+    }
+    return value;
+  }
+
+  private static int[] signedLongArray(String value, String name,
+    boolean triplets)
+  {
+    if (value == null || value.trim().isEmpty()) return null;
+    String[] fields = value.split(",", -1);
+    if (triplets && fields.length % 3 != 0) {
+      throw new IllegalArgumentException(
+        "NDPI " + name + " must contain X/Y/Z triplets");
+    }
+    int[] result = new int[fields.length];
+    for (int i = 0; i < fields.length; i++) {
+      String field = fields[i].trim();
+      if (field.isEmpty()) {
+        throw new IllegalArgumentException(
+          "NDPI " + name + " contains an empty value");
+      }
+      long parsed = Long.parseLong(field);
+      if (parsed < Integer.MIN_VALUE || parsed > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException(
+          "NDPI " + name + " values must fit signed 32-bit integers");
+      }
+      result[i] = (int) parsed;
+    }
+    return result;
+  }
+
+  private static Long signedLong(Long value, String name) {
+    if (value == null) return null;
+    if (value.longValue() < Integer.MIN_VALUE ||
+      value.longValue() > Integer.MAX_VALUE)
+    {
+      throw new IllegalArgumentException(
+        "NDPI " + name + " must fit a signed 32-bit integer");
+    }
+    return value;
+  }
+
+  private static Long unsignedLong(Long value, String name) {
+    if (value == null) return null;
+    if (value.longValue() < 0 || value.longValue() > 0xffffffffL) {
+      throw new IllegalArgumentException(
+        "NDPI " + name + " must fit an unsigned 32-bit integer");
+    }
+    return Long.valueOf(value);
+  }
+
+  private static double resolveJPEGQuality(CodecOptions options)
+    throws FormatException
+  {
+    double quality = options == null || options.quality == 0 ?
+      DEFAULT_JPEG_QUALITY : options.quality;
+    if (!Double.isFinite(quality) || quality < 0.25 || quality > 1) {
+      throw new FormatException(
+        "NDPI JPEG quality must be between 0.25 and 1");
+    }
+    return quality;
+  }
+
+  /**
+   * Records where one payload lies, in the two tags whose 64-bit values NDPI
+   * splits across an entry and its extension word.
+   */
+  static void putStripTags(IFD ifd, long payloadOffset, long payloadLength) {
+    ifd.put(IFD.STRIP_OFFSETS, new long[] {payloadOffset});
+    ifd.put(IFD.STRIP_BYTE_COUNTS, new long[] {payloadLength});
+  }
+
+  private void planRestartGeometry() throws FormatException {
+    int resolutions = getResolutionCount();
+    pyramidRestartMCUs = new int[resolutions];
+    indexedPyramidLevels = new boolean[resolutions];
+    super.setResolution(0);
+    int baseColumns = mcuColumns(getSizeX());
+    int baseRestart =
+      baseRestartInterval(baseColumns, restartMCUsOverride);
+    int tileColumns = baseRestart == 0 ? 1 : baseColumns / baseRestart;
+
+    for (int r = 0; r < resolutions; r++) {
+      super.setResolution(r);
+      int width = getSizeX();
+      int height = getSizeY();
+      int columns = mcuColumns(width);
+      long rows = ((long) height + 7) / 8;
+      boolean completeMCUs = width % 8 == 0 && height % 8 == 0;
+      int restart = restartIntervalForGrid(columns, tileColumns);
+      boolean preservesGrid = baseRestart != 0 && restart != 0;
+      long proposedCount = (long) tileColumns * rows;
+      boolean needsIndex = proposedCount >= MINIMUM_MCU_STARTS;
+      boolean indexed = needsIndex && completeMCUs && preservesGrid;
+
+      // Only reachable for images far beyond the dimensions a classic-TIFF
+      // NDPI container can address.
+      if (indexed && proposedCount > Integer.MAX_VALUE) {
+        throw new FormatException("NDPI contains too many MCU start entries");
+      }
+      indexedPyramidLevels[r] = indexed;
+      pyramidRestartMCUs[r] = indexed ? restart : 0;
+      // restartIntervalForGrid() already rejects any interval that does not
+      // fit the 16-bit DRI field, so an indexed level's interval is always
+      // representable here.
+      if (!indexed) {
+        validateNonIndexedBuffer(width, height, "resolution " + r);
+      }
+    }
+    super.setResolution(0);
+    if (macroSeries != null) {
+      super.setSeries(macroSeries);
+      validateNonIndexedBuffer(getSizeX(), getSizeY(), "macro");
+    }
+    super.setSeries(0);
+    super.setResolution(0);
+  }
+
+  private static void validateNonIndexedBuffer(int width, int height,
+    String description) throws FormatException
+  {
+    long bytes = (long) width * height * CHANNELS;
+    // A non-indexed image is buffered whole, so reject it here rather than
+    // attempting a >2 GiB allocation.
+    if (bytes > Integer.MAX_VALUE) {
+      throw new FormatException("NDPI non-indexed " + description +
+        " is too large to buffer as one JPEG");
+    }
+  }
+
+  static int automaticRestartInterval(int mcuColumns) {
+    if (mcuColumns <= 0) return 0;
+    if (mcuColumns <= 512) return mcuColumns;
+    for (int restart : NOMINAL_RESTART_MCUS) {
+      if (mcuColumns % restart == 0) return restart;
+    }
+    for (int restart = 512; restart > 1; restart--) {
+      if (mcuColumns % restart == 0) return restart;
+    }
+    // Every positive column count is divisible by one, so a prime column
+    // count wider than the largest candidate falls back to one MCU per
+    // restart interval.
+    return 1;
+  }
+
+  static int baseRestartInterval(int mcuColumns, Integer override)
+    throws FormatException
+  {
+    if (override == null) return automaticRestartInterval(mcuColumns);
+    if (mcuColumns % override.intValue() != 0) {
+      throw new FormatException("NDPI restart interval must exactly divide " +
+        "the base image MCU-column count");
+    }
+    return override.intValue();
+  }
+
+  static int restartIntervalForGrid(int mcuColumns, int tileColumns) {
+    if (tileColumns <= 0 || mcuColumns % tileColumns != 0) return 0;
+    int restart = mcuColumns / tileColumns;
+    return restart > 0 && restart <= 0xffff ? restart : 0;
+  }
+
+  private static int mcuColumns(int width) {
+    return (int) (((long) width + 7) / 8);
+  }
+
+  private static long mcuStartCount(int width, int height, int restartMCUs) {
+    long columns = ((long) width + 7) / 8;
+    long rows = ((long) height + 7) / 8;
+    return columns / restartMCUs * rows;
+  }
+
+  private double sourceLens(int width) {
+    Double magnification = objectiveMagnification();
+    if (magnification == null) return 0;
+    int baseWidth =
+      getMetadataRetrieve().getPixelsSizeX(0).getValue().intValue();
+    return magnification * width / baseWidth;
+  }
+
+  private Double objectiveMagnification() {
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+    String objectiveID = retrieve.getObjectiveSettingsID(0);
+    for (int instrument = 0;
+      instrument < retrieve.getInstrumentCount(); instrument++)
+    {
+      for (int objective = 0;
+        objective < retrieve.getObjectiveCount(instrument); objective++)
+      {
+        if (objectiveID == null ||
+          objectiveID.equals(retrieve.getObjectiveID(instrument, objective)))
+        {
+          Double magnification =
+            retrieve.getObjectiveNominalMagnification(instrument, objective);
+          if (magnification != null) return magnification;
+        }
+      }
+    }
+    return null;
+  }
+
+  private void addResolution(IFD ifd, int width, int height, ImageRole role) {
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+    int image = role == ImageRole.PYRAMID ? 0 :
+      role == ImageRole.MACRO ? macroSeries.intValue() :
+      tissueMapSeries.intValue();
+    Length physicalX = retrieve.getPixelsPhysicalSizeX(image);
+    Length physicalY = retrieve.getPixelsPhysicalSizeY(image);
+    Number valueX =
+      physicalX == null ? null : physicalX.value(UNITS.MICROMETER);
+    Number valueY =
+      physicalY == null ? null : physicalY.value(UNITS.MICROMETER);
+    Double micronsX = valueX == null ? null : valueX.doubleValue();
+    Double micronsY = valueY == null ? null : valueY.doubleValue();
+    int baseWidth = retrieve.getPixelsSizeX(image).getValue().intValue();
+    int baseHeight = retrieve.getPixelsSizeY(image).getValue().intValue();
+    if (micronsX != null && micronsX > 0 &&
+      micronsY != null && micronsY > 0)
+    {
+      double pixelsPerCentimeter =
+        10000d / (micronsX * baseWidth / width);
+      ifd.put(IFD.X_RESOLUTION, rational(pixelsPerCentimeter));
+      pixelsPerCentimeter =
+        10000d / (micronsY * baseHeight / height);
+      ifd.put(IFD.Y_RESOLUTION, rational(pixelsPerCentimeter));
+      ifd.putIFDValue(IFD.RESOLUTION_UNIT, 3);
+    }
+  }
+
+  private static TiffRational rational(double value) {
+    long denominator = 10000;
+    return new TiffRational(Math.round(value * denominator), denominator);
+  }
+
+  private static long lowWord(long value) {
+    return value & 0xffffffffL;
+  }
+
+  private static long highWord(long value) {
+    return value >>> 32;
+  }
+
+  private static long[] lowWords(long[] values) {
+    long[] words = new long[values.length];
+    for (int i = 0; i < values.length; i++) words[i] = lowWord(values[i]);
+    return words;
+  }
+
+  private static long[] highWords(long[] values) {
+    long[] words = new long[values.length];
+    for (int i = 0; i < values.length; i++) words[i] = highWord(values[i]);
+    return words;
+  }
+
+  private static boolean hasHighWords(long[] values) {
+    for (long value : values) {
+      if (highWord(value) != 0) return true;
+    }
+    return false;
+  }
+
+  private static final class Level {
+
+    private final long jpegOffset;
+    private final long jpegLength;
+    private final long[] mcuStarts;
+    private final Integer authCode;
+    private final int width;
+    private final int height;
+    private final double sourceLens;
+    private final ImageRole role;
+
+    private Level(NDPIJPEGAssembler.Result jpeg, int width, int height,
+      ImageRole role, double sourceLens, Integer authCode)
+    {
+      jpegOffset = jpeg.getJPEGOffset();
+      jpegLength = jpeg.getJPEGLength();
+      mcuStarts = authCode == null ? new long[0] : jpeg.getMCUStarts();
+      this.width = width;
+      this.height = height;
+      this.sourceLens = sourceLens;
+      this.authCode = authCode;
+      this.role = role;
+    }
+
+    private Level(long offset, long length, int width, int height,
+      ImageRole role)
+    {
+      jpegOffset = offset;
+      jpegLength = length;
+      mcuStarts = new long[0];
+      authCode = null;
+      this.width = width;
+      this.height = height;
+      sourceLens = -2;
+      this.role = role;
+    }
+  }
+
+  private enum ImageRole {
+    PYRAMID, MACRO, TISSUE_MAP
+  }
+}

--- a/components/formats-gpl/src/loci/formats/out/package.html
+++ b/components/formats-gpl/src/loci/formats/out/package.html
@@ -1,0 +1,28 @@
+<!--
+  #%L
+  OME Bio-Formats package for reading and converting biological file formats.
+  %%
+  Copyright (C) 2026 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as
+  published by the Free Software Foundation, either version 2 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/gpl-2.0.html>.
+  #L%
+  -->
+
+<html><body>
+Package containing Bio-Formats file format writers.
+</body></html>

--- a/components/formats-gpl/test/loci/formats/out/NDPIJPEGAssemblyTest.java
+++ b/components/formats-gpl/test/loci/formats/out/NDPIJPEGAssemblyTest.java
@@ -1,0 +1,1021 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import loci.common.ByteArrayHandle;
+import loci.common.RandomAccessOutputStream;
+import loci.formats.FormatException;
+import loci.formats.codec.CodecOptions;
+import loci.formats.codec.JPEGCodec;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests assembly of an NDPI-style restart-marked JPEG, and keeps an
+ * independent reference implementation for decode-equivalence checks.
+ */
+public class NDPIJPEGAssemblyTest {
+
+  private static final int CHANNELS = 3;
+  private static final int MCU_SIZE = 8;
+  private static final int RESTART_MCUS = 4;
+  private static final int DRI = 0xffdd;
+  private static final int EOI = 0xffd9;
+  private static final int SOS = 0xffda;
+  private static final int PREFIX_LENGTH = 37;
+
+  /** One restart region wide and two MCU rows high. */
+  private static final int SMALL_WIDTH = RESTART_MCUS * MCU_SIZE;
+  private static final int SMALL_HEIGHT = 2 * MCU_SIZE;
+
+  @DataProvider(name = "dimensions")
+  public Object[][] dimensions() {
+    return new Object[][] {
+      {128, 80}, // four restart intervals per row and RST wraparound
+      {125, 19}  // four intervals per row plus right and bottom padding
+    };
+  }
+
+  @Test(dataProvider = "dimensions")
+  public void testRestartMarkedAssembly(int width, int height)
+    throws Exception
+  {
+    List<ParsedJPEG> pieces = new ArrayList<ParsedJPEG>();
+    byte[] expected = new byte[width * height * CHANNELS];
+    int regionWidth = RESTART_MCUS * MCU_SIZE;
+    int regionIndex = 0;
+
+    for (int y = 0; y < height; y += MCU_SIZE) {
+      int pieceHeight = Math.min(MCU_SIZE, height - y);
+      for (int x = 0; x < width; x += regionWidth) {
+        int pieceWidth = Math.min(regionWidth, width - x);
+        byte[] piecePixels = makeRegion(x, y, pieceWidth, pieceHeight,
+          regionIndex++);
+        CodecOptions options = options(pieceWidth, pieceHeight);
+        byte[] compressed = new JPEGCodec().compress(piecePixels, options);
+        ParsedJPEG piece = ParsedJPEG.parse(compressed);
+        pieces.add(piece);
+        copyRegion(new JPEGCodec().decompress(compressed, options), expected,
+          x, y, pieceWidth, pieceHeight, width);
+      }
+    }
+
+    assertTrue(pieces.size() > 1, "The test needs multiple regions");
+    for (int i = 1; i < pieces.size(); i++) {
+      pieces.get(0).assertCompatible(pieces.get(i));
+    }
+    pieces.get(0).assert444Sampling();
+
+    byte[] assembled = assemble(pieces, width, height);
+    ParsedJPEG parsed = ParsedJPEG.parse(assembled);
+    assertEquals(parsed.restartInterval, RESTART_MCUS);
+    assertEquals(parsed.restartMarkers.size(), pieces.size() - 1);
+    for (int i = 0; i < parsed.restartMarkers.size(); i++) {
+      assertEquals((int) parsed.restartMarkers.get(i), 0xffd0 + (i & 7),
+        "Restart marker sequence differs at boundary " + i);
+    }
+
+    byte[] actual = new JPEGCodec().decompress(assembled,
+      options(width, height));
+    assertEquals(actual, expected,
+      "Restart assembly must decode like the independent JPEG regions");
+  }
+
+  @Test(dataProvider = "dimensions")
+  public void testAssemblerOutputStructure(int width, int height)
+    throws Exception
+  {
+    byte[] pixels = new byte[width * height * CHANNELS];
+    byte[] expected = new byte[pixels.length];
+    int regionWidth = RESTART_MCUS * MCU_SIZE;
+    int regionIndex = 0;
+
+    for (int y = 0; y < height; y += MCU_SIZE) {
+      int pieceHeight = Math.min(MCU_SIZE, height - y);
+      for (int x = 0; x < width; x += regionWidth) {
+        int pieceWidth = Math.min(regionWidth, width - x);
+        byte[] piece = makeRegion(x, y, pieceWidth, pieceHeight,
+          regionIndex++);
+        copyRegion(piece, pixels, x, y, pieceWidth, pieceHeight, width);
+        byte[] compressed = new JPEGCodec().compress(piece,
+          options(pieceWidth, pieceHeight));
+        copyRegion(new JPEGCodec().decompress(compressed,
+          options(pieceWidth, pieceHeight)), expected, x, y, pieceWidth,
+          pieceHeight, width);
+      }
+    }
+
+    ByteArrayHandle handle = new ByteArrayHandle();
+    NDPIJPEGAssembler.Result result;
+    try (RandomAccessOutputStream out = new RandomAccessOutputStream(handle)) {
+      out.write(new byte[PREFIX_LENGTH]);
+      NDPIJPEGAssembler assembler =
+        new NDPIJPEGAssembler(out, width, height, RESTART_MCUS, true, 0.8,
+          null);
+      int row = 0;
+      while (row < height) {
+        int rows = Math.min(row % 2 == 0 ? 3 : 7, height - row);
+        assembler.writeRows(pixels, row * width * CHANNELS, rows);
+        row += rows;
+      }
+      result = assembler.finish();
+    }
+
+    assertEquals(result.getJPEGOffset(), PREFIX_LENGTH);
+    assertEquals(result.getMCUStarts().length,
+      ((width + regionWidth - 1) / regionWidth) *
+      ((height + MCU_SIZE - 1) / MCU_SIZE));
+    assertEquals(handle.length() - PREFIX_LENGTH, result.getJPEGLength());
+    byte[] assembled = Arrays.copyOfRange(handle.getBytes(), PREFIX_LENGTH,
+      PREFIX_LENGTH + (int) result.getJPEGLength());
+    ParsedJPEG parsed = ParsedJPEG.parse(assembled);
+    assertEquals(parsed.restartInterval, RESTART_MCUS);
+    assertEquals(parsed.restartMarkers.size(),
+      result.getMCUStarts().length - 1);
+    for (int i = 0; i < result.getMCUStarts().length; i++) {
+      long start = result.getMCUStarts()[i];
+      if (i == 0) {
+        assertEquals(start, (long) parsed.header.length);
+      }
+      else {
+        assertEquals(ParsedJPEG.marker(assembled, (int) start - 2),
+          0xffd0 + ((i - 1) & 7));
+      }
+    }
+    assertEquals(new JPEGCodec().decompress(assembled, options(width, height)),
+      expected);
+  }
+
+  @Test
+  public void testOversizedSOFDimensionsBecomeZero() {
+    byte[] header = new byte[16];
+
+    patchDimensions(header, 0, 0x10000, 123);
+    assertEquals(u16(header, 5), 123);
+    assertEquals(u16(header, 7), 0);
+
+    patchDimensions(header, 0, 456, 0x10000);
+    assertEquals(u16(header, 5), 0);
+    assertEquals(u16(header, 7), 456);
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Padded JPEG width must contain a whole number of restart intervals")
+  public void testRejectsPartialRestartIntervalAtRowBoundary()
+    throws Exception
+  {
+    ByteArrayHandle handle = new ByteArrayHandle();
+    try (RandomAccessOutputStream out = new RandomAccessOutputStream(handle)) {
+      new NDPIJPEGAssembler(out, 65, 8, RESTART_MCUS, true, 0.8, null);
+    }
+  }
+
+  // -- Constructor validation tests --
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+    expectedExceptionsMessageRegExp = "Destination stream cannot be null")
+  public void testRejectsNullDestinationStream() throws Exception {
+    new NDPIJPEGAssembler(null, SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      0.8, null);
+  }
+
+  @Test
+  public void testRejectsNonPositiveWidth() throws Exception {
+    String message = "JPEG dimensions must be positive";
+    assertConstructorRejects(0, SMALL_HEIGHT, RESTART_MCUS, true, 0.8, null,
+      message);
+    assertConstructorRejects(-SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      0.8, null, message);
+  }
+
+  @Test
+  public void testRejectsNonPositiveHeight() throws Exception {
+    String message = "JPEG dimensions must be positive";
+    assertConstructorRejects(SMALL_WIDTH, 0, RESTART_MCUS, true, 0.8, null,
+      message);
+    assertConstructorRejects(SMALL_WIDTH, -SMALL_HEIGHT, RESTART_MCUS, true,
+      0.8, null, message);
+  }
+
+  @Test
+  public void testRejectsRestartIntervalOutOfRange() throws Exception {
+    String message = "JPEG restart interval must be 1..65535 MCUs";
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, 0, true, 0.8, null,
+      message);
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, -1, true, 0.8, null,
+      message);
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, 0x10000, true, 0.8,
+      null, message);
+  }
+
+  @Test
+  public void testRejectsQualityOutOfRange() throws Exception {
+    String message = "JPEG quality must be between 0.25 and 1";
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      0.2499, null, message);
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      1.0001, null, message);
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      Double.NaN, null, message);
+    assertConstructorRejects(SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS, true,
+      Double.POSITIVE_INFINITY, null, message);
+  }
+
+  /** The guard runs before allocation, so the huge width costs no memory. */
+  @Test
+  public void testRejectsOversizedMCURowBuffer() throws Exception {
+    assertConstructorRejects(100000000, MCU_SIZE, 1, true, 0.8, null,
+      "One JPEG MCU row is too large to buffer");
+  }
+
+  /** Also guarded before allocation; this mode has no MCU row buffer. */
+  @Test
+  public void testRejectsOversizedNonIndexedImageBuffer() throws Exception {
+    assertConstructorRejects(100000, 10000, 0, false, 0.8, null,
+      "Non-indexed JPEG is too large to buffer as one image");
+  }
+
+  /** Nine restart columns need only a 1728-byte MCU row buffer. */
+  @Test
+  public void testRejectsTooManyRestartRegions() throws Exception {
+    assertConstructorRejects(9 * MCU_SIZE, Integer.MAX_VALUE, 1, true, 0.8,
+      null, "JPEG contains too many restart regions");
+  }
+
+  @Test
+  public void testRejectsCaptureRegionsWhenNotIndexed() throws Exception {
+    assertConstructorRejects(MCU_SIZE, MCU_SIZE, 0, false, 0.8, new int[] {0},
+      "Non-indexed JPEG cannot capture restart regions");
+  }
+
+  @Test
+  public void testRejectsCaptureRegionOutOfRange() throws Exception {
+    String message = "Captured JPEG region is out of range";
+    assertConstructorRejects(SMALL_WIDTH, MCU_SIZE, RESTART_MCUS, true, 0.8,
+      new int[] {-1}, message);
+    assertConstructorRejects(SMALL_WIDTH, MCU_SIZE, RESTART_MCUS, true, 0.8,
+      new int[] {1}, message);
+  }
+
+  // -- writeRows and finish validation tests --
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+    expectedExceptionsMessageRegExp = "Pixel buffer cannot be null")
+  public void testWriteRowsRejectsNullPixelBuffer() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      newAssembler(out).writeRows(null, 0, 1);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Rows must be written once, top to bottom")
+  public void testWriteRowsRejectsNonPositiveRowCount() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      newAssembler(out).writeRows(new byte[smallPixelCount()], 0, 0);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Rows must be written once, top to bottom")
+  public void testWriteRowsRejectsMoreRowsThanRemain() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      NDPIJPEGAssembler assembler = newAssembler(out);
+      byte[] pixels = new byte[smallPixelCount()];
+      assembler.writeRows(pixels, 0, SMALL_HEIGHT - 1);
+      assembler.writeRows(pixels, 0, 2);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Pixel buffer does not contain 2 complete RGB rows")
+  public void testWriteRowsRejectsShortPixelBuffer() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      newAssembler(out).writeRows(new byte[SMALL_WIDTH * CHANNELS], 0, 2);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Pixel buffer does not contain 1 complete RGB rows")
+  public void testWriteRowsRejectsNegativeOffset() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      newAssembler(out).writeRows(new byte[smallPixelCount()], -1, 1);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "Expected 16 rows but received 8")
+  public void testFinishRejectsMissingRows() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      NDPIJPEGAssembler assembler = newAssembler(out);
+      assembler.writeRows(new byte[smallPixelCount()], 0, MCU_SIZE);
+      assembler.finish();
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "JPEG assembly is already complete")
+  public void testWriteRowsAfterFinishIsRejected() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      byte[] pixels = new byte[smallPixelCount()];
+      NDPIJPEGAssembler assembler = finishedAssembler(out, pixels);
+      assembler.writeRows(pixels, 0, 1);
+    }
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "JPEG assembly is already complete")
+  public void testFinishAfterFinishIsRejected() throws Exception {
+    try (RandomAccessOutputStream out = newStream()) {
+      finishedAssembler(out, new byte[smallPixelCount()]).finish();
+    }
+  }
+
+  // -- JPEG parser rejection tests --
+
+  @Test
+  public void testParseRejectsMissingSOI() {
+    String message = "JPEG piece does not begin with SOI";
+    assertParseRejects(bytes(0xff), message);
+    assertParseRejects(bytes(0xff, 0xd8, 0x00), message);
+    assertParseRejects(bytes(0x00, 0xd8, 0xff, 0xd9), message);
+  }
+
+  @Test
+  public void testParseRejectsNonMarkerByte() {
+    assertParseRejects(concat(soi(), bytes(0x00, 0x11, 0x22, 0x33)),
+      "Expected JPEG marker at 2");
+  }
+
+  @Test
+  public void testParseRejectsTruncatedMarker() {
+    assertParseRejects(concat(soi(), bytes(0xff, 0xdb, 0x00)),
+      "Truncated JPEG marker");
+  }
+
+  @Test
+  public void testParseRejectsInvalidMarkerLength() {
+    String message = "Invalid JPEG marker length";
+    assertParseRejects(concat(soi(), bytes(0xff, 0xdb, 0x00, 0x01, 0x00,
+      0x00)), message);
+    assertParseRejects(concat(soi(), bytes(0xff, 0xdb, 0x00, 0x40, 0x00,
+      0x00)), message);
+  }
+
+  @Test
+  public void testParseRejectsNonBaselineSOF() {
+    assertParseRejects(concat(soi(), bytes(0xff, 0xc2, 0x00, 0x04, 0x00,
+      0x00), eoi()), "Only baseline sequential JPEG is supported, " +
+      "found SOF marker 0xffc2");
+  }
+
+  @Test
+  public void testParseRejectsMissingFrameAndScan() {
+    assertParseRejects(concat(soi(), dqt(0x00, 0x10), eoi()),
+      "Incomplete JPEG marker structure");
+  }
+
+  @Test
+  public void testParseRejectsTruncatedFillBytes() {
+    assertParseRejects(jpegWithEntropy(bytes(0x11, 0xff, 0xff)),
+      "Truncated JPEG fill bytes");
+  }
+
+  @Test
+  public void testParseRejectsMultipleScans() {
+    assertParseRejects(jpegWithEntropy(bytes(0x11, 0xff, 0xda, 0x00, 0x00)),
+      "Multiple JPEG scans are not supported");
+  }
+
+  @Test
+  public void testParseRejectsFillBeforeStuffedByte() {
+    assertParseRejects(jpegWithEntropy(bytes(0xff, 0xff, 0x00, 0x11)),
+      "Invalid fill before stuffed entropy byte");
+  }
+
+  @Test
+  public void testParseRejectsUnexpectedEntropyMarker() {
+    assertParseRejects(jpegWithEntropy(bytes(0x11, 0xff, 0xc4, 0x00)),
+      "Unexpected marker in JPEG entropy data");
+  }
+
+  @Test
+  public void testParseRejectsEntropyWithoutEOI() {
+    assertParseRejects(jpegWithEntropy(bytes(0x11, 0x22, 0x33)),
+      "JPEG entropy data has no EOI");
+  }
+
+  /** Byte stuffing, restart markers, and 0xff fill bytes are skipped. */
+  @Test
+  public void testParseSkipsStuffingFillAndRestartMarkers() throws Exception {
+    NDPIJPEGAssembler.ParsedJPEG parsed = parsed(jpegWithEntropy(bytes(0x11,
+      0xff, 0xd0, 0x22, 0xff, 0x00, 0x33, 0xff, 0xff, 0xd9)));
+    parsed.assert444Sampling();
+    parsed.assertCompatible(parsed);
+  }
+
+  @Test
+  public void testAssertCompatibleRejectsDifferingQuantizationTables()
+    throws Exception
+  {
+    String message = "JPEG quantization tables differ between restart regions";
+    assertIncompatible(minimalJPEG(), jpeg(dqt(0x00, 0x11), dht(0x00, 0x20),
+      sof0(0x11, 0x11, 0x11), sos(0x00), entropy()), message);
+    assertIncompatible(minimalJPEG(), jpeg(concat(dqt(0x00, 0x10),
+      dqt(0x01, 0x10)), dht(0x00, 0x20), sof0(0x11, 0x11, 0x11), sos(0x00),
+      entropy()), message);
+  }
+
+  @Test
+  public void testAssertCompatibleRejectsDifferingHuffmanTables()
+    throws Exception
+  {
+    assertIncompatible(minimalJPEG(), jpeg(dqt(0x00, 0x10), dht(0x00, 0x21),
+      sof0(0x11, 0x11, 0x11), sos(0x00), entropy()),
+      "JPEG Huffman tables differ between restart regions");
+  }
+
+  @Test
+  public void testAssertCompatibleRejectsDifferingFrameComponents()
+    throws Exception
+  {
+    assertIncompatible(minimalJPEG(), jpeg(dqt(0x00, 0x10), dht(0x00, 0x20),
+      sof0(0x11, 0x11, 0x22), sos(0x00), entropy()),
+      "JPEG frame components or sampling factors differ between restart " +
+      "regions");
+  }
+
+  @Test
+  public void testAssertCompatibleRejectsDifferingScanComponents()
+    throws Exception
+  {
+    assertIncompatible(minimalJPEG(), jpeg(dqt(0x00, 0x10), dht(0x00, 0x20),
+      sof0(0x11, 0x11, 0x11), sos(0x10), entropy()),
+      "JPEG scan components differ between restart regions");
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "NDPI JPEG requires three components")
+  public void testAssert444SamplingRejectsWrongComponentCount()
+    throws Exception
+  {
+    parsed(jpeg(dqt(0x00, 0x10), dht(0x00, 0x20), sofOneComponent(),
+      sos(0x00), entropy())).assert444Sampling();
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "NDPI JPEG requires 4:4:4 sampling")
+  public void testAssert444SamplingRejectsSubsampledComponent()
+    throws Exception
+  {
+    parsed(jpeg(dqt(0x00, 0x10), dht(0x00, 0x20), sof0(0x11, 0x21, 0x11),
+      sos(0x00), entropy())).assert444Sampling();
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp = "Non-indexed JPEG must not contain DRI")
+  public void testAssertNoRestartMarkersRejectsDRI() throws Exception {
+    parsed(concat(soi(), dqt(0x00, 0x10), dht(0x00, 0x20), dri(),
+      sof0(0x11, 0x11, 0x11), sos(0x00), entropy()))
+      .assertNoRestartMarkers();
+  }
+
+  @Test(expectedExceptions = FormatException.class,
+    expectedExceptionsMessageRegExp =
+      "Non-indexed JPEG must not contain restart markers")
+  public void testAssertNoRestartMarkersRejectsRestartMarker()
+    throws Exception
+  {
+    parsed(jpegWithEntropy(bytes(0x11, 0xff, 0xd0, 0x22, 0xff, 0xd9)))
+      .assertNoRestartMarkers();
+  }
+
+  // -- Validation test helpers --
+
+  private static RandomAccessOutputStream newStream() {
+    return new RandomAccessOutputStream(new ByteArrayHandle());
+  }
+
+  private static int smallPixelCount() {
+    return SMALL_WIDTH * SMALL_HEIGHT * CHANNELS;
+  }
+
+  private static NDPIJPEGAssembler newAssembler(RandomAccessOutputStream out)
+    throws FormatException
+  {
+    return new NDPIJPEGAssembler(out, SMALL_WIDTH, SMALL_HEIGHT, RESTART_MCUS,
+      true, 0.8, null);
+  }
+
+  private static NDPIJPEGAssembler finishedAssembler(
+    RandomAccessOutputStream out, byte[] pixels) throws Exception
+  {
+    NDPIJPEGAssembler assembler = newAssembler(out);
+    assembler.writeRows(pixels, 0, SMALL_HEIGHT);
+    assembler.finish();
+    return assembler;
+  }
+
+  private static void assertConstructorRejects(int width, int height,
+    int restartMCUs, boolean indexed, double quality, int[] captureRegions,
+    String message) throws Exception
+  {
+    String description = "width=" + width + " height=" + height +
+      " restartMCUs=" + restartMCUs + " indexed=" + indexed + " quality=" +
+      quality + " captureRegions=" + Arrays.toString(captureRegions);
+    try (RandomAccessOutputStream out = newStream()) {
+      new NDPIJPEGAssembler(out, width, height, restartMCUs, indexed, quality,
+        captureRegions);
+      fail("Expected rejection of " + description);
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(), message,
+        "Wrong rejection for " + description);
+    }
+  }
+
+  private static NDPIJPEGAssembler.ParsedJPEG parsed(byte[] jpeg)
+    throws FormatException
+  {
+    return NDPIJPEGAssembler.ParsedJPEG.parse(jpeg);
+  }
+
+  private static void assertParseRejects(byte[] jpeg, String message) {
+    try {
+      NDPIJPEGAssembler.ParsedJPEG.parse(jpeg);
+      fail("Expected rejection: " + message);
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(), message);
+    }
+  }
+
+  private static void assertIncompatible(byte[] first, byte[] second,
+    String message) throws FormatException
+  {
+    try {
+      parsed(first).assertCompatible(parsed(second));
+      fail("Expected rejection: " + message);
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(), message);
+    }
+  }
+
+  // -- Handcrafted JPEG structure helpers --
+
+  private static byte[] bytes(int... values) {
+    byte[] result = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      result[i] = (byte) values[i];
+    }
+    return result;
+  }
+
+  private static byte[] concat(byte[]... parts) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    for (byte[] part : parts) {
+      out.write(part, 0, part.length);
+    }
+    return out.toByteArray();
+  }
+
+  private static byte[] soi() {
+    return bytes(0xff, 0xd8);
+  }
+
+  private static byte[] eoi() {
+    return bytes(0xff, 0xd9);
+  }
+
+  /** A two-byte quantization table segment. */
+  private static byte[] dqt(int first, int second) {
+    return bytes(0xff, 0xdb, 0x00, 0x04, first, second);
+  }
+
+  /** A two-byte Huffman table segment. */
+  private static byte[] dht(int first, int second) {
+    return bytes(0xff, 0xc4, 0x00, 0x04, first, second);
+  }
+
+  private static byte[] dri() {
+    return bytes(0xff, 0xdd, 0x00, 0x04, 0x00, 0x04);
+  }
+
+  /** A baseline SOF0 for three 8-by-8 components with the given sampling. */
+  private static byte[] sof0(int first, int second, int third) {
+    return bytes(0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x08, 0x00, 0x08, 0x03,
+      0x01, first, 0x00, 0x02, second, 0x01, 0x03, third, 0x01);
+  }
+
+  private static byte[] sofOneComponent() {
+    return bytes(0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x08, 0x00, 0x08, 0x01,
+      0x01, 0x11, 0x00);
+  }
+
+  /** A three-component scan header with a variable first table selector. */
+  private static byte[] sos(int firstTables) {
+    return bytes(0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, firstTables, 0x02, 0x11,
+      0x03, 0x11, 0x00, 0x3f, 0x00);
+  }
+
+  /** Entropy data containing one stuffed 0xff byte and a closing EOI. */
+  private static byte[] entropy() {
+    return bytes(0x11, 0x22, 0xff, 0x00, 0x33, 0xff, 0xd9);
+  }
+
+  private static byte[] jpeg(byte[] quantization, byte[] huffman, byte[] frame,
+    byte[] scan, byte[] entropy)
+  {
+    return concat(soi(), quantization, huffman, frame, scan, entropy);
+  }
+
+  private static byte[] minimalJPEG() {
+    return jpeg(dqt(0x00, 0x10), dht(0x00, 0x20), sof0(0x11, 0x11, 0x11),
+      sos(0x00), entropy());
+  }
+
+  private static byte[] jpegWithEntropy(byte[] entropy) {
+    return jpeg(dqt(0x00, 0x10), dht(0x00, 0x20), sof0(0x11, 0x11, 0x11),
+      sos(0x00), entropy);
+  }
+
+  private static byte[] assemble(List<ParsedJPEG> pieces, int width,
+    int height)
+  {
+    ParsedJPEG first = pieces.get(0);
+    byte[] header = Arrays.copyOf(first.header, first.header.length);
+    patchDimensions(header, first.sofOffset, width, height);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(header, 0, first.sosOffset);
+    writeMarker(out, DRI);
+    out.write(0);
+    out.write(4);
+    out.write(RESTART_MCUS >>> 8);
+    out.write(RESTART_MCUS);
+    out.write(header, first.sosOffset, header.length - first.sosOffset);
+
+    for (int i = 0; i < pieces.size(); i++) {
+      byte[] entropy = pieces.get(i).entropy;
+      out.write(entropy, 0, entropy.length);
+      if (i + 1 < pieces.size()) {
+        writeMarker(out, 0xffd0 + (i & 7));
+      }
+    }
+    writeMarker(out, EOI);
+    return out.toByteArray();
+  }
+
+  private static void patchDimensions(byte[] header, int sofOffset, int width,
+    int height)
+  {
+    int jpegWidth = width > 0xffff ? 0 : width;
+    int jpegHeight = height > 0xffff ? 0 : height;
+    header[sofOffset + 5] = (byte) (jpegHeight >>> 8);
+    header[sofOffset + 6] = (byte) jpegHeight;
+    header[sofOffset + 7] = (byte) (jpegWidth >>> 8);
+    header[sofOffset + 8] = (byte) jpegWidth;
+  }
+
+  private static void writeMarker(ByteArrayOutputStream out, int marker) {
+    out.write(marker >>> 8);
+    out.write(marker);
+  }
+
+  private static CodecOptions options(int width, int height) {
+    CodecOptions options = CodecOptions.getDefaultOptions();
+    options.width = width;
+    options.height = height;
+    options.channels = CHANNELS;
+    options.bitsPerSample = 8;
+    options.interleaved = true;
+    options.lossless = false;
+    options.quality = 0.8;
+    options.disableChromaSubsampling = true;
+    return options;
+  }
+
+  private static byte[] makeRegion(int imageX, int imageY, int width,
+    int height, int regionIndex)
+  {
+    byte[] pixels = new byte[width * height * CHANNELS];
+    int content = regionIndex & 3;
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        int offset = (y * width + x) * CHANNELS;
+        int globalX = imageX + x;
+        int globalY = imageY + y;
+        if (content == 0) {
+          // Uniform region.
+          pixels[offset] = 24;
+          pixels[offset + 1] = (byte) 160;
+          pixels[offset + 2] = 72;
+        }
+        else if (content == 1) {
+          // Deterministic high-frequency noise.
+          int noise = mix(globalX, globalY, regionIndex);
+          pixels[offset] = (byte) noise;
+          pixels[offset + 1] = (byte) (noise >>> 8);
+          pixels[offset + 2] = (byte) (noise >>> 16);
+        }
+        else if (content == 2) {
+          // High-contrast edges.
+          int value = ((globalX / 4 + globalY / 4) & 1) == 0 ? 0 : 255;
+          pixels[offset] = (byte) value;
+          pixels[offset + 1] = (byte) (255 - value);
+          pixels[offset + 2] = (byte) value;
+        }
+        else {
+          // Smooth but colorful gradient.
+          pixels[offset] = (byte) (globalX * 7 + globalY * 3);
+          pixels[offset + 1] = (byte) (globalX * 2 + globalY * 11);
+          pixels[offset + 2] = (byte) (globalX * 13 + globalY * 5);
+        }
+      }
+    }
+    return pixels;
+  }
+
+  private static int mix(int x, int y, int region) {
+    int value = x * 0x1f123bb5 ^ y * 0x5f356495 ^ region * 0x6c8e9cf5;
+    value ^= value >>> 16;
+    value *= 0x7feb352d;
+    value ^= value >>> 15;
+    return value;
+  }
+
+  private static void copyRegion(byte[] region, byte[] image, int x, int y,
+    int width, int height, int imageWidth)
+  {
+    int rowBytes = width * CHANNELS;
+    for (int row = 0; row < height; row++) {
+      System.arraycopy(region, row * rowBytes, image,
+        ((y + row) * imageWidth + x) * CHANNELS, rowBytes);
+    }
+  }
+
+  private static int u16(byte[] bytes, int offset) {
+    return (bytes[offset] & 0xff) << 8 | bytes[offset + 1] & 0xff;
+  }
+
+  private static final class ParsedJPEG {
+
+    private final byte[] header;
+    private final byte[] entropy;
+    private final List<byte[]> quantizationTables;
+    private final List<byte[]> huffmanTables;
+    private final byte[] frameComponents;
+    private final byte[] scanComponents;
+    private final int sofOffset;
+    private final int sosOffset;
+    private final List<Integer> restartMarkers;
+    private final int restartInterval;
+
+    private ParsedJPEG(byte[] header, byte[] entropy,
+      List<byte[]> quantizationTables, List<byte[]> huffmanTables,
+      byte[] frameComponents, byte[] scanComponents, int sofOffset,
+      int sosOffset, List<Integer> restartMarkers, int restartInterval)
+    {
+      this.header = header;
+      this.entropy = entropy;
+      this.quantizationTables = quantizationTables;
+      this.huffmanTables = huffmanTables;
+      this.frameComponents = frameComponents;
+      this.scanComponents = scanComponents;
+      this.sofOffset = sofOffset;
+      this.sosOffset = sosOffset;
+      this.restartMarkers = restartMarkers;
+      this.restartInterval = restartInterval;
+    }
+
+    private static ParsedJPEG parse(byte[] jpeg) throws FormatException {
+      if (jpeg.length < 4 || marker(jpeg, 0) != 0xffd8) {
+        throw new FormatException("JPEG does not begin with SOI");
+      }
+
+      List<byte[]> dqt = new ArrayList<byte[]>();
+      List<byte[]> dht = new ArrayList<byte[]>();
+      byte[] frame = null;
+      byte[] scan = null;
+      int sof = -1;
+      int sos = -1;
+      int entropyStart = -1;
+      int entropyEnd = -1;
+      int restartInterval = 0;
+      int offset = 2;
+
+      while (offset + 1 < jpeg.length) {
+        if ((jpeg[offset] & 0xff) != 0xff) {
+          throw new FormatException("Expected JPEG marker at " + offset);
+        }
+        int code = marker(jpeg, offset);
+        if (code == EOI) {
+          entropyEnd = offset;
+          break;
+        }
+        if (code >= 0xffd0 && code <= 0xffd7) {
+          offset += 2;
+          continue;
+        }
+        if (offset + 3 >= jpeg.length) {
+          throw new FormatException("Truncated JPEG marker");
+        }
+        int length = u16(jpeg, offset + 2);
+        if (length < 2 || offset + 2 + length > jpeg.length) {
+          throw new FormatException("Invalid JPEG marker length");
+        }
+        if (code == 0xffdb) {
+          dqt.add(slice(jpeg, offset + 4, offset + 2 + length));
+        }
+        else if (code == 0xffc4) {
+          dht.add(slice(jpeg, offset + 4, offset + 2 + length));
+        }
+        else if (code == DRI) {
+          if (length != 4) {
+            throw new FormatException("Invalid DRI marker length");
+          }
+          restartInterval = u16(jpeg, offset + 4);
+        }
+        else if (code == 0xffc0) {
+          sof = offset;
+          int components = jpeg[offset + 9] & 0xff;
+          frame = slice(jpeg, offset + 9, offset + 10 + 3 * components);
+        }
+        else if (isSOF(code)) {
+          throw new FormatException("Only baseline sequential JPEG is " +
+            "supported, found SOF marker 0x" + Integer.toHexString(code));
+        }
+        else if (code == SOS) {
+          sos = offset;
+          int components = jpeg[offset + 4] & 0xff;
+          scan = slice(jpeg, offset + 4, offset + 5 + 2 * components);
+          entropyStart = offset + 2 + length;
+          entropyEnd = findEntropyEnd(jpeg, entropyStart);
+          break;
+        }
+        offset += 2 + length;
+      }
+
+      if (sof < 0 || sos < 0 || entropyStart < 0 || entropyEnd < 0) {
+        throw new FormatException("Incomplete JPEG marker structure");
+      }
+      return new ParsedJPEG(slice(jpeg, 0, entropyStart),
+        slice(jpeg, entropyStart, entropyEnd), dqt, dht, frame, scan, sof, sos,
+        restartMarkers(jpeg, entropyStart, entropyEnd), restartInterval);
+    }
+
+    private void assertCompatible(ParsedJPEG other) {
+      assertByteListsEqual(other.quantizationTables, quantizationTables,
+        "Quantization tables differ between pieces");
+      assertByteListsEqual(other.huffmanTables, huffmanTables,
+        "Huffman tables differ between pieces");
+      assertEquals(other.frameComponents, frameComponents,
+        "SOF component order or sampling differs between pieces");
+      assertEquals(other.scanComponents, scanComponents,
+        "SOS component order differs between pieces");
+    }
+
+    private void assert444Sampling() {
+      assertEquals(frameComponents[0] & 0xff, CHANNELS);
+      for (int i = 0; i < CHANNELS; i++) {
+        assertEquals(frameComponents[2 + 3 * i] & 0xff, 0x11,
+          "Every component must use 1x1 (4:4:4) sampling");
+      }
+    }
+
+    private static int findEntropyEnd(byte[] jpeg, int start)
+      throws FormatException
+    {
+      int offset = start;
+      while (offset + 1 < jpeg.length) {
+        if ((jpeg[offset] & 0xff) != 0xff) {
+          offset++;
+          continue;
+        }
+        int next = jpeg[offset + 1] & 0xff;
+        if (next == 0) {
+          offset += 2;
+          continue;
+        }
+        int markerOffset = offset;
+        while (next == 0xff) {
+          offset++;
+          if (offset + 1 >= jpeg.length) {
+            throw new FormatException("Truncated JPEG fill bytes");
+          }
+          next = jpeg[offset + 1] & 0xff;
+        }
+        if (next == 0xd9) {
+          // Exclude all fill bytes preceding EOI from the entropy segment.
+          return markerOffset;
+        }
+        if (next == 0xda) {
+          throw new FormatException("Multiple JPEG scans are not supported");
+        }
+        if (next == 0) {
+          throw new FormatException("Invalid fill before stuffed entropy byte");
+        }
+        if (next >= 0xd0 && next <= 0xd7) {
+          offset += 2;
+          continue;
+        }
+        throw new FormatException("Unexpected marker in JPEG entropy data");
+      }
+      throw new FormatException("JPEG entropy data has no EOI");
+    }
+
+    private static boolean isSOF(int code) {
+      int low = code & 0xff;
+      return code >= 0xffc0 && code <= 0xffcf &&
+        low != 0xc4 && low != 0xc8 && low != 0xcc;
+    }
+
+    private static List<Integer> restartMarkers(byte[] jpeg, int start,
+      int end)
+    {
+      List<Integer> markers = new ArrayList<Integer>();
+      int offset = start;
+      while (offset + 1 < end) {
+        if ((jpeg[offset] & 0xff) != 0xff) {
+          offset++;
+          continue;
+        }
+        int next = jpeg[offset + 1] & 0xff;
+        if (next == 0) {
+          offset += 2;
+          continue;
+        }
+        while (next == 0xff) {
+          offset++;
+          if (offset + 1 >= end) {
+            break;
+          }
+          next = jpeg[offset + 1] & 0xff;
+        }
+        if (next >= 0xd0 && next <= 0xd7) {
+          markers.add(0xff00 | next);
+          offset += 2;
+          continue;
+        }
+        offset++;
+      }
+      return markers;
+    }
+
+    private static void assertByteListsEqual(List<byte[]> actual,
+      List<byte[]> expected, String message)
+    {
+      assertEquals(actual.size(), expected.size(), message);
+      for (int i = 0; i < actual.size(); i++) {
+        assertEquals(actual.get(i), expected.get(i), message);
+      }
+    }
+
+    private static byte[] slice(byte[] bytes, int start, int end) {
+      return Arrays.copyOfRange(bytes, start, end);
+    }
+
+    private static int marker(byte[] bytes, int offset) {
+      return (bytes[offset] & 0xff) << 8 | bytes[offset + 1] & 0xff;
+    }
+
+  }
+}

--- a/components/formats-gpl/test/loci/formats/out/NDPIWriterTest.java
+++ b/components/formats-gpl/test/loci/formats/out/NDPIWriterTest.java
@@ -758,6 +758,31 @@ public class NDPIWriterTest {
   }
 
   @Test
+  public void testRejectsMissingObjectiveSettings() throws Exception {
+    Path file = Files.createTempFile("bioformats-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(WIDTH, HEIGHT);
+      metadata.setObjectiveSettingsID(null, 0);
+      metadata.setObjectiveNominalMagnification(null, 0, 0);
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      try {
+        writer.setId(file.toString());
+        fail("Missing objective settings must be rejected");
+      }
+      catch (loci.formats.FormatException e) {
+        assertEquals(e.getMessage(),
+          "NDPI requires a positive objective nominal magnification");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
   public void testRejectsUnsupportedWriterContracts() throws Exception {
     assertSetIdRejected(metadata(64, 64), false, true,
       "NDPI requires sequential writing");

--- a/components/formats-gpl/test/loci/formats/out/NDPIWriterTest.java
+++ b/components/formats-gpl/test/loci/formats/out/NDPIWriterTest.java
@@ -1,0 +1,3050 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2026 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import javax.swing.filechooser.FileFilter;
+
+import loci.common.ByteArrayHandle;
+import loci.common.RandomAccessInputStream;
+import loci.common.RandomAccessOutputStream;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.IFormatWriter;
+import loci.formats.ImageWriter;
+import loci.formats.MetadataTools;
+import loci.formats.codec.CodecOptions;
+import loci.formats.gui.GUITools;
+import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.NDPIReader;
+import loci.formats.meta.IMetadata;
+import loci.formats.meta.IPyramidStore;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.TiffCompression;
+import loci.formats.tiff.TiffParser;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
+
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/**
+ * Structural tests for the minimal NDPI container writer.
+ */
+public class NDPIWriterTest {
+
+  /** TIFF type code of an ASCII value. */
+  private static final int ASCII_TYPE = 2;
+
+  private static final int WIDTH = 65536;
+  private static final int HEIGHT = 24;
+
+  private static final int PYRAMID_WIDTH = 512;
+  private static final int PYRAMID_HEIGHT = 352;
+  private static final int MACRO_WIDTH = 64;
+  private static final int MACRO_HEIGHT = 352;
+  private static final int MAP_WIDTH = 32;
+  private static final int MAP_HEIGHT = 16;
+
+  private static final String CALIBRATION_PROPERTIES =
+    "System.Version=1..0\r\nCalibration.Version=500\r\n";
+
+  /** Message of the simulated underlying output-stream close failure. */
+  private static final String CLOSE_FAILURE =
+    "Simulated NDPI output stream close failure";
+
+  @Test
+  public void testWriterRegistration() throws Exception {
+    ImageWriter imageWriter = new ImageWriter();
+    try {
+      IFormatWriter writer = imageWriter.getWriter("registered.ndpi");
+      assertEquals(writer.getClass(), NDPIWriter.class);
+      assertEquals(writer.getFormat(), "Hamamatsu NDPI");
+      assertEquals(writer.getSuffixes(), new String[] {"ndpi"});
+      assertEquals(writer.getCompressionTypes(), new String[] {"JPEG"});
+
+      int ndpiIndex = -1;
+      int ndpiCount = 0;
+      IFormatWriter[] writers = imageWriter.getWriters();
+      for (int i = 0; i < writers.length; i++) {
+        if (writers[i].getClass() == NDPIWriter.class) {
+          ndpiIndex = i;
+          ndpiCount++;
+        }
+      }
+      assertEquals(ndpiCount, 1,
+        "Writer discovery must expose NDPI exactly once");
+      assertTrue(ndpiIndex >= 0);
+
+      int ndpiFilterCount = 0;
+      for (FileFilter filter : GUITools.buildFileFilters(imageWriter)) {
+        if (filter.accept(new File("registered.ndpi"))) {
+          ndpiFilterCount++;
+          assertTrue(filter.getDescription().contains("Hamamatsu NDPI"));
+        }
+      }
+      assertEquals(ndpiFilterCount, 1,
+        "GUI writer discovery must expose NDPI exactly once");
+    }
+    finally {
+      imageWriter.close();
+    }
+  }
+
+  @Test
+  public void testRoundTripPyramid() throws Exception {
+    int[] widths = {7680, 3840};
+    int[] heights = {352, 176};
+    int[] restartMCUs = {480, 240};
+    int[] mcuStartCounts = {88, 44};
+    Path file = Files.createTempFile("bioformats-pyramid-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(widths[0], heights[0]);
+      IPyramidStore pyramid = (IPyramidStore) metadata;
+      pyramid.setResolutionSizeX(new PositiveInteger(widths[1]), 0, 1);
+      pyramid.setResolutionSizeY(new PositiveInteger(heights[1]), 0, 1);
+
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      for (int resolution = 0; resolution < widths.length; resolution++) {
+        writer.setResolution(resolution);
+        byte[] pixels = pixels(widths[resolution], heights[resolution],
+          resolution);
+        writer.saveBytes(0, pixels, 0, 0, widths[resolution],
+          heights[resolution]);
+      }
+      writer.close();
+
+      assertAuthCodes(file, widths.length);
+      assertMCUStarts(file);
+      assertRestartGeometry(file, restartMCUs, mcuStartCounts);
+
+      NDPIReader reader = new NDPIReader();
+      try {
+        reader.setMetadataStore(MetadataTools.createOMEXMLMetadata());
+        reader.setFlattenedResolutions(false);
+        reader.setId(file.toString());
+        assertEquals(reader.getSeriesCount(), 1);
+        assertEquals(reader.getResolutionCount(), widths.length);
+        assertEquals(reader.getRGBChannelCount(), 3);
+        assertEquals(reader.getBitsPerPixel(), 8);
+
+        for (int resolution = 0; resolution < widths.length; resolution++) {
+          reader.setResolution(resolution);
+          assertEquals(reader.getSizeX(), widths[resolution]);
+          assertEquals(reader.getSizeY(), heights[resolution]);
+          byte[] expected =
+            pixels(widths[resolution], heights[resolution], resolution);
+          if (!reader.isInterleaved()) {
+            expected = planar(expected);
+          }
+          assertJPEGClose(reader.openBytes(0), expected);
+        }
+
+        IMetadata readMetadata = (IMetadata) reader.getMetadataStore();
+        assertEquals(
+          readMetadata.getObjectiveNominalMagnification(0, 0), 40d);
+        assertEquals(readMetadata.getPixelsPhysicalSizeX(0)
+          .value(UNITS.MICROMETER).doubleValue(), 0.25d, 0.0001d);
+        assertEquals(readMetadata.getPixelsPhysicalSizeY(0)
+          .value(UNITS.MICROMETER).doubleValue(), 0.25d, 0.0001d);
+      }
+      finally {
+        reader.close();
+      }
+
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testPlanarRGBRoundTrip() throws Exception {
+    int width = 768;
+    int height = 352;
+    byte[] expected = pixels(width, height, 0);
+    Path file = Files.createTempFile("bioformats-planar-", ".ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(false);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, planar(expected));
+      writer.close();
+
+      NDPIReader reader = new NDPIReader();
+      try {
+        reader.setId(file.toString());
+        byte[] actual = reader.openBytes(0);
+        if (!reader.isInterleaved()) {
+          expected = planar(expected);
+        }
+        assertJPEGClose(actual, expected);
+      }
+      finally {
+        reader.close();
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testCompleteCloseKeepsOutput() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-complete-close-", ".ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.close();
+
+      assertTrue(Files.exists(file),
+        "Closing a complete NDPI output must preserve the file");
+      assertTrue(Files.size(file) > 0,
+        "A preserved complete NDPI output must not be empty");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testIncompleteCloseRemovesOutputWithoutFailing()
+    throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-incomplete-", ".ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(WIDTH, HEIGHT));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, new byte[WIDTH * 3], 0, 0, WIDTH, 1);
+      writer.close();
+
+      assertFalse(Files.exists(file),
+        "Incomplete NDPI output must be removed by close");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testCloseFailureIsThePrimaryException() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-close-failure-", ".ndpi");
+    try {
+      FailingCloseNDPIWriter writer = new FailingCloseNDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.failNextClose();
+      try {
+        writer.close();
+        fail("A failing underlying close must be reported");
+      }
+      catch (IOException e) {
+        assertEquals(e.getMessage(), CLOSE_FAILURE,
+          "The underlying close failure must be the primary exception");
+        assertEquals(e.getSuppressed().length, 0,
+          "A complete output must not add a cleanup failure");
+      }
+      assertTrue(Files.exists(file),
+        "A complete NDPI output must survive a close failure");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testUnremovableIncompleteOutputIsReported() throws Exception {
+    Path directory =
+      Files.createTempDirectory("bioformats-unremovable-");
+    Path file = directory.resolve("incomplete.ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writeIncompletePixels(writer, file);
+      lockDirectory(directory);
+      try {
+        writer.close();
+        skipIfDeletionWasPermitted(file);
+        fail("An unremovable incomplete NDPI output must be reported");
+      }
+      catch (IOException e) {
+        assertTrue(e.getMessage().startsWith(
+          "Could not remove incomplete NDPI output"),
+          "Cleanup failures must describe the unremovable output, not \"" +
+          e.getMessage() + "\"");
+      }
+    }
+    finally {
+      unlockDirectory(directory);
+      Files.deleteIfExists(file);
+      Files.deleteIfExists(directory);
+    }
+  }
+
+  @Test
+  public void testCleanupFailureIsSuppressedUnderCloseFailure()
+    throws Exception
+  {
+    Path directory = Files.createTempDirectory("bioformats-both-failed-");
+    Path file = directory.resolve("incomplete.ndpi");
+    try {
+      FailingCloseNDPIWriter writer = new FailingCloseNDPIWriter();
+      writeIncompletePixels(writer, file);
+      writer.failNextClose();
+      lockDirectory(directory);
+      try {
+        writer.close();
+        fail("A failing underlying close must be reported");
+      }
+      catch (IOException e) {
+        assertEquals(e.getMessage(), CLOSE_FAILURE,
+          "The close failure must remain the primary exception");
+        skipIfDeletionWasPermitted(file);
+        assertEquals(e.getSuppressed().length, 1,
+          "The cleanup failure must be suppressed under the close failure");
+        assertTrue(e.getSuppressed()[0].getMessage().startsWith(
+          "Could not remove incomplete NDPI output"),
+          "The suppressed exception must describe the cleanup failure");
+      }
+    }
+    finally {
+      unlockDirectory(directory);
+      Files.deleteIfExists(file);
+      Files.deleteIfExists(directory);
+    }
+  }
+
+  @Test
+  public void testExistingOutputIsTruncated() throws Exception {
+    int width = 512;
+    int height = 352;
+    long staleLength = 8L * 1024 * 1024;
+    Path file = Files.createTempFile("bioformats-existing-", ".ndpi");
+    try {
+      try (RandomAccessFile stale = new RandomAccessFile(file.toFile(), "rw")) {
+        stale.setLength(staleLength);
+        stale.seek(8);
+        stale.writeInt(0x7fffffff);
+      }
+
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.close();
+
+      assertTrue(Files.size(file) < staleLength,
+        "Rewritten NDPI must not retain the old file length");
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        in.order(true);
+        in.seek(4);
+        long header = in.readLong();
+        assertEquals(header >>> 32, 0L,
+          "NDPI header must contain an explicit zero high word");
+        assertEquals(header, firstIFD(in),
+          "The stale first-IFD pointer must have been overwritten");
+        assertTrue(header > NDPIClassicTiffWriter.HEADER_LENGTH,
+          "The first NDPI directory must follow the image it describes");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testLongTagsAndLittleEndianContainer() throws Exception {
+    Path file = Files.createTempFile("bioformats-", ".ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(WIDTH, HEIGHT));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.setId(file.toString());
+
+      byte[] row = new byte[WIDTH * 3];
+      for (int y = 0; y < HEIGHT; y++) {
+        for (int x = 0; x < WIDTH; x++) {
+          int offset = x * 3;
+          row[offset] = (byte) (x + y);
+          row[offset + 1] = (byte) (x >>> 3);
+          row[offset + 2] = (byte) (y * 11);
+        }
+        writer.saveBytes(0, row, 0, y, WIDTH, 1);
+      }
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        assertEquals(in.readUnsignedByte(), 'I');
+        assertEquals(in.readUnsignedByte(), 'I');
+        in.order(true);
+        in.seek(4);
+        long ifdOffset = in.readLong();
+        assertTrue(ifdOffset > NDPIClassicTiffWriter.HEADER_LENGTH,
+          "The first NDPI directory must follow its own image");
+
+        assertTag(in, ifdOffset, IFD.IMAGE_WIDTH, 4, WIDTH);
+        assertTag(in, ifdOffset, IFD.IMAGE_LENGTH, 4, HEIGHT);
+        assertTag(in, ifdOffset, IFD.ROWS_PER_STRIP, 4, HEIGHT);
+        assertTag(in, ifdOffset, NDPITags.TISSUE_INDEX, 4, 0);
+        assertTag(in, ifdOffset, NDPITags.AUTH_CODE, 4, null);
+        assertTag(in, ifdOffset, NDPITags.JPEG_QUALITY, 4, 80);
+        assertTag(in, ifdOffset, NDPITags.VERSION, 3, 1);
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * Native NDPI output interleaves images and directories: for each image
+   * its own external values, then its payload, then its restart index where
+   * it has one, then its completed directory. Every IFD of every genuine
+   * file in the reference corpus is laid out this way.
+   */
+  @Test
+  public void testNativePhysicalLayout() throws Exception {
+    Path file = Files.createTempFile("bioformats-native-layout-", ".ndpi");
+    try {
+      writeNativeLayoutOutput(file);
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        long[] ifds = chain(in);
+        assertEquals(ifds.length, 4, "Two pyramid levels, the macro and the " +
+          "tissue map must each be described");
+
+        long previousIFD = NDPIClassicTiffWriter.HEADER_LENGTH;
+        for (int i = 0; i < ifds.length; i++) {
+          long payload = extendedScalar(in, ifds[i], IFD.STRIP_OFFSETS);
+          long payloadEnd =
+            payload + extendedScalar(in, ifds[i], IFD.STRIP_BYTE_COUNTS);
+          assertEquals(ifds[i] & 1, 0,
+            "NDPI directories must begin on TIFF word boundaries");
+          assertTrue(payload > previousIFD,
+            "Image " + i + " must be written after the previous directory");
+          assertTrue(payloadEnd <= ifds[i],
+            "Image " + i + " must be written before its own directory");
+          assertRestartIndexPlacement(in, ifds[i], payloadEnd);
+          previousIFD = ifds[i];
+        }
+        assertEquals(nextIFDOffset(in, ifds[ifds.length - 1]), 0L,
+          "The final NDPI directory must end the chain");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * Values an IFD names are written before it: the ones every directory
+   * repeats once, near the beginning of the file, and the rest immediately
+   * before the image they belong to.
+   */
+  @Test
+  public void testExternalValuePlacement() throws Exception {
+    Path file = Files.createTempFile("bioformats-external-values-", ".ndpi");
+    try {
+      writeNativeLayoutOutput(file);
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        long[] ifds = chain(in);
+        long firstPayload = extendedScalar(in, ifds[0], IFD.STRIP_OFFSETS);
+
+        int[] shared = {
+          IFD.SOFTWARE, IFD.MAKE, IFD.MODEL, IFD.DATE_TIME,
+          NDPITags.REFERENCE, NDPITags.SERIAL_NUMBER, NDPITags.CALIBRATION
+        };
+        for (int tag : shared) {
+          long offset = externalOffset(in, ifds[0], tag);
+          assertTrue(offset < firstPayload,
+            "Shared value " + tag + " must precede every payload");
+          for (long ifd : ifds) {
+            assertEquals(externalOffset(in, ifd, tag), offset,
+              "Every NDPI directory must reuse shared value " + tag);
+          }
+        }
+
+        assertEquals(entry(in, ifds[0], NDPITags.REFERENCE)[1], 3L,
+          "The two-character reference must be stored as three ASCII bytes");
+        assertTrue(externalOffset(in, ifds[0], NDPITags.REFERENCE) >
+          NDPIClassicTiffWriter.HEADER_LENGTH,
+          "Short ASCII values must still be stored outside their entry");
+
+        long previousIFD = NDPIClassicTiffWriter.HEADER_LENGTH;
+        for (int i = 0; i < ifds.length; i++) {
+          long payload = extendedScalar(in, ifds[i], IFD.STRIP_OFFSETS);
+          for (int tag : new int[] {IFD.X_RESOLUTION, IFD.Y_RESOLUTION}) {
+            long offset = externalOffset(in, ifds[i], tag);
+            assertTrue(offset > previousIFD && offset < payload,
+              "Resolution value " + tag + " of image " + i +
+              " must be written just before that image");
+          }
+          previousIFD = ifds[i];
+        }
+
+        for (long ifd : ifds) {
+          for (long[] region : externalRegions(in, ifd)) {
+            assertEquals(region[0] & 1, 0,
+              "External NDPI values must begin on TIFF word boundaries");
+            assertTrue(region[0] + region[1] <= ifd,
+              "External NDPI values must be complete before their IFD");
+          }
+        }
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * Exercises the 64-bit header and chain pointers by placing the first
+   * payload just below 4 GiB, so that its directory, the whole of the second
+   * image and every value that image names lie above the classic TIFF
+   * address space.
+   */
+  @Test
+  public void testSparseChainBeyondFourGiB() throws Exception {
+    int width = 512;
+    int height = 352;
+    long boundary = 0x100000000L;
+    long sparseOffset = boundary - 2048;
+    Path file = Files.createTempFile("bioformats-sparse-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(width, height);
+      IPyramidStore pyramid = (IPyramidStore) metadata;
+      pyramid.setResolutionSizeX(new PositiveInteger(width / 2), 0, 1);
+      pyramid.setResolutionSizeY(new PositiveInteger(height / 2), 0, 1);
+
+      SparseNDPIWriter writer = new SparseNDPIWriter();
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.seekPayload(sparseOffset);
+      byte[] expected = pixels(width, height, 0);
+      writer.saveBytes(0, expected, 0, 0, width, height);
+      writer.setResolution(1);
+      writer.saveBytes(0, pixels(width / 2, height / 2, 1), 0, 0,
+        width / 2, height / 2);
+      writer.close();
+
+      assertTrue(Files.size(file) > boundary,
+        "Sparse NDPI must cross the classic TIFF 4 GiB boundary");
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        long[] ifds = chain(in);
+        assertEquals(ifds.length, 2, "Both resolutions must be described");
+        assertEquals(ifds[0], firstIFD(in),
+          "The header must name the first directory");
+        assertTrue(firstIFD(in) >>> 32 != 0,
+          "The header first-IFD pointer must use its high word");
+        assertTrue(nextIFDOffset(in, ifds[0]) >>> 32 != 0,
+          "The chain's next-IFD pointer must use its high word");
+        assertEquals(nextIFDOffset(in, ifds[1]), 0L,
+          "The final NDPI directory must end the chain");
+
+        long payload = extendedScalar(in, ifds[0], IFD.STRIP_OFFSETS);
+        long length = extendedScalar(in, ifds[0], IFD.STRIP_BYTE_COUNTS);
+        assertTrue(externalOffset(in, ifds[0], IFD.X_RESOLUTION) >=
+          sparseOffset,
+          "The first image's own values must be written where it begins");
+        assertTrue(payload < boundary && payload + length > boundary,
+          "The first payload must cross the 4 GiB boundary");
+        assertTrue(payload + length <= ifds[0] && ifds[0] > boundary,
+          "The first directory must follow its payload, above 4 GiB");
+        assertTrue(extendedScalar(in, ifds[1], IFD.STRIP_OFFSETS) > boundary,
+          "The second payload must lie above 4 GiB");
+
+        assertTrue(externalOffset(in, ifds[0], NDPITags.MCU_STARTS) > boundary,
+          "The restart index must be addressed above 4 GiB");
+        assertTrue(externalOffset(in, ifds[1], IFD.X_RESOLUTION) > boundary,
+          "Per-image values must be addressed above 4 GiB");
+        assertTrue(externalOffset(in, ifds[1], IFD.SOFTWARE) < boundary,
+          "Shared values stay below 4 GiB, where the file begins");
+
+        in.order(false);
+        in.seek(payload);
+        assertEquals(in.readUnsignedShort(), 0xffd8,
+          "Reconstructed 64-bit strip offset must point to JPEG SOI");
+      }
+
+      NDPIReader reader = new NDPIReader();
+      try {
+        reader.setFlattenedResolutions(false);
+        reader.setId(file.toString());
+        assertEquals(reader.getResolutionCount(), 2,
+          "The reader must recover both resolutions of a 4 GiB NDPI");
+        byte[] readExpected = reader.isInterleaved() ?
+          expected : planar(expected);
+        assertJPEGClose(reader.openBytes(0), readExpected);
+      }
+      finally {
+        reader.close();
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testSerializesAllHighWordTags() throws Exception {
+    long payloadOffset = 0x123456789aL;
+    long payloadLength = 0x23456789abL;
+    long[] starts = {0x3456789abcL, 0x456789abcdL};
+    ByteArrayHandle handle = new ByteArrayHandle();
+    long ifdOffset;
+    try (RandomAccessOutputStream out = new RandomAccessOutputStream(handle)) {
+      NDPIClassicTiffWriter saver = new NDPIClassicTiffWriter(out);
+      saver.writeHeader();
+      java.util.List<NDPIClassicTiffWriter.Entry> entries =
+        new java.util.ArrayList<NDPIClassicTiffWriter.Entry>();
+      entries.add(saver.entry(NDPIClassicTiffWriter.value(
+        NDPITags.MCU_STARTS, words(starts, 0))));
+      entries.add(saver.entry(NDPIClassicTiffWriter.value(
+        NDPITags.MCU_STARTS_HIGH_BYTES, words(starts, 32))));
+      IFD ifd = new IFD();
+      NDPIWriter.putStripTags(ifd, payloadOffset, payloadLength);
+      for (NDPIClassicTiffWriter.Value value :
+        NDPIClassicTiffWriter.values(ifd))
+      {
+        entries.add(saver.entry(value));
+      }
+      NDPIClassicTiffWriter.Directory directory = saver.writeIFD(entries);
+      ifdOffset = directory.offset();
+      saver.patchOffset(NDPIClassicTiffWriter.FIRST_IFD_POINTER, ifdOffset);
+    }
+
+    try (RandomAccessInputStream in = new RandomAccessInputStream(handle)) {
+      assertEquals(firstIFD(in), ifdOffset,
+        "The header must be backpatched with the completed IFD offset");
+      assertEquals(extendedScalar(in, ifdOffset, IFD.STRIP_OFFSETS),
+        payloadOffset);
+      assertEquals(extendedScalar(in, ifdOffset, IFD.STRIP_BYTE_COUNTS),
+        payloadLength);
+      assertTrue(externalOffset(in, ifdOffset, NDPITags.MCU_STARTS) < ifdOffset,
+        "External values must precede the directory that names them");
+      TiffParser parser = new TiffParser(in);
+      IFD parsed = parser.getIFD(ifdOffset);
+      parser.fillInIFD(parsed);
+      assertEquals(reconstruct(parsed.getIFDLongArray(NDPITags.MCU_STARTS),
+        parsed.getIFDLongArray(NDPITags.MCU_STARTS_HIGH_BYTES)), starts);
+    }
+  }
+
+  /**
+   * A negative signed value is an ordinary inline scalar, so its extension
+   * word must stay zero rather than sign-extending into a huge offset.
+   */
+  @Test
+  public void testNegativeScalarExtendsToZero() throws Exception {
+    ByteArrayHandle handle = new ByteArrayHandle();
+    long ifdOffset;
+    try (RandomAccessOutputStream out = new RandomAccessOutputStream(handle)) {
+      NDPIClassicTiffWriter saver = new NDPIClassicTiffWriter(out);
+      saver.writeHeader();
+      IFD ifd = new IFD();
+      ifd.putIFDValue(NDPITags.X_POSITION, -101L);
+      java.util.List<NDPIClassicTiffWriter.Entry> entries =
+        new java.util.ArrayList<NDPIClassicTiffWriter.Entry>();
+      for (NDPIClassicTiffWriter.Value value :
+        NDPIClassicTiffWriter.values(ifd))
+      {
+        entries.add(saver.entry(value));
+      }
+      ifdOffset = saver.writeIFD(entries).offset();
+    }
+
+    try (RandomAccessInputStream in = new RandomAccessInputStream(handle)) {
+      assertEquals(extensionWord(in, ifdOffset, NDPITags.X_POSITION), 0L,
+        "A negative SLONG must receive a zero extension word");
+    }
+  }
+
+  @Test
+  public void testRejectsMissingObjectiveMagnification() throws Exception {
+    Path file = Files.createTempFile("bioformats-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(WIDTH, HEIGHT);
+      metadata.setObjectiveNominalMagnification(null, 0, 0);
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      try {
+        writer.setId(file.toString());
+        fail("Missing objective magnification must be rejected");
+      }
+      catch (loci.formats.FormatException e) {
+        assertEquals(e.getMessage(),
+          "NDPI requires a positive objective nominal magnification");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsUnsupportedWriterContracts() throws Exception {
+    assertSetIdRejected(metadata(64, 64), false, true,
+      "NDPI requires sequential writing");
+
+    IMetadata uint16 = metadata(64, 64);
+    uint16.setPixelsType(PixelType.UINT16, 0);
+    assertSetIdRejected(uint16, true, true,
+      "NDPI supports only unsigned 8-bit pixels");
+
+    IMetadata nonRGB = metadata(64, 64);
+    nonRGB.setPixelsSizeC(new PositiveInteger(1), 0);
+    nonRGB.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
+    assertSetIdRejected(nonRGB, true, true,
+      "NDPI requires SizeC == 3 as one RGB plane");
+
+    IMetadata unordered = metadata(64, 64);
+    IPyramidStore pyramid = (IPyramidStore) unordered;
+    pyramid.setResolutionSizeX(new PositiveInteger(128), 0, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(32), 0, 1);
+    assertSetIdRejected(unordered, true, true,
+      "NDPI resolutions must be ordered largest to smallest");
+  }
+
+  @Test
+  public void testRejectsNonSequentialPixelWrites() throws Exception {
+    int width = 64;
+    int height = 64;
+    Path file = Files.createTempFile("bioformats-contract-", ".ndpi");
+    Files.delete(file);
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      try {
+        writer.saveBytes(0, new byte[(width - 1) * 3], 0, 0,
+          width - 1, 1);
+        fail("Partial-width NDPI writes must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(),
+          "NDPI row blocks must span the full width");
+      }
+      try {
+        writer.saveBytes(0, new byte[width * 3], 0, 1, width, 1);
+        fail("Out-of-order NDPI rows must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(),
+          "NDPI rows must be written once, top to bottom");
+      }
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsOutOfOrderResolutionWrites() throws Exception {
+    Path file = Files.createTempFile("bioformats-resolution-order-", ".ndpi");
+    Files.delete(file);
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      IMetadata metadata = metadata(128, 64);
+      IPyramidStore pyramid = (IPyramidStore) metadata;
+      pyramid.setResolutionSizeX(new PositiveInteger(64), 0, 1);
+      pyramid.setResolutionSizeY(new PositiveInteger(32), 0, 1);
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      try {
+        writer.setResolution(1);
+        fail("Skipping the largest NDPI resolution must be rejected");
+      }
+      catch (IllegalArgumentException e) {
+        assertEquals(e.getMessage(),
+          "NDPI resolutions must be written from largest to smallest");
+      }
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsInvalidAssociatedSeriesContracts() throws Exception {
+    IMetadata unidentified = metadata(64, 32);
+    addImage(unidentified, 1, 32, 16, 3, 3);
+    assertMetadataOptionsRejected(unidentified, new DynamicMetadataOptions(),
+      "NDPI requires every non-pyramid series to be identified as macro or " +
+      "tissue map");
+
+    IMetadata duplicate = metadata(64, 32);
+    addImage(duplicate, 1, 32, 16, 3, 3);
+    addImage(duplicate, 2, 16, 8, 1, 1);
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.MACRO_SERIES_KEY, 1);
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 1);
+    assertMetadataOptionsRejected(duplicate, options,
+      "NDPI macro and tissue-map series must be different");
+
+    options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.MACRO_SERIES_KEY, 2);
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 1);
+    assertMetadataOptionsRejected(duplicate, options,
+      "NDPI macro series must follow the pyramid");
+
+    IMetadata oneAssociated = metadata(64, 32);
+    addImage(oneAssociated, 1, 16, 8, 1, 1);
+    options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 2);
+    assertMetadataOptionsRejected(oneAssociated, options,
+      "NDPI associated-image series index is out of range");
+
+    options = new DynamicMetadataOptions();
+    options.setBoolean(NDPIWriter.LABEL_OBSCURED_KEY, true);
+    assertMetadataOptionsRejected(metadata(64, 32), options,
+      "NDPI label-obscured option requires a macro series");
+
+    IMetadata multiPlaneMacro = metadata(64, 32);
+    addImage(multiPlaneMacro, 1, 32, 16, 3, 3);
+    multiPlaneMacro.setPixelsSizeT(new PositiveInteger(2), 1);
+    options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.MACRO_SERIES_KEY, 1);
+    assertMetadataOptionsRejected(multiPlaneMacro, options,
+      "NDPI macro requires exactly one image plane and resolution");
+  }
+
+  @Test
+  public void testSmallLevelOmitsIndexAndAuthCode() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-small-", ".ndpi");
+    try {
+      DynamicMetadataOptions options = new DynamicMetadataOptions();
+      options.set(NDPIWriter.REFERENCE_KEY, "");
+      options.setLong(NDPIWriter.EXPOSURE_RATIO_KEY, 123L);
+      options.setLong(NDPIWriter.RED_MULTIPLIER_KEY, 456L);
+      options.setLong(NDPIWriter.GREEN_MULTIPLIER_KEY, 789L);
+      options.setLong(NDPIWriter.BLUE_MULTIPLIER_KEY, 1011L);
+      options.setFloat(NDPIWriter.WAVELENGTH_KEY, 550.5f);
+
+      NDPIWriter writer = new NDPIWriter();
+      IMetadata metadata = metadata(width, height);
+      metadata.setImageAcquisitionDate(
+        new Timestamp("2026-07-29T19:56:16-04:00"), 0);
+      writer.setMetadataRetrieve(metadata);
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      byte[] expected = pixels(width, height, 0);
+      writer.saveBytes(0, expected, 0, 0, width, height);
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        TiffParser parser = new TiffParser(in);
+        IFD ifd = parser.getFirstIFD();
+        parser.fillInIFD(ifd);
+        assertFalse(ifd.containsKey(NDPITags.MCU_STARTS));
+        assertFalse(ifd.containsKey(NDPITags.MCU_STARTS_HIGH_BYTES));
+        assertFalse(ifd.containsKey(NDPITags.AUTH_CODE));
+        assertOrdinaryJPEG(in, ifd);
+        assertFalse(ifd.containsKey(NDPITags.REFERENCE),
+          "Empty ASCII options must be omitted");
+        assertFalse(ifd.containsKey(IFD.MAKE),
+          "Unknown microscope manufacturer must be omitted");
+        assertFalse(ifd.containsKey(IFD.MODEL),
+          "Unknown microscope model must be omitted");
+        assertTag(in, firstIFD(in), NDPITags.EXPOSURE_RATIO, 4, 123);
+        assertTag(in, firstIFD(in), NDPITags.RED_MULTIPLIER, 4, 456);
+        assertTag(in, firstIFD(in), NDPITags.GREEN_MULTIPLIER, 4, 789);
+        assertTag(in, firstIFD(in), NDPITags.BLUE_MULTIPLIER, 4, 1011);
+        assertTag(in, firstIFD(in), NDPITags.X_POSITION, 9, 0);
+        assertTag(in, firstIFD(in), NDPITags.Y_POSITION, 9, 0);
+        assertTag(in, firstIFD(in), NDPITags.Z_POSITION, 9, 0);
+        assertFloatTag(in, firstIFD(in), NDPITags.WAVELENGTH, 550.5f);
+        assertAsciiTag(in, firstIFD(in), IFD.DATE_TIME,
+          "2026:07:29 23:56:16");
+      }
+
+      NDPIReader reader = new NDPIReader();
+      try {
+        reader.setId(file.toString());
+        byte[] readExpected = reader.isInterleaved() ?
+          expected : planar(expected);
+        assertJPEGClose(reader.openBytes(0), readExpected);
+      }
+      finally {
+        reader.close();
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testSignedPositionAndOffsetTags() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      long ifd = firstIFD(in);
+      assertTag(in, ifd, NDPITags.X_POSITION, 9, -101);
+      assertTag(in, ifd, NDPITags.Y_POSITION, 9, 202);
+      assertTag(in, ifd, NDPITags.Z_POSITION, 9, -303);
+      assertTag(in, ifd, NDPITags.REFOCUS_INTERVAL, 9, -15);
+      assertTag(in, ifd, NDPITags.FOCUS_OFFSET, 9, 16);
+      assertEquals(extensionWord(in, ifd, NDPITags.X_POSITION), 0L,
+        "Signed X position must reserve a zero 64-bit extension word");
+      assertEquals(extensionWord(in, ifd, NDPITags.Y_POSITION), 0L,
+        "Signed Y position must reserve a zero 64-bit extension word");
+      assertEquals(extensionWord(in, ifd, NDPITags.Z_POSITION), 0L,
+        "Signed Z position must reserve a zero 64-bit extension word");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testExposureGainTimingAndAutofocusTags() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      long ifd = firstIFD(in);
+      assertTag(in, ifd, NDPITags.EXPOSURE_RATIO, 4, 11);
+      assertTag(in, ifd, NDPITags.RED_MULTIPLIER, 4, 12);
+      assertTag(in, ifd, NDPITags.GREEN_MULTIPLIER, 4, 13);
+      assertTag(in, ifd, NDPITags.BLUE_MULTIPLIER, 4, 14);
+      assertFloatTag(in, ifd, NDPITags.WAVELENGTH, 550.5f);
+      assertTag(in, ifd, NDPITags.LAMP_AGE, 4, 17);
+      assertTag(in, ifd, NDPITags.EXPOSURE_TIME, 4, 18);
+      assertTag(in, ifd, NDPITags.FOCUS_TIME, 4, 19);
+      assertTag(in, ifd, NDPITags.SCAN_TIME, 4, 20);
+      assertTag(in, ifd, NDPITags.WRITE_TIME, 4, 21);
+      assertTag(in, ifd, NDPITags.FULLY_AUTO_FOCUS, 4, 1);
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testFocusPointAndRegionArrays() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      assertTagCount(in, firstIFD(in), NDPITags.FOCUS_POINTS, 9, 6);
+      assertTagCount(in, firstIFD(in), NDPITags.FOCUS_POINT_REGIONS, 9, 2);
+      for (IFD parsed : mainIFDs(in)) {
+        assertEquals(parsed.getIFDIntArray(NDPITags.FOCUS_POINTS),
+          new int[] {-1, 2, -3, 4, 5, 6},
+          "Every NDPI IFD must repeat the signed focus-point triplets");
+        assertEquals(parsed.getIFDIntArray(NDPITags.FOCUS_POINT_REGIONS),
+          new int[] {7, -8},
+          "Every NDPI IFD must repeat the signed focus-point regions");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testScannerIdentityAndPropertyMapTags() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      long ifd = firstIFD(in);
+      assertTag(in, ifd, NDPITags.VERSION, 3, 1);
+      assertFloatTag(in, ifd, NDPITags.SOURCE_LENS, 40f);
+      assertTag(in, ifd, NDPITags.CAPTURE_MODE, 4, 0);
+      assertTag(in, ifd, NDPITags.JPEG_QUALITY, 4, 80);
+      assertAsciiTag(in, ifd, NDPITags.REFERENCE, "A1");
+      assertAsciiTag(in, ifd, NDPITags.SERIAL_NUMBER, "RGB");
+      assertAsciiTag(in, ifd, IFD.MAKE, "Acme");
+      assertAsciiTag(in, ifd, IFD.MODEL, "S1");
+      assertAsciiTag(in, ifd, NDPITags.FIRMWARE_VERSION, "IVR");
+      assertAsciiTag(in, ifd, NDPITags.CALIBRATION, CALIBRATION_PROPERTIES);
+      for (IFD parsed : mainIFDs(in)) {
+        assertEquals(parsed.getIFDStringValue(NDPITags.CALIBRATION),
+          CALIBRATION_PROPERTIES,
+          "Every NDPI IFD must repeat the calibration property map");
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testBarcodeAndMedicalRegulationTags() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      for (int i = 0; i < 8; i++) {
+        assertAsciiTag(in, firstIFD(in), NDPITags.FIRST_BARCODE + i, "B" + i);
+      }
+      assertAsciiTag(in, firstIFD(in), NDPITags.MEDICAL_REGULATION, "MR");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testFileWideASCIITagsRepeatInEveryIFD() throws Exception {
+    Path file = writePrivateMetadataOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      long secondIFD = nextIFDOffset(in, firstIFD(in));
+      assertTrue(secondIFD > firstIFD(in),
+        "The second NDPI directory must follow the first");
+      assertEquals(secondIFD & 1, 0,
+        "NDPI IFDs must begin on TIFF word boundaries");
+      assertAsciiTag(in, secondIFD, NDPITags.REFERENCE, "A1");
+      assertAsciiTag(in, secondIFD, NDPITags.SERIAL_NUMBER, "RGB");
+      assertAsciiTag(in, secondIFD, IFD.MAKE, "Acme");
+      assertAsciiTag(in, secondIFD, IFD.MODEL, "S1");
+      assertAsciiTag(in, secondIFD, NDPITags.FIRMWARE_VERSION, "IVR");
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testEmptyASCIIOptionsAreOmitted() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-empty-options-", ".ndpi");
+    try {
+      DynamicMetadataOptions options = new DynamicMetadataOptions();
+      options.set(NDPIWriter.REFERENCE_KEY, "");
+      options.set(NDPIWriter.SERIAL_NUMBER_KEY, "");
+      options.set(NDPIWriter.SCANNER_MANUFACTURER_KEY, "");
+      options.set(NDPIWriter.SCANNER_MODEL_KEY, "");
+      options.set(NDPIWriter.FIRMWARE_VERSION_KEY, "");
+      options.set(NDPIWriter.CALIBRATION_KEY, "");
+      for (int i = 0; i < 8; i++) {
+        options.set(NDPIWriter.BARCODE_KEY_PREFIX + i, "");
+      }
+      options.set(NDPIWriter.MEDICAL_REGULATION_KEY, "");
+
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0));
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        TiffParser parser = new TiffParser(in);
+        IFD ifd = parser.getFirstIFD();
+        parser.fillInIFD(ifd);
+        int[] omitted = {
+          NDPITags.REFERENCE, NDPITags.SERIAL_NUMBER,
+          NDPITags.FIRMWARE_VERSION, NDPITags.CALIBRATION,
+          NDPITags.MEDICAL_REGULATION, IFD.MAKE, IFD.MODEL
+        };
+        for (int tag : omitted) {
+          assertFalse(ifd.containsKey(tag),
+            "Empty ASCII option must omit TIFF tag " + tag);
+        }
+        for (int i = 0; i < 8; i++) {
+          assertFalse(ifd.containsKey(NDPITags.FIRST_BARCODE + i),
+            "Empty barcode option must omit TIFF tag " +
+            (NDPITags.FIRST_BARCODE + i));
+        }
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testJPEGQualityPropagationAndValidation() throws Exception {
+    byte[] unspecified = writeAtQuality(0, 80);
+    byte[] quality80 = writeAtQuality(0.8, 80);
+    assertTrue(Arrays.equals(unspecified, quality80),
+      "Unspecified quality must use the NDPI default");
+    byte[] quality90 = writeAtQuality(0.9, 90);
+    assertFalse(Arrays.equals(quality80, quality90),
+      "Caller quality must affect JPEG encoding");
+
+    double[] invalid = {
+      Double.NaN, Double.POSITIVE_INFINITY, 0.24, 1.01
+    };
+    for (double quality : invalid) {
+      Path file = Files.createTempFile("bioformats-quality-rejected-", ".ndpi");
+      Files.delete(file);
+      NDPIWriter writer = new NDPIWriter();
+      try {
+        CodecOptions options = CodecOptions.getDefaultOptions();
+        options.quality = quality;
+        writer.setCodecOptions(options);
+        writer.setMetadataRetrieve(metadata(64, 32));
+        writer.setInterleaved(true);
+        writer.setWriteSequentially(true);
+        try {
+          writer.setId(file.toString());
+          fail("Invalid JPEG quality must be rejected");
+        }
+        catch (FormatException e) {
+          assertEquals(e.getMessage(),
+            "NDPI JPEG quality must be between 0.25 and 1");
+        }
+        assertFalse(Files.exists(file),
+          "JPEG quality must be rejected before opening the output");
+      }
+      finally {
+        Files.deleteIfExists(file);
+      }
+    }
+  }
+
+  @Test
+  public void testRejectsInvalidPrivateMetadataOptions() throws Exception {
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setLong(NDPIWriter.EXPOSURE_RATIO_KEY, -1L);
+    assertOptionsRejected(options,
+      "NDPI exposure ratio must fit an unsigned 32-bit integer");
+
+    options = new DynamicMetadataOptions();
+    options.setLong(NDPIWriter.X_POSITION_KEY, 0x80000000L);
+    assertOptionsRejected(options,
+      "NDPI X position must fit a signed 32-bit integer");
+
+    options = new DynamicMetadataOptions();
+    options.setLong(NDPIWriter.CAPTURE_MODE_KEY, 1L);
+    assertOptionsRejected(options,
+      "NDPI capture mode must be 0 for brightfield RGB");
+
+    options = new DynamicMetadataOptions();
+    options.setFloat(NDPIWriter.WAVELENGTH_KEY, Float.NaN);
+    assertOptionsRejected(options,
+      "NDPI wavelength must be finite and non-negative");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.REFERENCE_KEY, "non\u00a0ASCII");
+    assertOptionsRejected(options,
+      "NDPI slide reference must contain printable ASCII");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.FOCUS_POINTS_KEY, "1,2");
+    assertOptionsRejected(options,
+      "NDPI focus points must contain X/Y/Z triplets");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.FOCUS_POINT_REGIONS_KEY, "1,,2");
+    assertOptionsRejected(options,
+      "NDPI focus-point regions contains an empty value");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.CALIBRATION_KEY, "CAL");
+    assertOptionsRejected(options,
+      "NDPI calibration metadata must contain key=value records");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.CALIBRATION_KEY, "System.Version=1\nProduct=X");
+    assertOptionsRejected(options,
+      "NDPI calibration metadata must use printable ASCII and CRLF");
+
+    options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.RESTART_MCUS_KEY, 0);
+    assertOptionsRejected(options,
+      "NDPI restart interval must be between 1 and 65535 MCUs");
+
+    options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.RESTART_MCUS_KEY, 257);
+    assertMetadataOptionsRejected(metadata(64, 32), options,
+      "NDPI restart interval must exactly divide the base image " +
+      "MCU-column count");
+  }
+
+  @Test
+  public void testExactMCUIndexBoundary() throws Exception {
+    assertIndexPresence(64, 43 * 8, false);
+    assertIndexPresence(64, 44 * 8, true);
+  }
+
+  @Test
+  public void testAuthCodeSamplingAndClamping() throws Exception {
+    long[] starts = uniformMCUStarts(44, 60);
+    byte[][] entropy = authEntropy(60);
+    int baseline = invokeAuthCode(entropy, starts);
+
+    byte[][] changed = clone(entropy);
+    changed[2][48] ^= 1;
+    assertTrue(invokeAuthCode(changed, starts) != baseline,
+      "Changing an authenticated byte must change AuthCode");
+
+    changed = clone(entropy);
+    changed[2][0] ^= 1;
+    assertEquals(invokeAuthCode(changed, starts), baseline,
+      "Changing an unauthenticated byte must not change AuthCode");
+
+    starts = uniformMCUStarts(44, 1);
+    entropy = new byte[][] {{1}, {2}, {3}, {4}};
+    int expected =
+      0x1d6edb2a ^ 1 ^ (3 << 8) ^ (4 << 16) ^ (2 << 24);
+    assertEquals(invokeAuthCode(entropy, starts), expected,
+      "Short AuthCode segments must clamp sampling to their final byte");
+  }
+
+  @Test
+  public void testDeterministicRestartGridPolicy() throws Exception {
+    assertEquals(NDPIWriter.automaticRestartInterval(496), 496);
+    assertEquals(NDPIWriter.automaticRestartInterval(1024), 512);
+    assertEquals(NDPIWriter.automaticRestartInterval(1440), 480);
+    assertEquals(NDPIWriter.automaticRestartInterval(1280), 256);
+    assertEquals(NDPIWriter.automaticRestartInterval(720), 240);
+    assertEquals(NDPIWriter.automaticRestartInterval(3840), 480);
+    assertEquals(NDPIWriter.baseRestartInterval(3840, null), 480);
+    assertEquals(NDPIWriter.baseRestartInterval(3840, 240), 240);
+    assertEquals(NDPIWriter.automaticRestartInterval(1030), 206);
+    assertEquals(NDPIWriter.restartIntervalForGrid(3840, 8), 480);
+    assertEquals(NDPIWriter.restartIntervalForGrid(1920, 8), 240);
+    assertEquals(NDPIWriter.restartIntervalForGrid(960, 8), 120);
+    assertEquals(NDPIWriter.restartIntervalForGrid(125, 8), 0);
+
+    assertIndexPresence(512, 44 * 8 + 1, false);
+    assertIndexPresence(800, 596, false);
+
+    // The base level's 1024 MCU columns divide into two restart-interval
+    // columns, which the 125 MCU columns of the second level cannot preserve.
+    IMetadata incompatible = metadata(8192, 352);
+    IPyramidStore pyramid = (IPyramidStore) incompatible;
+    pyramid.setResolutionSizeX(new PositiveInteger(1000), 0, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(344), 0, 1);
+    assertLevelIndexPresence(incompatible, new int[] {8192, 1000},
+      new int[] {352, 344}, new boolean[] {true, false});
+  }
+
+  @Test
+  public void testRestartMCUOverrideIsWritten() throws Exception {
+    int width = 30720;
+    int height = 24;
+    int restartMCUs = 240;
+    Path file = Files.createTempFile("bioformats-restart-override-", ".ndpi");
+    try {
+      DynamicMetadataOptions options = new DynamicMetadataOptions();
+      options.setInteger(NDPIWriter.RESTART_MCUS_KEY, restartMCUs);
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0));
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        TiffParser parser = new TiffParser(in);
+        IFD ifd = parser.getFirstIFD();
+        parser.fillInIFD(ifd);
+        assertEquals(ifd.getIFDLongArray(NDPITags.MCU_STARTS).length,
+          width / (restartMCUs * 8) * (height / 8));
+        assertEquals(readRestartInterval(in, ifd.getStripOffsets()[0]),
+          restartMCUs);
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testMacroPixelRoundTrip() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    NDPIReader reader = new NDPIReader();
+    try {
+      reader.setFlattenedResolutions(false);
+      reader.setId(output.file.toString());
+      reader.setSeries(1);
+      assertEquals(reader.getSizeX(), MACRO_WIDTH,
+        "The macro series must keep its written width");
+      assertEquals(reader.getSizeY(), MACRO_HEIGHT,
+        "The macro series must keep its written height");
+      byte[] expected = reader.isInterleaved() ?
+        output.macro : planar(output.macro);
+      assertJPEGClose(reader.openBytes(0), expected);
+    }
+    finally {
+      reader.close();
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testTissueMapPixelRoundTrip() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    NDPIReader reader = new NDPIReader();
+    try {
+      reader.setFlattenedResolutions(false);
+      reader.setId(output.file.toString());
+      reader.setSeries(2);
+      assertEquals(reader.getSizeX(), MAP_WIDTH,
+        "The tissue-map series must keep its written width");
+      assertEquals(reader.getSizeY(), MAP_HEIGHT,
+        "The tissue-map series must keep its written height");
+      assertEquals(reader.openBytes(0), output.map,
+        "Uncompressed tissue-map pixels must round trip exactly, using " +
+        "only the valid prefix of an oversized caller buffer");
+    }
+    finally {
+      reader.close();
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testAssociatedSeriesOrdering() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    try {
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(output.file.toString()))
+      {
+        java.util.List<IFD> ifds = mainIFDs(in);
+        assertEquals(ifds.size(), 3,
+          "NDPI must write one IFD each for the pyramid, macro and map");
+        assertEquals(ifds.get(0).getImageWidth(), PYRAMID_WIDTH,
+          "The pyramid must be written first");
+        assertEquals(ifds.get(1).getImageWidth(), MACRO_WIDTH,
+          "The macro must be written after the pyramid");
+        assertEquals(ifds.get(2).getImageWidth(), MAP_WIDTH,
+          "The tissue map must be written after the macro");
+        assertEquals(
+          ((Float) ifds.get(1).get(NDPITags.SOURCE_LENS)).floatValue(), -1f,
+          "The macro IFD must be identified by SourceLens -1");
+        assertEquals(
+          ((Float) ifds.get(2).get(NDPITags.SOURCE_LENS)).floatValue(), -2f,
+          "The tissue-map IFD must be identified by SourceLens -2");
+      }
+
+      NDPIReader reader = new NDPIReader();
+      try {
+        reader.setFlattenedResolutions(false);
+        reader.setId(output.file.toString());
+        assertEquals(reader.getSeriesCount(), 3,
+          "The reader must recover the pyramid, macro and map series");
+      }
+      finally {
+        reader.close();
+      }
+    }
+    finally {
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testMacroLabelObscured() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(output.file.toString()))
+    {
+      java.util.List<IFD> ifds = mainIFDs(in);
+      assertEquals(ifds.get(1).getIFDLongValue(NDPITags.LABEL_OBSCURED, -1),
+        1, "The macro IFD must record the label-obscured option");
+      assertFalse(ifds.get(2).containsKey(NDPITags.LABEL_OBSCURED),
+        "The tissue-map IFD must omit the macro-only LabelObscured tag");
+    }
+    finally {
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testAssociatedImageTagRoles() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(output.file.toString()))
+    {
+      java.util.List<IFD> ifds = mainIFDs(in);
+      IFD pyramidIFD = ifds.get(0);
+      IFD macroIFD = ifds.get(1);
+      IFD mapIFD = ifds.get(2);
+      for (int tag : pyramidOnlyTags()) {
+        assertTrue(pyramidIFD.containsKey(tag),
+          "Pyramid IFD must contain private tag " + tag);
+        assertFalse(macroIFD.containsKey(tag),
+          "Macro IFD must omit pyramid-only tag " + tag);
+        assertFalse(mapIFD.containsKey(tag),
+          "Tissue-map IFD must omit pyramid-only tag " + tag);
+      }
+      for (int tag : fileWideTags()) {
+        for (IFD ifd : ifds) {
+          assertTrue(ifd.containsKey(tag),
+            "Every IFD must contain file-wide tag " + tag);
+        }
+      }
+      for (IFD ifd : ifds) {
+        assertEquals(ifd.getIFDTextValue(IFD.MAKE), "Acme",
+          "Every IFD must repeat the microscope manufacturer");
+        assertEquals(ifd.getIFDTextValue(IFD.MODEL), "Scope",
+          "Every IFD must repeat the microscope model");
+        assertEquals(ifd.getIFDTextValue(IFD.SOFTWARE),
+          "Bio-Formats NDPIWriter",
+          "Every IFD must repeat the writing software");
+        assertEquals(ifd.getIFDTextValue(IFD.DATE_TIME),
+          "2026:07:29 23:56:16",
+          "Every IFD must repeat the acquisition date");
+      }
+      assertEquals(macroIFD.getIFDLongValue(NDPITags.X_POSITION, -1), 0,
+        "The macro must record a zero X position");
+      assertEquals(macroIFD.getIFDLongValue(NDPITags.Y_POSITION, -1), 0,
+        "The macro must record a zero Y position");
+      assertEquals(mapIFD.getIFDLongValue(NDPITags.X_POSITION, -1), 0,
+        "The tissue map must record a zero X position");
+      assertEquals(mapIFD.getIFDLongValue(NDPITags.Y_POSITION, -1), 0,
+        "The tissue map must record a zero Y position");
+      assertTrue(macroIFD.containsKey(NDPITags.JPEG_QUALITY),
+        "The JPEG-compressed macro must record its JPEG quality");
+      assertTrue(macroIFD.containsKey(NDPITags.CAPTURE_MODE),
+        "The macro must record its capture mode");
+      assertFalse(mapIFD.containsKey(NDPITags.JPEG_QUALITY),
+        "The uncompressed tissue map must omit JPEG quality");
+      assertFalse(mapIFD.containsKey(NDPITags.CAPTURE_MODE),
+        "The tissue map must omit the capture mode");
+    }
+    finally {
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testAssociatedImageEncoding() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(output.file.toString()))
+    {
+      java.util.List<IFD> ifds = mainIFDs(in);
+      IFD pyramidIFD = ifds.get(0);
+      IFD macroIFD = ifds.get(1);
+      IFD mapIFD = ifds.get(2);
+      long[] referenceBlackWhite = {0, 255, 128, 255, 128, 255};
+      for (IFD ifd : new IFD[] {pyramidIFD, macroIFD}) {
+        assertEquals(ifd.getPhotometricInterpretation(),
+          loci.formats.tiff.PhotoInterp.Y_CB_CR,
+          "JPEG NDPI images must be YCbCr");
+        assertEquals(ifd.getIFDIntArray(IFD.Y_CB_CR_SUB_SAMPLING),
+          new int[] {1, 1}, "JPEG NDPI images must not subsample chroma");
+        assertEquals(ifd.getIFDLongArray(IFD.REFERENCE_BLACK_WHITE),
+          referenceBlackWhite,
+          "JPEG NDPI images must declare full-range YCbCr");
+      }
+      assertFalse(macroIFD.containsKey(NDPITags.MCU_STARTS),
+        "The macro must not be indexed with restart offsets");
+      assertFalse(macroIFD.containsKey(NDPITags.AUTH_CODE),
+        "The unindexed macro must omit AuthCode");
+      assertFalse(mapIFD.containsKey(IFD.REFERENCE_BLACK_WHITE),
+        "The uncompressed tissue map must omit ReferenceBlackWhite");
+      assertEquals(mapIFD.getCompression(), TiffCompression.UNCOMPRESSED,
+        "The tissue map must be stored uncompressed");
+      assertEquals(mapIFD.getSamplesPerPixel(), 1,
+        "The tissue map must be single-channel");
+      long macroIFDOffset = nextIFDOffset(in, firstIFD(in));
+      assertTagCount(in, firstIFD(in), IFD.REFERENCE_BLACK_WHITE, 4, 6);
+      assertTagCount(in, macroIFDOffset, IFD.REFERENCE_BLACK_WHITE, 4, 6);
+      assertOrdinaryJPEG(in, macroIFD);
+    }
+    finally {
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testAssociatedImagePhysicalResolution() throws Exception {
+    AssociatedOutput output = writeAssociatedOutput();
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(output.file.toString()))
+    {
+      java.util.List<IFD> ifds = mainIFDs(in);
+      IFD macroIFD = ifds.get(1);
+      IFD mapIFD = ifds.get(2);
+      assertEquals(macroIFD.getIFDRationalValue(IFD.X_RESOLUTION)
+        .doubleValue(), 2000d, 0.0001d,
+        "The macro X resolution must invert its 5 um physical size");
+      assertEquals(macroIFD.getIFDRationalValue(IFD.Y_RESOLUTION)
+        .doubleValue(), 10000d / 6, 0.0001d,
+        "The macro Y resolution must invert its 6 um physical size");
+      assertEquals(macroIFD.getIFDLongValue(IFD.RESOLUTION_UNIT, -1), 3,
+        "NDPI physical resolutions must be per centimeter");
+      assertEquals(mapIFD.getIFDRationalValue(IFD.X_RESOLUTION)
+        .doubleValue(), 500d, 0.0001d,
+        "The tissue-map X resolution must invert its 20 um physical size");
+      assertEquals(mapIFD.getIFDRationalValue(IFD.Y_RESOLUTION)
+        .doubleValue(), 10000d / 24, 0.0001d,
+        "The tissue-map Y resolution must invert its 24 um physical size");
+      assertEquals(mapIFD.getIFDLongValue(IFD.RESOLUTION_UNIT, -1), 3,
+        "NDPI physical resolutions must be per centimeter");
+    }
+    finally {
+      Files.deleteIfExists(output.file);
+    }
+  }
+
+  @Test
+  public void testRejectsRGBTissueMap() throws Exception {
+    IMetadata metadata = metadata(512, 352);
+    addImage(metadata, 1, 64, 64, 3, 3);
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 1);
+    assertMetadataOptionsRejected(metadata, options,
+      "NDPI tissue map requires SizeC == 1 in one plane");
+  }
+
+  @Test
+  public void testWriterCapabilityContract() throws Exception {
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      assertFalse(writer.canDoStacks(),
+        "NDPI stores one plane per image and must not claim stacks");
+      assertEquals(writer.getPixelTypes("JPEG"),
+        new int[] {FormatTools.UINT8},
+        "NDPI must offer only unsigned 8-bit pixels");
+    }
+    finally {
+      writer.close();
+    }
+  }
+
+  @Test
+  public void testRejectsNonJPEGCompression() throws Exception {
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      try {
+        writer.setCompression("LZW");
+        fail("A non-JPEG NDPI codec must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(), "NDPI supports only JPEG compression");
+      }
+      assertEquals(writer.getCompression(), "JPEG",
+        "A rejected codec must leave JPEG compression selected");
+      writer.setCompression("JPEG");
+      assertEquals(writer.getCompression(), "JPEG",
+        "JPEG must remain selected when it is requested explicitly");
+      writer.setCompression(null);
+      assertEquals(writer.getCompression(), "JPEG",
+        "An unspecified codec must leave JPEG compression selected");
+    }
+    finally {
+      writer.close();
+    }
+  }
+
+  @Test
+  public void testSetIdDiscardsThePreviousOutput() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path first = Files.createTempFile("bioformats-reopen-first-", ".ndpi");
+    Path second = Files.createTempFile("bioformats-reopen-second-", ".ndpi");
+    NDPIWriter writer = openWriter(metadata(width, height), null, first);
+    try {
+      assertTrue(Files.exists(first),
+        "The first NDPI output must have been opened");
+      writer.setId(second.toString());
+      assertFalse(Files.exists(first),
+        "Reopening must close the previous incomplete NDPI output, which " +
+        "close() then removes");
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.close();
+      assertTrue(Files.exists(second),
+        "The reopened NDPI output must be completed normally");
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(first);
+      Files.deleteIfExists(second);
+    }
+  }
+
+  @Test
+  public void testUntruncatableExistingOutputIsReported() throws Exception {
+    Path directory = Files.createTempDirectory("bioformats-untruncatable-");
+    Path file = directory.resolve("existing.ndpi");
+    Files.write(file, new byte[] {1, 2, 3, 4});
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata(64, 32));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      lockDirectory(directory);
+      try {
+        writer.setId(file.toString());
+        // A process that may delete from a read-only directory, such as
+        // root, cannot exercise this failure.
+        throw new SkipException(
+          "This platform allows deletion from a read-only directory");
+      }
+      catch (IOException e) {
+        assertEquals(e.getMessage(),
+          "Could not truncate existing NDPI output: " + file.toString(),
+          "Truncation failures must name the unremovable output");
+      }
+    }
+    finally {
+      unlockDirectory(directory);
+      writer.close();
+      Files.deleteIfExists(file);
+      Files.deleteIfExists(directory);
+    }
+  }
+
+  @Test
+  public void testRejectsNonZeroAssociatedResolution() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-macro-resolution-", ".ndpi");
+    NDPIWriter writer =
+      openWriter(macroMetadata(width, height), macroOptions(), file);
+    try {
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.setSeries(1);
+      try {
+        writer.setResolution(1);
+        fail("A non-zero NDPI associated-image resolution must be rejected");
+      }
+      catch (IllegalArgumentException e) {
+        assertEquals(e.getMessage(),
+          "NDPI associated images support only resolution zero");
+      }
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsUnexpectedSeriesOrder() throws Exception {
+    Path file = Files.createTempFile("bioformats-series-order-", ".ndpi");
+    NDPIWriter writer =
+      openWriter(macroMetadata(64, 32), macroOptions(), file);
+    try {
+      writer.setSeries(1);
+      fail("Writing the NDPI macro before the pyramid must be rejected");
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(),
+        "NDPI series must be written as pyramid, macro, then tissue map");
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsWritesAfterCompletion() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-after-complete-", ".ndpi");
+    NDPIWriter writer = openWriter(metadata(width, height), null, file);
+    try {
+      byte[] pixels = pixels(width, height, 0);
+      writer.saveBytes(0, pixels, 0, 0, width, height);
+      try {
+        writer.saveBytes(0, pixels, 0, 0, width, height);
+        fail("Writing after the NDPI directories must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(), "NDPI writing is already complete");
+      }
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * A second OME Channel makes the inherited plane-index check accept plane
+   * one, so that the NDPI single-plane contract is the rule under test.
+   */
+  @Test
+  public void testRejectsASecondPlane() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-second-plane-", ".ndpi");
+    IMetadata metadata = metadata(width, height);
+    metadata.setChannelID("Channel:0:1", 0, 1);
+    metadata.setChannelSamplesPerPixel(new PositiveInteger(3), 0, 1);
+    NDPIWriter writer = openWriter(metadata, null, file);
+    try {
+      writer.saveBytes(1, pixels(width, height, 0), 0, 0, width, height);
+      fail("A second NDPI plane must be rejected");
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(), "NDPI supports one plane per image");
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsRewritingACompletedResolution() throws Exception {
+    int width = 128;
+    int height = 64;
+    Path file = Files.createTempFile("bioformats-resolution-rewrite-",
+      ".ndpi");
+    IMetadata metadata = metadata(width, height);
+    IPyramidStore pyramid = (IPyramidStore) metadata;
+    pyramid.setResolutionSizeX(new PositiveInteger(width / 2), 0, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(height / 2), 0, 1);
+    NDPIWriter writer = openWriter(metadata, null, file);
+    try {
+      byte[] pixels = pixels(width, height, 0);
+      writer.saveBytes(0, pixels, 0, 0, width, height);
+      writer.saveBytes(0, pixels, 0, 0, width, height);
+      fail("Rewriting a completed NDPI resolution must be rejected");
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(),
+        "NDPI resolutions must be written from largest to smallest");
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsMultiplePlanesInMetadata() throws Exception {
+    IMetadata multiZ = metadata(64, 32);
+    multiZ.setPixelsSizeZ(new PositiveInteger(2), 0);
+    assertSetIdRejected(multiZ, true, true, "NDPI supports one RGB plane");
+
+    IMetadata multiT = metadata(64, 32);
+    multiT.setPixelsSizeT(new PositiveInteger(2), 0);
+    assertSetIdRejected(multiT, true, true, "NDPI supports one RGB plane");
+  }
+
+  @Test
+  public void testRejectsInvalidAssociatedSeriesLayout() throws Exception {
+    IMetadata wideMacro = macroMetadata(64, 32);
+    wideMacro.setPixelsType(PixelType.UINT16, 1);
+    assertMetadataOptionsRejected(wideMacro, macroOptions(),
+      "NDPI macro supports only unsigned 8-bit pixels");
+
+    IMetadata multiResolutionMap = metadata(64, 32);
+    addImage(multiResolutionMap, 1, 32, 16, 1, 1);
+    IPyramidStore pyramid = (IPyramidStore) multiResolutionMap;
+    // The store only counts resolutions for an image once every earlier
+    // image has its own resolution list, so the pyramid is given one too.
+    pyramid.setResolutionSizeX(new PositiveInteger(32), 0, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(16), 0, 1);
+    pyramid.setResolutionSizeX(new PositiveInteger(16), 1, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(8), 1, 1);
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 1);
+    assertMetadataOptionsRejected(multiResolutionMap, options,
+      "NDPI tissue map requires exactly one image plane and resolution");
+  }
+
+  @Test
+  public void testPlanePositionZIsWrittenInNanometers() throws Exception {
+    Path file = writeZPositionOutput(new Length(1.5, UNITS.MICROMETER), null);
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      assertTag(in, firstIFD(in), NDPITags.Z_POSITION, 9, 1500);
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testExplicitZPositionOverridesPlanePosition() throws Exception {
+    Path file =
+      writeZPositionOutput(new Length(1.5, UNITS.MICROMETER), -303L);
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      assertTag(in, firstIFD(in), NDPITags.Z_POSITION, 9, -303);
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void testRejectsOversizedFocusPointValues() throws Exception {
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.FOCUS_POINTS_KEY, "1,2,2147483648");
+    assertOptionsRejected(options,
+      "NDPI focus points values must fit signed 32-bit integers");
+
+    options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.FOCUS_POINT_REGIONS_KEY, "-2147483649");
+    assertOptionsRejected(options,
+      "NDPI focus-point regions values must fit signed 32-bit integers");
+  }
+
+  @Test
+  public void testPrimeMCUColumnCountUsesSingleMCUIntervals()
+    throws Exception
+  {
+    assertEquals(NDPIWriter.automaticRestartInterval(521), 1,
+      "A prime MCU-column count above 512 must fall back to one MCU");
+  }
+
+  @Test
+  public void testRejectsInvalidMCUSegment() throws Exception {
+    long[] starts = uniformMCUStarts(44, 60);
+    byte[][] truncated = authEntropy(60);
+    truncated[1] = new byte[59];
+    try {
+      invokeAuthCode(truncated, starts);
+      fail("A mismatched NDPI MCU segment length must be rejected");
+    }
+    catch (java.lang.reflect.InvocationTargetException e) {
+      assertEquals(e.getCause().getMessage(),
+        "NDPI JPEG contains an invalid MCU segment");
+    }
+  }
+
+  @Test
+  public void testRejectsUnsupportedTIFFValueType() throws Exception {
+    IFD ifd = new IFD();
+    ifd.putIFDValue(IFD.IMAGE_WIDTH, Boolean.TRUE);
+    try {
+      NDPIClassicTiffWriter.values(ifd);
+      fail("An unsupported NDPI TIFF value type must be rejected");
+    }
+    catch (FormatException e) {
+      assertEquals(e.getMessage(),
+        "Unsupported NDPI TIFF value for tag " + IFD.IMAGE_WIDTH);
+    }
+  }
+
+  private static IMetadata metadata(int width, int height) throws Exception {
+    IMetadata metadata = MetadataTools.createOMEXMLMetadata();
+    metadata.setImageID("Image:0", 0);
+    metadata.setPixelsID("Pixels:0", 0);
+    metadata.setPixelsDimensionOrder(DimensionOrder.XYZCT, 0);
+    metadata.setPixelsSizeX(new PositiveInteger(width), 0);
+    metadata.setPixelsSizeY(new PositiveInteger(height), 0);
+    metadata.setPixelsSizeZ(new PositiveInteger(1), 0);
+    metadata.setPixelsSizeC(new PositiveInteger(3), 0);
+    metadata.setPixelsSizeT(new PositiveInteger(1), 0);
+    metadata.setPixelsType(PixelType.UINT8, 0);
+    metadata.setPixelsBigEndian(false, 0);
+    metadata.setChannelID("Channel:0", 0, 0);
+    metadata.setChannelSamplesPerPixel(new PositiveInteger(3), 0, 0);
+    metadata.setPixelsPhysicalSizeX(new Length(0.25, UNITS.MICROMETER), 0);
+    metadata.setPixelsPhysicalSizeY(new Length(0.25, UNITS.MICROMETER), 0);
+    metadata.setInstrumentID("Instrument:0", 0);
+    metadata.setImageInstrumentRef("Instrument:0", 0);
+    metadata.setObjectiveID("Objective:0", 0, 0);
+    metadata.setObjectiveNominalMagnification(40d, 0, 0);
+    metadata.setObjectiveSettingsID("Objective:0", 0);
+    return metadata;
+  }
+
+  /**
+   * Opens an interleaved, sequential NDPI writer, which the caller must
+   * close. Options may be null.
+   */
+  private static NDPIWriter openWriter(IMetadata metadata,
+    DynamicMetadataOptions options, Path file) throws Exception
+  {
+    NDPIWriter writer = new NDPIWriter();
+    writer.setMetadataRetrieve(metadata);
+    if (options != null) writer.setMetadataOptions(options);
+    writer.setInterleaved(true);
+    writer.setWriteSequentially(true);
+    writer.setId(file.toString());
+    return writer;
+  }
+
+  /** Describes one pyramid of the given size followed by an RGB macro. */
+  private static IMetadata macroMetadata(int width, int height)
+    throws Exception
+  {
+    IMetadata metadata = metadata(width, height);
+    addImage(metadata, 1, width / 2, height / 2, 3, 3);
+    return metadata;
+  }
+
+  /** Identifies the second series of macroMetadata as the macro. */
+  private static DynamicMetadataOptions macroOptions() {
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.MACRO_SERIES_KEY, 1);
+    return options;
+  }
+
+  /**
+   * Writes one completed NDPI pyramid whose metadata carries a plane Z
+   * position, optionally overridden by an explicit Z-position option.
+   * Returns the new output, which the caller must delete.
+   */
+  private static Path writeZPositionOutput(Length planeZ, Long option)
+    throws Exception
+  {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-plane-z-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(width, height);
+      metadata.setPlanePositionZ(planeZ, 0, 0);
+      DynamicMetadataOptions options = new DynamicMetadataOptions();
+      if (option != null) {
+        options.setLong(NDPIWriter.Z_POSITION_KEY, option);
+      }
+      NDPIWriter writer = openWriter(metadata, options, file);
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.close();
+    }
+    catch (Exception e) {
+      Files.deleteIfExists(file);
+      throw e;
+    }
+    return file;
+  }
+
+  /**
+   * One NDPI output holding a pyramid, a macro and a tissue map, together
+   * with the pixels each associated series was written from.
+   */
+  private static final class AssociatedOutput {
+
+    private final Path file;
+    private final byte[] macro;
+    private final byte[] map;
+
+    private AssociatedOutput(Path file, byte[] macro, byte[] map) {
+      this.file = file;
+      this.macro = macro;
+      this.map = map;
+    }
+  }
+
+  /**
+   * Writes a fresh pyramid, macro and tissue-map NDPI output, returning it
+   * with its expected associated-series pixels. Every call produces an
+   * independent temporary file, which the caller must delete.
+   */
+  private static AssociatedOutput writeAssociatedOutput() throws Exception {
+    Path file = Files.createTempFile("bioformats-associated-", ".ndpi");
+    byte[] macro = pixels(MACRO_WIDTH, MACRO_HEIGHT, 1);
+    byte[] map = new byte[MAP_WIDTH * MAP_HEIGHT];
+    for (int i = 0; i < map.length; i++) map[i] = (byte) (i * 7);
+
+    // The tissue map is written from an oversized, partly stale buffer so
+    // that only its valid prefix may reach the output.
+    byte[] reusableMapBuffer = new byte[map.length + 97];
+    System.arraycopy(map, 0, reusableMapBuffer, 0, map.length);
+    for (int i = map.length; i < reusableMapBuffer.length; i++) {
+      reusableMapBuffer[i] = (byte) 0xa5;
+    }
+
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(associatedMetadata());
+      writer.setMetadataOptions(associatedOptions());
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(PYRAMID_WIDTH, PYRAMID_HEIGHT, 0), 0, 0,
+        PYRAMID_WIDTH, PYRAMID_HEIGHT);
+      writer.setSeries(1);
+      writer.setResolution(0);
+      writer.saveBytes(0, macro, 0, 0, MACRO_WIDTH, MACRO_HEIGHT);
+      writer.setSeries(2);
+      writer.setResolution(0);
+      writer.saveBytes(0, reusableMapBuffer, 0, 0, MAP_WIDTH, MAP_HEIGHT);
+      writer.close();
+    }
+    catch (Exception e) {
+      Files.deleteIfExists(file);
+      throw e;
+    }
+    return new AssociatedOutput(file, macro, map);
+  }
+
+  /** Describes the pyramid, macro and tissue-map series of one NDPI file. */
+  private static IMetadata associatedMetadata() throws Exception {
+    IMetadata metadata = metadata(PYRAMID_WIDTH, PYRAMID_HEIGHT);
+    addImage(metadata, 1, MACRO_WIDTH, MACRO_HEIGHT, 3, 3);
+    addImage(metadata, 2, MAP_WIDTH, MAP_HEIGHT, 1, 1);
+    metadata.setMicroscopeManufacturer("Acme", 0);
+    metadata.setMicroscopeModel("Scope", 0);
+    metadata.setImageAcquisitionDate(
+      new Timestamp("2026-07-29T19:56:16-04:00"), 0);
+    metadata.setPixelsPhysicalSizeX(new Length(5, UNITS.MICROMETER), 1);
+    metadata.setPixelsPhysicalSizeY(new Length(6, UNITS.MICROMETER), 1);
+    metadata.setPixelsPhysicalSizeX(new Length(20, UNITS.MICROMETER), 2);
+    metadata.setPixelsPhysicalSizeY(new Length(24, UNITS.MICROMETER), 2);
+    return metadata;
+  }
+
+  /** Identifies the associated series and sets one value per private tag. */
+  private static DynamicMetadataOptions associatedOptions() {
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.setInteger(NDPIWriter.MACRO_SERIES_KEY, 1);
+    options.setInteger(NDPIWriter.TISSUE_MAP_SERIES_KEY, 2);
+    options.setBoolean(NDPIWriter.LABEL_OBSCURED_KEY, true);
+    options.set(NDPIWriter.REFERENCE_KEY, "role-test");
+    options.setLong(NDPIWriter.X_POSITION_KEY, 101L);
+    options.setLong(NDPIWriter.Y_POSITION_KEY, 202L);
+    options.setLong(NDPIWriter.Z_POSITION_KEY, 303L);
+    options.setLong(NDPIWriter.EXPOSURE_RATIO_KEY, 11L);
+    options.setLong(NDPIWriter.RED_MULTIPLIER_KEY, 12L);
+    options.setLong(NDPIWriter.GREEN_MULTIPLIER_KEY, 13L);
+    options.setLong(NDPIWriter.BLUE_MULTIPLIER_KEY, 14L);
+    options.set(NDPIWriter.SERIAL_NUMBER_KEY, "serial");
+    options.setLong(NDPIWriter.REFOCUS_INTERVAL_KEY, 15L);
+    options.setLong(NDPIWriter.FOCUS_OFFSET_KEY, 16L);
+    options.set(NDPIWriter.FIRMWARE_VERSION_KEY, "firmware");
+    options.set(NDPIWriter.CALIBRATION_KEY, CALIBRATION_PROPERTIES);
+    options.set(NDPIWriter.FOCUS_POINTS_KEY, "1,2,3");
+    options.set(NDPIWriter.FOCUS_POINT_REGIONS_KEY, "4");
+    options.setFloat(NDPIWriter.WAVELENGTH_KEY, 550f);
+    options.setLong(NDPIWriter.LAMP_AGE_KEY, 17L);
+    options.setLong(NDPIWriter.EXPOSURE_TIME_KEY, 18L);
+    options.setLong(NDPIWriter.FOCUS_TIME_KEY, 19L);
+    options.setLong(NDPIWriter.SCAN_TIME_KEY, 20L);
+    options.setLong(NDPIWriter.WRITE_TIME_KEY, 21L);
+    options.setBoolean(NDPIWriter.FULLY_AUTO_FOCUS_KEY, true);
+    options.set(NDPIWriter.BARCODE_KEY_PREFIX + 0, "barcode");
+    options.set(NDPIWriter.MEDICAL_REGULATION_KEY, "regulation");
+    return options;
+  }
+
+  /** Private tags that only a pyramid level may carry. */
+  private static int[] pyramidOnlyTags() {
+    return new int[] {
+      NDPITags.TISSUE_INDEX, NDPITags.Z_POSITION, NDPITags.EXPOSURE_RATIO,
+      NDPITags.RED_MULTIPLIER, NDPITags.GREEN_MULTIPLIER,
+      NDPITags.BLUE_MULTIPLIER, NDPITags.WAVELENGTH, NDPITags.LAMP_AGE,
+      NDPITags.EXPOSURE_TIME, NDPITags.FOCUS_TIME, NDPITags.SCAN_TIME,
+      NDPITags.WRITE_TIME, NDPITags.FULLY_AUTO_FOCUS
+    };
+  }
+
+  /** Private tags that every IFD of one NDPI file must repeat. */
+  private static int[] fileWideTags() {
+    return new int[] {
+      NDPITags.REFERENCE, NDPITags.FOCUS_POINTS,
+      NDPITags.FOCUS_POINT_REGIONS, NDPITags.SERIAL_NUMBER,
+      NDPITags.REFOCUS_INTERVAL, NDPITags.FOCUS_OFFSET,
+      NDPITags.FIRMWARE_VERSION, NDPITags.CALIBRATION,
+      NDPITags.FIRST_BARCODE, NDPITags.MEDICAL_REGULATION
+    };
+  }
+
+  /** Parses and fully populates every main IFD of an NDPI output. */
+  private static java.util.List<IFD> mainIFDs(RandomAccessInputStream in)
+    throws Exception
+  {
+    TiffParser parser = new TiffParser(in);
+    java.util.List<IFD> ifds = parser.getMainIFDs();
+    for (IFD ifd : ifds) parser.fillInIFD(ifd);
+    return ifds;
+  }
+
+  /**
+   * Writes a two-resolution NDPI output with every private metadata option
+   * set to a distinct value. Every call produces an independent temporary
+   * file, which the caller must delete.
+   */
+  private static Path writePrivateMetadataOutput() throws Exception {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-options-", ".ndpi");
+    try {
+      IMetadata metadata = metadata(width, height);
+      IPyramidStore pyramid = (IPyramidStore) metadata;
+      pyramid.setResolutionSizeX(new PositiveInteger(width / 2), 0, 1);
+      pyramid.setResolutionSizeY(new PositiveInteger(height / 2), 0, 1);
+
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata);
+      writer.setMetadataOptions(privateMetadataOptions());
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.setResolution(1);
+      writer.saveBytes(0, pixels(width / 2, height / 2, 1), 0, 0,
+        width / 2, height / 2);
+      writer.close();
+    }
+    catch (Exception e) {
+      Files.deleteIfExists(file);
+      throw e;
+    }
+    return file;
+  }
+
+  /** Sets one distinct value for every supported private metadata option. */
+  private static DynamicMetadataOptions privateMetadataOptions() {
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.set(NDPIWriter.REFERENCE_KEY, "A1");
+    options.setLong(NDPIWriter.X_POSITION_KEY, -101L);
+    options.setLong(NDPIWriter.Y_POSITION_KEY, 202L);
+    options.setLong(NDPIWriter.Z_POSITION_KEY, -303L);
+    options.setLong(NDPIWriter.EXPOSURE_RATIO_KEY, 11L);
+    options.setLong(NDPIWriter.RED_MULTIPLIER_KEY, 12L);
+    options.setLong(NDPIWriter.GREEN_MULTIPLIER_KEY, 13L);
+    options.setLong(NDPIWriter.BLUE_MULTIPLIER_KEY, 14L);
+    options.set(NDPIWriter.FOCUS_POINTS_KEY, "-1, 2, -3, 4, 5, 6");
+    options.set(NDPIWriter.FOCUS_POINT_REGIONS_KEY, "7, -8");
+    options.setLong(NDPIWriter.CAPTURE_MODE_KEY, 0L);
+    options.set(NDPIWriter.SERIAL_NUMBER_KEY, "RGB");
+    options.set(NDPIWriter.SCANNER_MANUFACTURER_KEY, "Acme");
+    options.set(NDPIWriter.SCANNER_MODEL_KEY, "S1");
+    options.setLong(NDPIWriter.REFOCUS_INTERVAL_KEY, -15L);
+    options.setLong(NDPIWriter.FOCUS_OFFSET_KEY, 16L);
+    options.set(NDPIWriter.FIRMWARE_VERSION_KEY, "IVR");
+    options.set(NDPIWriter.CALIBRATION_KEY, CALIBRATION_PROPERTIES);
+    options.setFloat(NDPIWriter.WAVELENGTH_KEY, 550.5f);
+    options.setLong(NDPIWriter.LAMP_AGE_KEY, 17L);
+    options.setLong(NDPIWriter.EXPOSURE_TIME_KEY, 18L);
+    options.setLong(NDPIWriter.FOCUS_TIME_KEY, 19L);
+    options.setLong(NDPIWriter.SCAN_TIME_KEY, 20L);
+    options.setLong(NDPIWriter.WRITE_TIME_KEY, 21L);
+    options.setBoolean(NDPIWriter.FULLY_AUTO_FOCUS_KEY, true);
+    for (int i = 0; i < 8; i++) {
+      options.set(NDPIWriter.BARCODE_KEY_PREFIX + i, "B" + i);
+    }
+    options.set(NDPIWriter.MEDICAL_REGULATION_KEY, "MR");
+    return options;
+  }
+
+  /**
+   * Opens the given output and writes one row of a much taller image, so
+   * that the writer never completes its directory chain.
+   */
+  private static void writeIncompletePixels(NDPIWriter writer, Path file)
+    throws Exception
+  {
+    writer.setMetadataRetrieve(metadata(WIDTH, HEIGHT));
+    writer.setInterleaved(true);
+    writer.setWriteSequentially(true);
+    writer.setId(file.toString());
+    writer.saveBytes(0, new byte[WIDTH * 3], 0, 0, WIDTH, 1);
+  }
+
+  /** Makes the given directory reject the removal of its entries. */
+  private static void lockDirectory(Path directory) {
+    directory.toFile().setWritable(false);
+  }
+
+  /** Restores write access so the fixture can always be cleaned up. */
+  private static void unlockDirectory(Path directory) {
+    directory.toFile().setWritable(true);
+  }
+
+  /**
+   * Skips the calling test when the platform removed the incomplete output
+   * from a read-only directory anyway, which a process running as root is
+   * allowed to do.
+   */
+  private static void skipIfDeletionWasPermitted(Path file) {
+    if (!Files.exists(file)) {
+      throw new SkipException(
+        "This platform allows deletion from a read-only directory");
+    }
+  }
+
+  private static void addImage(IMetadata metadata, int image, int width,
+    int height, int sizeC, int samplesPerPixel)
+  {
+    metadata.setImageID("Image:" + image, image);
+    metadata.setPixelsID("Pixels:" + image, image);
+    metadata.setPixelsDimensionOrder(DimensionOrder.XYZCT, image);
+    metadata.setPixelsSizeX(new PositiveInteger(width), image);
+    metadata.setPixelsSizeY(new PositiveInteger(height), image);
+    metadata.setPixelsSizeZ(new PositiveInteger(1), image);
+    metadata.setPixelsSizeC(new PositiveInteger(sizeC), image);
+    metadata.setPixelsSizeT(new PositiveInteger(1), image);
+    metadata.setPixelsType(PixelType.UINT8, image);
+    metadata.setPixelsBigEndian(false, image);
+    metadata.setChannelID("Channel:" + image + ":0", image, 0);
+    metadata.setChannelSamplesPerPixel(
+      new PositiveInteger(samplesPerPixel), image, 0);
+  }
+
+  private static byte[] pixels(int width, int height, int resolution) {
+    byte[] pixels = new byte[width * height * 3];
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        int offset = (y * width + x) * 3;
+        pixels[offset] = (byte) (32 + (x / 16 + resolution * 7) % 160);
+        pixels[offset + 1] = (byte) (48 + (y / 16) % 144);
+        pixels[offset + 2] =
+          (byte) (64 + ((x / 32 + y / 32) * 9) % 128);
+      }
+    }
+    return pixels;
+  }
+
+  private static void assertJPEGClose(byte[] actual, byte[] expected) {
+    assertEquals(actual.length, expected.length);
+    long totalDifference = 0;
+    int maximumDifference = 0;
+    for (int i = 0; i < actual.length; i++) {
+      int difference = Math.abs((actual[i] & 0xff) - (expected[i] & 0xff));
+      totalDifference += difference;
+      maximumDifference = Math.max(maximumDifference, difference);
+    }
+    double meanDifference = (double) totalDifference / actual.length;
+    assertTrue(maximumDifference <= 20,
+      "Maximum JPEG difference was " + maximumDifference);
+    assertTrue(meanDifference <= 2.0,
+      "Mean JPEG difference was " + meanDifference);
+  }
+
+  private static byte[] planar(byte[] interleaved) {
+    byte[] planar = new byte[interleaved.length];
+    int pixels = interleaved.length / 3;
+    for (int pixel = 0; pixel < pixels; pixel++) {
+      for (int channel = 0; channel < 3; channel++) {
+        planar[channel * pixels + pixel] =
+          interleaved[pixel * 3 + channel];
+      }
+    }
+    return planar;
+  }
+
+  private static byte[] writeAtQuality(double quality, long expectedTag)
+    throws Exception
+  {
+    int width = 64;
+    int height = 32;
+    Path file = Files.createTempFile("bioformats-quality-", ".ndpi");
+    try {
+      CodecOptions options = CodecOptions.getDefaultOptions();
+      options.quality = quality;
+      NDPIWriter writer = new NDPIWriter();
+      writer.setCodecOptions(options);
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0));
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        TiffParser parser = new TiffParser(in);
+        IFD ifd = parser.getFirstIFD();
+        parser.fillInIFD(ifd);
+        assertEquals(ifd.getIFDLongValue(NDPITags.JPEG_QUALITY, -1),
+          expectedTag);
+        long offset = ifd.getStripOffsets()[0];
+        long byteCount = ifd.getStripByteCounts()[0];
+        assertTrue(byteCount <= Integer.MAX_VALUE);
+        byte[] jpeg = new byte[(int) byteCount];
+        in.seek(offset);
+        in.readFully(jpeg);
+        return jpeg;
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  private static void assertAuthCodes(Path file, int levels)
+    throws Exception
+  {
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      TiffParser parser = new TiffParser(in);
+      for (IFD ifd : parser.getMainIFDs()) {
+        long[] starts = ifd.getIFDLongArray(NDPITags.MCU_STARTS);
+        long jpegOffset = ifd.getStripOffsets()[0];
+        long expected = expectedAuthCode(in, jpegOffset, starts);
+        assertEquals(ifd.getIFDLongValue(NDPITags.AUTH_CODE, -1) & 0xffffffffL,
+          expected, "Incorrect independently calculated NDPI AuthCode");
+      }
+      assertEquals(parser.getMainIFDs().size(), levels);
+    }
+  }
+
+  private static void assertMCUStarts(Path file) throws Exception {
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      TiffParser parser = new TiffParser(in);
+      for (IFD ifd : parser.getMainIFDs()) {
+        long jpegOffset = ifd.getStripOffsets()[0];
+        long[] starts = ifd.getIFDLongArray(NDPITags.MCU_STARTS);
+        assertTrue(starts.length > 0);
+        in.order(false);
+        in.seek(jpegOffset);
+        assertEquals(in.readUnsignedShort(), 0xffd8);
+        while (in.getFilePointer() - jpegOffset < starts[0]) {
+          assertEquals(in.readUnsignedByte(), 0xff);
+          int marker = in.readUnsignedByte();
+          int length = in.readUnsignedShort();
+          if (marker == 0xda) {
+            assertEquals(in.getFilePointer() + length - 2 - jpegOffset,
+              starts[0], "First MCU start must immediately follow SOS");
+          }
+          in.skipBytes(length - 2);
+        }
+        assertEquals(in.getFilePointer() - jpegOffset, starts[0],
+          "First MCU start must immediately follow SOS");
+        for (int i = 1; i < starts.length; i++) {
+          in.seek(jpegOffset + starts[i] - 2);
+          assertEquals(in.readUnsignedByte(), 0xff);
+          int marker = in.readUnsignedByte();
+          assertTrue(marker >= 0xd0 && marker <= 0xd7,
+            "MCU start must immediately follow a restart marker");
+        }
+      }
+    }
+  }
+
+  private static void assertRestartGeometry(Path file, int[] restartMCUs,
+    int[] mcuStartCounts) throws Exception
+  {
+    try (RandomAccessInputStream in =
+      new RandomAccessInputStream(file.toString()))
+    {
+      TiffParser parser = new TiffParser(in);
+      java.util.List<IFD> ifds = parser.getMainIFDs();
+      assertEquals(ifds.size(), restartMCUs.length);
+      for (int i = 0; i < ifds.size(); i++) {
+        IFD ifd = ifds.get(i);
+        parser.fillInIFD(ifd);
+        assertEquals(ifd.getIFDLongArray(NDPITags.MCU_STARTS).length,
+          mcuStartCounts[i]);
+        assertEquals(readRestartInterval(in, ifd.getStripOffsets()[0]),
+          restartMCUs[i]);
+      }
+    }
+  }
+
+  private static int readRestartInterval(RandomAccessInputStream in,
+    long jpegOffset) throws IOException
+  {
+    in.order(false);
+    in.seek(jpegOffset);
+    assertEquals(in.readUnsignedShort(), 0xffd8);
+    while (true) {
+      assertEquals(in.readUnsignedByte(), 0xff);
+      int marker = in.readUnsignedByte();
+      int length = in.readUnsignedShort();
+      if (marker == 0xdd) {
+        assertEquals(length, 4);
+        return in.readUnsignedShort();
+      }
+      if (marker == 0xda) {
+        fail("Indexed NDPI JPEG has no DRI marker");
+      }
+      in.skipBytes(length - 2);
+    }
+  }
+
+  private static void assertOrdinaryJPEG(RandomAccessInputStream in, IFD ifd)
+    throws Exception
+  {
+    long offset = ifd.getStripOffsets()[0];
+    long length = ifd.getStripByteCounts()[0];
+    assertTrue(length <= Integer.MAX_VALUE);
+    byte[] jpeg = new byte[(int) length];
+    in.seek(offset);
+    in.readFully(jpeg);
+    assertEquals(((jpeg[0] & 0xff) << 8) | (jpeg[1] & 0xff), 0xffd8);
+
+    int position = 2;
+    boolean scan = false;
+    while (position + 1 < jpeg.length) {
+      if ((jpeg[position] & 0xff) != 0xff) {
+        assertTrue(scan, "JPEG data outside entropy scan");
+        position++;
+        continue;
+      }
+      int next = jpeg[position + 1] & 0xff;
+      if (scan && next == 0) {
+        position += 2;
+        continue;
+      }
+      if (next == 0xd9) return;
+      assertFalse(next == 0xdd, "Non-indexed JPEG must omit DRI");
+      assertFalse(next >= 0xd0 && next <= 0xd7,
+        "Non-indexed JPEG must omit restart markers");
+      assertFalse(scan, "Unexpected marker in ordinary JPEG entropy");
+      int markerLength =
+        (jpeg[position + 2] & 0xff) << 8 | jpeg[position + 3] & 0xff;
+      if (next == 0xda) scan = true;
+      position += 2 + markerLength;
+    }
+    fail("Ordinary JPEG has no EOI marker");
+  }
+
+  private static void assertSetIdRejected(IMetadata metadata,
+    boolean sequential, boolean interleaved, String message) throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-rejected-", ".ndpi");
+    Files.delete(file);
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(interleaved);
+      writer.setWriteSequentially(sequential);
+      try {
+        writer.setId(file.toString());
+        fail("Unsupported NDPI writer contract must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(), message);
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  private static void assertOptionsRejected(DynamicMetadataOptions options,
+    String detail) throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-invalid-option-", ".ndpi");
+    Files.delete(file);
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata(64, 32));
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      try {
+        writer.setId(file.toString());
+        fail("Invalid NDPI writer option must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(),
+          "Invalid NDPI writer option: " + detail);
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  private static void assertMetadataOptionsRejected(IMetadata metadata,
+    DynamicMetadataOptions options, String message) throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-invalid-series-", ".ndpi");
+    Files.delete(file);
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata);
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      try {
+        writer.setId(file.toString());
+        fail("Invalid NDPI associated-series contract must be rejected");
+      }
+      catch (FormatException e) {
+        assertEquals(e.getMessage(), message);
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  private static long expectedAuthCode(RandomAccessInputStream in,
+    long jpegOffset, long[] starts) throws Exception
+  {
+    int count = starts.length;
+    int[] segments = {
+      (int) (72L * count / 100), (int) (80L * count / 100),
+      (int) (75L * count / 100), 42
+    };
+    int[] percentages = {0, 75, 80, 72};
+    int[] masks = {0x1d, 0x6e, 0xdb, 0x2a};
+    long authCode = 0;
+    for (int i = 0; i < segments.length; i++) {
+      int segment = segments[i];
+      long entropyLength = starts[segment + 1] - starts[segment] - 2;
+      assertTrue(entropyLength > 0, "Invalid restart segment length");
+      long sample = i == 0 ? 42 : percentages[i] * entropyLength / 100;
+      long sampleOffset = Math.min(entropyLength - 1, sample);
+      in.seek(jpegOffset + starts[segment] + sampleOffset);
+      authCode = (authCode << 8) |
+        ((in.readUnsignedByte() ^ masks[i]) & 0xff);
+    }
+    return authCode;
+  }
+
+  private static int invokeAuthCode(byte[][] entropy, long[] starts)
+    throws Exception
+  {
+    java.lang.reflect.Constructor<NDPIJPEGAssembler.Result> constructor =
+      NDPIJPEGAssembler.Result.class.getDeclaredConstructor(
+        long.class, long.class, long[].class, byte[][].class);
+    constructor.setAccessible(true);
+    NDPIJPEGAssembler.Result result =
+      constructor.newInstance(0L, 0L, starts, entropy);
+    java.lang.reflect.Method calculate = NDPIWriter.class.getDeclaredMethod(
+      "calculateAuthCode", NDPIJPEGAssembler.Result.class, long[].class);
+    calculate.setAccessible(true);
+    return ((Integer) calculate.invoke(new NDPIWriter(), result, starts))
+      .intValue();
+  }
+
+  private static long[] uniformMCUStarts(int count, int entropyLength) {
+    long[] starts = new long[count];
+    for (int i = 0; i < starts.length; i++) {
+      starts[i] = (long) i * (entropyLength + 2);
+    }
+    return starts;
+  }
+
+  private static byte[][] authEntropy(int length) {
+    byte[][] entropy = new byte[4][length];
+    for (int segment = 0; segment < entropy.length; segment++) {
+      for (int i = 0; i < length; i++) {
+        entropy[segment][i] = (byte) (segment * 67 + i);
+      }
+    }
+    return entropy;
+  }
+
+  private static byte[][] clone(byte[][] values) {
+    byte[][] copy = new byte[values.length][];
+    for (int i = 0; i < values.length; i++) copy[i] = values[i].clone();
+    return copy;
+  }
+
+  private static void assertTag(RandomAccessInputStream in, long ifdOffset,
+    int expectedTag, int expectedType, Integer expectedValue) throws Exception
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      int tag = in.readUnsignedShort();
+      int type = in.readUnsignedShort();
+      long valueCount = in.readInt() & 0xffffffffL;
+      long value = in.readInt() & 0xffffffffL;
+      if (tag == expectedTag) {
+        assertEquals(type, expectedType, "Wrong TIFF type for tag " + tag);
+        assertEquals(valueCount, 1L, "Wrong count for tag " + tag);
+        if (expectedValue != null) {
+          assertEquals(value, expectedValue.intValue() & 0xffffffffL,
+            "Wrong value for tag " + tag);
+        }
+        return;
+      }
+    }
+    assertTrue(false, "Missing TIFF tag " + expectedTag);
+  }
+
+  private static void assertFloatTag(RandomAccessInputStream in,
+    long ifdOffset, int expectedTag, float expectedValue) throws Exception
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      int tag = in.readUnsignedShort();
+      int type = in.readUnsignedShort();
+      long valueCount = in.readInt() & 0xffffffffL;
+      int bits = in.readInt();
+      if (tag == expectedTag) {
+        assertEquals(type, 11, "Wrong TIFF type for tag " + tag);
+        assertEquals(valueCount, 1L, "Wrong count for tag " + tag);
+        assertEquals(Float.intBitsToFloat(bits), expectedValue);
+        return;
+      }
+    }
+    assertTrue(false, "Missing TIFF tag " + expectedTag);
+  }
+
+  private static void assertTagCount(RandomAccessInputStream in,
+    long ifdOffset, int expectedTag, int expectedType, long expectedCount)
+    throws Exception
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      int tag = in.readUnsignedShort();
+      int type = in.readUnsignedShort();
+      long valueCount = in.readInt() & 0xffffffffL;
+      in.skipBytes(4);
+      if (tag == expectedTag) {
+        assertEquals(type, expectedType, "Wrong TIFF type for tag " + tag);
+        assertEquals(valueCount, expectedCount,
+          "Wrong count for tag " + tag);
+        return;
+      }
+    }
+    assertTrue(false, "Missing TIFF tag " + expectedTag);
+  }
+
+  private static void assertAsciiTag(RandomAccessInputStream in,
+    long ifdOffset, int expectedTag, String expectedValue) throws Exception
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      int tag = in.readUnsignedShort();
+      int type = in.readUnsignedShort();
+      long valueCount = in.readInt() & 0xffffffffL;
+      long valueOffset = in.readInt() & 0xffffffffL;
+      if (tag == expectedTag) {
+        assertEquals(type, 2, "Wrong TIFF type for tag " + tag);
+        assertEquals(valueCount, expectedValue.length() + 1L,
+          "Wrong count for tag " + tag);
+        assertEquals(valueOffset & 1, 0,
+          "TIFF ASCII values must begin on word boundaries");
+        assertTrue(valueOffset < ifdOffset,
+          "NDPI ASCII values must be stored out-of-line, before their IFD");
+        byte[] value = new byte[(int) valueCount - 1];
+        in.seek(valueOffset);
+        in.readFully(value);
+        assertEquals(new String(value, StandardCharsets.US_ASCII),
+          expectedValue);
+        assertEquals(in.readUnsignedByte(), 0,
+          "NDPI ASCII values must be NUL-terminated");
+        return;
+      }
+    }
+    assertTrue(false, "Missing TIFF tag " + expectedTag);
+  }
+
+  /**
+   * Reads the offset of the first directory from the NDPI header. Native
+   * NDPI output places each directory after the image it describes, so the
+   * header offset is the only way to find the first one.
+   */
+  private static long firstIFD(RandomAccessInputStream in) throws IOException {
+    in.order(true);
+    in.seek(4);
+    return in.readLong();
+  }
+
+  private static long nextIFDOffset(RandomAccessInputStream in,
+    long ifdOffset) throws IOException
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    in.seek(ifdOffset + 2 + 12L * count);
+    return in.readLong();
+  }
+
+  private static void assertIndexPresence(int width, int height,
+    boolean expected) throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-index-boundary-", ".ndpi");
+    try {
+      NDPIWriter writer = new NDPIWriter();
+      writer.setMetadataRetrieve(metadata(width, height));
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(width, height, 0), 0, 0, width, height);
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        TiffParser parser = new TiffParser(in);
+        IFD ifd = parser.getFirstIFD();
+        parser.fillInIFD(ifd);
+        assertEquals(ifd.containsKey(NDPITags.MCU_STARTS), expected);
+        assertEquals(ifd.containsKey(NDPITags.AUTH_CODE), expected);
+        if (expected) {
+          assertEquals(ifd.getIFDLongArray(NDPITags.MCU_STARTS).length, 44);
+        }
+        else {
+          assertOrdinaryJPEG(in, ifd);
+        }
+      }
+    }
+    finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * Writes a whole pyramid and checks which of its levels were indexed.
+   *
+   * @param metadata the pyramid to write
+   * @param widths the width of each resolution
+   * @param heights the height of each resolution
+   * @param indexed whether each resolution is expected to carry a restart
+   *   index and the AuthCode that authenticates it
+   */
+  private static void assertLevelIndexPresence(IMetadata metadata,
+    int[] widths, int[] heights, boolean[] indexed) throws Exception
+  {
+    Path file = Files.createTempFile("bioformats-index-levels-", ".ndpi");
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      for (int r = 0; r < widths.length; r++) {
+        writer.setResolution(r);
+        writer.saveBytes(0, pixels(widths[r], heights[r], r), 0, 0,
+          widths[r], heights[r]);
+      }
+      writer.close();
+
+      try (RandomAccessInputStream in =
+        new RandomAccessInputStream(file.toString()))
+      {
+        long[] ifds = chain(in);
+        assertEquals(ifds.length, widths.length,
+          "Every resolution must be described");
+        for (int r = 0; r < ifds.length; r++) {
+          assertEquals(entry(in, ifds[r], NDPITags.MCU_STARTS) != null,
+            indexed[r], "Wrong restart-index presence at resolution " + r);
+          assertEquals(entry(in, ifds[r], NDPITags.AUTH_CODE) != null,
+            indexed[r], "Wrong AuthCode presence at resolution " + r);
+        }
+      }
+    }
+    finally {
+      writer.close();
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /**
+   * Checks that an indexed image's restart arrays lie between the end of its
+   * payload and the beginning of its directory.
+   */
+  private static void assertRestartIndexPlacement(RandomAccessInputStream in,
+    long ifdOffset, long payloadEnd) throws IOException
+  {
+    long[] low = entry(in, ifdOffset, NDPITags.MCU_STARTS);
+    if (low == null) {
+      assertTrue(entry(in, ifdOffset, NDPITags.MCU_STARTS_HIGH_BYTES) == null,
+        "A non-indexed NDPI image must omit both restart arrays");
+      return;
+    }
+    long lowEnd = low[2] + low[1] * 4;
+    assertTrue(low[2] >= payloadEnd,
+      "The restart index must follow the payload it indexes");
+    long[] high = entry(in, ifdOffset, NDPITags.MCU_STARTS_HIGH_BYTES);
+    if (high != null) {
+      assertTrue(lowEnd <= high[2], "The high restart words must follow the " +
+        "low words");
+      lowEnd = high[2] + high[1] * 4;
+    }
+    assertTrue(lowEnd <= ifdOffset,
+      "The restart index must precede the directory that names it");
+  }
+
+  /**
+   * Writes a two-level pyramid, a macro and a tissue map into one NDPI file,
+   * with every private option set, for the layout tests to inspect.
+   */
+  private static void writeNativeLayoutOutput(Path file) throws Exception {
+    IMetadata metadata = associatedMetadata();
+    IPyramidStore pyramid = (IPyramidStore) metadata;
+    pyramid.setResolutionSizeX(new PositiveInteger(PYRAMID_WIDTH / 2), 0, 1);
+    pyramid.setResolutionSizeY(new PositiveInteger(PYRAMID_HEIGHT / 2), 0, 1);
+    DynamicMetadataOptions options = associatedOptions();
+    options.set(NDPIWriter.REFERENCE_KEY, "A1");
+
+    NDPIWriter writer = new NDPIWriter();
+    try {
+      writer.setMetadataRetrieve(metadata);
+      writer.setMetadataOptions(options);
+      writer.setInterleaved(true);
+      writer.setWriteSequentially(true);
+      writer.setId(file.toString());
+      writer.saveBytes(0, pixels(PYRAMID_WIDTH, PYRAMID_HEIGHT, 0), 0, 0,
+        PYRAMID_WIDTH, PYRAMID_HEIGHT);
+      writer.setResolution(1);
+      writer.saveBytes(0, pixels(PYRAMID_WIDTH / 2, PYRAMID_HEIGHT / 2, 1),
+        0, 0, PYRAMID_WIDTH / 2, PYRAMID_HEIGHT / 2);
+      writer.setSeries(1);
+      writer.setResolution(0);
+      writer.saveBytes(0, pixels(MACRO_WIDTH, MACRO_HEIGHT, 1), 0, 0,
+        MACRO_WIDTH, MACRO_HEIGHT);
+      writer.setSeries(2);
+      writer.setResolution(0);
+      writer.saveBytes(0, new byte[MAP_WIDTH * MAP_HEIGHT], 0, 0, MAP_WIDTH,
+        MAP_HEIGHT);
+    }
+    finally {
+      writer.close();
+    }
+  }
+
+  private static long[] reconstruct(long[] low, long[] high) {
+    long[] values = new long[low.length];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = (low[i] & 0xffffffffL) | (high[i] << 32);
+    }
+    return values;
+  }
+
+  /**
+   * Reads one directory entry and joins its value field to the NDPI
+   * extension word that follows the directory.
+   *
+   * @return {type, count, value}, where the value is either the entry's own
+   *   64-bit scalar or the offset of its external value, or null when the
+   *   directory does not contain the tag
+   */
+  private static long[] entry(RandomAccessInputStream in, long ifdOffset,
+    int expectedTag) throws IOException
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      in.seek(ifdOffset + 2 + 12L * i);
+      int tag = in.readUnsignedShort();
+      if (tag != expectedTag) continue;
+      long type = in.readUnsignedShort();
+      long valueCount = in.readInt() & 0xffffffffL;
+      long low = in.readInt() & 0xffffffffL;
+      in.seek(ifdOffset + 2 + 12L * count + 8 + 4L * i);
+      long high = in.readInt() & 0xffffffffL;
+      return new long[] {type, valueCount, low | (high << 32)};
+    }
+    return null;
+  }
+
+  /** Follows the whole directory chain from the NDPI header. */
+  private static long[] chain(RandomAccessInputStream in) throws IOException {
+    java.util.List<Long> offsets = new java.util.ArrayList<Long>();
+    for (long offset = firstIFD(in); offset != 0;
+      offset = nextIFDOffset(in, offset))
+    {
+      assertTrue(offsets.size() < 64, "The NDPI directory chain must end");
+      offsets.add(Long.valueOf(offset));
+    }
+    long[] chain = new long[offsets.size()];
+    for (int i = 0; i < chain.length; i++) chain[i] = offsets.get(i);
+    return chain;
+  }
+
+  /** Locates the external value of one tag, or fails when it has none. */
+  private static long externalOffset(RandomAccessInputStream in,
+    long ifdOffset, int tag) throws IOException
+  {
+    long[] entry = entry(in, ifdOffset, tag);
+    assertTrue(entry != null, "Missing TIFF tag " + tag);
+    assertTrue(isExternal(entry), "TIFF tag " + tag + " is not stored " +
+      "externally");
+    return entry[2];
+  }
+
+  /** Locates every external value one directory names. */
+  private static java.util.List<long[]> externalRegions(
+    RandomAccessInputStream in, long ifdOffset) throws IOException
+  {
+    java.util.List<long[]> regions = new java.util.ArrayList<long[]>();
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      in.seek(ifdOffset + 2 + 12L * i);
+      int tag = in.readUnsignedShort();
+      long[] entry = entry(in, ifdOffset, tag);
+      if (isExternal(entry)) {
+        regions.add(new long[] {entry[2], entry[1] * typeBytes(entry[0])});
+      }
+    }
+    return regions;
+  }
+
+  /**
+   * Whether one entry's value is stored outside it. Every ASCII value is,
+   * as genuine NDPI files store even short strings externally.
+   */
+  private static boolean isExternal(long[] entry) {
+    return entry[0] == ASCII_TYPE || entry[1] * typeBytes(entry[0]) > 4;
+  }
+
+  private static long typeBytes(long type) {
+    switch ((int) type) {
+      case ASCII_TYPE: return 1;
+      case 3: return 2;
+      case 5: return 8;
+      default: return 4;
+    }
+  }
+
+  /** Extracts the low or high 32-bit words of 64-bit offsets. */
+  private static long[] words(long[] values, int shift) {
+    long[] words = new long[values.length];
+    for (int i = 0; i < values.length; i++) {
+      words[i] = (values[i] >>> shift) & 0xffffffffL;
+    }
+    return words;
+  }
+
+  private static long extendedScalar(RandomAccessInputStream in,
+    long ifdOffset, int expectedTag) throws IOException
+  {
+    long[] entry = entry(in, ifdOffset, expectedTag);
+    if (entry == null) {
+      throw new IOException("Missing TIFF tag " + expectedTag);
+    }
+    return entry[2];
+  }
+
+  private static long extensionWord(RandomAccessInputStream in,
+    long ifdOffset, int expectedTag) throws IOException
+  {
+    in.order(true);
+    in.seek(ifdOffset);
+    int count = in.readUnsignedShort();
+    for (int i = 0; i < count; i++) {
+      int tag = in.readUnsignedShort();
+      in.skipBytes(10);
+      if (tag == expectedTag) {
+        long extension = ifdOffset + 2 + 12L * count + 8 + 4L * i;
+        in.seek(extension);
+        return in.readInt() & 0xffffffffL;
+      }
+    }
+    throw new IOException("Missing TIFF tag " + expectedTag);
+  }
+
+  private static final class SparseNDPIWriter extends NDPIWriter {
+
+    private void seekPayload(long offset) throws IOException {
+      out.seek(offset);
+    }
+  }
+
+  /**
+   * An NDPI writer whose underlying output stream can be made to fail on
+   * close, by swapping in a different FormatWriter.out stream.
+   */
+  private static final class FailingCloseNDPIWriter extends NDPIWriter {
+
+    /**
+     * Flushes and closes the real output, then substitutes a stream that
+     * refuses to close.
+     */
+    private void failNextClose() throws IOException {
+      out.close();
+      out = new FailingCloseStream();
+    }
+  }
+
+  /** An output stream that always fails to close. */
+  private static final class FailingCloseStream
+    extends RandomAccessOutputStream
+  {
+
+    private FailingCloseStream() {
+      super(new ByteArrayHandle());
+    }
+
+    @Override
+    public void close() throws IOException {
+      throw new IOException(CLOSE_FAILURE);
+    }
+  }
+}

--- a/components/formats-gpl/test/loci/formats/utests/testng.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng.xml
@@ -65,4 +65,16 @@
         <class name="loci.formats.utests.XMLAnnotationTest"/>
       </classes>
     </test>
+    <test name="NDPI JPEG assembler">
+      <groups/>
+      <classes>
+        <class name="loci.formats.out.NDPIJPEGAssemblyTest"/>
+      </classes>
+    </test>
+    <test name="NDPI writer">
+      <groups/>
+      <classes>
+        <class name="loci.formats.out.NDPIWriterTest"/>
+      </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Adds support for writing NDPI files.

  - Writes pyramid levels, macro images, and tissue maps.
  - Supports restart-indexed JPEG data, AuthCode generation, associated-image metadata, and files larger than 4 GiB.
  - Sequential bounded-memory writing for large images.
  - Derives NDPI tags from OME metadata when mapping is clear, with writer options for NDPI-specific fields.
  - Includes structural, metadata, pixel, cleanup, and writer-discovery coverage.

Mainly generated by Codex. Outputs verified against NDPIReader and OpenSlide, and confirmed readable by Hamamatsu NDP.view2 and Aperio ImageScope