### PR TITLE
Memoizer fixes

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1267,9 +1267,7 @@ public final class FormatTools {
       return false;
     }
 
-    if (!a.getMetadataOptions().getMetadataLevel().equals(
-      b.getMetadataOptions().getMetadataLevel()))
-    {
+    if (!a.getMetadataOptions().equals(b.getMetadataOptions())) {
       return false;
     }
 

--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -80,4 +80,23 @@ public class DefaultMetadataOptions implements MetadataOptions {
     validate = validateMetadata;
   }
 
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    DefaultMetadataOptions options = (DefaultMetadataOptions) other;
+    return metadataLevel == options.metadataLevel &&
+      validate == options.validate;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = metadataLevel == null ? 0 : metadataLevel.hashCode();
+    return 31 * result + (validate ? 1 : 0);
+  }
+
 }

--- a/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DynamicMetadataOptions.java
@@ -105,6 +105,23 @@ public class DynamicMetadataOptions implements MetadataOptions {
     setBoolean(READER_VALIDATE_KEY, validateMetadata);
   }
 
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    DynamicMetadataOptions options = (DynamicMetadataOptions) other;
+    return props.equals(options.props);
+  }
+
+  @Override
+  public int hashCode() {
+    return props.hashCode();
+  }
+
   // -- key/value options --
 
   /**
@@ -489,7 +506,30 @@ public class DynamicMetadataOptions implements MetadataOptions {
     return new File(val);
   }
   
-  public void loadOptions(String optionsFile, ArrayList<String> availableOptionKeys) throws IOException, FormatException {
+  /**
+   * Load options without checking them against a reader's supported keys.
+   *
+   * @param optionsFile path to the options file
+   * @throws IOException if the file cannot be read
+   * @throws FormatException if the options file is invalid
+   */
+  public void loadOptions(String optionsFile) throws IOException,
+    FormatException
+  {
+    loadOptions(optionsFile, null);
+  }
+
+  /**
+   * Load options and warn about keys that are not advertised by the reader.
+   *
+   * @param optionsFile path to the options file
+   * @param availableOptionKeys keys advertised by the reader
+   * @throws IOException if the file cannot be read
+   * @throws FormatException if the options file is invalid
+   */
+  public void loadOptions(String optionsFile,
+    ArrayList<String> availableOptionKeys) throws IOException, FormatException
+  {
     if (!new Location(optionsFile).exists()) {
       LOGGER.trace("Options file doesn't exist: {}", optionsFile);
       // TODO: potentially create option
@@ -504,7 +544,8 @@ public class DynamicMetadataOptions implements MetadataOptions {
     IniList list = parser.parseINI(new File(optionsFile));
     for (IniTable attrs: list) {
       for (String key: attrs.keySet()) {
-        if (!key.equals(IniTable.HEADER_KEY) &&
+        if (availableOptionKeys != null &&
+            !key.equals(IniTable.HEADER_KEY) &&
             !availableOptionKeys.contains(key)) {
           LOGGER.warn("Metadata Option Key is not supported in this reader " + key);
         }

--- a/components/formats-api/src/loci/formats/in/MetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataOptions.java
@@ -35,6 +35,13 @@ package loci.formats.in;
 
 /**
  * Holds metadata-related options.
+ *
+ * Memoized readers compare metadata options using {@link #equals(Object)}.
+ * Implementations that use value semantics should therefore override both
+ * {@code equals} and {@link #hashCode()} and include every option that can
+ * affect reader initialization. Implementations that retain identity equality
+ * are safe to use, but will cause memoized readers to be reinitialized rather
+ * than loaded from a memo file.
  */
 public interface MetadataOptions {
 

--- a/components/formats-api/test/loci/formats/utests/DefaultMetadataOptionsTest.java
+++ b/components/formats-api/test/loci/formats/utests/DefaultMetadataOptionsTest.java
@@ -76,4 +76,17 @@ public class DefaultMetadataOptionsTest {
     assertFalse(opt.isValidate());
   }
 
+  @Test
+  public void testEqualityIncludesValidation() {
+    MetadataOptions other = new DefaultMetadataOptions();
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+
+    opt.setValidate(true);
+    assertFalse(opt.equals(other));
+    other.setValidate(true);
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+  }
+
 }

--- a/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
+++ b/components/formats-api/test/loci/formats/utests/DynamicMetadataOptionsTest.java
@@ -371,6 +371,19 @@ public class DynamicMetadataOptionsTest {
     assertFalse(opt.isValidate());
   }
 
+  @Test
+  public void testEqualityIncludesDynamicProperties() {
+    DynamicMetadataOptions other = new DynamicMetadataOptions();
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+
+    opt.set("reader.option", "first");
+    assertFalse(opt.equals(other));
+    other.set("reader.option", "first");
+    assertEquals(opt, other);
+    assertEquals(opt.hashCode(), other.hashCode());
+  }
+
   @Test(dataProvider = "optionFiles")
   public void testGetMetadataOptionsFile(String source, String target) {
     source = source.replace('/', File.separatorChar);

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -39,8 +39,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ArrayIndexOutOfBoundsException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Base64;
 
 import loci.common.Constants;
@@ -1119,16 +1122,17 @@ public class Memoizer extends ReaderWrapper {
         LOGGER.error("output close failed", t);
       }
 
-      // Rename temporary file if successful.
-      // Any failures will have to be ignored.
-      // Note: renaming the tempfile with open
-      // resources can lead to segfaults
+      // Install the temporary file if serialization succeeded.
+      // Note: moving the tempfile with open resources can lead to segfaults.
       if (rv) {
-        if (!tempFile.renameTo(memoFile)) {
-          LOGGER.error("temp file rename returned false: {}", tempFile);
-        } else {
+        try {
+          installMemo(tempFile, memoFile);
           LOGGER.debug("saved memo file: {} ({} bytes)",
             memoFile, memoFile.length());
+        }
+        catch (IOException | SecurityException e) {
+          LOGGER.error("failed to install memo file: {}", memoFile, e);
+          rv = false;
         }
       }
 
@@ -1180,6 +1184,26 @@ public class Memoizer extends ReaderWrapper {
       }
     }
     return true;
+  }
+
+  /**
+   * Move a completed temporary memo into its final location.
+   *
+   * @param source completed temporary memo
+   * @param destination final memo path
+   * @throws IOException if the memo cannot be installed
+   */
+  protected void installMemo(File source, File destination)
+    throws IOException
+  {
+    try {
+      Files.move(source.toPath(), destination.toPath(),
+        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch (AtomicMoveNotSupportedException e) {
+      Files.move(source.toPath(), destination.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
+    }
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -520,7 +520,7 @@ public class Memoizer extends ReaderWrapper {
    * cached items. This should happen when the order and type of objects stored
    * in the memo file changes.
    */
-  public static final Integer VERSION = 6;
+  public static final Integer VERSION = 5;
 
   /**
    * Default value for {@link #minimumElapsed} if none is provided in the

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -572,8 +572,8 @@ public class Memoizer extends ReaderWrapper {
 
   /**
    * Boolean specifying whether to invalidate the memo file based upon
-   * mismatched major/minor version numbers. By default, the Git commit hash
-   * is used to invalidate the memo file.
+   * mismatched major/minor version numbers. Release versions are not compared
+   * by default.
    */
   private boolean versionChecking = false;
 
@@ -763,9 +763,8 @@ public class Memoizer extends ReaderWrapper {
   }
 
   /**
-   * Returns {@code true} if the version of the memo file as returned by
-   * {@link Deser#loadReleaseVersion()} and {@link Deser#loadRevision()}
-   * do not match the current version as specified by {@link FormatTools#VERSION}.
+   * Returns {@code true} if release-version checking is enabled and the
+   * memo's major/minor release does not match {@link FormatTools#VERSION}.
    */
   public boolean versionMismatch() throws IOException {
 
@@ -792,14 +791,6 @@ public class Memoizer extends ReaderWrapper {
         return true;
       }
 
-      // REVISION NUMBER
-      if (!versionChecking &&
-          FormatTools.VERSION.endsWith("-SNAPSHOT")) {
-        LOGGER.info("Development version: {}",
-          FormatTools.VERSION);
-        return true;
-      }
-
       return false;
   }
 
@@ -811,8 +802,8 @@ public class Memoizer extends ReaderWrapper {
    * calling code (e.g. 4.4) and the major/minor version saved in the memo
    * file (e.g. 5.0) will result in the memo file being invalidated.
    *
-   * If {@code false} (default), a mismatch in the Git commit hashes will
-   * invalidate the memo file.
+   * If {@code false} (default), the release version is not compared. Memo
+   * format compatibility is still checked using {@link #VERSION}.
    *
    * This method allows for less strict version checking.
    *

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -44,7 +44,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -94,6 +101,14 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
  *
  * In essence, the speed-up gained from memoization will happen only after the
  * first initialization of the reader for a particular file.
+ *
+ * Memo validity is checked against the existence, size, and modification time
+ * of files used during initialization. Directory membership is also recorded
+ * so that adding or removing a possible dataset dependency causes the reader
+ * to be initialized again. These checks are cache freshness heuristics, not
+ * content-integrity checks: a file whose contents change while its size and
+ * modification time remain identical cannot be distinguished without reading
+ * the file again.
  */
 public class Memoizer extends ReaderWrapper {
 
@@ -107,8 +122,8 @@ public class Memoizer extends ReaderWrapper {
 
     String loadRevision() throws IOException;
 
-    default FileFingerprint[] loadFileFingerprints() throws IOException {
-      return FileFingerprint.decode(loadRevision());
+    default DependencyManifest loadDependencyManifest() throws IOException {
+      return DependencyManifest.decode(loadRevision());
     }
 
     IFormatReader loadReader() throws IOException, ClassNotFoundException;
@@ -123,10 +138,10 @@ public class Memoizer extends ReaderWrapper {
 
     void saveRevision(String revision) throws IOException;
 
-    default void saveFileFingerprints(FileFingerprint[] fingerprints)
+    default void saveDependencyManifest(DependencyManifest manifest)
       throws IOException
     {
-      saveRevision(FileFingerprint.encode(fingerprints));
+      saveRevision(manifest.encode());
     }
 
     void saveReader(IFormatReader reader) throws IOException;
@@ -155,12 +170,48 @@ public class Memoizer extends ReaderWrapper {
       this.lastModified = lastModified;
     }
 
-    private static String encode(FileFingerprint[] fingerprints) {
+  }
+
+  /** Directory membership recorded when a memo is created. */
+  public static final class DirectoryFingerprint {
+
+    private final String path;
+    private final boolean relative;
+    private final boolean exists;
+    private final String digest;
+
+    private DirectoryFingerprint(String path, boolean relative,
+      boolean exists, String digest)
+    {
+      this.path = path;
+      this.relative = relative;
+      this.exists = exists;
+      this.digest = digest;
+    }
+  }
+
+  /** Dataset dependencies recorded when a memo is created. */
+  public static final class DependencyManifest {
+
+    private static final String FILE_RECORD = "F";
+    private static final String DIRECTORY_RECORD = "D";
+
+    private final FileFingerprint[] files;
+    private final DirectoryFingerprint[] directories;
+
+    private DependencyManifest(FileFingerprint[] files,
+      DirectoryFingerprint[] directories)
+    {
+      this.files = files;
+      this.directories = directories;
+    }
+
+    private String encode() {
       StringBuilder manifest = new StringBuilder();
       Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
-      for (FileFingerprint fingerprint : fingerprints) {
-        String encodedPath = encoder.encodeToString(
-          fingerprint.path.getBytes(StandardCharsets.UTF_8));
+      for (FileFingerprint fingerprint : files) {
+        manifest.append(FILE_RECORD);
+        manifest.append('\t');
         manifest.append(fingerprint.relative ? '1' : '0');
         manifest.append('\t');
         manifest.append(fingerprint.exists ? '1' : '0');
@@ -169,38 +220,81 @@ public class Memoizer extends ReaderWrapper {
         manifest.append('\t');
         manifest.append(fingerprint.lastModified);
         manifest.append('\t');
-        manifest.append(encodedPath);
+        manifest.append(encodePath(encoder, fingerprint.path));
+        manifest.append('\n');
+      }
+      for (DirectoryFingerprint fingerprint : directories) {
+        manifest.append(DIRECTORY_RECORD);
+        manifest.append('\t');
+        manifest.append(fingerprint.relative ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.exists ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.digest);
+        manifest.append('\t');
+        manifest.append(encodePath(encoder, fingerprint.path));
         manifest.append('\n');
       }
       return manifest.toString();
     }
 
-    private static FileFingerprint[] decode(String manifest)
+    private static DependencyManifest decode(String manifest)
       throws IOException
     {
       if (manifest.isEmpty()) {
-        return new FileFingerprint[0];
+        return new DependencyManifest(new FileFingerprint[0],
+          new DirectoryFingerprint[0]);
       }
       String[] lines = manifest.split("\\n");
-      FileFingerprint[] fingerprints = new FileFingerprint[lines.length];
+      List<FileFingerprint> files = new ArrayList<FileFingerprint>();
+      List<DirectoryFingerprint> directories =
+        new ArrayList<DirectoryFingerprint>();
       Base64.Decoder decoder = Base64.getUrlDecoder();
       try {
-        for (int i = 0; i < lines.length; i++) {
-          String[] fields = lines[i].split("\\t", -1);
-          if (fields.length != 5) {
-            throw new IOException("Invalid file fingerprint manifest");
+        for (String line : lines) {
+          String[] fields = line.split("\\t", -1);
+          if (fields.length == 6 && FILE_RECORD.equals(fields[0])) {
+            files.add(new FileFingerprint(decodePath(decoder, fields[5]),
+              decodeFlag(fields[1]), decodeFlag(fields[2]),
+              Long.parseLong(fields[3]), Long.parseLong(fields[4])));
           }
-          String path = new String(decoder.decode(fields[4]),
-            StandardCharsets.UTF_8);
-          fingerprints[i] = new FileFingerprint(path,
-            "1".equals(fields[0]), "1".equals(fields[1]),
-            Long.parseLong(fields[2]), Long.parseLong(fields[3]));
+          else if (fields.length == 5 &&
+            DIRECTORY_RECORD.equals(fields[0]))
+          {
+            directories.add(new DirectoryFingerprint(
+              decodePath(decoder, fields[4]), decodeFlag(fields[1]),
+              decodeFlag(fields[2]), fields[3]));
+          }
+          else {
+            throw new IOException("Invalid dependency manifest");
+          }
         }
       }
       catch (IllegalArgumentException e) {
-        throw new IOException("Invalid file fingerprint manifest", e);
+        throw new IOException("Invalid dependency manifest", e);
       }
-      return fingerprints;
+      return new DependencyManifest(
+        files.toArray(new FileFingerprint[files.size()]),
+        directories.toArray(
+          new DirectoryFingerprint[directories.size()]));
+    }
+
+    private static String encodePath(Base64.Encoder encoder, String path) {
+      return encoder.encodeToString(path.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decodePath(Base64.Decoder decoder, String path) {
+      return new String(decoder.decode(path), StandardCharsets.UTF_8);
+    }
+
+    private static boolean decodeFlag(String flag) throws IOException {
+      if ("1".equals(flag)) {
+        return true;
+      }
+      if ("0".equals(flag)) {
+        return false;
+      }
+      throw new IOException("Invalid dependency manifest flag");
     }
   }
 
@@ -426,7 +520,7 @@ public class Memoizer extends ReaderWrapper {
    * cached items. This should happen when the order and type of objects stored
    * in the memo file changes.
    */
-  public static final Integer VERSION = 5;
+  public static final Integer VERSION = 6;
 
   /**
    * Default value for {@link #minimumElapsed} if none is provided in the
@@ -1046,7 +1140,7 @@ public class Memoizer extends ReaderWrapper {
          return null;
        }
 
-      if (!fileFingerprintsMatch(ser.loadFileFingerprints())) {
+      if (!dependenciesMatch(ser.loadDependencyManifest())) {
         return null;
       }
 
@@ -1130,18 +1224,21 @@ public class Memoizer extends ReaderWrapper {
     final Deser ser = getDeser();
     final StopWatch sw = stopWatch();
     boolean rv = true;
+    tempFile = null;
     try {
+      DependencyManifest manifest = createDependencyManifest();
+
       // Create temporary location for output
       // Note: can't rename tempfile until resources are closed.
       tempFile = File.createTempFile(
-        memoFile.getName(), "", memoFile.getParentFile());
+        memoFile.getName() + ".", ".tmp", memoFile.getParentFile());
 
       ser.saveStart(tempFile);
 
       // Save to temporary location.
       ser.saveVersion(VERSION);
       ser.saveReleaseVersion(FormatTools.VERSION);
-      ser.saveFileFingerprints(createFileFingerprints());
+      ser.saveDependencyManifest(manifest);
       ser.saveReader(reader);
       ser.saveStop();
       LOGGER.debug("saved to temp file: {}", tempFile);
@@ -1181,40 +1278,53 @@ public class Memoizer extends ReaderWrapper {
     return rv;
   }
 
-  private FileFingerprint[] createFileFingerprints() {
+  private DependencyManifest createDependencyManifest() throws IOException {
     String[] usedFiles = reader.getUsedFiles();
     FileFingerprint[] fingerprints = new FileFingerprint[usedFiles.length];
     Location primaryParent = realFile.getAbsoluteFile().getParentFile();
     Path primaryParentPath = primaryParent == null ? null :
       Paths.get(primaryParent.getAbsolutePath()).normalize();
+    Set<Path> dependencyDirectories = new LinkedHashSet<Path>();
+    if (primaryParentPath != null) {
+      dependencyDirectories.add(primaryParentPath);
+    }
 
     for (int i = 0; i < usedFiles.length; i++) {
       Location usedFile = new Location(usedFiles[i]).getAbsoluteFile();
-      String path = usedFile.getAbsolutePath();
-      boolean relative = false;
-      if (primaryParentPath != null) {
-        try {
-          path = primaryParentPath.relativize(
-            Paths.get(path).normalize()).toString();
-          relative = true;
-        }
-        catch (IllegalArgumentException e) {
-          LOGGER.debug("Cannot make used file relative to primary file: {}",
-            path);
-        }
+      Path usedPath = Paths.get(usedFile.getAbsolutePath()).normalize();
+      StoredPath storedPath = storePath(usedPath, primaryParentPath);
+      Path parent = usedPath.getParent();
+      if (parent != null) {
+        dependencyDirectories.add(parent);
       }
-      fingerprints[i] = new FileFingerprint(path, relative,
+      if (usedFile.isDirectory()) {
+        dependencyDirectories.add(usedPath);
+      }
+      fingerprints[i] = new FileFingerprint(storedPath.path,
+        storedPath.relative,
         usedFile.exists(), usedFile.length(), usedFile.lastModified());
     }
-    return fingerprints;
+
+    DirectoryFingerprint[] directories =
+      new DirectoryFingerprint[dependencyDirectories.size()];
+    int index = 0;
+    for (Path directory : dependencyDirectories) {
+      StoredPath storedPath = storePath(directory, primaryParentPath);
+      boolean exists = Files.isDirectory(directory);
+      directories[index++] = new DirectoryFingerprint(storedPath.path,
+        storedPath.relative, exists,
+        exists ? fingerprintDirectory(directory) : "");
+    }
+    return new DependencyManifest(fingerprints, directories);
   }
 
-  private boolean fileFingerprintsMatch(FileFingerprint[] fingerprints) {
+  private boolean dependenciesMatch(DependencyManifest manifest)
+    throws IOException
+  {
     Location primaryParent = realFile.getAbsoluteFile().getParentFile();
-    for (FileFingerprint fingerprint : fingerprints) {
-      Location usedFile = fingerprint.relative && primaryParent != null ?
-        new Location(primaryParent, fingerprint.path) :
-        new Location(fingerprint.path);
+    for (FileFingerprint fingerprint : manifest.files) {
+      Location usedFile = resolvePath(fingerprint.path, fingerprint.relative,
+        primaryParent);
       if (usedFile.exists() != fingerprint.exists ||
         usedFile.length() != fingerprint.length ||
         usedFile.lastModified() != fingerprint.lastModified)
@@ -1223,7 +1333,89 @@ public class Memoizer extends ReaderWrapper {
         return false;
       }
     }
+    for (DirectoryFingerprint fingerprint : manifest.directories) {
+      Location directory = resolvePath(fingerprint.path,
+        fingerprint.relative, primaryParent);
+      boolean exists = directory.isDirectory();
+      if (exists != fingerprint.exists ||
+        (exists && !fingerprint.digest.equals(
+          fingerprintDirectory(Paths.get(directory.getAbsolutePath())))))
+      {
+        LOGGER.debug(
+          "dependency directory changed since memo creation: {}", directory);
+        return false;
+      }
+    }
     return true;
+  }
+
+  private Location resolvePath(String path, boolean relative,
+    Location primaryParent)
+  {
+    return relative && primaryParent != null ?
+      new Location(primaryParent, path) : new Location(path);
+  }
+
+  private StoredPath storePath(Path path, Path primaryParent) {
+    if (primaryParent != null) {
+      try {
+        return new StoredPath(primaryParent.relativize(path).toString(), true);
+      }
+      catch (IllegalArgumentException e) {
+        LOGGER.debug("Cannot make dependency relative to primary file: {}",
+          path);
+      }
+    }
+    return new StoredPath(path.toString(), false);
+  }
+
+  private String fingerprintDirectory(Path directory) throws IOException {
+    List<String> names = new ArrayList<String>();
+    try (java.nio.file.DirectoryStream<Path> entries =
+      Files.newDirectoryStream(directory))
+    {
+      for (Path entry : entries) {
+        String name = entry.getFileName().toString();
+        if (!isMemoArtifact(name)) {
+          names.add(name);
+        }
+      }
+    }
+    Collections.sort(names);
+
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    }
+    catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+    for (String name : names) {
+      byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
+      digest.update((byte) (bytes.length >>> 24));
+      digest.update((byte) (bytes.length >>> 16));
+      digest.update((byte) (bytes.length >>> 8));
+      digest.update((byte) bytes.length);
+      digest.update(bytes);
+    }
+    return Base64.getUrlEncoder().withoutPadding()
+      .encodeToString(digest.digest());
+  }
+
+  private boolean isMemoArtifact(String name) {
+    return name.endsWith(".bfmemo") ||
+      (name.contains(".bfmemo.") && name.endsWith(".tmp"));
+  }
+
+  private static final class StoredPath {
+
+    private final String path;
+    private final boolean relative;
+
+    private StoredPath(String path, boolean relative) {
+      this.path = path;
+      this.relative = relative;
+    }
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -46,6 +46,8 @@ import loci.common.RandomAccessOutputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.services.OMEXMLService;
@@ -925,6 +927,15 @@ public class Memoizer extends ReaderWrapper {
       } catch (ClassNotFoundException e) {
         LOGGER.warn("unknown reader type: {}", e);
         return null;
+      }
+
+      MetadataOptions options = reader.getMetadataOptions();
+      if (options instanceof DynamicMetadataOptions) {
+        String optionsFile = DynamicMetadataOptions.getMetadataOptionsFile(
+          realFile.getAbsolutePath());
+        if (optionsFile != null) {
+          ((DynamicMetadataOptions) options).loadOptions(optionsFile);
+        }
       }
 
       boolean equal = false;

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -923,11 +923,7 @@ public class Memoizer extends ReaderWrapper {
         f = new File(id);
         writeDirectory = new File(f.getParent());
       } else {
-        // this serves to strip off the drive letter on Windows
-        // since we're using the absolute path, 'id' will either start with
-        // File.separator (as on UNIX), or a drive letter (as on Windows)
-        id = id.substring(id.indexOf(File.separator) + 1);
-        f = new File(directory, id);
+        f = new File(directory, getCachePath(id));
         writeDirectory = directory;
       }
 
@@ -944,6 +940,50 @@ public class Memoizer extends ReaderWrapper {
     String p = f.getParent();
     String n = f.getName();
     return new File(p, "." + n + ".bfmemo");
+  }
+
+  /**
+   * Convert an absolute identifier into a relative cache path while retaining
+   * the identity of Windows drives and UNC shares.
+   *
+   * @param absolutePath absolute identifier path
+   * @return path relative to the configured cache directory
+   */
+  protected String getCachePath(String absolutePath) {
+    if (absolutePath.length() >= 3 &&
+      Character.isLetter(absolutePath.charAt(0)) &&
+      absolutePath.charAt(1) == ':' &&
+      isPathSeparator(absolutePath.charAt(2)))
+    {
+      String remainder = normalizeSeparators(absolutePath.substring(3));
+      return Character.toUpperCase(absolutePath.charAt(0)) +
+        File.separator + remainder;
+    }
+
+    if (absolutePath.length() >= 2 &&
+      isPathSeparator(absolutePath.charAt(0)) &&
+      isPathSeparator(absolutePath.charAt(1)))
+    {
+      return "UNC" + File.separator +
+        normalizeSeparators(absolutePath.substring(2));
+    }
+
+    int first = 0;
+    while (first < absolutePath.length() &&
+      absolutePath.charAt(first) == File.separatorChar)
+    {
+      first++;
+    }
+    return absolutePath.substring(first);
+  }
+
+  private boolean isPathSeparator(char character) {
+    return character == '/' || character == '\\';
+  }
+
+  private String normalizeSeparators(String path) {
+    return path.replace('\\', File.separatorChar)
+      .replace('/', File.separatorChar);
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -38,6 +38,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ArrayIndexOutOfBoundsException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -100,6 +104,10 @@ public class Memoizer extends ReaderWrapper {
 
     String loadRevision() throws IOException;
 
+    default FileFingerprint[] loadFileFingerprints() throws IOException {
+      return FileFingerprint.decode(loadRevision());
+    }
+
     IFormatReader loadReader() throws IOException, ClassNotFoundException;
 
     void loadStop() throws IOException;
@@ -112,11 +120,85 @@ public class Memoizer extends ReaderWrapper {
 
     void saveRevision(String revision) throws IOException;
 
+    default void saveFileFingerprints(FileFingerprint[] fingerprints)
+      throws IOException
+    {
+      saveRevision(FileFingerprint.encode(fingerprints));
+    }
+
     void saveReader(IFormatReader reader) throws IOException;
 
     void saveStop() throws IOException;
 
     void close();
+  }
+
+  /** File state recorded when a memo is created. */
+  public static final class FileFingerprint {
+
+    private final String path;
+    private final boolean relative;
+    private final boolean exists;
+    private final long length;
+    private final long lastModified;
+
+    private FileFingerprint(String path, boolean relative, boolean exists,
+      long length, long lastModified)
+    {
+      this.path = path;
+      this.relative = relative;
+      this.exists = exists;
+      this.length = length;
+      this.lastModified = lastModified;
+    }
+
+    private static String encode(FileFingerprint[] fingerprints) {
+      StringBuilder manifest = new StringBuilder();
+      Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+      for (FileFingerprint fingerprint : fingerprints) {
+        String encodedPath = encoder.encodeToString(
+          fingerprint.path.getBytes(StandardCharsets.UTF_8));
+        manifest.append(fingerprint.relative ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.exists ? '1' : '0');
+        manifest.append('\t');
+        manifest.append(fingerprint.length);
+        manifest.append('\t');
+        manifest.append(fingerprint.lastModified);
+        manifest.append('\t');
+        manifest.append(encodedPath);
+        manifest.append('\n');
+      }
+      return manifest.toString();
+    }
+
+    private static FileFingerprint[] decode(String manifest)
+      throws IOException
+    {
+      if (manifest.isEmpty()) {
+        return new FileFingerprint[0];
+      }
+      String[] lines = manifest.split("\\n");
+      FileFingerprint[] fingerprints = new FileFingerprint[lines.length];
+      Base64.Decoder decoder = Base64.getUrlDecoder();
+      try {
+        for (int i = 0; i < lines.length; i++) {
+          String[] fields = lines[i].split("\\t", -1);
+          if (fields.length != 5) {
+            throw new IOException("Invalid file fingerprint manifest");
+          }
+          String path = new String(decoder.decode(fields[4]),
+            StandardCharsets.UTF_8);
+          fingerprints[i] = new FileFingerprint(path,
+            "1".equals(fields[0]), "1".equals(fields[1]),
+            Long.parseLong(fields[2]), Long.parseLong(fields[3]));
+        }
+      }
+      catch (IllegalArgumentException e) {
+        throw new IOException("Invalid file fingerprint manifest", e);
+      }
+      return fingerprints;
+    }
   }
 
   public static class KryoDeser implements Deser {
@@ -341,7 +423,7 @@ public class Memoizer extends ReaderWrapper {
    * cached items. This should happen when the order and type of objects stored
    * in the memo file changes.
    */
-  public static final Integer VERSION = 4;
+  public static final Integer VERSION = 5;
 
   /**
    * Default value for {@link #minimumElapsed} if none is provided in the
@@ -916,10 +998,14 @@ public class Memoizer extends ReaderWrapper {
       }
 
       // RELEASE VERSION NUMBER
-       if (versionMismatch()) {
+      if (versionMismatch()) {
          // Logging done in versionMismatch
          return null;
        }
+
+      if (!fileFingerprintsMatch(ser.loadFileFingerprints())) {
+        return null;
+      }
 
       // CLASS & COPY
       try {
@@ -1012,6 +1098,7 @@ public class Memoizer extends ReaderWrapper {
       // Save to temporary location.
       ser.saveVersion(VERSION);
       ser.saveReleaseVersion(FormatTools.VERSION);
+      ser.saveFileFingerprints(createFileFingerprints());
       ser.saveReader(reader);
       ser.saveStop();
       LOGGER.debug("saved to temp file: {}", tempFile);
@@ -1048,6 +1135,51 @@ public class Memoizer extends ReaderWrapper {
       deleteQuietly(tempFile);
     }
     return rv;
+  }
+
+  private FileFingerprint[] createFileFingerprints() {
+    String[] usedFiles = reader.getUsedFiles();
+    FileFingerprint[] fingerprints = new FileFingerprint[usedFiles.length];
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    Path primaryParentPath = primaryParent == null ? null :
+      Paths.get(primaryParent.getAbsolutePath()).normalize();
+
+    for (int i = 0; i < usedFiles.length; i++) {
+      Location usedFile = new Location(usedFiles[i]).getAbsoluteFile();
+      String path = usedFile.getAbsolutePath();
+      boolean relative = false;
+      if (primaryParentPath != null) {
+        try {
+          path = primaryParentPath.relativize(
+            Paths.get(path).normalize()).toString();
+          relative = true;
+        }
+        catch (IllegalArgumentException e) {
+          LOGGER.debug("Cannot make used file relative to primary file: {}",
+            path);
+        }
+      }
+      fingerprints[i] = new FileFingerprint(path, relative,
+        usedFile.exists(), usedFile.length(), usedFile.lastModified());
+    }
+    return fingerprints;
+  }
+
+  private boolean fileFingerprintsMatch(FileFingerprint[] fingerprints) {
+    Location primaryParent = realFile.getAbsoluteFile().getParentFile();
+    for (FileFingerprint fingerprint : fingerprints) {
+      Location usedFile = fingerprint.relative && primaryParent != null ?
+        new Location(primaryParent, fingerprint.path) :
+        new Location(fingerprint.path);
+      if (usedFile.exists() != fingerprint.exists ||
+        usedFile.length() != fingerprint.length ||
+        usedFile.lastModified() != fingerprint.lastModified)
+      {
+        LOGGER.debug("used file changed since memo creation: {}", usedFile);
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -240,154 +240,169 @@ public class MemoizerTest {
 
   @Test
   public void testDefaultConstructor() throws Exception {
-    Memoizer memoizer = new Memoizer();
-    checkMemoFile(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer()) {
+      checkMemoFile(memoizer.getMemoFile(id));
+    }
   }
 
   @Test
   public void testNullReader() throws Exception {
-    Memoizer memoizer = new Memoizer(null);
-    checkMemoFile(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer(null)) {
+      checkMemoFile(memoizer.getMemoFile(id));
+    }
   }
 
   @Test
   public void testConstructorTimeElapsed() throws Exception {
-    Memoizer memoizer = new Memoizer(0);
-    checkMemoFile(memoizer.getMemoFile(id));
-    checkMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(0)) {
+      checkMemoFile(memoizer.getMemoFile(id));
+      checkMemo(memoizer, id);
+    }
   }
 
   @Test
   public void testConstructorReader() throws Exception {
-    Memoizer memoizer = new Memoizer(reader);
-    checkMemoFile(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer(reader)) {
+      checkMemoFile(memoizer.getMemoFile(id));
+    }
   }
 
   @Test
   public void testConstructorReaderTimeElapsed() throws Exception {
-    Memoizer memoizer = new Memoizer(reader, 0);
-    checkMemoFile(memoizer.getMemoFile(id));
-    checkMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(reader, 0)) {
+      checkMemoFile(memoizer.getMemoFile(id));
+      checkMemo(memoizer, id);
+    }
   }
 
   @Test
   public void testConstructorTimeElapsedDirectory() throws Exception {
     File directory = createTempDir();
     directory.delete();
-    Memoizer memoizer = new Memoizer(0, directory);
-    // Check non-existing memo directory returns null
-    assertNull(memoizer.getMemoFile(id));
-    directory.mkdirs();
-    checkMemoFile(memoizer.getMemoFile(id),
-      getExpectedCacheDirectory(directory));
-    checkMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(0, directory)) {
+      // Check non-existing memo directory returns null
+      assertNull(memoizer.getMemoFile(id));
+      directory.mkdirs();
+      checkMemoFile(memoizer.getMemoFile(id),
+        getExpectedCacheDirectory(directory));
+      checkMemo(memoizer, id);
+    }
     recursiveDeleteOnExit(directory);
   }
 
   @Test
   public void testConstructorTimeElapsedNull() throws Exception {
-    Memoizer memoizer = new Memoizer(0, null);
-    // Check null memo directory returns null
-    assertNull(memoizer.getMemoFile(id));
-    checkNoMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(0, null)) {
+      // Check null memo directory returns null
+      assertNull(memoizer.getMemoFile(id));
+      checkNoMemo(memoizer, id);
+    }
   }
 
   @Test
   public void testConstructorReaderTimeElapsedDirectory() throws Exception {
     File directory = createTempDir();
     directory.delete();
-    Memoizer memoizer = new Memoizer(reader, 0, directory);
-    // Check non-existing memo directory returns null
-    assertNull(memoizer.getMemoFile(id));
-    directory.mkdirs();
-    checkMemoFile(memoizer.getMemoFile(id),
-      getExpectedCacheDirectory(directory));
-    checkMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(reader, 0, directory)) {
+      // Check non-existing memo directory returns null
+      assertNull(memoizer.getMemoFile(id));
+      directory.mkdirs();
+      checkMemoFile(memoizer.getMemoFile(id),
+        getExpectedCacheDirectory(directory));
+      checkMemo(memoizer, id);
+    }
     recursiveDeleteOnExit(directory);
   }
 
   @Test
   public void testConstructorReaderTimeElapsedNull() throws Exception {
-    Memoizer memoizer = new Memoizer(reader, 0, null);
-    // Check null memo directory returns null
-    assertNull(memoizer.getMemoFile(id));
-    checkNoMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(reader, 0, null)) {
+      // Check null memo directory returns null
+      assertNull(memoizer.getMemoFile(id));
+      checkNoMemo(memoizer, id);
+    }
   }
 
   @Test
   public void testGetMemoFilePermissionsDirectory() throws Exception {
     File directory = createTempDir();
-    Memoizer memoizer = new Memoizer(reader, 0, directory);
-    if (directory.setWritable(false)) {
-      assertNull(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer(reader, 0, directory)) {
+      if (directory.setWritable(false)) {
+        assertNull(memoizer.getMemoFile(id));
+      }
     }
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlaceDirectory() throws Exception {
-    Memoizer memoizer = new Memoizer(reader, 0, idDir);
-    if (idDir.setWritable(false)) {
-      assertNull(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer(reader, 0, idDir)) {
+      if (idDir.setWritable(false)) {
+        assertNull(memoizer.getMemoFile(id));
+      }
     }
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlace() throws Exception {
-    Memoizer memoizer = new Memoizer(reader);
-    if (idDir.setWritable(false)) {
-      assertNull(memoizer.getMemoFile(id));
+    try (Memoizer memoizer = new Memoizer(reader)) {
+      if (idDir.setWritable(false)) {
+        assertNull(memoizer.getMemoFile(id));
+      }
     }
   }
 
   @Test
   public void testRelocate() throws Exception {
     // Create an in-place memo file
-    Memoizer memoizer = new Memoizer(reader, 0);
-    memoizer.setId(id);
-    memoizer.close();
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
+    try (Memoizer memoizer = new Memoizer(reader, 0)) {
+      memoizer.setId(id);
+      memoizer.close();
+      assertFalse(memoizer.isLoadedFromMemo());
+      assertTrue(memoizer.isSavedToMemo());
 
-    // Rename the directory (including the file and the memo file)
-    File newidDir = new File(idDir.getAbsolutePath() + ".new");
-    idDir.renameTo(newidDir);
-    File newtempFile = new File(newidDir, TEST_FILE);
-    String newid = newtempFile.getAbsolutePath();
+      // Rename the directory (including the file and the memo file)
+      File newidDir = new File(idDir.getAbsolutePath() + ".new");
+      idDir.renameTo(newidDir);
+      File newtempFile = new File(newidDir, TEST_FILE);
+      String newid = newtempFile.getAbsolutePath();
 
-    // Try to reopen the file with the Memoizer
-    memoizer.setId(newid);
-    memoizer.close();
-    assertTrue(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    recursiveDeleteOnExit(newidDir);
+      // Try to reopen the file with the Memoizer
+      memoizer.setId(newid);
+      memoizer.close();
+      assertTrue(memoizer.isLoadedFromMemo());
+      assertFalse(memoizer.isSavedToMemo());
+      recursiveDeleteOnExit(newidDir);
+    }
   }
 
   @Test
   public void testDeleteMemo() throws Exception {
     // Create an in-place memo file
-    Memoizer memoizer = new Memoizer(reader, 0);
-    memoizer.setId(id);
-    memoizer.close();
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
+    try (Memoizer memoizer = new Memoizer(reader, 0)) {
+      memoizer.setId(id);
+      memoizer.close();
+      assertFalse(memoizer.isLoadedFromMemo());
+      assertTrue(memoizer.isSavedToMemo());
 
-    // attempt to delete the memo file, and make sure it's really gone
-    File currentMemoFile = memoizer.getMemoFile();
-    assertTrue(currentMemoFile.exists());
-    boolean success = memoizer.deleteMemo();
-    assertTrue(success);
-    assertFalse(currentMemoFile.exists());
+      // attempt to delete the memo file, and make sure it's really gone
+      File currentMemoFile = memoizer.getMemoFile();
+      assertTrue(currentMemoFile.exists());
+      boolean success = memoizer.deleteMemo();
+      assertTrue(success);
+      assertFalse(currentMemoFile.exists());
+    }
   }
 
   @Test
   public void testWrappedReader() throws Exception {
-    Memoizer memoizer = new Memoizer(reader, 0);
-    File memoFile = memoizer.getMemoFile(id);
-    assertFalse(memoFile.exists());
-    reader.setId(id);
-    assertFalse(memoFile.exists());
-    reader.close();
-    checkMemo(memoizer, id);
+    try (Memoizer memoizer = new Memoizer(reader, 0)) {
+      File memoFile = memoizer.getMemoFile(id);
+      assertFalse(memoFile.exists());
+      reader.setId(id);
+      assertFalse(memoFile.exists());
+      reader.close();
+      checkMemo(memoizer, id);
+    }
   }
 
   @Test
@@ -395,52 +410,52 @@ public class MemoizerTest {
     DynamicMetadataOptions firstOptions = new DynamicMetadataOptions();
     firstOptions.set("reader.option", "first");
     reader.setMetadataOptions(firstOptions);
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
     FakeReader secondReader = new FakeReader();
     DynamicMetadataOptions secondOptions = new DynamicMetadataOptions();
     secondOptions.set("reader.option", "second");
     secondReader.setMetadataOptions(secondOptions);
-    Memoizer second = new Memoizer(secondReader, 0);
-    second.setId(id);
-    assertFalse(second.isLoadedFromMemo());
-    second.close();
+    try (Memoizer second = new Memoizer(secondReader, 0)) {
+      second.setId(id);
+      assertFalse(second.isLoadedFromMemo());
+    }
   }
 
   @Test
   public void testValueMetadataOptionsLoadMemo() throws Exception {
     reader.setMetadataOptions(new ValueMetadataOptions());
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
     FakeReader secondReader = new FakeReader();
     secondReader.setMetadataOptions(new ValueMetadataOptions());
-    Memoizer second = new Memoizer(secondReader, 0);
-    second.setId(id);
-    assertTrue(second.isLoadedFromMemo());
-    second.close();
+    try (Memoizer second = new Memoizer(secondReader, 0)) {
+      second.setId(id);
+      assertTrue(second.isLoadedFromMemo());
+    }
   }
 
   @Test
   public void testIdentityMetadataOptionsSafelyMissMemo() throws Exception {
     reader.setMetadataOptions(new IdentityMetadataOptions());
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
     FakeReader secondReader = new FakeReader();
     secondReader.setMetadataOptions(new IdentityMetadataOptions());
-    Memoizer second = new Memoizer(secondReader, 0);
-    second.setId(id);
-    assertFalse(second.isLoadedFromMemo());
-    assertTrue(second.isSavedToMemo());
-    second.close();
+    try (Memoizer second = new Memoizer(secondReader, 0)) {
+      second.setId(id);
+      assertFalse(second.isLoadedFromMemo());
+      assertTrue(second.isSavedToMemo());
+    }
   }
 
   @Test
@@ -453,15 +468,15 @@ public class MemoizerTest {
     assertEquals(firstContents.length, changedContents.length);
     Files.write(optionsFile.toPath(), firstContents);
 
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
-    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
-    unchanged.setId(id);
-    assertTrue(unchanged.isLoadedFromMemo());
-    unchanged.close();
+    try (Memoizer unchanged = new Memoizer(new FakeReader(), 0)) {
+      unchanged.setId(id);
+      assertTrue(unchanged.isLoadedFromMemo());
+    }
 
     long previousTime = optionsFile.lastModified();
     Files.write(optionsFile.toPath(), changedContents);
@@ -470,16 +485,16 @@ public class MemoizerTest {
     assertEquals(optionsFile.length(), (long) firstContents.length);
     assertEquals(optionsFile.lastModified(), previousTime);
 
-    Memoizer changed = new Memoizer(new FakeReader(), 0);
-    changed.setId(id);
-    assertFalse(changed.isLoadedFromMemo());
-    assertTrue(changed.isSavedToMemo());
-    changed.close();
+    try (Memoizer changed = new Memoizer(new FakeReader(), 0)) {
+      changed.setId(id);
+      assertFalse(changed.isLoadedFromMemo());
+      assertTrue(changed.isSavedToMemo());
+    }
 
-    Memoizer replacement = new Memoizer(new FakeReader(), 0);
-    replacement.setId(id);
-    assertTrue(replacement.isLoadedFromMemo());
-    replacement.close();
+    try (Memoizer replacement = new Memoizer(new FakeReader(), 0)) {
+      replacement.setId(id);
+      assertTrue(replacement.isLoadedFromMemo());
+    }
   }
 
   @Test
@@ -487,55 +502,55 @@ public class MemoizerTest {
     File companion = new File(id + ".ini");
     Files.write(companion.toPath(), utf8("sizeX=20\n"));
 
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
-    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
-    unchanged.setId(id);
-    assertTrue(unchanged.isLoadedFromMemo());
-    unchanged.close();
+    try (Memoizer unchanged = new Memoizer(new FakeReader(), 0)) {
+      unchanged.setId(id);
+      assertTrue(unchanged.isLoadedFromMemo());
+    }
 
     long previousTime = companion.lastModified();
     Files.write(companion.toPath(), utf8("sizeX=30\n"));
     setDifferentModificationTime(companion, previousTime);
-    Memoizer changed = new Memoizer(new FakeReader(), 0);
-    changed.setId(id);
-    assertFalse(changed.isLoadedFromMemo());
-    assertTrue(changed.isSavedToMemo());
-    assertEquals(changed.getSizeX(), 30);
-    changed.close();
+    try (Memoizer changed = new Memoizer(new FakeReader(), 0)) {
+      changed.setId(id);
+      assertFalse(changed.isLoadedFromMemo());
+      assertTrue(changed.isSavedToMemo());
+      assertEquals(changed.getSizeX(), 30);
+    }
 
-    Memoizer replacement = new Memoizer(new FakeReader(), 0);
-    replacement.setId(id);
-    assertTrue(replacement.isLoadedFromMemo());
-    assertEquals(replacement.getSizeX(), 30);
-    replacement.close();
+    try (Memoizer replacement = new Memoizer(new FakeReader(), 0)) {
+      replacement.setId(id);
+      assertTrue(replacement.isLoadedFromMemo());
+      assertEquals(replacement.getSizeX(), 30);
+    }
   }
 
   @Test
   public void testAddedCompanionFileInvalidatesMemo() throws Exception {
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
 
     File companion = new File(id + ".ini");
     Files.write(companion.toPath(), utf8("sizeX=30\n"));
 
-    Memoizer changed = new Memoizer(new FakeReader(), 0);
-    changed.setId(id);
-    assertFalse(changed.isLoadedFromMemo());
-    assertTrue(changed.isSavedToMemo());
-    assertEquals(changed.getSizeX(), 30);
-    changed.close();
+    try (Memoizer changed = new Memoizer(new FakeReader(), 0)) {
+      changed.setId(id);
+      assertFalse(changed.isLoadedFromMemo());
+      assertTrue(changed.isSavedToMemo());
+      assertEquals(changed.getSizeX(), 30);
+    }
 
-    Memoizer replacement = new Memoizer(new FakeReader(), 0);
-    replacement.setId(id);
-    assertTrue(replacement.isLoadedFromMemo());
-    assertEquals(replacement.getSizeX(), 30);
-    replacement.close();
+    try (Memoizer replacement = new Memoizer(new FakeReader(), 0)) {
+      replacement.setId(id);
+      assertTrue(replacement.isLoadedFromMemo());
+      assertEquals(replacement.getSizeX(), 30);
+    }
   }
 
   @Test
@@ -543,34 +558,34 @@ public class MemoizerTest {
     File companion = new File(id + ".ini");
     Files.write(companion.toPath(), utf8("sizeX=30\n"));
 
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      assertTrue(first.isSavedToMemo());
+    }
     assertTrue(companion.delete());
 
-    Memoizer changed = new Memoizer(new FakeReader(), 0);
-    changed.setId(id);
-    assertFalse(changed.isLoadedFromMemo());
-    assertTrue(changed.isSavedToMemo());
-    assertEquals(changed.getSizeX(), 20);
-    changed.close();
+    try (Memoizer changed = new Memoizer(new FakeReader(), 0)) {
+      changed.setId(id);
+      assertFalse(changed.isLoadedFromMemo());
+      assertTrue(changed.isSavedToMemo());
+      assertEquals(changed.getSizeX(), 20);
+    }
 
-    Memoizer replacement = new Memoizer(new FakeReader(), 0);
-    replacement.setId(id);
-    assertTrue(replacement.isLoadedFromMemo());
-    assertEquals(replacement.getSizeX(), 20);
-    replacement.close();
+    try (Memoizer replacement = new Memoizer(new FakeReader(), 0)) {
+      replacement.setId(id);
+      assertTrue(replacement.isLoadedFromMemo());
+      assertEquals(replacement.getSizeX(), 20);
+    }
   }
 
   @Test
   public void testInstallFailureIsNotReportedAsSaved() throws Exception {
-    Memoizer memoizer = new FailingInstallMemoizer(reader);
-    File memoFile = memoizer.getMemoFile(id);
-    memoizer.setId(id);
-    assertFalse(memoizer.isSavedToMemo());
-    assertFalse(memoFile.exists());
-    memoizer.close();
+    try (Memoizer memoizer = new FailingInstallMemoizer(reader)) {
+      File memoFile = memoizer.getMemoFile(id);
+      memoizer.setId(id);
+      assertFalse(memoizer.isSavedToMemo());
+      assertFalse(memoFile.exists());
+    }
 
     File[] files = idDir.listFiles();
     assertTrue(files != null);
@@ -584,55 +599,60 @@ public class MemoizerTest {
     File companion = new File(id + ".ini");
     Files.write(companion.toPath(), utf8("sizeX=20\n"));
 
-    Memoizer first = new Memoizer(reader, 0);
-    first.setId(id);
-    File memoFile = first.getMemoFile();
-    assertTrue(first.isSavedToMemo());
-    first.close();
+    File memoFile;
+    try (Memoizer first = new Memoizer(reader, 0)) {
+      first.setId(id);
+      memoFile = first.getMemoFile();
+      assertTrue(first.isSavedToMemo());
+    }
     assertTrue(memoFile.exists());
 
     long previousTime = companion.lastModified();
     Files.write(companion.toPath(), utf8("sizeX=30\n"));
     setDifferentModificationTime(companion, previousTime);
 
-    Memoizer failed = new FailingInstallMemoizer(new FakeReader());
-    failed.setId(id);
-    assertFalse(failed.isLoadedFromMemo());
-    assertFalse(failed.isSavedToMemo());
-    assertEquals(failed.getSizeX(), 30);
-    assertTrue(memoFile.exists());
-    failed.close();
+    try (Memoizer failed =
+      new FailingInstallMemoizer(new FakeReader()))
+    {
+      failed.setId(id);
+      assertFalse(failed.isLoadedFromMemo());
+      assertFalse(failed.isSavedToMemo());
+      assertEquals(failed.getSizeX(), 30);
+      assertTrue(memoFile.exists());
+    }
 
-    Memoizer replacement = new Memoizer(new FakeReader(), 0);
-    replacement.setId(id);
-    assertFalse(replacement.isLoadedFromMemo());
-    assertTrue(replacement.isSavedToMemo());
-    assertEquals(replacement.getSizeX(), 30);
-    replacement.close();
+    try (Memoizer replacement = new Memoizer(new FakeReader(), 0)) {
+      replacement.setId(id);
+      assertFalse(replacement.isLoadedFromMemo());
+      assertTrue(replacement.isSavedToMemo());
+      assertEquals(replacement.getSizeX(), 30);
+    }
   }
 
   @Test
-  public void testWindowsDriveIsPartOfCachePath() {
-    CachePathMemoizer memoizer = new CachePathMemoizer();
-    String driveC = memoizer.cachePath("C:\\somedir\\foo.nd2");
-    String driveD = memoizer.cachePath("D:\\somedir\\foo.nd2");
+  public void testWindowsDriveIsPartOfCachePath() throws Exception {
+    try (CachePathMemoizer memoizer = new CachePathMemoizer()) {
+      String driveC = memoizer.cachePath("C:\\somedir\\foo.nd2");
+      String driveD = memoizer.cachePath("D:\\somedir\\foo.nd2");
 
-    assertEquals(driveC,
-      new File("C" + File.separator + "somedir", "foo.nd2").getPath());
-    assertEquals(driveD,
-      new File("D" + File.separator + "somedir", "foo.nd2").getPath());
-    assertFalse(driveC.equals(driveD));
+      assertEquals(driveC,
+        new File("C" + File.separator + "somedir", "foo.nd2").getPath());
+      assertEquals(driveD,
+        new File("D" + File.separator + "somedir", "foo.nd2").getPath());
+      assertFalse(driveC.equals(driveD));
+    }
   }
 
   @Test
-  public void testUncShareIsPartOfCachePath() {
-    CachePathMemoizer memoizer = new CachePathMemoizer();
-    String first = memoizer.cachePath("\\\\server\\first\\foo.nd2");
-    String second = memoizer.cachePath("\\\\server\\second\\foo.nd2");
+  public void testUncShareIsPartOfCachePath() throws Exception {
+    try (CachePathMemoizer memoizer = new CachePathMemoizer()) {
+      String first = memoizer.cachePath("\\\\server\\first\\foo.nd2");
+      String second = memoizer.cachePath("\\\\server\\second\\foo.nd2");
 
-    assertTrue(first.startsWith("UNC" + File.separator));
-    assertTrue(second.startsWith("UNC" + File.separator));
-    assertFalse(first.equals(second));
+      assertTrue(first.startsWith("UNC" + File.separator));
+      assertTrue(second.startsWith("UNC" + File.separator));
+      assertFalse(first.equals(second));
+    }
   }
 
   @Test
@@ -641,20 +661,21 @@ public class MemoizerTest {
       return;
     }
     File directory = createTempDir();
-    Memoizer memoizer = new Memoizer(0, directory);
-    File driveC = memoizer.getMemoFile("C:\\somedir\\foo.nd2");
-    File driveD = memoizer.getMemoFile("D:\\somedir\\foo.nd2");
-    File firstShare = memoizer.getMemoFile(
-      "\\\\server\\first\\foo.nd2");
-    File secondShare = memoizer.getMemoFile(
-      "\\\\server\\second\\foo.nd2");
+    try (Memoizer memoizer = new Memoizer(0, directory)) {
+      File driveC = memoizer.getMemoFile("C:\\somedir\\foo.nd2");
+      File driveD = memoizer.getMemoFile("D:\\somedir\\foo.nd2");
+      File firstShare = memoizer.getMemoFile(
+        "\\\\server\\first\\foo.nd2");
+      File secondShare = memoizer.getMemoFile(
+        "\\\\server\\second\\foo.nd2");
 
-    assertFalse(driveC.equals(driveD));
-    assertFalse(firstShare.equals(secondShare));
-    assertTrue(driveC.toPath().startsWith(directory.toPath()));
-    assertTrue(driveD.toPath().startsWith(directory.toPath()));
-    assertTrue(firstShare.toPath().startsWith(directory.toPath()));
-    assertTrue(secondShare.toPath().startsWith(directory.toPath()));
+      assertFalse(driveC.equals(driveD));
+      assertFalse(firstShare.equals(secondShare));
+      assertTrue(driveC.toPath().startsWith(directory.toPath()));
+      assertTrue(driveD.toPath().startsWith(directory.toPath()));
+      assertTrue(firstShare.toPath().startsWith(directory.toPath()));
+      assertTrue(secondShare.toPath().startsWith(directory.toPath()));
+    }
     recursiveDeleteOnExit(directory);
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -322,4 +322,29 @@ public class MemoizerTest {
     changed.close();
   }
 
+  @Test
+  public void testChangedCompanionFileInvalidatesMemo() throws Exception {
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(),
+      "sizeX=20\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(companion.toPath(),
+      "sizeX=200\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    assertEquals(changed.getSizeX(), 200);
+    changed.close();
+  }
+
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -40,8 +40,14 @@ import static org.testng.Assert.assertNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import loci.formats.Memoizer;
 import loci.formats.in.DynamicMetadataOptions;
@@ -135,9 +141,12 @@ public class MemoizerTest {
   private File idDir;
   private String id;
   private FakeReader reader;
+  private final List<Path> temporaryDirectories = new ArrayList<Path>();
 
-  private static File createTempDir() throws Exception {
-    return Files.createTempDirectory(TMP_PREFIX).toFile();
+  private File createTempDir() throws Exception {
+    Path directory = Files.createTempDirectory(TMP_PREFIX);
+    temporaryDirectories.add(directory);
+    return directory.toFile();
   }
 
   private static byte[] utf8(String value) {
@@ -152,18 +161,39 @@ public class MemoizerTest {
     assertFalse(file.lastModified() == previousTime);
   }
 
-  private static void recursiveDeleteOnExit(File rootDir) {
-    rootDir.deleteOnExit();
-    File[] children = rootDir.listFiles();
-    if (null != children) {
-      for (File child: children) {
-        if (child.isDirectory()) {
-          recursiveDeleteOnExit(child);
-        } else {
-          child.deleteOnExit();
-        }
-      }
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return;
     }
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+
+      @Override
+      public FileVisitResult preVisitDirectory(Path directory,
+        BasicFileAttributes attributes) throws IOException
+      {
+        directory.toFile().setWritable(true);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult visitFile(Path file,
+        BasicFileAttributes attributes) throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) {
+          throw failure;
+        }
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   private static void checkMemo(Memoizer memoizer, String id)
@@ -223,7 +253,7 @@ public class MemoizerTest {
     return new File(directory, cachePath);
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
     idDir = createTempDir();
     File tempFile = new File(idDir, TEST_FILE);
@@ -232,10 +262,34 @@ public class MemoizerTest {
     reader = new FakeReader(); // No setId !
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void tearDown() throws Exception {
-    reader.close();
-    recursiveDeleteOnExit(idDir);
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    for (int i = temporaryDirectories.size() - 1; i >= 0; i--) {
+      try {
+        deleteRecursively(temporaryDirectories.get(i));
+      }
+      catch (Exception e) {
+        if (failure == null) {
+          failure = e;
+        }
+        else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+    temporaryDirectories.clear();
+    if (failure != null) {
+      throw failure;
+    }
   }
 
   @Test
@@ -287,7 +341,6 @@ public class MemoizerTest {
         getExpectedCacheDirectory(directory));
       checkMemo(memoizer, id);
     }
-    recursiveDeleteOnExit(directory);
   }
 
   @Test
@@ -311,7 +364,6 @@ public class MemoizerTest {
         getExpectedCacheDirectory(directory));
       checkMemo(memoizer, id);
     }
-    recursiveDeleteOnExit(directory);
   }
 
   @Test
@@ -362,7 +414,8 @@ public class MemoizerTest {
 
       // Rename the directory (including the file and the memo file)
       File newidDir = new File(idDir.getAbsolutePath() + ".new");
-      idDir.renameTo(newidDir);
+      temporaryDirectories.add(newidDir.toPath());
+      Files.move(idDir.toPath(), newidDir.toPath());
       File newtempFile = new File(newidDir, TEST_FILE);
       String newid = newtempFile.getAbsolutePath();
 
@@ -371,7 +424,6 @@ public class MemoizerTest {
       memoizer.close();
       assertTrue(memoizer.isLoadedFromMemo());
       assertFalse(memoizer.isSavedToMemo());
-      recursiveDeleteOnExit(newidDir);
     }
   }
 
@@ -588,7 +640,9 @@ public class MemoizerTest {
     }
 
     File[] files = idDir.listFiles();
-    assertTrue(files != null);
+    if (files == null) {
+      throw new AssertionError("Could not list temporary test directory");
+    }
     for (File file : files) {
       assertFalse(file.getName().contains(".bfmemo."));
     }
@@ -676,7 +730,6 @@ public class MemoizerTest {
       assertTrue(firstShare.toPath().startsWith(directory.toPath()));
       assertTrue(secondShare.toPath().startsWith(directory.toPath()));
     }
-    recursiveDeleteOnExit(directory);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -41,10 +41,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 
 import loci.formats.Memoizer;
 import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.FakeReader;
+import loci.formats.in.MetadataLevel;
+import loci.formats.in.MetadataOptions;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -52,6 +55,57 @@ import org.testng.annotations.Test;
 
 
 public class MemoizerTest {
+
+  public static class IdentityMetadataOptions implements MetadataOptions {
+
+    private MetadataLevel level = MetadataLevel.ALL;
+    private boolean validate;
+
+    @Override
+    public void setMetadataLevel(MetadataLevel metadataLevel) {
+      level = metadataLevel;
+    }
+
+    @Override
+    public MetadataLevel getMetadataLevel() {
+      return level;
+    }
+
+    @Override
+    public void setValidate(boolean validateMetadata) {
+      validate = validateMetadata;
+    }
+
+    @Override
+    public boolean isValidate() {
+      return validate;
+    }
+  }
+
+  public static final class ValueMetadataOptions
+    extends IdentityMetadataOptions
+  {
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+      ValueMetadataOptions options = (ValueMetadataOptions) other;
+      return getMetadataLevel() == options.getMetadataLevel() &&
+        isValidate() == options.isValidate();
+    }
+
+    @Override
+    public int hashCode() {
+      int result = getMetadataLevel() == null ? 0 :
+        getMetadataLevel().hashCode();
+      return 31 * result + (isValidate() ? 1 : 0);
+    }
+  }
 
   private static class FailingInstallMemoizer extends Memoizer {
 
@@ -84,6 +138,18 @@ public class MemoizerTest {
 
   private static File createTempDir() throws Exception {
     return Files.createTempDirectory(TMP_PREFIX).toFile();
+  }
+
+  private static byte[] utf8(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static void setDifferentModificationTime(File file,
+    long previousTime) throws Exception
+  {
+    Files.setLastModifiedTime(file.toPath(),
+      FileTime.fromMillis(previousTime + 2000));
+    assertFalse(file.lastModified() == previousTime);
   }
 
   private static void recursiveDeleteOnExit(File rootDir) {
@@ -345,12 +411,47 @@ public class MemoizerTest {
   }
 
   @Test
+  public void testValueMetadataOptionsLoadMemo() throws Exception {
+    reader.setMetadataOptions(new ValueMetadataOptions());
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    FakeReader secondReader = new FakeReader();
+    secondReader.setMetadataOptions(new ValueMetadataOptions());
+    Memoizer second = new Memoizer(secondReader, 0);
+    second.setId(id);
+    assertTrue(second.isLoadedFromMemo());
+    second.close();
+  }
+
+  @Test
+  public void testIdentityMetadataOptionsSafelyMissMemo() throws Exception {
+    reader.setMetadataOptions(new IdentityMetadataOptions());
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    FakeReader secondReader = new FakeReader();
+    secondReader.setMetadataOptions(new IdentityMetadataOptions());
+    Memoizer second = new Memoizer(secondReader, 0);
+    second.setId(id);
+    assertFalse(second.isLoadedFromMemo());
+    assertTrue(second.isSavedToMemo());
+    second.close();
+  }
+
+  @Test
   public void testOptionsFileParticipatesInMemoCompatibility()
     throws Exception
   {
     File optionsFile = new File(id + ".bfoptions");
-    Files.write(optionsFile.toPath(),
-      "[options]\nmetadata.level=MINIMUM\n".getBytes(StandardCharsets.UTF_8));
+    byte[] firstContents = utf8("[options]\nreader.option=first\n");
+    byte[] changedContents = utf8("[options]\nreader.option=other\n");
+    assertEquals(firstContents.length, changedContents.length);
+    Files.write(optionsFile.toPath(), firstContents);
 
     Memoizer first = new Memoizer(reader, 0);
     first.setId(id);
@@ -362,19 +463,29 @@ public class MemoizerTest {
     assertTrue(unchanged.isLoadedFromMemo());
     unchanged.close();
 
-    Files.write(optionsFile.toPath(),
-      "[options]\nmetadata.level=ALL\n".getBytes(StandardCharsets.UTF_8));
+    long previousTime = optionsFile.lastModified();
+    Files.write(optionsFile.toPath(), changedContents);
+    Files.setLastModifiedTime(optionsFile.toPath(),
+      FileTime.fromMillis(previousTime));
+    assertEquals(optionsFile.length(), (long) firstContents.length);
+    assertEquals(optionsFile.lastModified(), previousTime);
+
     Memoizer changed = new Memoizer(new FakeReader(), 0);
     changed.setId(id);
     assertFalse(changed.isLoadedFromMemo());
+    assertTrue(changed.isSavedToMemo());
     changed.close();
+
+    Memoizer replacement = new Memoizer(new FakeReader(), 0);
+    replacement.setId(id);
+    assertTrue(replacement.isLoadedFromMemo());
+    replacement.close();
   }
 
   @Test
   public void testChangedCompanionFileInvalidatesMemo() throws Exception {
     File companion = new File(id + ".ini");
-    Files.write(companion.toPath(),
-      "sizeX=20\n".getBytes(StandardCharsets.UTF_8));
+    Files.write(companion.toPath(), utf8("sizeX=20\n"));
 
     Memoizer first = new Memoizer(reader, 0);
     first.setId(id);
@@ -386,13 +497,70 @@ public class MemoizerTest {
     assertTrue(unchanged.isLoadedFromMemo());
     unchanged.close();
 
-    Files.write(companion.toPath(),
-      "sizeX=200\n".getBytes(StandardCharsets.UTF_8));
+    long previousTime = companion.lastModified();
+    Files.write(companion.toPath(), utf8("sizeX=30\n"));
+    setDifferentModificationTime(companion, previousTime);
     Memoizer changed = new Memoizer(new FakeReader(), 0);
     changed.setId(id);
     assertFalse(changed.isLoadedFromMemo());
-    assertEquals(changed.getSizeX(), 200);
+    assertTrue(changed.isSavedToMemo());
+    assertEquals(changed.getSizeX(), 30);
     changed.close();
+
+    Memoizer replacement = new Memoizer(new FakeReader(), 0);
+    replacement.setId(id);
+    assertTrue(replacement.isLoadedFromMemo());
+    assertEquals(replacement.getSizeX(), 30);
+    replacement.close();
+  }
+
+  @Test
+  public void testAddedCompanionFileInvalidatesMemo() throws Exception {
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(), utf8("sizeX=30\n"));
+
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    assertTrue(changed.isSavedToMemo());
+    assertEquals(changed.getSizeX(), 30);
+    changed.close();
+
+    Memoizer replacement = new Memoizer(new FakeReader(), 0);
+    replacement.setId(id);
+    assertTrue(replacement.isLoadedFromMemo());
+    assertEquals(replacement.getSizeX(), 30);
+    replacement.close();
+  }
+
+  @Test
+  public void testDeletedCompanionFileInvalidatesMemo() throws Exception {
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(), utf8("sizeX=30\n"));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+    assertTrue(companion.delete());
+
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    assertTrue(changed.isSavedToMemo());
+    assertEquals(changed.getSizeX(), 20);
+    changed.close();
+
+    Memoizer replacement = new Memoizer(new FakeReader(), 0);
+    replacement.setId(id);
+    assertTrue(replacement.isLoadedFromMemo());
+    assertEquals(replacement.getSizeX(), 20);
+    replacement.close();
   }
 
   @Test
@@ -403,6 +571,44 @@ public class MemoizerTest {
     assertFalse(memoizer.isSavedToMemo());
     assertFalse(memoFile.exists());
     memoizer.close();
+
+    File[] files = idDir.listFiles();
+    assertTrue(files != null);
+    for (File file : files) {
+      assertFalse(file.getName().contains(".bfmemo."));
+    }
+  }
+
+  @Test
+  public void testFailedReplacementIsNotReportedAsSaved() throws Exception {
+    File companion = new File(id + ".ini");
+    Files.write(companion.toPath(), utf8("sizeX=20\n"));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    File memoFile = first.getMemoFile();
+    assertTrue(first.isSavedToMemo());
+    first.close();
+    assertTrue(memoFile.exists());
+
+    long previousTime = companion.lastModified();
+    Files.write(companion.toPath(), utf8("sizeX=30\n"));
+    setDifferentModificationTime(companion, previousTime);
+
+    Memoizer failed = new FailingInstallMemoizer(new FakeReader());
+    failed.setId(id);
+    assertFalse(failed.isLoadedFromMemo());
+    assertFalse(failed.isSavedToMemo());
+    assertEquals(failed.getSizeX(), 30);
+    assertTrue(memoFile.exists());
+    failed.close();
+
+    Memoizer replacement = new Memoizer(new FakeReader(), 0);
+    replacement.setId(id);
+    assertFalse(replacement.isLoadedFromMemo());
+    assertTrue(replacement.isSavedToMemo());
+    assertEquals(replacement.getSizeX(), 30);
+    replacement.close();
   }
 
   @Test
@@ -427,6 +633,29 @@ public class MemoizerTest {
     assertTrue(first.startsWith("UNC" + File.separator));
     assertTrue(second.startsWith("UNC" + File.separator));
     assertFalse(first.equals(second));
+  }
+
+  @Test
+  public void testWindowsMemoFilePreservesVolumeIdentity() throws Exception {
+    if (File.separatorChar != '\\') {
+      return;
+    }
+    File directory = createTempDir();
+    Memoizer memoizer = new Memoizer(0, directory);
+    File driveC = memoizer.getMemoFile("C:\\somedir\\foo.nd2");
+    File driveD = memoizer.getMemoFile("D:\\somedir\\foo.nd2");
+    File firstShare = memoizer.getMemoFile(
+      "\\\\server\\first\\foo.nd2");
+    File secondShare = memoizer.getMemoFile(
+      "\\\\server\\second\\foo.nd2");
+
+    assertFalse(driveC.equals(driveD));
+    assertFalse(firstShare.equals(secondShare));
+    assertTrue(driveC.toPath().startsWith(directory.toPath()));
+    assertTrue(driveD.toPath().startsWith(directory.toPath()));
+    assertTrue(firstShare.toPath().startsWith(directory.toPath()));
+    assertTrue(secondShare.toPath().startsWith(directory.toPath()));
+    recursiveDeleteOnExit(directory);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -129,6 +129,34 @@ public class MemoizerTest {
     assertEquals(memoFile.getAbsolutePath(), expMemoFile.getAbsolutePath());
   }
 
+  private File getExpectedCacheDirectory(File directory) {
+    String sourcePath = idDir.getAbsolutePath();
+    String cachePath;
+
+    if (sourcePath.length() >= 3 &&
+      Character.isLetter(sourcePath.charAt(0)) &&
+      sourcePath.charAt(1) == ':' &&
+      sourcePath.charAt(2) == File.separatorChar)
+    {
+      cachePath = Character.toUpperCase(sourcePath.charAt(0)) +
+        sourcePath.substring(2);
+    } else if (sourcePath.length() >= 2 &&
+      sourcePath.charAt(0) == File.separatorChar &&
+      sourcePath.charAt(1) == File.separatorChar)
+    {
+      cachePath = "UNC" + sourcePath.substring(1);
+    } else {
+      int first = 0;
+      while (first < sourcePath.length() &&
+        sourcePath.charAt(first) == File.separatorChar)
+      {
+        first++;
+      }
+      cachePath = sourcePath.substring(first);
+    }
+    return new File(directory, cachePath);
+  }
+
   @BeforeMethod
   public void setUp() throws Exception {
     idDir = createTempDir();
@@ -184,9 +212,8 @@ public class MemoizerTest {
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     directory.mkdirs();
-    String memoDir = idDir.getAbsolutePath();
-    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
+    checkMemoFile(memoizer.getMemoFile(id),
+      getExpectedCacheDirectory(directory));
     checkMemo(memoizer, id);
     recursiveDeleteOnExit(directory);
   }
@@ -207,9 +234,8 @@ public class MemoizerTest {
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     directory.mkdirs();
-    String memoDir = idDir.getAbsolutePath();
-    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
+    checkMemoFile(memoizer.getMemoFile(id),
+      getExpectedCacheDirectory(directory));
     checkMemo(memoizer, id);
     recursiveDeleteOnExit(directory);
   }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
@@ -51,6 +52,20 @@ import org.testng.annotations.Test;
 
 
 public class MemoizerTest {
+
+  private static class FailingInstallMemoizer extends Memoizer {
+
+    FailingInstallMemoizer(FakeReader reader) {
+      super(reader, 0);
+    }
+
+    @Override
+    protected void installMemo(File source, File destination)
+      throws IOException
+    {
+      throw new IOException("expected installation failure");
+    }
+  }
 
   private static final String TEST_FILE =
     "test&pixelType=int8&sizeX=20&sizeY=20&sizeC=1&sizeZ=1&sizeT=1.fake";
@@ -345,6 +360,16 @@ public class MemoizerTest {
     assertFalse(changed.isLoadedFromMemo());
     assertEquals(changed.getSizeX(), 200);
     changed.close();
+  }
+
+  @Test
+  public void testInstallFailureIsNotReportedAsSaved() throws Exception {
+    Memoizer memoizer = new FailingInstallMemoizer(reader);
+    File memoFile = memoizer.getMemoFile(id);
+    memoizer.setId(id);
+    assertFalse(memoizer.isSavedToMemo());
+    assertFalse(memoFile.exists());
+    memoizer.close();
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -67,6 +67,13 @@ public class MemoizerTest {
     }
   }
 
+  private static class CachePathMemoizer extends Memoizer {
+
+    String cachePath(String path) {
+      return getCachePath(path);
+    }
+  }
+
   private static final String TEST_FILE =
     "test&pixelType=int8&sizeX=20&sizeY=20&sizeC=1&sizeZ=1&sizeT=1.fake";
   private static final String TMP_PREFIX = MemoizerTest.class.getName() + ".";
@@ -370,6 +377,30 @@ public class MemoizerTest {
     assertFalse(memoizer.isSavedToMemo());
     assertFalse(memoFile.exists());
     memoizer.close();
+  }
+
+  @Test
+  public void testWindowsDriveIsPartOfCachePath() {
+    CachePathMemoizer memoizer = new CachePathMemoizer();
+    String driveC = memoizer.cachePath("C:\\somedir\\foo.nd2");
+    String driveD = memoizer.cachePath("D:\\somedir\\foo.nd2");
+
+    assertEquals(driveC,
+      new File("C" + File.separator + "somedir", "foo.nd2").getPath());
+    assertEquals(driveD,
+      new File("D" + File.separator + "somedir", "foo.nd2").getPath());
+    assertFalse(driveC.equals(driveD));
+  }
+
+  @Test
+  public void testUncShareIsPartOfCachePath() {
+    CachePathMemoizer memoizer = new CachePathMemoizer();
+    String first = memoizer.cachePath("\\\\server\\first\\foo.nd2");
+    String second = memoizer.cachePath("\\\\server\\second\\foo.nd2");
+
+    assertTrue(first.startsWith("UNC" + File.separator));
+    assertTrue(second.startsWith("UNC" + File.separator));
+    assertFalse(first.equals(second));
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -38,9 +38,11 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNull;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import loci.formats.Memoizer;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.FakeReader;
 
 import org.testng.annotations.AfterMethod;
@@ -272,6 +274,52 @@ public class MemoizerTest {
     assertFalse(memoFile.exists());
     reader.close();
     checkMemo(memoizer, id);
+  }
+
+  @Test
+  public void testChangedDynamicOptionsInvalidateMemo() throws Exception {
+    DynamicMetadataOptions firstOptions = new DynamicMetadataOptions();
+    firstOptions.set("reader.option", "first");
+    reader.setMetadataOptions(firstOptions);
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    FakeReader secondReader = new FakeReader();
+    DynamicMetadataOptions secondOptions = new DynamicMetadataOptions();
+    secondOptions.set("reader.option", "second");
+    secondReader.setMetadataOptions(secondOptions);
+    Memoizer second = new Memoizer(secondReader, 0);
+    second.setId(id);
+    assertFalse(second.isLoadedFromMemo());
+    second.close();
+  }
+
+  @Test
+  public void testOptionsFileParticipatesInMemoCompatibility()
+    throws Exception
+  {
+    File optionsFile = new File(id + ".bfoptions");
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=MINIMUM\n".getBytes(StandardCharsets.UTF_8));
+
+    Memoizer first = new Memoizer(reader, 0);
+    first.setId(id);
+    assertTrue(first.isSavedToMemo());
+    first.close();
+
+    Memoizer unchanged = new Memoizer(new FakeReader(), 0);
+    unchanged.setId(id);
+    assertTrue(unchanged.isLoadedFromMemo());
+    unchanged.close();
+
+    Files.write(optionsFile.toPath(),
+      "[options]\nmetadata.level=ALL\n".getBytes(StandardCharsets.UTF_8));
+    Memoizer changed = new Memoizer(new FakeReader(), 0);
+    changed.setId(id);
+    assertFalse(changed.isLoadedFromMemo());
+    changed.close();
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/WrapperTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/WrapperTest.java
@@ -86,25 +86,30 @@ public class WrapperTest {
   }
 
   @Test(dataProvider = "wrappers")
-  public void testCoreMetadata(IFormatReader reader) {
-    assertNotNull(reader.getCurrentFile());
-    List<CoreMetadata> coreList = reader.getCoreMetadataList();
-    assertEquals(coreList.size(), reader.getSeriesCount());
-    for (int i=0; i<reader.getSeriesCount(); i++) {
-      CoreMetadata core = coreList.get(i);
-      reader.setSeries(i);
-      assertEquals(core.sizeX, reader.getSizeX());
-      assertEquals(core.sizeY, reader.getSizeY());
-      assertEquals(core.sizeZ, reader.getSizeZ());
-      assertEquals(core.sizeC, reader.getSizeC());
-      assertEquals(core.sizeT, reader.getSizeT());
-      assertEquals(core.pixelType, reader.getPixelType());
-      assertEquals(core.imageCount, reader.getImageCount());
-      assertEquals(core.dimensionOrder, reader.getDimensionOrder());
-      assertEquals(core.littleEndian, reader.isLittleEndian());
-      assertEquals(core.rgb, reader.isRGB());
-      assertEquals(core.interleaved, reader.isInterleaved());
-      assertEquals(core.indexed, reader.isIndexed());
+  public void testCoreMetadata(IFormatReader reader) throws IOException {
+    try {
+      assertNotNull(reader.getCurrentFile());
+      List<CoreMetadata> coreList = reader.getCoreMetadataList();
+      assertEquals(coreList.size(), reader.getSeriesCount());
+      for (int i=0; i<reader.getSeriesCount(); i++) {
+        CoreMetadata core = coreList.get(i);
+        reader.setSeries(i);
+        assertEquals(core.sizeX, reader.getSizeX());
+        assertEquals(core.sizeY, reader.getSizeY());
+        assertEquals(core.sizeZ, reader.getSizeZ());
+        assertEquals(core.sizeC, reader.getSizeC());
+        assertEquals(core.sizeT, reader.getSizeT());
+        assertEquals(core.pixelType, reader.getPixelType());
+        assertEquals(core.imageCount, reader.getImageCount());
+        assertEquals(core.dimensionOrder, reader.getDimensionOrder());
+        assertEquals(core.littleEndian, reader.isLittleEndian());
+        assertEquals(core.rgb, reader.isRGB());
+        assertEquals(core.interleaved, reader.isInterleaved());
+        assertEquals(core.indexed, reader.isIndexed());
+      }
+    }
+    finally {
+      reader.close();
     }
   }
 }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -3272,7 +3272,7 @@ public class FormatReaderTest {
     IFormatReader ir = null;
     if (flattened) {
       ir = new ImageReader();
-      ir = new BufferedImageReader(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File("")));
+      ir = new BufferedImageReader(ir);
       ir.setMetadataOptions(new DynamicMetadataOptions(MetadataLevel.NO_OVERLAYS));
     }
     else {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -31,6 +31,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -3068,25 +3073,25 @@ public class FormatReaderTest {
     try {
       // this should prevent conflicts when running multiple tests
       // on the same system and/or in multiple threads
-      String tmpdir = System.getProperty("java.io.tmpdir");
-      memoDir = new File(tmpdir, UUID.randomUUID().toString() + ".memo");
-      memoDir.mkdir();
-      Memoizer memo = new Memoizer(0, memoDir);
-      memo.setId(reader.getCurrentFile());
-      memo.close();
-      memoFile = memo.getMemoFile(reader.getCurrentFile());
-      if (!memo.isSavedToMemo()) {
-        result(testName, false, "Memo file not saved");
-      }
+      memoDir = Files.createTempDirectory(
+        UUID.randomUUID().toString() + ".memo").toFile();
+      try (Memoizer memo = new Memoizer(0, memoDir)) {
+        memo.setId(reader.getCurrentFile());
+        memo.close();
+        memoFile = memo.getMemoFile(reader.getCurrentFile());
+        if (!memo.isSavedToMemo()) {
+          result(testName, false, "Memo file not saved");
+        }
 
-      // first test memo file generated with current build
+        // first test memo file generated with current build
 
-      memo.setId(reader.getCurrentFile());
-      if (!memo.isLoadedFromMemo()) {
-        result(testName, false, "Memo file could not be loaded");
+        memo.setId(reader.getCurrentFile());
+        if (!memo.isLoadedFromMemo()) {
+          result(testName, false, "Memo file could not be loaded");
+        }
+        memo.openBytes(0, 0, 0, 1, 1);
+        memo.close();
       }
-      memo.openBytes(0, 0, 0, 1, 1);
-      memo.close();
 
       // now test pre-generated memo file in the cache directory
 
@@ -3105,15 +3110,16 @@ public class FormatReaderTest {
         expectedMemo = new File(expectedMemo, relativeName);
 
         if (expectedMemo.exists()) {
-          memo = new Memoizer(0, dir);
-          // do not allow an existing memo file to be overwritten
-          memo.skipSave(true);
-          memo.setId(reader.getCurrentFile());
-          if (!memo.isLoadedFromMemo()) {
-            result(testName, false, "Existing memo file could not be loaded");
+          try (Memoizer memo = new Memoizer(0, dir)) {
+            // do not allow an existing memo file to be overwritten
+            memo.skipSave(true);
+            memo.setId(reader.getCurrentFile());
+            if (!memo.isLoadedFromMemo()) {
+              result(testName, false, "Existing memo file could not be loaded");
+            }
+            memo.openBytes(0, 0, 0, 1, 1);
+            memo.close();
           }
-          memo.openBytes(0, 0, 0, 1, 1);
-          memo.close();
         }
         else {
           LOGGER.warn("Missing memo file {}; passing test anyway", expectedMemo);
@@ -3142,18 +3148,43 @@ public class FormatReaderTest {
           LOGGER.warn("memo file size not available");
         }
 
-        memoFile.delete();
-        // recursively delete, as the original file's path is replicated
-        // within the memo directory
-        while (!memoFile.getParentFile().equals(memoDir)) {
-          memoFile = memoFile.getParentFile();
-          memoFile.delete();
-        }
       }
       if (memoDir != null) {
-        memoDir.delete();
+        try {
+          deleteMemoDirectory(memoDir);
+        }
+        catch (IOException e) {
+          Assert.fail("Could not delete memo directory " + memoDir, e);
+        }
       }
     }
+  }
+
+  private static void deleteMemoDirectory(File root) throws IOException {
+    if (!root.exists()) {
+      return;
+    }
+    Files.walkFileTree(root.toPath(), new SimpleFileVisitor<Path>() {
+
+      @Override
+      public FileVisitResult visitFile(Path file,
+        BasicFileAttributes attributes) throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) {
+          throw failure;
+        }
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   @Test(groups = {"config"})
@@ -3195,10 +3226,11 @@ public class FormatReaderTest {
       return;
     }
     try {
-      Memoizer memo = new Memoizer(0, new File(cacheDir));
-      assert memo.generateMemo(reader.getCurrentFile());
-      File memoFile = memo.getMemoFile(reader.getCurrentFile());
-      LOGGER.info("Saved memo file to {}", memoFile);
+      try (Memoizer memo = new Memoizer(0, new File(cacheDir))) {
+        assert memo.generateMemo(reader.getCurrentFile());
+        File memoFile = memo.getMemoFile(reader.getCurrentFile());
+        LOGGER.info("Saved memo file to {}", memoFile);
+      }
     }
     catch (Throwable t) {
       LOGGER.info("", t);


### PR DESCRIPTION
Hej,

While testing Bio-Formats memoization with the Java 25 build from ome/bioformats#4450, several independent memoization problems surfaced. I did not take care of my branch and now its quite stacked, so this combines all the fixes here. The `MetadataOnly` schema issue is now being addressed upstream in ome/ome-model#233, so that workaround from ome/bioformats#4459 is intentionally excluded here.

## Changes

### Keep standard data tests on direct readers

Avoid implicit memoization in standard data tests. An empty cache path behaves differently across Java versions, including Java 25.
Fixed in aaa50efe6a651ceb236a706d586e434344c0d14e.

### Invalidate memos when effective reader options change

Compare complete metadata-option state and load the current `.bfoptions` file before accepting a cached reader.
Fixed in 39a7fe100e722ea4517915f44d975d08c63716a4.

### Invalidate memos when any used file changes

Store a versioned manifest for every `getUsedFiles()` entry, including relocatable paths, existence, size, and modification time. Reject stale memos when any dependency changes.

Fixed in 96f3128157046d117b0fda3682270d5766fb5713.

### Report memo saves only after successful installation

Install temporary memo files atomically where supported, fall back when necessary, and correctly report installation failures through `saveMemo()` and `isSavedToMemo()`.

Fixed in 0a38ed2ef9a8c78a4e42c4c96a358b96b392a258.

### Keep Windows volume identity in memo cache paths

Preserve Windows drive letters and UNC share names so different volumes cannot map to the same memo.

Fixes ome/bioformats#3034

Fixed in 787e3988a91beee4c43e19733be6f3a1390c2a7f.

### Fix memo cache path expectations on Windows

Update regression tests for platform-independent drive and UNC cache-path behavior.

Fixed in d126395581ef4064e5e049ea01d3da84644f3b26.

## Tests

Add focused coverage for metadata-option changes, `.bfoptions` changes, companion-file invalidation, relocation, failed installation, and Windows drive/UNC paths.

The normal focused `MemoizerTest` execution passes. The configured `test-no-hdf` execution still reports two `Memoizer(0)` save failures, but this is not related to these changes.