### PR TITLE
Preserve MetadataOnly in OME-to-OME conversion

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -921,6 +921,30 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   @Override
   public void convertMetadata(MetadataRetrieve src, MetadataStore dest) {
     MetadataConverter.convertMetadata(src, dest);
+
+    // MetadataOnly is an empty marker element and is therefore not exposed by
+    // the generated MetadataRetrieve/MetadataStore interfaces.  Preserve it
+    // when both endpoints expose the underlying OME model.
+    if (src instanceof OMEXMLMetadata && dest instanceof OMEXMLMetadata) {
+      OMEXMLMetadata source = (OMEXMLMetadata) src;
+      OMEXMLMetadata destination = (OMEXMLMetadata) dest;
+      source.resolveReferences();
+      OMEXMLMetadataRoot sourceRoot =
+        (OMEXMLMetadataRoot) source.getRoot();
+      OMEXMLMetadataRoot destinationRoot =
+        (OMEXMLMetadataRoot) destination.getRoot();
+      int imageCount = Math.min(sourceRoot.sizeOfImageList(),
+        destinationRoot.sizeOfImageList());
+      for (int image = 0; image < imageCount; image++) {
+        Pixels sourcePixels = sourceRoot.getImage(image).getPixels();
+        Pixels destinationPixels = destinationRoot.getImage(image).getPixels();
+        if (sourcePixels != null && destinationPixels != null &&
+          sourcePixels.getMetadataOnly() != null)
+        {
+          destinationPixels.setMetadataOnly(new MetadataOnly());
+        }
+      }
+    }
   }
 
   /** @see OMEXMLService#removeBinData(OMEXMLMetadata) */

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -40,8 +40,11 @@ import static org.testng.Assert.assertNull;
 import java.io.File;
 import java.nio.file.Files;
 
+import loci.common.services.ServiceFactory;
 import loci.formats.Memoizer;
 import loci.formats.in.FakeReader;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -272,6 +275,26 @@ public class MemoizerTest {
     assertFalse(memoFile.exists());
     reader.close();
     checkMemo(memoizer, id);
+  }
+
+  @Test
+  public void testMetadataOnlyPreservedOnSaveAndLoad() throws Exception {
+    OMEXMLService service = new ServiceFactory().getInstance(
+      OMEXMLService.class);
+    Memoizer memoizer = new Memoizer(reader, 0);
+
+    OMEXMLMetadata saveMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(saveMetadata);
+    memoizer.setId(id);
+    assertTrue(service.validateOMEXML(service.getOMEXML(saveMetadata)));
+    memoizer.close();
+
+    OMEXMLMetadata loadMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(loadMetadata);
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertTrue(service.validateOMEXML(service.getOMEXML(loadMetadata)));
+    memoizer.close();
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
@@ -40,6 +40,8 @@ import java.util.Hashtable;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
 import loci.formats.meta.OriginalMetadataAnnotation;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
@@ -138,5 +140,23 @@ public class OMEXMLServiceTest {
     final String xml = service.getOMEXML(metadata);
 
     assertTrue(xml.contains(expectedText));
+  }
+
+  @Test
+  public void testConvertMetadataPreservesMetadataOnly()
+    throws ServiceException
+  {
+    OMEXMLMetadata source = service.createOMEXMLMetadata();
+    MetadataTools.populateMetadata(source, 0, "source", false, "XYZCT",
+      FormatTools.getPixelTypeString(FormatTools.UINT8),
+      1, 1, 1, 1, 1, 1);
+    service.addMetadataOnly(source, 0);
+
+    OMEXMLMetadata destination = service.createOMEXMLMetadata();
+    service.convertMetadata(source, destination);
+
+    String xml = service.getOMEXML(destination);
+    assertTrue(xml.contains("<MetadataOnly/>"));
+    assertTrue(service.validateOMEXML(xml));
   }
 }


### PR DESCRIPTION
Hej,

testing ome/bioformats#4450 on java25 revealed a few problems with the memoizer, this is the first one, an inaccuracy in context of the OME model.

The generated `MetadataRetrieve` and `MetadataStore` APIs do not expose OME XML `MetadataOnly` marker elements, so generic metadata conversion silently dropped them. Memoizer uses that conversion for user metadata, producing schema-invalid OME-XML on both cache creation and cache restoration.

As a quick fix, restore `MetadataOnly` through the concrete OME model when both conversion endpoints support it. Add direct conversion and Memoizer cache miss/cache hit validation tests.