### PR TITLE
Report memo saves only after successful installation

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -38,6 +38,13 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ArrayIndexOutOfBoundsException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Base64;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -1021,22 +1028,88 @@ public class Memoizer extends ReaderWrapper {
         LOGGER.error("output close failed", t);
       }
 
-      // Rename temporary file if successful.
-      // Any failures will have to be ignored.
-      // Note: renaming the tempfile with open
-      // resources can lead to segfaults
+      // Install the temporary file if serialization succeeded.
+      // Note: moving the tempfile with open resources can lead to segfaults.
       if (rv) {
-        if (!tempFile.renameTo(memoFile)) {
-          LOGGER.error("temp file rename returned false: {}", tempFile);
-        } else {
+        try {
+          installMemo(tempFile, memoFile);
           LOGGER.debug("saved memo file: {} ({} bytes)",
             memoFile, memoFile.length());
+        }
+        catch (IOException | SecurityException e) {
+          LOGGER.error("failed to install memo file: {}", memoFile, e);
+          rv = false;
         }
       }
 
       deleteQuietly(tempFile);
     }
     return rv;
+  }
+
+  /**
+   * Move a completed temporary memo into its final location.
+   *
+   * @param source completed temporary memo
+   * @param destination final memo path
+   * @throws IOException if the memo cannot be installed
+   */
+  protected void installMemo(File source, File destination)
+    throws IOException
+  {
+    try {
+      Files.move(source.toPath(), destination.toPath(),
+        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch (AtomicMoveNotSupportedException e) {
+      Files.move(source.toPath(), destination.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private FileFingerprint[] createFileFingerprints() {
+    String[] usedFiles = reader.getUsedFiles();
+    FileFingerprint[] fingerprints = new FileFingerprint[usedFiles.length];
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    Path primaryParentPath = primaryParent == null ? null :
+      Paths.get(primaryParent.getAbsolutePath()).normalize();
+
+    for (int i = 0; i < usedFiles.length; i++) {
+      Location usedFile = new Location(usedFiles[i]).getAbsoluteFile();
+      String path = usedFile.getAbsolutePath();
+      boolean relative = false;
+      if (primaryParentPath != null) {
+        try {
+          path = primaryParentPath.relativize(
+            Paths.get(path).normalize()).toString();
+          relative = true;
+        }
+        catch (IllegalArgumentException e) {
+          LOGGER.debug("Cannot make used file relative to primary file: {}",
+            path);
+        }
+      }
+      fingerprints[i] = new FileFingerprint(path, relative,
+        usedFile.exists(), usedFile.length(), usedFile.lastModified());
+    }
+    return fingerprints;
+  }
+
+  private boolean fileFingerprintsMatch(FileFingerprint[] fingerprints) {
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    for (FileFingerprint fingerprint : fingerprints) {
+      Location usedFile = fingerprint.relative && primaryParent != null ?
+        new Location(primaryParent, fingerprint.path) :
+        new Location(fingerprint.path);
+      if (usedFile.exists() != fingerprint.exists ||
+        usedFile.length() != fingerprint.length ||
+        usedFile.lastModified() != fingerprint.lastModified)
+      {
+        LOGGER.debug("used file changed since memo creation: {}", usedFile);
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -38,6 +38,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNull;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import loci.formats.Memoizer;
@@ -49,6 +51,20 @@ import org.testng.annotations.Test;
 
 
 public class MemoizerTest {
+
+  private static class FailingInstallMemoizer extends Memoizer {
+
+    FailingInstallMemoizer(FakeReader reader) {
+      super(reader, 0);
+    }
+
+    @Override
+    protected void installMemo(File source, File destination)
+      throws IOException
+    {
+      throw new IOException("expected installation failure");
+    }
+  }
 
   private static final String TEST_FILE =
     "test&pixelType=int8&sizeX=20&sizeY=20&sizeC=1&sizeZ=1&sizeT=1.fake";
@@ -272,6 +288,107 @@ public class MemoizerTest {
     assertFalse(memoFile.exists());
     reader.close();
     checkMemo(memoizer, id);
+  }
+
+  @Test
+  public void testMetadataOnlyPreservedOnSaveAndLoad() throws Exception {
+    OMEXMLService service = new ServiceFactory().getInstance(
+      OMEXMLService.class);
+    Memoizer memoizer = new Memoizer(reader, 0);
+
+    OMEXMLMetadata saveMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(saveMetadata);
+    memoizer.setId(id);
+    assertTrue(service.validateOMEXML(service.getOMEXML(saveMetadata)));
+    memoizer.close();
+
+    OMEXMLMetadata loadMetadata = service.createOMEXMLMetadata();
+    memoizer.setMetadataStore(loadMetadata);
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertTrue(service.validateOMEXML(service.getOMEXML(loadMetadata)));
+    memoizer.close();
+  }
+
+  @Test
+  public void testChangedDynamicOptionsInvalidateMemo() throws Exception {
+    DynamicMetadataOptions firstOptions = new DynamicMetadataOptions();
+    firstOptions.set("reader.option", "first");
+    reader.setMetadataOptions(firstOptions);
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    FakeReader secondReader = new FakeReader();
+    DynamicMetadataOptions secondOptions = new DynamicMetadataOptions();
+    secondOptions.set("reader.option", "second");
+    secondReader.setMetadataOptions(secondOptions);
+    Memoizer second = new Memoizer(secondReader, 0);
+    second.setId(id);
+    assertFalse(second.isLoadedFromMemo());
+    second.close();
+  }
+
+  @Test
+  public void testOptionsFileParticipatesInMemoCompatibility()
+    throws Exception
+  {
+    File optionsFile = new File(id + ".bfoptions");
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=MINIMUM\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=ALL\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    changed.close();
+  }
+
+  @Test
+  public void testChangedCompanionFileInvalidatesMemo() throws Exception {
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(),
+      "sizeX=20\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(companion.toPath(),
+      "sizeX=200\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    assertEquals(changed.getSizeX(), 200);
+    changed.close();
+  }
+
+  @Test
+  public void testInstallFailureIsNotReportedAsSaved() throws Exception {
+    Memoizer memoizer = new FailingInstallMemoizer(reader);
+    File memoFile = memoizer.getMemoFile(id);
+    memoizer.setId(id);
+    assertFalse(memoizer.isSavedToMemo());
+    assertFalse(memoFile.exists());
+    memoizer.close();
   }
 
 }


### PR DESCRIPTION
Hej,

testing ome/bioformats#4450 on Java 25 revealed a few problems with the memoizer, this is the fourth one.

File.renameTo returned only a boolean and Memoizer logged a false result without clearing its success flag. Callers could consequently observe saveMemo and isSavedToMemo as true even though the final memo file did not exist.

Install completed temporary memos with a checked atomic Files.move, falling back to a replace move when atomic moves are unsupported. Propagate installation failure into the returned status and cover the failure path with an injected move error.