### PR TITLE
Update `codeql` and `report` to use checkout v6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check the output of the daily job
         shell: bash
         run: |


### PR DESCRIPTION
Build warning noticed in https://github.com/ome/bioformats/actions/runs/30620464883/job/91123549824. This updates the version of `checkout` used to match the other configurations.