### PR TITLE
Improve memo invalidation

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1267,9 +1267,7 @@ public final class FormatTools {
       return false;
     }
 
-    if (!a.getMetadataOptions().getMetadataLevel().equals(
-      b.getMetadataOptions().getMetadataLevel()))
-    {
+    if (!a.getMetadataOptions().equals(b.getMetadataOptions())) {
       return false;
     }
 

--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -80,4 +80,23 @@ public class DefaultMetadataOptions implements MetadataOptions {
     validate = validateMetadata;
   }
 
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    DefaultMetadataOptions options = (DefaultMetadataOptions) other;
+    return metadataLevel == options.metadataLevel &&
+      validate == options.validate;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = metadataLevel == null ? 0 : metadataLevel.hashCode();
+    return 31 * result + (validate ? 1 : 0);
+  }
+
 }

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -105,6 +105,23 @@ public class DynamicMetadataOptions implements MetadataOptions {
     setBoolean(READER_VALIDATE_KEY, validateMetadata);
   }
 
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    DynamicMetadataOptions options = (DynamicMetadataOptions) other;
+    return props.equals(options.props);
+  }
+
+  @Override
+  public int hashCode() {
+    return props.hashCode();
+  }
+
   // -- key/value options --
 
   /**
@@ -489,7 +506,30 @@ public class DynamicMetadataOptions implements MetadataOptions {
     return new File(val);
   }
   
-  public void loadOptions(String optionsFile, ArrayList<String> availableOptionKeys) throws IOException, FormatException {
+  /**
+   * Load options without checking them against a reader's supported keys.
+   *
+   * @param optionsFile path to the options file
+   * @throws IOException if the file cannot be read
+   * @throws FormatException if the options file is invalid
+   */
+  public void loadOptions(String optionsFile) throws IOException,
+    FormatException
+  {
+    loadOptions(optionsFile, null);
+  }
+
+  /**
+   * Load options and warn about keys that are not advertised by the reader.
+   *
+   * @param optionsFile path to the options file
+   * @param availableOptionKeys keys advertised by the reader
+   * @throws IOException if the file cannot be read
+   * @throws FormatException if the options file is invalid
+   */
+  public void loadOptions(String optionsFile,
+    ArrayList<String> availableOptionKeys) throws IOException, FormatException
+  {
     if (!new Location(optionsFile).exists()) {
       LOGGER.trace("Options file doesn't exist: {}", optionsFile);
       // TODO: potentially create option
@@ -504,7 +544,8 @@ public class DynamicMetadataOptions implements MetadataOptions {
     IniList list = parser.parseINI(new File(optionsFile));
     for (IniTable attrs: list) {
       for (String key: attrs.keySet()) {
-        if (!key.equals(IniTable.HEADER_KEY) &&
+        if (availableOptionKeys != null &&
+            !key.equals(IniTable.HEADER_KEY) &&
             !availableOptionKeys.contains(key)) {
           LOGGER.warn("Metadata Option Key is not supported in this reader " + key);
         }

--- a/components/formats-api/test/loci/formats/utests/DefaultMetadataOptionsTest.java
+++ b/components/formats-api/test/loci/formats/utests/DefaultMetadataOptionsTest.java
@@ -76,4 +76,17 @@ public class DefaultMetadataOptionsTest {
     assertFalse(opt.isValidate());
   }
 
+  @Test
+  public void testEqualityIncludesValidation() {
+    MetadataOptions other = new DefaultMetadataOptions();
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+
+    opt.setValidate(true);
+    assertFalse(opt.equals(other));
+    other.setValidate(true);
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+  }
+
 }

--- a/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
+++ b/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
@@ -371,6 +371,19 @@ public class DynamicMetadataOptionsTest {
     assertFalse(opt.isValidate());
   }
 
+  @Test
+  public void testEqualityIncludesDynamicProperties() {
+    DynamicMetadataOptions other = new DynamicMetadataOptions();
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+
+    opt.set("reader.option", "first");
+    assertFalse(opt.equals(other));
+    other.set("reader.option", "first");
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+  }
+
   @Test(dataProvider = "optionFiles")
   public void testGetMetadataOptionsFile(String source, String target) {
     source = source.replace('/', File.separatorChar);

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -46,6 +46,8 @@ import loci.common.RandomAccessOutputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.services.OMEXMLService;
@@ -925,6 +927,15 @@ public class Memoizer extends ReaderWrapper {
       } catch (ClassNotFoundException e) {
         LOGGER.warn("unknown reader type: {}", e);
         return null;
+      }
+
+      MetadataOptions options = reader.getMetadataOptions();
+      if (options instanceof DynamicMetadataOptions) {
+        String optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(
+          realFile.getAbsolutePath());
+        if (optionsFile != null) {
+          ((DynamicMetadataOptions) options).loadOptions(optionsFile);
+        }
       }
 
       boolean equal = false;

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -38,6 +38,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ArrayIndexOutOfBoundsException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -100,6 +104,10 @@ public class Memoizer extends ReaderWrapper {
 
     String loadRevision() throws IOException;
 
+    default FileFingerprint[] loadFileFingerprints() throws IOException {
+      return FileFingerprint.decode(loadRevision());
+    }
+
     IFormatReader loadReader() throws IOException, ClassNotFoundException;
 
     void loadStop() throws IOException;
@@ -112,11 +120,85 @@ public class Memoizer extends ReaderWrapper {
 
     void saveRevision(String revision) throws IOException;
 
+    default void saveFileFingerprints(FileFingerprint[] fingerprints)
+      throws IOException
+    {
+      saveRevision(FileFingerprint.encode(fingerprints));
+    }
+
     void saveReader(IFormatReader reader) throws IOException;
 
     void saveStop() throws IOException;
 
     void close();
+  }
+
+  /** File state recorded when a memo is created. */
+  public static final class FileFingerprint {
+
+    private final String path;
+    private final boolean relative;
+    private final boolean exists;
+    private final long length;
+    private final long lastModified;
+
+    private FileFingerprint(String path, boolean relative, boolean exists,
+      long length, long lastModified)
+    {
+      this.path = path;
+      this.relative = relative;
+      this.exists = exists;
+      this.length = length;
+      this.lastModified = lastModified;
+    }
+
+    private static String encode(FileFingerprint[] fingerprints) {
+      StringBuilder manifest = new StringBuilder();
+      Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+      for (FileFingerprint fingerprint : fingerprints) {
+        String encodedPath = encoder.encodeToString(
+          fingerprint.path.getBytes(StandardCharsets.UTF_8));
+        manifest.append(fingerprint.relative ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.exists ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.length);
+        manifest.append('\t');
+        manifest.append(fingerprint.lastModified);
+        manifest.append('\t');
+        manifest.append(encodedPath);
+        manifest.append('\n');
+      }
+      return manifest.toString();
+    }
+
+    private static FileFingerprint[] decode(String manifest)
+      throws IOException
+    {
+      if (manifest.isEmpty()) {
+        return new FileFingerprint[0];
+      }
+      String[] lines = manifest.split("\\n");
+      FileFingerprint[] fingerprints = new FileFingerprint[lines.length];
+      Base64.Decoder decoder = Base64.getUrlDecoder();
+      try {
+        for (int i = 0; i < lines.length; i++) {
+          String[] fields = lines[i].split("\\t", -1);
+          if (fields.length != 5) {
+            throw new IOException("Invalid file fingerprint manifest");
+          }
+          String path = new String(decoder.decode(fields[4]),
+            StandardCharsets.UTF_8);
+          fingerprints[i] = new FileFingerprint(path,
+            "1".equals(fields[0]), "1".equals(fields[1]),
+            Long.parseLong(fields[2]), Long.parseLong(fields[3]));
+        }
+      }
+      catch (IllegalArgumentException e) {
+        throw new IOException("Invalid file fingerprint manifest", e);
+      }
+      return fingerprints;
+    }
   }
 
   public static class KryoDeser implements Deser {
@@ -341,7 +423,7 @@ public class Memoizer extends ReaderWrapper {
    * cached items. This should happen when the order and type of objects stored
    * in the memo file changes.
    */
-  public static final Integer VERSION = 4;
+  public static final Integer VERSION = 5;
 
   /**
    * Default value for {@link #minimumElapsed} if none is provided in the
@@ -916,10 +998,14 @@ public class Memoizer extends ReaderWrapper {
       }
 
       // RELEASE VERSION NUMBER
-       if (versionMismatch()) {
+      if (versionMismatch()) {
          // Logging done in versionMismatch
          return null;
        }
+
+      if (!fileFingerprintsMatch(ser.loadFileFingerprints())) {
+        return null;
+      }
 
       // CLASS & COPY
       try {
@@ -1012,6 +1098,7 @@ public class Memoizer extends ReaderWrapper {
       // Save to temporary location.
       ser.saveVersion(VERSION);
       ser.saveReleaseVersion(FormatTools.VERSION);
+      ser.saveFileFingerprints(createFileFingerprints());
       ser.saveReader(reader);
       ser.saveStop();
       LOGGER.debug("saved to temp file: {}", tempFile);
@@ -1048,6 +1135,51 @@ public class Memoizer extends ReaderWrapper {
       deleteQuietly(tempFile);
     }
     return rv;
+  }
+
+  private FileFingerprint[] createFileFingerprints() {
+    String[] usedFiles = reader.getUsedFiles();
+    FileFingerprint[] fingerprints = new FileFingerprint[usedFiles.length];
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    Path primaryParentPath = primaryParent == null ? null :
+      Paths.get(primaryParent.getAbsolutePath()).normalize();
+
+    for (int i = 0; i < usedFiles.length; i++) {
+      Location usedFile = new Location(usedFiles[i]).getAbsoluteFile();
+      String path = usedFile.getAbsolutePath();
+      boolean relative = false;
+      if (primaryParentPath != null) {
+        try {
+          path = primaryParentPath.relativize(
+            Paths.get(path).normalize()).toString();
+          relative = true;
+        }
+        catch (IllegalArgumentException e) {
+          LOGGER.debug("Cannot make used file relative to primary file: {}",
+            path);
+        }
+      }
+      fingerprints[i] = new FileFingerprint(path, relative,
+        usedFile.exists(), usedFile.length(), usedFile.lastModified());
+    }
+    return fingerprints;
+  }
+
+  private boolean fileFingerprintsMatch(FileFingerprint[] fingerprints) {
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    for (FileFingerprint fingerprint : fingerprints) {
+      Location usedFile = fingerprint.relative && primaryParent != null ?
+        new Location(primaryParent, fingerprint.path) :
+        new Location(fingerprint.path);
+      if (usedFile.exists() != fingerprint.exists ||
+        usedFile.length() != fingerprint.length ||
+        usedFile.lastModified() != fingerprint.lastModified)
+      {
+        LOGGER.debug("used file changed since memo creation: {}", usedFile);
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -342,4 +342,29 @@ public class MemoizerTest {
     changed.close();
   }
 
+  @Test
+  public void testChangedCompanionFileInvalidatesMemo() throws Exception {
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(),
+      "sizeX=20\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(companion.toPath(),
+      "sizeX=200\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    assertEquals(changed.getSizeX(), 200);
+    changed.close();
+  }
+
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -38,9 +38,11 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNull;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import loci.formats.Memoizer;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.FakeReader;
 
 import org.testng.annotations.AfterMethod;
@@ -272,6 +274,72 @@ public class MemoizerTest {
     assertFalse(memoFile.exists());
     reader.close();
     checkMemo(memoizer, id);
+  }
+
+  @Test
+  public void testMetadataOnlyPreservedOnSaveAndLoad() throws Exception {
+    OMEXMLService service = new ServiceFactory().getInstance(
+      OMEXMLService.class);
+    Memoizer memoizer = new Memoizer(reader, 0);
+
+    OMEXMLMetadata saveMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(saveMetadata);
+    memoizer.setId(id);
+    assertTrue(service.validateOMEXML(service.getOMEXML(saveMetadata)));
+    memoizer.close();
+
+    OMEXMLMetadata loadMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(loadMetadata);
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertTrue(service.validateOMEXML(service.getOMEXML(loadMetadata)));
+    memoizer.close();
+  }
+
+  @Test
+  public void testChangedDynamicOptionsInvalidateMemo() throws Exception {
+    DynamicMetadataOptions firstOptions = new DynamicMetadataOptions();
+    firstOptions.set("reader.option", "first");
+    reader.setMetadataOptions(firstOptions);
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    FakeReader secondReader = new FakeReader();
+    DynamicMetadataOptions secondOptions = new DynamicMetadataOptions();
+    secondOptions.set("reader.option", "second");
+    secondReader.setMetadataOptions(secondOptions);
+    Memoizer second = new Memoizer(secondReader, 0);
+    second.setId(id);
+    assertFalse(second.isLoadedFromMemo());
+    second.close();
+  }
+
+  @Test
+  public void testOptionsFileParticipatesInMemoCompatibility()
+    throws Exception
+  {
+    File optionsFile = new File(id + ".bfoptions");
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=MINIMUM\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=ALL\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    changed.close();
   }
 
 }


### PR DESCRIPTION
Hej,

testing ome/bioformats#4450 on Java 25 revealed a few problems with the memoizer, this is the third one.

Memoized readers can become stale when an input file, companion file, or reader option changes. This can cause outdated metadata or dimensions to be reused from the cache.

Record fingerprints for all files used by the reader and invalidate the memo when their existence, size, or modification time changes. Also include complete metadata options in compatibility checks, including dynamic properties and sidecar option files.

Bump the memo version and add tests covering changed files, options, and metadata preservation.