### PR TITLE
Quicktime fixes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/QTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/QTReader.java
@@ -178,7 +178,7 @@ public class QTReader extends FormatReader {
     preparePreviousFrame(no, code);
 
     int offset = offsets.get(no).intValue();
-    int nextOffset = (int) pixelBytes;
+    int nextOffset = (int) (pixelOffset + pixelBytes);
 
     scale = offsets.get(0).intValue();
     offset -= scale;
@@ -472,11 +472,12 @@ public class QTReader extends FormatReader {
         if (atomType.equals("mdat")) {
           // we've found the pixel data
           pixelOffset = in.getFilePointer();
-          pixelBytes = offset + atomSize;
+          long pixelEnd = offset + atomSize;
 
-          if (pixelBytes > in.length()) {
-            pixelBytes = in.length();
+          if (pixelEnd > in.length()) {
+            pixelEnd = in.length();
           }
+          pixelBytes = pixelEnd - pixelOffset;
         }
         else if (atomType.equals("tkhd")) {
           // we've found the dimensions
@@ -537,9 +538,9 @@ public class QTReader extends FormatReader {
           if (numPlanes != getImageCount()) {
             int off = in.readInt();
             offsets.add(off);
-            for (int i=1; i<getImageCount(); i++) {
-              if (i - 1 < chunkSizes.size()) {
-                rawSize = chunkSizes.get(i - 1).intValue();
+            for (int i=0; i<getImageCount() - 1; i++) {
+              if (chunkSizes.size() > 0 && i < chunkSizes.size()) {
+                rawSize = chunkSizes.get(i).intValue();
               }
               else i = getImageCount();
               off += rawSize;

--- a/components/formats-bsd/src/loci/formats/in/QTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/QTReader.java
@@ -182,8 +182,9 @@ public class QTReader extends FormatReader {
     offset -= scale;
 
     if (no < offsets.size() - 1) {
-      nextOffset = offsets.get(no + 1).intValue() - scale;
+      nextOffset = offsets.get(no + 1).intValue();
     }
+    nextOffset -= scale;
 
     if ((nextOffset - offset) < 0) {
       int temp = offset;
@@ -448,10 +449,10 @@ public class QTReader extends FormatReader {
         if (atomType.equals("mdat")) {
           // we've found the pixel data
           pixelOffset = in.getFilePointer();
-          pixelBytes = atomSize;
+          pixelBytes = offset + atomSize;
 
-          if (pixelBytes > (in.length() - pixelOffset)) {
-            pixelBytes = in.length() - pixelOffset;
+          if (pixelBytes > in.length()) {
+            pixelBytes = in.length();
           }
         }
         else if (atomType.equals("tkhd")) {
@@ -511,12 +512,11 @@ public class QTReader extends FormatReader {
           in.skipBytes(4);
           int numPlanes = in.readInt();
           if (numPlanes != getImageCount()) {
-            in.seek(in.getFilePointer() - 4);
             int off = in.readInt();
             offsets.add(off);
             for (int i=1; i<getImageCount(); i++) {
-              if ((chunkSizes.size() > 0) && (i < chunkSizes.size())) {
-                rawSize = chunkSizes.get(i).intValue();
+              if (i - 1 < chunkSizes.size()) {
+                rawSize = chunkSizes.get(i - 1).intValue();
               }
               else i = getImageCount();
               off += rawSize;
@@ -574,7 +574,6 @@ public class QTReader extends FormatReader {
           core.get(0).imageCount = in.readInt();
 
           if (rawSize == 0) {
-            in.seek(in.getFilePointer() - 4);
             for (int b=0; b<getImageCount(); b++) {
               chunkSizes.add(in.readInt());
             }

--- a/components/formats-bsd/src/loci/formats/in/QTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/QTReader.java
@@ -94,7 +94,7 @@ public class QTReader extends FormatReader {
   private byte[] prevPixels;
 
   /** Previous plane number. */
-  private int prevPlane;
+  private int prevPlane = -1;
 
   /** Flag indicating whether we can safely use prevPixels. */
   private boolean canUsePrevious;
@@ -174,6 +174,8 @@ public class QTReader extends FormatReader {
 
     String code = codec;
     if (no >= getImageCount() - altPlanes) code = altCodec;
+
+    preparePreviousFrame(no, code);
 
     int offset = offsets.get(no).intValue();
     int nextOffset = (int) pixelBytes;
@@ -285,7 +287,8 @@ public class QTReader extends FormatReader {
       prevPixels = null;
       codec = altCodec = null;
       pixelOffset = pixelBytes = bitsPerPixel = rawSize = 0;
-      prevPlane = altPlanes = 0;
+      prevPlane = -1;
+      altPlanes = 0;
       canUsePrevious = false;
       scale = 0;
       chunkSizes = null;
@@ -408,6 +411,26 @@ public class QTReader extends FormatReader {
   }
 
   // -- Helper methods --
+
+  /**
+   * Rebuild the frame needed to decode a randomly accessed QTRLE delta frame.
+   */
+  private void preparePreviousFrame(int no, String code)
+    throws FormatException, IOException
+  {
+    if (no == 0 || !"rle ".equals(code) || code.equals(altCodec) ||
+      prevPlane == no || (prevPixels != null && prevPlane == no - 1))
+    {
+      return;
+    }
+
+    prevPixels = null;
+    prevPlane = -1;
+    canUsePrevious = false;
+    for (int plane = 0; plane < no; plane++) {
+      openBytes(plane);
+    }
+  }
 
   /** Parse all of the atoms in the file. */
   private void parse(int depth, long offset, long length)

--- a/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
@@ -33,11 +33,13 @@
 package loci.formats.utests;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Base64;
 
+import loci.formats.Memoizer;
 import loci.formats.in.QTReader;
 
 import org.testng.annotations.AfterMethod;
@@ -66,6 +68,7 @@ public class QTReaderTest {
 
   private File testDirectory;
   private File movie;
+  private File memoDirectory;
 
   @BeforeMethod
   public void setUp() throws Exception {
@@ -73,6 +76,8 @@ public class QTReaderTest {
       QTReaderTest.class.getName()).toFile();
     movie = new File(testDirectory, "delta.mov");
     Files.write(movie.toPath(), Base64.getDecoder().decode(QTRLE_MOVIE));
+    memoDirectory = new File(testDirectory, "memo");
+    assertTrue(memoDirectory.mkdir());
   }
 
   @AfterMethod
@@ -89,6 +94,31 @@ public class QTReaderTest {
       for (int plane = 1; plane < direct.getImageCount(); plane++) {
         assertEquals(direct.openBytes(plane), expected);
       }
+    }
+  }
+
+  @Test
+  public void testMemoizedRandomAccessToDeltaFrames() throws Exception {
+    byte[][] expected;
+    try (QTReader direct = new QTReader()) {
+      direct.setId(movie.getAbsolutePath());
+      expected = new byte[direct.getImageCount()][];
+      for (int plane = 0; plane < expected.length; plane++) {
+        expected[plane] = direct.openBytes(plane);
+      }
+    }
+
+    Memoizer seed = new Memoizer(new QTReader(), 0, memoDirectory);
+    seed.setId(movie.getAbsolutePath());
+    assertTrue(seed.isSavedToMemo());
+    seed.close();
+
+    for (int plane = 0; plane < expected.length; plane++) {
+      Memoizer memoized = new Memoizer(new QTReader(), 0, memoDirectory);
+      memoized.setId(movie.getAbsolutePath());
+      assertTrue(memoized.isLoadedFromMemo());
+      assertEquals(memoized.openBytes(plane), expected[plane]);
+      memoized.close();
     }
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
@@ -36,7 +36,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Base64;
 
 import loci.formats.Memoizer;
@@ -67,22 +72,29 @@ public class QTReaderTest {
     "AAAAFHN0Y28AAAAAAAAAAQAAACQAAAAhdWR0YQAAABmpc3dyAA1VxExhdmY2MC4xNi4xMDA=";
 
   private File testDirectory;
+  private Path testDirectoryPath;
   private File movie;
   private File memoDirectory;
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
-    testDirectory = Files.createTempDirectory(
-      QTReaderTest.class.getName()).toFile();
+    testDirectoryPath = Files.createTempDirectory(QTReaderTest.class.getName());
+    testDirectory = testDirectoryPath.toFile();
     movie = new File(testDirectory, "delta.mov");
     Files.write(movie.toPath(), Base64.getDecoder().decode(QTRLE_MOVIE));
     memoDirectory = new File(testDirectory, "memo");
     assertTrue(memoDirectory.mkdir());
   }
 
-  @AfterMethod
-  public void tearDown() {
-    deleteOnExit(testDirectory);
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws Exception {
+    if (testDirectoryPath != null) {
+      deleteRecursively(testDirectoryPath);
+      testDirectoryPath = null;
+      testDirectory = null;
+      movie = null;
+      memoDirectory = null;
+    }
   }
 
   @Test
@@ -124,13 +136,30 @@ public class QTReaderTest {
     }
   }
 
-  private static void deleteOnExit(File file) {
-    File[] children = file.listFiles();
-    if (children != null) {
-      for (File child : children) {
-        deleteOnExit(child);
-      }
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return;
     }
-    file.deleteOnExit();
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+
+      @Override
+      public FileVisitResult visitFile(Path file,
+        BasicFileAttributes attributes) throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) {
+          throw failure;
+        }
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
@@ -108,17 +108,19 @@ public class QTReaderTest {
       }
     }
 
-    Memoizer seed = new Memoizer(new QTReader(), 0, memoDirectory);
-    seed.setId(movie.getAbsolutePath());
-    assertTrue(seed.isSavedToMemo());
-    seed.close();
+    try (Memoizer seed = new Memoizer(new QTReader(), 0, memoDirectory)) {
+      seed.setId(movie.getAbsolutePath());
+      assertTrue(seed.isSavedToMemo());
+    }
 
     for (int plane = 0; plane < expected.length; plane++) {
-      Memoizer memoized = new Memoizer(new QTReader(), 0, memoDirectory);
-      memoized.setId(movie.getAbsolutePath());
-      assertTrue(memoized.isLoadedFromMemo());
-      assertEquals(memoized.openBytes(plane), expected[plane]);
-      memoized.close();
+      try (Memoizer memoized =
+        new Memoizer(new QTReader(), 0, memoDirectory))
+      {
+        memoized.setId(movie.getAbsolutePath());
+        assertTrue(memoized.isLoadedFromMemo());
+        assertEquals(memoized.openBytes(plane), expected[plane]);
+      }
     }
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/QTReaderTest.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Base64;
+
+import loci.formats.in.QTReader;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class QTReaderTest {
+
+  /** Six-frame 8x8 QTRLE movie with delta frames after the first frame. */
+  private static final String QTRLE_MOVIE =
+    "AAAAFGZ0eXBxdCAgAAACAHF0ICAAAAAId2lkZQAAAMdtZGF0AAAAnAAIAAAAAAAIAAAB+P8AAP8B+AD/AP8B+AAA" +
+    "//8B+P//AP8B+P8A//8B+AD///8B+ICAgP8B+P////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAA" +
+    "AAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAcAAAAAAALubW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAF3AA" +
+    "AQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAA" +
+    "AAAAAAAAAAAAAAAAAgAAAll0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAF3AAAAAAAAAAAAAAAAAA" +
+    "AAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAgAAAAIAAAAAAAkZWR0cwAAABxlbHN0AAAA" +
+    "AAAAAAEAABdwAAAAAAABAAAAAAHRbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABAAAABgAB//wAAAAAALWhkbHIA" +
+    "AAAAbWhscnZpZGUAAAAAAAAAAAAAAAAMVmlkZW9IYW5kbGVyAAABfG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAA" +
+    "ACxoZGxyAAAAAGRobHJ1cmwgAAAAAAAAAAAAAAAAC0RhdGFIYW5kbGVyAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAAB" +
+    "AAAADHVybCAAAAABAAABEHN0YmwAAACAc3RzZAAAAAAAAAABAAAAcHJsZSAAAAAAAAAAAQAAAABGRk1QAAACAAAA" +
+    "AgAACAAIAEgAAABIAAAAAAAAAAETTGF2YzYwLjMxLjEwMiBxdHJsZQAAAAAAAAAAAAAAAAAY//8AAAAKZmllbAEA" +
+    "AAAAEHBhc3AAAAABAAAAAQAAABhzdHRzAAAAAAAAAAEAAAAGAABAAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAHHN0" +
+    "c2MAAAAAAAAAAQAAAAEAAAAGAAAAAQAAACxzdHN6AAAAAAAAAAAAAAAGAAAAnAAAAAcAAAAHAAAABwAAAAcAAAAH" +
+    "AAAAFHN0Y28AAAAAAAAAAQAAACQAAAAhdWR0YQAAABmpc3dyAA1VxExhdmY2MC4xNi4xMDA=";
+
+  private File testDirectory;
+  private File movie;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    testDirectory = Files.createTempDirectory(
+      QTReaderTest.class.getName()).toFile();
+    movie = new File(testDirectory, "delta.mov");
+    Files.write(movie.toPath(), Base64.getDecoder().decode(QTRLE_MOVIE));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    deleteOnExit(testDirectory);
+  }
+
+  @Test
+  public void testVariableSampleSizesAfterLeadingAtoms() throws Exception {
+    try (QTReader direct = new QTReader()) {
+      direct.setId(movie.getAbsolutePath());
+      assertEquals(direct.getImageCount(), 6);
+      byte[] expected = direct.openBytes(0);
+      for (int plane = 1; plane < direct.getImageCount(); plane++) {
+        assertEquals(direct.openBytes(plane), expected);
+      }
+    }
+  }
+
+  private static void deleteOnExit(File file) {
+    File[] children = file.listFiles();
+    if (children != null) {
+      for (File child : children) {
+        deleteOnExit(child);
+      }
+    }
+    file.deleteOnExit();
+  }
+}

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -132,6 +132,12 @@
         <class name="loci.formats.utests.MemoizerTest"/>
       </classes>
     </test>
+    <test name="QTReaderTest">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.QTReaderTest"/>
+      </classes>
+    </test>
     <test name="AxisGuesserTest">
       <groups/>
       <classes>


### PR DESCRIPTION
Hej,
while investigating weird memoization behaviors, I came upon the old issue ome/bioformats#4091. It was on the way, and only partially related to the memoization problems.

These commits now fix QuickTime parsing for variable-sized samples and random access to QTRLE delta frames after memoization, by which it fixes ome/bioformats#4091

## Changes

- Correct QuickTime sample-size and chunk-offset table parsing.
- Handle leading atoms and final sample boundaries correctly.
- Rebuild preceding QTRLE reference frames when accessing delta frames non-sequentially.
- Add regression tests covering variable sample sizes and memoized random access.