### PR TITLE
Keep standard data tests on direct readers

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -3272,7 +3272,7 @@ public class FormatReaderTest {
     IFormatReader ir = null;
     if (flattened) {
       ir = new ImageReader();
-      ir = new BufferedImageReader(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File("")));
+      ir = new BufferedImageReader(ir);
       ir.setMetadataOptions(new DynamicMetadataOptions(MetadataLevel.NO_OVERLAYS));
     }
     else {


### PR DESCRIPTION
Hej,

testing ome/bioformats#4450 on Java 25 revealed a few problems with the memoizer, this is the second one.

The empty File path used for the implicit Memoizer cache is not a stable way to disable memoization: Java 25 resolves it as the current directory while older JDKs reject it as a cache directory. This made the standard data tests exercise different code paths depending on the JDK.

Remove the implicit Memoizer wrapper from standard flattened-reader setup. Memoization remains covered by testMemoFileUsage, which already uses an isolated temporary cache directory.