### PR TITLE
formats-bsd tests resource cleanup fix

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/BaseModelNoBinDataReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelNoBinDataReaderTest.java
@@ -33,9 +33,9 @@
 package loci.formats.utests;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import loci.formats.ChannelFiller;
 import loci.formats.ChannelSeparator;
@@ -63,16 +63,37 @@ public class BaseModelNoBinDataReaderTest {
 
   private IMetadata metadata;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     mock = new BaseModelMock();
+    // Retain the fixture before model serialization can fail.
     temporaryFile = File.createTempFile(this.getClass().getName(), ".ome");
     SPWModelReaderTest.writeMockToFile(mock, temporaryFile, false);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    temporaryFile.delete();
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    if (temporaryFile != null) {
+      try {
+        Files.deleteIfExists(temporaryFile.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    reader = null;
+    temporaryFile = null;
+    if (failure != null) throw failure;
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/BaseModelReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelReaderTest.java
@@ -36,6 +36,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import loci.formats.ChannelFiller;
 import loci.formats.ChannelSeparator;
@@ -63,16 +64,37 @@ public class BaseModelReaderTest {
 
   private IMetadata metadata;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     mock = new BaseModelMock();
+    // Retain the fixture before model serialization can fail.
     temporaryFile = File.createTempFile(this.getClass().getName(), ".ome");
     SPWModelReaderTest.writeMockToFile(mock, temporaryFile, true);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    temporaryFile.delete();
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    if (temporaryFile != null) {
+      try {
+        Files.deleteIfExists(temporaryFile.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    reader = null;
+    temporaryFile = null;
+    if (failure != null) throw failure;
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ConversionTest.java
@@ -34,11 +34,18 @@ package loci.formats.utests;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 
 import loci.common.Constants;
 import loci.common.services.DependencyException;
@@ -54,12 +61,15 @@ import loci.formats.meta.IMetadata;
 import loci.formats.services.OMEXMLService;
 
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
 
 /**
  *
  * @author Melissa Linkert <melissa at glencoesoftware.com>
  */
 public class ConversionTest {
+
+  private final List<Path> temporaryFiles = new ArrayList<Path>();
 
   private static final int WIDTH = 64;
   private static final int HEIGHT = 64;
@@ -118,49 +128,93 @@ public class ConversionTest {
     boolean littleEndian)
     throws Exception
   {
-    File tmp = File.createTempFile("conversionTest", ext);
-    tmp.deleteOnExit();
-    ImageWriter writer = new ImageWriter();
-    writer.setMetadataRetrieve(createMetadata(
-      pixelType, rgbChannels, seriesCount, littleEndian));
-    writer.setId(tmp.getAbsolutePath());
+    File tmp = createTempFile(ext);
+    Plane originalPlane;
+    try (ImageWriter writer = new ImageWriter()) {
+      writer.setMetadataRetrieve(createMetadata(
+        pixelType, rgbChannels, seriesCount, littleEndian));
+      writer.setId(tmp.getAbsolutePath());
 
-    int bytes = FormatTools.getBytesPerPixel(pixelType);
-    byte[] plane = getPlane(WIDTH, HEIGHT, bytes * rgbChannels);
-    Plane originalPlane = new Plane(plane, littleEndian,
-      !writer.isInterleaved(), rgbChannels, pixelType);
+      int bytes = FormatTools.getBytesPerPixel(pixelType);
+      byte[] plane = getPlane(WIDTH, HEIGHT, bytes * rgbChannels);
+      originalPlane = new Plane(plane, littleEndian,
+        !writer.isInterleaved(), rgbChannels, pixelType);
 
-    for (int s=0; s<seriesCount; s++) {
-      writer.setSeries(s);
-      writer.saveBytes(0, plane);
-    }
-
-    writer.close();
-
-    ImageReader reader = new ImageReader();
-    reader.setFlattenedResolutions(false);
-    reader.setId(tmp.getAbsolutePath());
-
-    assertEquals(reader.getSeriesCount(), seriesCount);
-
-    for (int s=0; s<seriesCount; s++) {
-      reader.setSeries(s);
-
-      assertEquals(reader.getSizeC(), rgbChannels);
-      assertTrue(reader.getImageCount() == rgbChannels || reader.isRGB());
-
-      byte[] readPlane = reader.openBytes(0);
-
-      if (!lossy) {
-        Plane newPlane = new Plane(readPlane, reader.isLittleEndian(),
-          !reader.isInterleaved(), reader.getRGBChannelCount(),
-          FormatTools.getPixelTypeString(reader.getPixelType()));
-
-        assertTrue(originalPlane.equals(newPlane), tmp.getAbsolutePath());
+      for (int s=0; s<seriesCount; s++) {
+        writer.setSeries(s);
+        writer.saveBytes(0, plane);
       }
     }
 
-    reader.close();
+    try (ImageReader reader = new ImageReader()) {
+      reader.setFlattenedResolutions(false);
+      reader.setId(tmp.getAbsolutePath());
+
+      assertEquals(reader.getSeriesCount(), seriesCount);
+
+      for (int s=0; s<seriesCount; s++) {
+        reader.setSeries(s);
+
+        assertEquals(reader.getSizeC(), rgbChannels);
+        assertTrue(reader.getImageCount() == rgbChannels || reader.isRGB());
+
+        byte[] readPlane = reader.openBytes(0);
+
+        if (!lossy) {
+          Plane newPlane = new Plane(readPlane, reader.isLittleEndian(),
+            !reader.isInterleaved(), reader.getRGBChannelCount(),
+            FormatTools.getPixelTypeString(reader.getPixelType()));
+
+          assertTrue(originalPlane.equals(newPlane), tmp.getAbsolutePath());
+        }
+      }
+    }
+  }
+
+  private File createTempFile(String extension) throws IOException {
+    // Retain the path before writing so teardown also covers write failures.
+    Path path = Files.createTempFile("conversionTest", extension);
+    temporaryFiles.add(path);
+    return path.toFile();
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws IOException {
+    IOException failure = null;
+    for (Path path : temporaryFiles) {
+      try {
+        deleteRecursively(path);
+      }
+      catch (IOException e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    temporaryFiles.clear();
+    if (failure != null) throw failure;
+  }
+
+  private static void deleteRecursively(Path root) throws IOException {
+    // Files are removed during the walk and directories after their children.
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
@@ -35,9 +35,12 @@ package loci.formats.utests;
 import static org.testng.AssertJUnit.*;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 
-import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
@@ -54,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -68,16 +72,19 @@ public class EightBitLosslessJPEG2000Test {
 
   private ArrayList<String> files = new ArrayList<String>();
   private byte[][] pixels = new byte[256][1];
+  private final List<Path> temporaryFiles = new ArrayList<Path>();
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
     for (byte v=Byte.MIN_VALUE; v<Byte.MAX_VALUE; v++) {
       int index = v + Byte.MAX_VALUE + 1;
       pixels[index][0] = v;
 
       String file = index + ".jp2";
-      File tempFile = File.createTempFile("test", ".jp2");
-      tempFile.deleteOnExit();
+      Path tempPath = Files.createTempFile("test", ".jp2");
+      // Retain each fixture before metadata or writer setup can fail.
+      temporaryFiles.add(tempPath);
+      File tempFile = tempPath.toFile();
       Location.mapId(file, tempFile.getAbsolutePath());
       files.add(file);
 
@@ -97,11 +104,11 @@ public class EightBitLosslessJPEG2000Test {
 
       MetadataTools.populateMetadata(metadata, 0, "foo", false, "XYCZT",
         "uint8", 1, 1, 1, 1, 1, 1);
-      IFormatWriter writer = new JPEG2000Writer();
-      writer.setMetadataRetrieve(metadata);
-      writer.setId(file);
-      writer.saveBytes(0, pixels[index]);
-      writer.close();
+      try (IFormatWriter writer = new JPEG2000Writer()) {
+        writer.setMetadataRetrieve(metadata);
+        writer.setId(file);
+        writer.saveBytes(0, pixels[index]);
+      }
     }
   }
 
@@ -109,16 +116,36 @@ public class EightBitLosslessJPEG2000Test {
   public void testLosslessPixels() throws Exception {
     int failureCount = 0;
     for (int i=0; i<files.size(); i++) {
-      ImageReader reader = new ImageReader();
+      try (ImageReader reader = new ImageReader()) {
       reader.setId(files.get(i));
       byte[] plane = reader.openBytes(0);
       if (plane[0] != pixels[i][0]) {
         LOGGER.debug("FAILED on {}", pixels[i][0]);
         failureCount++;
       }
-      reader.close();
+      }
     }
     assertEquals(failureCount, 0);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws IOException {
+    IOException failure = null;
+    for (String file : files) {
+      Location.mapId(file, null);
+    }
+    for (Path path : temporaryFiles) {
+      try {
+        Files.deleteIfExists(path);
+      }
+      catch (IOException e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    files.clear();
+    temporaryFiles.clear();
+    if (failure != null) throw failure;
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -38,11 +38,15 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -174,23 +178,32 @@ public class FakeReaderTest {
     return fakeIni;
   }
 
-  /** Recursively set delete-on-exit for a directory tree. */
-  private void deleteTemporaryDirectoryOnExit(Location directoryRoot) {
-    directoryRoot.deleteOnExit();
-    Location[] children = directoryRoot.listFiles();
-    if (children != null) {
-      for (Location child : children) {
-        if (child.isDirectory()) {
-          deleteTemporaryDirectoryOnExit(child);
-        } else {
-          child.deleteOnExit();
-        }
+  /** Delete a temporary directory tree immediately, from its leaves upward. */
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
       }
-    }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
+    // Record the root as soon as it exists so setup failures are recoverable.
     wd = Files.createTempDirectory(this.getClass().getName());
     reader = new FakeReader();
     ServiceFactory sf = new ServiceFactory();
@@ -199,10 +212,29 @@ public class FakeReaderTest {
     reader.setFlattenedResolutions(false);
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void tearDown() throws Exception {
-    reader.close();
-    deleteTemporaryDirectoryOnExit(new Location(wd.toFile()));
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    if (wd != null) {
+      try {
+        deleteRecursively(wd);
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    reader = null;
+    wd = null;
+    if (failure != null) throw failure;
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
@@ -40,12 +40,16 @@ import java.nio.file.FileSystems;
 import java.io.IOException;
 import java.io.File;
 import java.math.BigInteger;
+import java.nio.file.FileVisitResult;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -55,6 +59,8 @@ import loci.common.Location;
 
 
 public class FilePatternTest {
+
+  private final List<Path> temporaryDirectories = new ArrayList<Path>();
 
   private static final String SEPARATOR =
     FileSystems.getDefault().getSeparator();
@@ -108,9 +114,54 @@ public class FilePatternTest {
     Path[] paths = new Path[basenames.length];
     for (int i = 0; i < basenames.length; i++) {
       paths[i] = Files.createFile(dir.resolve(basenames[i]));
-      paths[i].toFile().deleteOnExit();
     }
     return paths;
+  }
+
+  /** Create and retain a temporary root for cleanup after this test method. */
+  private Path createTempDirectory() throws IOException {
+    Path directory = Files.createTempDirectory("");
+    temporaryDirectories.add(directory);
+    return directory;
+  }
+
+  /** Delete a temporary directory tree immediately, from its leaves upward. */
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws IOException {
+    IOException failure = null;
+    for (int i = temporaryDirectories.size() - 1; i >= 0; i--) {
+      try {
+        deleteRecursively(temporaryDirectories.get(i));
+      }
+      catch (IOException e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    temporaryDirectories.clear();
+    if (failure != null) throw failure;
   }
 
   private static String[] resolveAll(Path dir, String[] basenames) {
@@ -170,8 +221,7 @@ public class FilePatternTest {
   @Test(dataProvider = "booleanStates")
   public void testRegex(Boolean createFiles) throws IOException {
     String[] names = {"z0.tif", "z1.tif"};
-    Path wd = Files.createTempDirectory("");
-    wd.toFile().deleteOnExit();
+    Path wd = createTempDirectory();
     String pattern = resolveToString(wd, "z.*.tif");
     FilePattern fp = new FilePattern(pattern);
     assertTrue(fp.isValid());
@@ -236,8 +286,7 @@ public class FilePatternTest {
                    mkPattern(prefixes, minCBlocks, suffix));
       return;
     }
-    Path wd = Files.createTempDirectory("");
-    wd.toFile().deleteOnExit();
+    Path wd = createTempDirectory();
     String absPattern = resolveToString(wd, pattern);
     String[] fullNames = mkFiles(wd, namesA);
     assertEquals(FilePattern.findPattern(fullNames[1]), absPattern);
@@ -279,8 +328,7 @@ public class FilePatternTest {
       );
       return;
     }
-    Path wd = Files.createTempDirectory("");
-    wd.toFile().deleteOnExit();
+    Path wd = createTempDirectory();
     String[] fullNames = mkFiles(wd, names);
     assertEqualsNoOrder(
         FilePattern.findSeriesPatterns(fullNames[0]),

--- a/components/formats-bsd/test/loci/formats/utests/LosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/LosslessJPEG2000Test.java
@@ -36,6 +36,10 @@ import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import loci.common.Location;
 import loci.common.services.DependencyException;
@@ -50,6 +54,7 @@ import loci.formats.out.JPEG2000Writer;
 import loci.formats.services.OMEXMLService;
 
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -59,18 +64,23 @@ import org.testng.annotations.Test;
  */
 public class LosslessJPEG2000Test {
 
+  private final List<Path> temporaryFiles = new ArrayList<Path>();
+
   private static final byte[] PIXELS_8 = new byte[] {119};
   private static final byte[] PIXELS_16 = new byte[] {0, 119};
 
   private static final String FILE_8 = "8.jp2";
   private static final String FILE_16 = "16.jp2";
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
-    File temp8 = File.createTempFile("test", ".jp2");
-    File temp16 = File.createTempFile("test", ".jp2");
-    temp8.deleteOnExit();
-    temp16.deleteOnExit();
+    Path temp8Path = Files.createTempFile("test", ".jp2");
+    // Retain each fixture before the remaining setup can fail.
+    temporaryFiles.add(temp8Path);
+    Path temp16Path = Files.createTempFile("test", ".jp2");
+    temporaryFiles.add(temp16Path);
+    File temp8 = temp8Path.toFile();
+    File temp16 = temp16Path.toFile();
     Location.mapId(FILE_8, temp8.getAbsolutePath());
     Location.mapId(FILE_16, temp16.getAbsolutePath());
 
@@ -90,11 +100,11 @@ public class LosslessJPEG2000Test {
 
     MetadataTools.populateMetadata(metadata8, 0, "foo", false, "XYCZT",
       "uint8", 1, 1, 1, 1, 1, 1);
-    IFormatWriter writer8 = new JPEG2000Writer();
-    writer8.setMetadataRetrieve(metadata8);
-    writer8.setId(FILE_8);
-    writer8.saveBytes(0, PIXELS_8);
-    writer8.close();
+    try (IFormatWriter writer8 = new JPEG2000Writer()) {
+      writer8.setMetadataRetrieve(metadata8);
+      writer8.setId(FILE_8);
+      writer8.saveBytes(0, PIXELS_8);
+    }
 
     IMetadata metadata16;
 
@@ -112,35 +122,53 @@ public class LosslessJPEG2000Test {
 
     MetadataTools.populateMetadata(metadata16, 0, "foo", false, "XYCZT",
       "uint16", 1, 1, 1, 1, 1, 1);
-    IFormatWriter writer16 = new JPEG2000Writer();
-    writer16.setMetadataRetrieve(metadata16);
-    writer16.setId(FILE_16);
-    writer16.saveBytes(0, PIXELS_16);
-    writer16.close();
+    try (IFormatWriter writer16 = new JPEG2000Writer()) {
+      writer16.setMetadataRetrieve(metadata16);
+      writer16.setId(FILE_16);
+      writer16.saveBytes(0, PIXELS_16);
+    }
   }
 
   @Test
   public void testEquivalentPixels8Bit() throws Exception {
-    ImageReader reader = new ImageReader();
-    reader.setId(FILE_8);
-    byte[] plane = reader.openBytes(0);
-    assertEquals(plane.length, PIXELS_8.length);
-    for (int q=0; q<plane.length; q++) {
-      assertEquals(plane[q], PIXELS_8[q]);
+    try (ImageReader reader = new ImageReader()) {
+      reader.setId(FILE_8);
+      byte[] plane = reader.openBytes(0);
+      assertEquals(plane.length, PIXELS_8.length);
+      for (int q=0; q<plane.length; q++) {
+        assertEquals(plane[q], PIXELS_8[q]);
+      }
     }
-    reader.close();
   }
 
   @Test
   public void testEquivalentPixels16Bit() throws Exception {
-    ImageReader reader = new ImageReader();
-    reader.setId(FILE_16);
-    byte[] plane = reader.openBytes(0);
-    assertEquals(plane.length, PIXELS_16.length);
-    for (int q=0; q<plane.length; q++) {
-      assertEquals(plane[q], PIXELS_16[q]);
+    try (ImageReader reader = new ImageReader()) {
+      reader.setId(FILE_16);
+      byte[] plane = reader.openBytes(0);
+      assertEquals(plane.length, PIXELS_16.length);
+      for (int q=0; q<plane.length; q++) {
+        assertEquals(plane[q], PIXELS_16[q]);
+      }
     }
-    reader.close();
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws IOException {
+    IOException failure = null;
+    Location.mapId(FILE_8, null);
+    Location.mapId(FILE_16, null);
+    for (Path path : temporaryFiles) {
+      try {
+        Files.deleteIfExists(path);
+      }
+      catch (IOException e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    temporaryFiles.clear();
+    if (failure != null) throw failure;
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
@@ -38,6 +38,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -79,7 +80,7 @@ public class SPWModelReaderTest {
 
   private IMetadata metadataWithNoLightSources;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     mock = new SPWModelMock(true);
     mockWithNoLightSources = new SPWModelMock(false);
@@ -105,14 +106,54 @@ public class SPWModelReaderTest {
     Element root = mock.getRoot().asXMLElement(document);
     SPWModelMock.postProcess(root, document, withBinData);
     // Write the OME DOM to the requested file
-    OutputStream stream = new FileOutputStream(file);
-    stream.write(SPWModelMock.asString(document).getBytes());
+    try (OutputStream stream = new FileOutputStream(file)) {
+      stream.write(SPWModelMock.asString(document).getBytes());
+    }
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    temporaryFile.delete();
-    temporaryFileWithNoLightSources.delete();
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    if (readerWithNoLightSources != null) {
+      try {
+        readerWithNoLightSources.close();
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    if (temporaryFile != null) {
+      try {
+        Files.deleteIfExists(temporaryFile.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    if (temporaryFileWithNoLightSources != null) {
+      try {
+        Files.deleteIfExists(temporaryFileWithNoLightSources.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    reader = null;
+    readerWithNoLightSources = null;
+    temporaryFile = null;
+    temporaryFileWithNoLightSources = null;
+    if (failure != null) throw failure;
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
@@ -34,8 +34,6 @@ package loci.formats.utests;
 
 import static org.testng.AssertJUnit.*;
 
-import java.util.ArrayList;
-
 import loci.common.ByteArrayHandle;
 import loci.common.DataTools;
 import loci.common.Location;
@@ -53,7 +51,6 @@ import loci.formats.services.OMEXMLService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -85,52 +82,60 @@ public class SixteenBitLosslessJPEG2000Test {
 
       String file = index + ".jp2";
       ByteArrayHandle tmpFile = new ByteArrayHandle(1);
-      Location.mapFile(file, tmpFile);
-
-      IMetadata metadata16;
-
+      // Keep the mapping and handle alive until the iteration cleanup runs.
       try {
-        ServiceFactory factory = new ServiceFactory();
-        OMEXMLService service = factory.getInstance(OMEXMLService.class);
-        metadata16 = service.createOMEXMLMetadata();
-      }
-      catch (DependencyException exc) {
-        throw new FormatException("Could not create OME-XML store.", exc);
-      }
-      catch (ServiceException exc) {
-        throw new FormatException("Could not create OME-XML store.", exc);
-      }
+        Location.mapFile(file, tmpFile);
 
-      MetadataTools.populateMetadata(metadata16, 0, "foo", false, "XYCZT",
-        "uint16", 1, 1, 1, 1, 1, 1);
-      IFormatWriter writer16 = new JPEG2000Writer();
-      writer16.setMetadataRetrieve(metadata16);
-      writer16.setId(file);
-      writer16.saveBytes(0, pixels);
-      writer16.close();
+        IMetadata metadata16;
 
-      byte[] buf = tmpFile.getBytes();
-      byte[] realData = new byte[(int) tmpFile.length()];
-      System.arraycopy(buf, 0, realData, 0, realData.length);
-      tmpFile.close();
-      tmpFile = new ByteArrayHandle(realData);
-      Location.mapFile(file, tmpFile);
+        try {
+          ServiceFactory factory = new ServiceFactory();
+          OMEXMLService service = factory.getInstance(OMEXMLService.class);
+          metadata16 = service.createOMEXMLMetadata();
+        }
+        catch (DependencyException exc) {
+          throw new FormatException("Could not create OME-XML store.", exc);
+        }
+        catch (ServiceException exc) {
+          throw new FormatException("Could not create OME-XML store.", exc);
+        }
 
-      ImageReader reader = new ImageReader();
-      reader.setId(file);
-      byte[] plane = reader.openBytes(0);
-      for (int q=0; q<plane.length; q++) {
-        if (plane[q] != pixels[q]) {
-          LOGGER.debug("FAILED on {}",
-            DataTools.bytesToShort(pixels, false));
-          failureCount++;
-          break;
+        MetadataTools.populateMetadata(metadata16, 0, "foo", false, "XYCZT",
+          "uint16", 1, 1, 1, 1, 1, 1);
+        try (IFormatWriter writer16 = new JPEG2000Writer()) {
+          writer16.setMetadataRetrieve(metadata16);
+          writer16.setId(file);
+          writer16.saveBytes(0, pixels);
+        }
+
+        byte[] buf = tmpFile.getBytes();
+        byte[] realData = new byte[(int) tmpFile.length()];
+        System.arraycopy(buf, 0, realData, 0, realData.length);
+        tmpFile.close();
+        tmpFile = new ByteArrayHandle(realData);
+        Location.mapFile(file, tmpFile);
+
+        try (ImageReader reader = new ImageReader()) {
+          reader.setId(file);
+          byte[] plane = reader.openBytes(0);
+          for (int q=0; q<plane.length; q++) {
+            if (plane[q] != pixels[q]) {
+              LOGGER.debug("FAILED on {}",
+                DataTools.bytesToShort(pixels, false));
+              failureCount++;
+              break;
+            }
+          }
         }
       }
-      reader.close();
-      tmpFile.close();
-
-      Location.mapFile(file, null);
+      finally {
+        try {
+          tmpFile.close();
+        }
+        finally {
+          Location.mapFile(file, null);
+        }
+      }
     }
     assertEquals(failureCount, 0);
   }

--- a/components/formats-bsd/test/loci/formats/utests/out/ICSWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/ICSWriterTest.java
@@ -36,6 +36,13 @@ import static org.testng.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Assert;
 import loci.common.ByteArrayHandle;
 import loci.common.Location;
@@ -61,6 +68,8 @@ import org.testng.annotations.Test;
 public class ICSWriterTest {
 
   private ICSWriter writer;
+  private final List<Path> temporaryPaths = new ArrayList<Path>();
+  private final List<String> mappedIds = new ArrayList<String>();
   private static int percentageOfSaveBytesTests = 0;
   
   @DataProvider(name = "writeParams")
@@ -81,14 +90,66 @@ public class ICSWriterTest {
     percentageOfSaveBytesTests = WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
     writer = new ICSWriter();
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void tearDown() throws Exception {
-    writer.close();
+    Exception failure = null;
+    if (writer != null) {
+      try {
+        writer.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    for (String id : mappedIds) Location.mapFile(id, null);
+    for (int i = temporaryPaths.size() - 1; i >= 0; i--) {
+      try {
+        deleteRecursively(temporaryPaths.get(i));
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    mappedIds.clear();
+    temporaryPaths.clear();
+    writer = null;
+    if (failure != null) throw failure;
+  }
+
+  /** Create and retain a temporary file for always-run teardown. */
+  private File createTempFile(String suffix) throws IOException {
+    Path path = Files.createTempFile("icsWriterTest", suffix);
+    temporaryPaths.add(path);
+    return path.toFile();
+  }
+
+  /** Delete a temporary path immediately, removing files before directories. */
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   @Test
@@ -107,8 +168,7 @@ public class ICSWriterTest {
     metadata.setPixelsPhysicalSizeZ(physicalSizeZ, 0);
     writer.setMetadataRetrieve(metadata);
 
-    File tmp = File.createTempFile("icsWriterTest", ".ics");
-    tmp.deleteOnExit();
+    File tmp = createTempFile(".ics");
 
     writer.setId(tmp.getAbsolutePath());
   }
@@ -119,8 +179,7 @@ public class ICSWriterTest {
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfSaveBytesTests == 0) return;
 
-    File tmp = File.createTempFile("icsWriterTest", ".ics");
-    tmp.deleteOnExit();
+    File tmp = createTempFile(".ics");
 
     String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
     writer.setMetadataRetrieve(WriterUtilities.createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian, sizeT));
@@ -144,10 +203,10 @@ public class ICSWriterTest {
       }
     }
 
-    ICSReader reader = new ICSReader();
-    reader.setId(tmp.getAbsolutePath());
+    try (ICSReader reader = new ICSReader()) {
+      reader.setId(tmp.getAbsolutePath());
 
-    for (int s=0; s<reader.getSeriesCount(); s++) {
+      for (int s=0; s<reader.getSeriesCount(); s++) {
       reader.setSeries(s);
       assertEquals(reader.getSizeC(), rgbChannels);
       int imageCount = reader.isRGB() ? seriesCount * sizeT : rgbChannels * sizeT * seriesCount;
@@ -159,9 +218,8 @@ public class ICSWriterTest {
           FormatTools.getPixelTypeString(reader.getPixelType()));
         assert(originalPlane.equals(newPlane));
       }
+      }
     }
-    tmp.delete();
-    reader.close();
   }
 
   // TODO: fix saveBytes parameters
@@ -173,6 +231,7 @@ public class ICSWriterTest {
 
     ByteArrayHandle handle = new ByteArrayHandle();
     String id = Math.random() + "-" + System.currentTimeMillis() + ".ics";
+    mappedIds.add(id);
     Location.mapFile(id, handle);
 
     String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
@@ -204,10 +263,10 @@ public class ICSWriterTest {
     handle = new ByteArrayHandle(file);
     Location.mapFile(id, handle);
 
-    ICSReader reader = new ICSReader();
-    reader.setId(id);
+    try (ICSReader reader = new ICSReader()) {
+      reader.setId(id);
 
-    for (int s=0; s<reader.getSeriesCount(); s++) {
+      for (int s=0; s<reader.getSeriesCount(); s++) {
       reader.setSeries(s);
       assertEquals(reader.getSizeC(), rgbChannels);
       int imageCount = reader.isRGB() ? seriesCount * sizeT : rgbChannels * sizeT * seriesCount;
@@ -219,9 +278,8 @@ public class ICSWriterTest {
           FormatTools.getPixelTypeString(reader.getPixelType()));
         assert(originalPlane.equals(newPlane));
       }
+      }
     }
-    reader.close();
-    Location.mapFile(id, null);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
@@ -37,7 +37,12 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 import loci.formats.FormatException;
 import loci.formats.in.TiffReader;
 import loci.formats.in.OMETiffReader;
@@ -59,6 +64,7 @@ import org.testng.annotations.Test;
 public class OMETiffWriterTest {
   private OMETiffWriter writer;
   private IMetadata metadata;
+  private final List<Path> temporaryPaths = new ArrayList<Path>();
 
   final long BIG_TIFF_CUTOFF = (long) 1024 * 1024 * 3990;
   private static final byte[] buf = new byte[1024*1024];
@@ -113,7 +119,7 @@ public class OMETiffWriterTest {
     percentageOfSaveBytesTests = WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
     writer = new OMETiffWriter();
     metadata = WriterUtilities.createMetadata();
@@ -123,9 +129,66 @@ public class OMETiffWriterTest {
     }
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void tearDown() throws Exception {
-    writer.close();
+    Exception failure = null;
+    if (writer != null) {
+      try {
+        writer.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    for (int i = temporaryPaths.size() - 1; i >= 0; i--) {
+      try {
+        deleteRecursively(temporaryPaths.get(i));
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    temporaryPaths.clear();
+    writer = null;
+    if (failure != null) throw failure;
+  }
+
+  /** Create and retain a temporary file for always-run teardown. */
+  private File createTempFile(String suffix) throws IOException {
+    Path path = Files.createTempFile("OMETiffWriterTest", suffix);
+    temporaryPaths.add(path);
+    return path.toFile();
+  }
+
+  /** Create and retain a temporary directory for always-run teardown. */
+  private Path createTempDirectory() throws IOException {
+    Path path = Files.createTempDirectory(this.getClass().getName());
+    temporaryPaths.add(path);
+    return path;
+  }
+
+  /** Delete a temporary path immediately, removing files before directories. */
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   @Test
@@ -144,12 +207,11 @@ public class OMETiffWriterTest {
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfTilingTests == 0) return;
 
-    File tmp = File.createTempFile("OMETiffWriterTest_Tiling", ".ome.tiff");
-    tmp.deleteOnExit();
+    File tmp = createTempFile("_Tiling.ome.tiff");
     Plane originalPlane = WriterUtilities.writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
-    TiffReader reader = new TiffReader();
-    reader.setId(tmp.getAbsolutePath());
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(tmp.getAbsolutePath());
 
     int expectedTileSize = tileSize;
     if (tileSize < TILE_GRANULARITY) {
@@ -165,8 +227,7 @@ public class OMETiffWriterTest {
 
     WriterUtilities.checkImage(reader, originalPlane, interleaved, rgbChannels, seriesCount, sizeT, compression);
 
-    tmp.delete();
-    reader.close();
+    }
   }
 
   @Test(dataProvider = "nonTiling")
@@ -174,22 +235,20 @@ public class OMETiffWriterTest {
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfSaveBytesTests == 0) return;
 
-    File tmp = File.createTempFile("OMETiffWriterTest", ".ome.tiff");
-    tmp.deleteOnExit();
+    File tmp = createTempFile(".ome.tiff");
     Plane originalPlane = WriterUtilities.writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
-    TiffReader reader = new TiffReader();
-    reader.setId(tmp.getAbsolutePath());
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(tmp.getAbsolutePath());
 
     WriterUtilities.checkImage(reader, originalPlane, interleaved, rgbChannels, seriesCount, sizeT, compression);
 
-    tmp.delete();
-    reader.close();
+    }
   }
 
   @Test
   public void testCompanion() throws Exception {
-    Path wd = Files.createTempDirectory(this.getClass().getName());
+    Path wd = createTempDirectory();
     File outFile = wd.resolve("test.ome.tif").toFile();
     File cFile = wd.resolve("test.companion.ome").toFile();
     String companion = cFile.getAbsolutePath();
@@ -198,28 +257,25 @@ public class OMETiffWriterTest {
     int planeCount =
       WriterUtilities.SIZE_Z * WriterUtilities.SIZE_C * WriterUtilities.SIZE_T;
 
-    OMETiffWriter cwriter = new OMETiffWriter();
-    cwriter.setMetadataOptions(options);
-    cwriter.setMetadataRetrieve(metadata);
-    cwriter.setId(outFile.getAbsolutePath());
-    cwriter.setSeries(0);
-    byte[] img = new byte[WriterUtilities.SIZE_X * WriterUtilities.SIZE_Y];
-    for (int i = 0; i < planeCount; i++) {
-      cwriter.saveBytes(i, img);
+    try (OMETiffWriter cwriter = new OMETiffWriter()) {
+      cwriter.setMetadataOptions(options);
+      cwriter.setMetadataRetrieve(metadata);
+      cwriter.setId(outFile.getAbsolutePath());
+      cwriter.setSeries(0);
+      byte[] img = new byte[WriterUtilities.SIZE_X * WriterUtilities.SIZE_Y];
+      for (int i = 0; i < planeCount; i++) {
+        cwriter.saveBytes(i, img);
+      }
     }
-    cwriter.close();
 
     assertTrue(cFile.exists());
-    OMETiffReader reader = new OMETiffReader();
-    reader.setId(companion);
-    assertEquals(reader.getSizeX(), WriterUtilities.SIZE_X);
-    assertEquals(reader.getSizeY(), WriterUtilities.SIZE_Y);
-    assertEquals(reader.getSizeZ(), WriterUtilities.SIZE_Z);
-    assertEquals(reader.getSizeC(), WriterUtilities.SIZE_C);
-    assertEquals(reader.getSizeT(), WriterUtilities.SIZE_T);
-    reader.close();
-    outFile.deleteOnExit();
-    cFile.deleteOnExit();
-    wd.toFile().deleteOnExit();
+    try (OMETiffReader reader = new OMETiffReader()) {
+      reader.setId(companion);
+      assertEquals(reader.getSizeX(), WriterUtilities.SIZE_X);
+      assertEquals(reader.getSizeY(), WriterUtilities.SIZE_Y);
+      assertEquals(reader.getSizeZ(), WriterUtilities.SIZE_Z);
+      assertEquals(reader.getSizeC(), WriterUtilities.SIZE_C);
+      assertEquals(reader.getSizeT(), WriterUtilities.SIZE_T);
+    }
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -36,18 +36,22 @@ import static org.testng.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Assert;
 import loci.common.ByteArrayHandle;
 import loci.common.Location;
-import loci.common.services.ServiceFactory;
 import loci.formats.FormatException;
 import loci.formats.in.TiffReader;
 import loci.formats.meta.IMetadata;
 import loci.formats.out.TiffWriter;
-import loci.formats.services.OMEXMLService;
 import loci.formats.tiff.IFD;
 import loci.formats.utests.tiff.TiffWriterMock;
-import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.PixelType;
 import ome.xml.model.primitives.PositiveInteger;
 import org.testng.annotations.AfterMethod;
@@ -64,6 +68,8 @@ public class TiffWriterTest {
   private IFD ifd;
   private TiffWriter writer;
   private IMetadata metadata;
+  private final List<Path> temporaryPaths = new ArrayList<Path>();
+  private final List<String> mappedIds = new ArrayList<String>();
 
   final long BIG_TIFF_CUTOFF = (long) 1024 * 1024 * 3990;
   private static final byte[] buf = new byte[1024*1024];
@@ -118,7 +124,7 @@ public class TiffWriterTest {
     percentageOfSaveBytesTests = WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
   }
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() throws Exception {
     ifd = new IFD();
     writer = new TiffWriterMock();
@@ -128,9 +134,61 @@ public class TiffWriterTest {
     }
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void tearDown() throws Exception {
-    writer.close();
+    Exception failure = null;
+    if (writer != null) {
+      try {
+        writer.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    for (String id : mappedIds) Location.mapFile(id, null);
+    for (int i = temporaryPaths.size() - 1; i >= 0; i--) {
+      try {
+        deleteRecursively(temporaryPaths.get(i));
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    temporaryPaths.clear();
+    mappedIds.clear();
+    writer = null;
+    if (failure != null) throw failure;
+  }
+
+  /** Create and retain a temporary file for always-run teardown. */
+  private File createTempFile(String suffix) throws IOException {
+    Path path = Files.createTempFile("tiffWriterTest", suffix);
+    temporaryPaths.add(path);
+    return path.toFile();
+  }
+
+  /** Delete a temporary path immediately, removing files before directories. */
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+        throws IOException
+      {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path directory,
+        IOException failure) throws IOException
+      {
+        if (failure != null) throw failure;
+        Files.delete(directory);
+        return FileVisitResult.CONTINUE;
+      }
+    });
   }
 
   @Test
@@ -399,12 +457,11 @@ public class TiffWriterTest {
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfTilingTests == 0) return;
 
-    File tmp = File.createTempFile("tiffWriterTest_Tiling", ".tiff");
-    tmp.deleteOnExit();
+    File tmp = createTempFile("_Tiling.tiff");
     Plane originalPlane = WriterUtilities.writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
-    TiffReader reader = new TiffReader();
-    reader.setId(tmp.getAbsolutePath());
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(tmp.getAbsolutePath());
 
     int expectedTileSize = tileSize;
     if (tileSize < TILE_GRANULARITY) {
@@ -420,8 +477,7 @@ public class TiffWriterTest {
 
     WriterUtilities.checkImage(reader, originalPlane, interleaved, rgbChannels, seriesCount, sizeT, compression);
 
-    tmp.delete();
-    reader.close();
+    }
   }
 
   @Test(dataProvider = "nonTiling")
@@ -429,17 +485,15 @@ public class TiffWriterTest {
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfSaveBytesTests == 0) return;
 
-    File tmp = File.createTempFile("tiffWriterTest", ".tiff");
-    tmp.deleteOnExit();
+    File tmp = createTempFile(".tiff");
     Plane originalPlane = WriterUtilities.writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
-    TiffReader reader = new TiffReader();
-    reader.setId(tmp.getAbsolutePath());
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(tmp.getAbsolutePath());
 
     WriterUtilities.checkImage(reader, originalPlane, interleaved, rgbChannels, seriesCount, sizeT, compression);
 
-    tmp.delete();
-    reader.close();
+    }
   }
 
   @Test(dataProvider = "nonTiling")
@@ -450,6 +504,8 @@ public class TiffWriterTest {
 
     ByteArrayHandle handle = new ByteArrayHandle();
     String id = Math.random() + "-" + System.currentTimeMillis() + ".tif";
+    // Keep the mapping registered until teardown can remove it on any path.
+    mappedIds.add(id);
     Location.mapFile(id, handle);
     Plane originalPlane = WriterUtilities.writeImage(id, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
@@ -460,13 +516,11 @@ public class TiffWriterTest {
     handle = new ByteArrayHandle(file);
     Location.mapFile(id, handle);
 
-    TiffReader reader = new TiffReader();
-    reader.setId(id);
-
-    WriterUtilities.checkImage(reader, originalPlane, interleaved, rgbChannels, seriesCount, sizeT, compression);
-
-    reader.close();
-    Location.mapFile(id, null);
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(id);
+      WriterUtilities.checkImage(reader, originalPlane, interleaved,
+        rgbChannels, seriesCount, sizeT, compression);
+    }
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
@@ -109,32 +109,33 @@ public final class WriterUtilities {
 
   public static Plane writeImage(String file, int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels,
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
-    TiffWriter writer = new TiffWriter();
-    String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
-    writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian, sizeT));
-    writer.setCompression(compression);
-    writer.setInterleaved(interleaved);
-    writer.setBigTiff(bigTiff);
-    if (tileSize != 0) {
-      writer.setTileSizeX(tileSize);
-      writer.setTileSizeY(tileSize);
-    }
-    writer.setId(file);
-
-    int bytes = FormatTools.getBytesPerPixel(pixelType);
-    byte[] plane = getPlane(PLANE_WIDTH, PLANE_HEIGHT, bytes * rgbChannels);
-    Plane originalPlane = new Plane(plane, littleEndian,
-      !writer.isInterleaved(), rgbChannels, FormatTools.getPixelTypeString(pixelType));
-
-    for (int s=0; s<seriesCount; s++) {
-      writer.setSeries(s);
-      for (int t=0; t<sizeT; t++) {
-        writer.saveBytes(t, plane);
+    try (TiffWriter writer = new TiffWriter()) {
+      String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
+      writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels,
+        seriesCount, littleEndian, sizeT));
+      writer.setCompression(compression);
+      writer.setInterleaved(interleaved);
+      writer.setBigTiff(bigTiff);
+      if (tileSize != 0) {
+        writer.setTileSizeX(tileSize);
+        writer.setTileSizeY(tileSize);
       }
-    }
+      writer.setId(file);
 
-    writer.close();
-    return originalPlane;
+      int bytes = FormatTools.getBytesPerPixel(pixelType);
+      byte[] plane = getPlane(PLANE_WIDTH, PLANE_HEIGHT, bytes * rgbChannels);
+      Plane originalPlane = new Plane(plane, littleEndian,
+        !writer.isInterleaved(), rgbChannels,
+        FormatTools.getPixelTypeString(pixelType));
+
+      for (int s=0; s<seriesCount; s++) {
+        writer.setSeries(s);
+        for (int t=0; t<sizeT; t++) {
+          writer.saveBytes(t, plane);
+        }
+      }
+      return originalPlane;
+    }
   }
 
   public static void checkImage(TiffReader reader, Plane originalPlane, boolean interleaved, int rgbChannels, 

--- a/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterBigTiffLargeImageWidthTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterBigTiffLargeImageWidthTest.java
@@ -35,6 +35,7 @@ package loci.formats.utests.tiff;
 import static org.testng.AssertJUnit.*;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import loci.common.services.ServiceFactory;
 import loci.formats.in.TiffReader;
@@ -75,8 +76,9 @@ public class OMETiffWriterBigTiffLargeImageWidthTest {
 
   private OMEXMLMetadata ms;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
+    // Retain the fixture before metadata setup can fail.
     target = File.createTempFile("OMETiffWriterTest", ".ome.tiff");
 
     ServiceFactory sf = new ServiceFactory();
@@ -96,22 +98,23 @@ public class OMETiffWriterBigTiffLargeImageWidthTest {
     ms.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    target.delete();
+    if (target != null) Files.deleteIfExists(target.toPath());
   }
 
   @Test
   public void testImageWidthWrittenCorrectly() throws Exception {
-    OMETiffWriter writer = new OMETiffWriter();
-    writer.setBigTiff(true);
-    writer.setMetadataRetrieve(ms);
-    writer.setId(target.getAbsolutePath());
-    writer.saveBytes(0, buf, 0, 0, buf.length, 1);
-    writer.close();
-    TiffReader reader = new TiffReader();
-    reader.setId(target.getAbsolutePath());
-    assertEquals(SIZE_X, reader.getSizeX());
-    assertEquals(SIZE_Y, reader.getSizeY());
+    try (OMETiffWriter writer = new OMETiffWriter()) {
+      writer.setBigTiff(true);
+      writer.setMetadataRetrieve(ms);
+      writer.setId(target.getAbsolutePath());
+      writer.saveBytes(0, buf, 0, 0, buf.length, 1);
+    }
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(target.getAbsolutePath());
+      assertEquals(SIZE_X, reader.getSizeX());
+      assertEquals(SIZE_Y, reader.getSizeY());
+    }
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterLargeImageWidthTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterLargeImageWidthTest.java
@@ -35,6 +35,7 @@ package loci.formats.utests.tiff;
 import static org.testng.AssertJUnit.*;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import loci.common.services.ServiceFactory;
 import loci.formats.ImageWriter;
@@ -75,8 +76,9 @@ public class OMETiffWriterLargeImageWidthTest {
 
   private OMEXMLMetadata ms;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
+    // Retain the fixture before metadata setup can fail.
     target = File.createTempFile("OMETiffWriterTest", ".ome.tiff");
 
     ServiceFactory sf = new ServiceFactory();
@@ -96,21 +98,22 @@ public class OMETiffWriterLargeImageWidthTest {
     ms.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    target.delete();
+    if (target != null) Files.deleteIfExists(target.toPath());
   }
 
   @Test
   public void testImageWidthWrittenCorrectly() throws Exception {
-    ImageWriter writer = new ImageWriter();
-    writer.setMetadataRetrieve(ms);
-    writer.setId(target.getAbsolutePath());
-    writer.saveBytes(0, buf, 0, 0, buf.length, 1);
-    writer.close();
-    TiffReader reader = new TiffReader();
-    reader.setId(target.getAbsolutePath());
-    assertEquals(SIZE_X, reader.getSizeX());
-    assertEquals(SIZE_Y, reader.getSizeY());
+    try (ImageWriter writer = new ImageWriter()) {
+      writer.setMetadataRetrieve(ms);
+      writer.setId(target.getAbsolutePath());
+      writer.saveBytes(0, buf, 0, 0, buf.length, 1);
+    }
+    try (TiffReader reader = new TiffReader()) {
+      reader.setId(target.getAbsolutePath());
+      assertEquals(SIZE_X, reader.getSizeX());
+      assertEquals(SIZE_Y, reader.getSizeY());
+    }
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterUnicodeTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterUnicodeTest.java
@@ -35,6 +35,7 @@ package loci.formats.utests.tiff;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import loci.common.services.ServiceFactory;
 import loci.formats.ImageReader;
@@ -82,8 +83,9 @@ public class OMETiffWriterUnicodeTest {
 
     private OMEXMLMetadata ms;
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setUp() throws Exception {
+      // Retain the fixture before metadata setup can fail.
       target = File.createTempFile("OMETiffWriterUnicodeTest", ".ome.tiff");
 
       ServiceFactory sf = new ServiceFactory();
@@ -106,21 +108,21 @@ public class OMETiffWriterUnicodeTest {
       ms.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown() throws Exception {
-      target.delete();
+      if (target != null) Files.deleteIfExists(target.toPath());
     }
 
     @Test
     public void testImageWidthWrittenCorrectly() throws Exception {
-      OMETiffWriter writer = new OMETiffWriter();
-      writer.setMetadataRetrieve(ms);
-      writer.setId(target.getAbsolutePath());
-      writer.saveBytes(0, buf, 0, 0, buf.length, 1);
-      writer.close();
-      ImageReader reader = new ImageReader();
-      reader.setId(target.getAbsolutePath());
-      assertEquals(reader.getFormat(), "OME-TIFF");
-      reader.close();
+      try (OMETiffWriter writer = new OMETiffWriter()) {
+        writer.setMetadataRetrieve(ms);
+        writer.setId(target.getAbsolutePath());
+        writer.saveBytes(0, buf, 0, 0, buf.length, 1);
+      }
+      try (ImageReader reader = new ImageReader()) {
+        reader.setId(target.getAbsolutePath());
+        assertEquals(reader.getFormat(), "OME-TIFF");
+      }
     }
 }

--- a/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
@@ -331,8 +331,7 @@ public class PyramidTest {
       populateImage(meta, p, EXTRA_WIDTH, EXTRA_HEIGHT, planes, bigEndian);
     }
   
-    PyramidOMETiffWriter writer = new PyramidOMETiffWriter();
-    try {
+    try (PyramidOMETiffWriter writer = new PyramidOMETiffWriter()) {
       writer.setBigTiff(bigTiff);
       writer.setWriteSequentially(true);
       writer.setMetadataRetrieve(meta);
@@ -370,9 +369,6 @@ public class PyramidTest {
           writer.saveBytes(plane, extraPlane);
         }
       }
-    }
-    finally {
-      writer.close();
     }
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
@@ -36,13 +36,13 @@ import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.MetadataTools;
-import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.IPyramidStore;
 import loci.formats.out.PyramidOMETiffWriter;
@@ -70,18 +70,28 @@ public class PyramidTest {
 
   private File[] files = new File[9];
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     for (int i=0; i<files.length; i++) {
+      // Retain each fixture before a later allocation can fail.
       files[i] = File.createTempFile("PyramidTest", ".ome.tiff");
     }
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
+    Exception failure = null;
     for (File f : files) {
-      f.delete();
+      if (f == null) continue;
+      try {
+        Files.deleteIfExists(f.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
     }
+    if (failure != null) throw failure;
   }
 
   @Test
@@ -256,9 +266,20 @@ public class PyramidTest {
 
   private IFormatReader getReader(int index) throws FormatException, IOException {
     ImageReader reader = new ImageReader();
-    reader.setFlattenedResolutions(false);
-    reader.setId(files[index].getAbsolutePath());
-    return reader;
+    try {
+      reader.setFlattenedResolutions(false);
+      reader.setId(files[index].getAbsolutePath());
+      return reader;
+    }
+    catch (FormatException | IOException e) {
+      try {
+        reader.close();
+      }
+      catch (IOException closeFailure) {
+        e.addSuppressed(closeFailure);
+      }
+      throw e;
+    }
   }
 
   private boolean checkPixels(IFormatReader reader) throws FormatException, IOException {
@@ -311,43 +332,48 @@ public class PyramidTest {
     }
   
     PyramidOMETiffWriter writer = new PyramidOMETiffWriter();
-    writer.setBigTiff(bigTiff);
-    writer.setWriteSequentially(true);
-    writer.setMetadataRetrieve(meta);
-    writer.setId(file);
+    try {
+      writer.setBigTiff(bigTiff);
+      writer.setWriteSequentially(true);
+      writer.setMetadataRetrieve(meta);
+      writer.setId(file);
 
-    int index = 1;
-    for (int p=0; p<widths.length; p++) {
-      writer.setSeries(p);
-      for (int r=0; r<RESOLUTION_COUNT; r++) {
-        writer.setResolution(r);
+      int index = 1;
+      for (int p=0; p<widths.length; p++) {
+        writer.setSeries(p);
+        for (int r=0; r<RESOLUTION_COUNT; r++) {
+          writer.setResolution(r);
 
-        int scale = (int) Math.pow(SCALE, r);
-        int width = widths[p] / scale;
-        int height = heights[p] / scale;
-        for (int plane=0; plane<planes; plane++) {
-          byte[] tile = new byte[] {(byte) index++};
-          IFD ifd = new IFD();
-          ifd.put(IFD.TILE_WIDTH, TILE_SIZE);
-          ifd.put(IFD.TILE_LENGTH, TILE_SIZE);
+          int scale = (int) Math.pow(SCALE, r);
+          int width = widths[p] / scale;
+          int height = heights[p] / scale;
+          for (int plane=0; plane<planes; plane++) {
+            byte[] tile = new byte[] {(byte) index++};
+            IFD ifd = new IFD();
+            ifd.put(IFD.TILE_WIDTH, TILE_SIZE);
+            ifd.put(IFD.TILE_LENGTH, TILE_SIZE);
 
-          for (int yy=0; yy<height; yy++) {
-            for (int xx=0; xx<width; xx++) {
-              writer.saveBytes(plane, tile, ifd, xx, yy, TILE_SIZE, TILE_SIZE);
+            for (int yy=0; yy<height; yy++) {
+              for (int xx=0; xx<width; xx++) {
+                writer.saveBytes(plane, tile, ifd, xx, yy,
+                  TILE_SIZE, TILE_SIZE);
+              }
             }
           }
         }
       }
-    }
-    for (int e=0; e<extra; e++) {
-      writer.setSeries(widths.length + e);
-      for (int plane=0; plane<planes; plane++) {
-        byte[] extraPlane = new byte[EXTRA_WIDTH * EXTRA_HEIGHT];
-        Arrays.fill(extraPlane, (byte) index++);
-        writer.saveBytes(plane, extraPlane);
+      for (int e=0; e<extra; e++) {
+        writer.setSeries(widths.length + e);
+        for (int plane=0; plane<planes; plane++) {
+          byte[] extraPlane = new byte[EXTRA_WIDTH * EXTRA_HEIGHT];
+          Arrays.fill(extraPlane, (byte) index++);
+          writer.saveBytes(plane, extraPlane);
+        }
       }
     }
-    writer.close();
+    finally {
+      writer.close();
+    }
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffTileReadingTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffTileReadingTest.java
@@ -138,8 +138,7 @@ public class TiffTileReadingTest {
     IMetadata meta = MetadataTools.createOMEXMLMetadata();
     populateImage(meta, 0, width, height, 1, false);
 
-    TiffWriter writer = new TiffWriter();
-    try {
+    try (TiffWriter writer = new TiffWriter()) {
       writer.setWriteSequentially(true);
       writer.setMetadataRetrieve(meta);
       writer.setId(file.getAbsolutePath());
@@ -157,9 +156,6 @@ public class TiffTileReadingTest {
           writer.saveBytes(0, tile, ifd, xx, yy, TILE_SIZE, TILE_SIZE);
         }
       }
-    }
-    finally {
-      writer.close();
     }
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffTileReadingTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffTileReadingTest.java
@@ -36,9 +36,9 @@ import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import loci.formats.FormatException;
-import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.MetadataTools;
 import loci.formats.meta.IMetadata;
@@ -62,18 +62,38 @@ public class TiffTileReadingTest {
   private File file;
   private ImageReader reader;
 
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
+    // Retain the fixture before writing or reader setup can fail.
     file = File.createTempFile("tileTest", ".tiff");
     writeFile(TILE_SIZE * 2, TILE_SIZE * 2);
     reader = new ImageReader();
     reader.setId(file.getAbsolutePath());
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() throws Exception {
-    reader.close();
-    file.delete();
+    Exception failure = null;
+    if (reader != null) {
+      try {
+        reader.close();
+      }
+      catch (Exception e) {
+        failure = e;
+      }
+    }
+    if (file != null) {
+      try {
+        Files.deleteIfExists(file.toPath());
+      }
+      catch (Exception e) {
+        if (failure == null) failure = e;
+        else failure.addSuppressed(e);
+      }
+    }
+    reader = null;
+    file = null;
+    if (failure != null) throw failure;
   }
 
   @Test
@@ -119,24 +139,28 @@ public class TiffTileReadingTest {
     populateImage(meta, 0, width, height, 1, false);
 
     TiffWriter writer = new TiffWriter();
-    writer.setWriteSequentially(true);
-    writer.setMetadataRetrieve(meta);
-    writer.setId(file.getAbsolutePath());
+    try {
+      writer.setWriteSequentially(true);
+      writer.setMetadataRetrieve(meta);
+      writer.setId(file.getAbsolutePath());
 
-    IFD ifd = new IFD();
-    ifd.put(IFD.TILE_WIDTH, TILE_SIZE);
-    ifd.put(IFD.TILE_LENGTH, TILE_SIZE);
+      IFD ifd = new IFD();
+      ifd.put(IFD.TILE_WIDTH, TILE_SIZE);
+      ifd.put(IFD.TILE_LENGTH, TILE_SIZE);
 
-    byte[] tile = new byte[TILE_SIZE * TILE_SIZE];
-    for (int yy=0; yy<height; yy+=TILE_SIZE) {
-      for (int xx=0; xx<width; xx+=TILE_SIZE) {
-        for (int q=0; q<tile.length; q++) {
-          tile[q] = getValue(xx, q);
+      byte[] tile = new byte[TILE_SIZE * TILE_SIZE];
+      for (int yy=0; yy<height; yy+=TILE_SIZE) {
+        for (int xx=0; xx<width; xx+=TILE_SIZE) {
+          for (int q=0; q<tile.length; q++) {
+            tile[q] = getValue(xx, q);
+          }
+          writer.saveBytes(0, tile, ifd, xx, yy, TILE_SIZE, TILE_SIZE);
         }
-        writer.saveBytes(0, tile, ifd, xx, yy, TILE_SIZE, TILE_SIZE);
       }
     }
-    writer.close();
+    finally {
+      writer.close();
+    }
   }
 
   private byte getValue(int x, int tilePos) {

--- a/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
@@ -37,6 +37,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -144,6 +147,7 @@ public class Schema_Transform_Test extends AbstractTest {
     private ServiceFactory factory;
     private OMEXMLService service;
     private IFormatReader reader;
+    private final List<Path> temporaryFiles = new ArrayList<Path>();
 
     /**
      * Validates the specified input.
@@ -186,7 +190,8 @@ public class Schema_Transform_Test extends AbstractTest {
                 resolver = new Resolver();
                 factory.setURIResolver(resolver);
                 output = File.createTempFile("tempFileName","."+ OME_XML);
-                output.deleteOnExit();
+                // Track the output before any later transform operation can fail.
+                temporaryFiles.add(output.toPath());
                 Source src = new StreamSource(stream);
                 Templates template = factory.newTemplates(src);
                 transformer = template.newTransformer();
@@ -214,7 +219,7 @@ public class Schema_Transform_Test extends AbstractTest {
      * @see AbstractServerTest#setUp()
      */
     @Override
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     protected void setUp() throws Exception {
         super.setUp();
         upgrades = new HashMap<String, List<String>>();
@@ -234,11 +239,31 @@ public class Schema_Transform_Test extends AbstractTest {
      * @see AbstractServerTest#tearDown()
      */
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown() throws Exception {
-        downgrades.clear();
-        upgrades.clear();
-        reader.close();
+        Exception failure = null;
+        if (downgrades != null) downgrades.clear();
+        if (upgrades != null) upgrades.clear();
+        if (reader != null) {
+            try {
+                reader.close();
+            }
+            catch (Exception e) {
+                failure = e;
+            }
+        }
+        for (int i = temporaryFiles.size() - 1; i >= 0; i--) {
+            try {
+                Files.deleteIfExists(temporaryFiles.get(i));
+            }
+            catch (IOException e) {
+                if (failure == null) failure = e;
+                else failure.addSuppressed(e);
+            }
+        }
+        temporaryFiles.clear();
+        reader = null;
+        if (failure != null) throw failure;
     }
 
     /**
@@ -254,6 +279,8 @@ public class Schema_Transform_Test extends AbstractTest {
     {
         // First create an image
         File f = File.createTempFile("tempFileName","." + OME_XML);
+        // Retain every fixture immediately so failed tests cannot orphan it.
+        temporaryFiles.add(f.toPath());
         XMLMockObjects xml = new XMLMockObjects();
         XMLWriter writer = new XMLWriter();
         if (index == IMAGE_ROI) {

--- a/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema_Transform_Test.java
@@ -173,41 +173,28 @@ public class Schema_Transform_Test extends AbstractTest {
      * @throws Exception
      *             Thrown if an error occurred during the transformations.
      */
-    private File applyTransforms(File inputXML, List<InputStream> transforms)
+    private File applyTransforms(File inputXML, List<String> transforms)
             throws Exception {
-        TransformerFactory factory;
-        Transformer transformer;
-        InputStream stream;
-        Iterator<InputStream> i = transforms.iterator();
-        File output;
-        InputStream in = null;
-        OutputStream out = null;
-        Resolver resolver = null;
-        while (i.hasNext()) {
-            stream = i.next();
-            try {
-                factory = TransformerFactory.newInstance();
-                resolver = new Resolver();
+        for (String transform : transforms) {
+            File output = File.createTempFile("tempFileName","."+ OME_XML);
+            // Track the output before any later transform operation can fail.
+            temporaryFiles.add(output.toPath());
+            try (InputStream stream = getRequiredStream(transform);
+                 Resolver resolver = new Resolver()) {
+                TransformerFactory factory = TransformerFactory.newInstance();
                 factory.setURIResolver(resolver);
-                output = File.createTempFile("tempFileName","."+ OME_XML);
-                // Track the output before any later transform operation can fail.
-                temporaryFiles.add(output.toPath());
                 Source src = new StreamSource(stream);
                 Templates template = factory.newTemplates(src);
-                transformer = template.newTransformer();
+                Transformer transformer = template.newTransformer();
                 transformer.setParameter(OutputKeys.ENCODING, Constants.ENCODING);
-                out = new FileOutputStream(output);
-                in = new FileInputStream(inputXML);
-                transformer.transform(new StreamSource(in),
-                        new StreamResult(out));
+                try (InputStream in = new FileInputStream(inputXML);
+                     OutputStream out = new FileOutputStream(output)) {
+                    transformer.transform(new StreamSource(in),
+                            new StreamResult(out));
+                }
                 inputXML = output;
             } catch (Exception e) {
                 throw new Exception("Cannot apply transform", e);
-            } finally {
-                if (stream != null) stream.close();
-                if (out != null) out.close();
-                if (in != null) in.close();
-                if (resolver != null) resolver.close();
             }
         }
         return inputXML;
@@ -392,8 +379,7 @@ public class Schema_Transform_Test extends AbstractTest {
      */
     private Map<String, List<String>> currentSchema() throws Exception
     {
-        InputStream stream = getStream(CATALOG);
-        try {
+        try (InputStream stream = getRequiredStream(CATALOG)) {
             Document doc = XMLTools.parseDOM(stream);
             currentSchema = doc.getDocumentElement().getAttribute(CURRENT);
             if (currentSchema.trim().isEmpty())
@@ -401,8 +387,6 @@ public class Schema_Transform_Test extends AbstractTest {
             return extractCurrentSchema(currentSchema, doc);
         } catch (Exception e) {
             throw new Exception("Unable to parse the catalog.", e);
-        } finally {
-            if (stream != null) stream.close();
         }
     }
 
@@ -419,18 +403,12 @@ public class Schema_Transform_Test extends AbstractTest {
         List<Target> targets = new ArrayList<Target>();
         Object[][] data = null;
         List<String> l;
-        Iterator<String> j;
         Entry<String, List<String>> e;
         Iterator<Entry<String, List<String>>> i = values.entrySet().iterator();
         while (i.hasNext()) {
             e = i.next();
             l = e.getValue();
-            List<InputStream> streams = new ArrayList<InputStream>();
-            j = l.iterator();
-            while (j.hasNext()) {
-                streams.add(getStream(j.next()));
-            }
-            targets.add(new Target(streams, e.getKey()));
+            targets.add(new Target(new ArrayList<String>(l), e.getKey()));
         }
         int index = 0;
         Iterator<Target> k = targets.iterator();
@@ -475,21 +453,32 @@ public class Schema_Transform_Test extends AbstractTest {
     }
 
     /**
+     * Opens a required transform resource.
+     *
+     * @param name The transform resource name.
+     * @return The opened resource stream.
+     * @throws IOException If the resource cannot be found.
+     */
+    private InputStream getRequiredStream(String name) throws IOException
+    {
+        InputStream stream = getStream(name);
+        if (stream == null) {
+            throw new IOException("Cannot find transform resource: " + name);
+        }
+        return stream;
+    }
+
+    /**
      * Returns the list of transformations to generate the file to upgrade.
      *
      * @param target The schema to start from for the upgrade.
      * @return See above.
      */
-    private List<InputStream> retrieveDowngrade(String target)
+    private List<String> retrieveDowngrade(String target)
     {
         List<String> list = downgrades.get(target);
         if (list == null || list.isEmpty()) return null;
-        List<InputStream> streams = new ArrayList<InputStream>();
-        Iterator<String> j = list.iterator();
-        while (j.hasNext()) {
-            streams.add(getStream(j.next()));
-        }
-        return streams;
+        return new ArrayList<String>(list);
     }
 
     /**
@@ -629,7 +618,7 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE); //2015 image
-            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            List<String> transforms = retrieveDowngrade(target.getSource());
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file.
@@ -658,7 +647,7 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE_ROI); //2015 image
-            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            List<String> transforms = retrieveDowngrade(target.getSource());
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file.
@@ -687,7 +676,7 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE_ANNOTATED_DATA); //2015 image
-            List<InputStream> transforms = retrieveDowngrade(target.getSource());
+            List<String> transforms = retrieveDowngrade(target.getSource());
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file.
@@ -717,12 +706,12 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE); //2015 image
-            List<InputStream> transforms = retrieveDowngrade("2003-FC");
+            List<String> transforms = retrieveDowngrade("2003-FC");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file to 2008-09
-            List<InputStream> upgrades = new ArrayList<InputStream>();
-            upgrades.add(getStream("2003-FC-to-2008-09.xsl"));
+            List<String> upgrades = new ArrayList<String>();
+            upgrades.add("2003-FC-to-2008-09.xsl");
             upgraded = applyTransforms(transformed, upgrades);
             //validate the file
             validate(upgraded);
@@ -747,12 +736,12 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE); //2015 image
-            List<InputStream> transforms = retrieveDowngrade("2007-06");
+            List<String> transforms = retrieveDowngrade("2007-06");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file to 2008-02
-            List<InputStream> upgrades = new ArrayList<InputStream>();
-            upgrades.add(getStream("2007-06-to-2008-02.xsl"));
+            List<String> upgrades = new ArrayList<String>();
+            upgrades.add("2007-06-to-2008-02.xsl");
             upgraded = applyTransforms(transformed, upgrades);
             //validate the file
             validate(upgraded);
@@ -777,12 +766,12 @@ public class Schema_Transform_Test extends AbstractTest {
         File upgraded = null;
         try {
             f = createImageFile(IMAGE); //2015 image
-            List<InputStream> transforms = retrieveDowngrade("2007-06");
+            List<String> transforms = retrieveDowngrade("2007-06");
             //Create file to upgrade
             transformed = applyTransforms(f, transforms);
             //now upgrade the file to 2008-09
-            List<InputStream> upgrades = new ArrayList<InputStream>();
-            upgrades.add(getStream("2007-06-to-2008-09.xsl"));
+            List<String> upgrades = new ArrayList<String>();
+            upgrades.add("2007-06-to-2008-09.xsl");
             upgraded = applyTransforms(transformed, upgrades);
             //validate the file
             validate(upgraded);
@@ -799,10 +788,10 @@ public class Schema_Transform_Test extends AbstractTest {
     class Target {
 
         /** The transforms to apply.*/
-        private List<InputStream> transforms;
+        private final List<String> transforms;
 
         /** The source schema.*/
-        private String source;
+        private final String source;
 
         /**
          * Creates a new instance.
@@ -810,7 +799,7 @@ public class Schema_Transform_Test extends AbstractTest {
          * @param transforms The transforms to apply.
          * @param source The source schema.
          */
-        Target(List<InputStream> transforms, String source)
+        Target(List<String> transforms, String source)
         {
             this.transforms = transforms;
             this.source = source;
@@ -821,7 +810,7 @@ public class Schema_Transform_Test extends AbstractTest {
          *
          * @return See above.
          */
-        List<InputStream> getTransforms() { return transforms; }
+        List<String> getTransforms() { return transforms; }
 
         /**
          * Returns the source schema.
@@ -832,22 +821,41 @@ public class Schema_Transform_Test extends AbstractTest {
 
     }
 
-    class Resolver implements URIResolver {
+    class Resolver implements AutoCloseable, URIResolver {
 
-        /** The stream.*/
-        private InputStream stream;
+        /** The streams opened while resolving transform dependencies.*/
+        private final List<InputStream> streams = new ArrayList<InputStream>();
 
-        /** Close the input stream if not <code>null</code>.*/
+        /** Close every stream opened by this resolver.*/
+        @Override
         public void close()
-            throws Exception
+            throws IOException
         {
-            if (stream != null) stream.close();
+            IOException failure = null;
+            for (InputStream stream : streams) {
+                try {
+                    stream.close();
+                }
+                catch (IOException e) {
+                    if (failure == null) failure = e;
+                    else failure.addSuppressed(e);
+                }
+            }
+            streams.clear();
+            if (failure != null) throw failure;
         }
 
         @Override
         public Source resolve(String href, String base)
                 throws TransformerException {
-            stream = getStream(UNITS_CONVERSION);
+            InputStream stream;
+            try {
+                stream = getRequiredStream(UNITS_CONVERSION);
+            }
+            catch (IOException e) {
+                throw new TransformerException(e);
+            }
+            streams.add(stream);
             return new StreamSource(stream);
         }
     }


### PR DESCRIPTION
Hej,

Based on the review of @melissalinkert I investigated the `formats-bsd` test suite for resource cleanup, because the `MemoizerTest` etc. failed their cleanup (also in ome/bioformats#4464 before the fixes). Looking deeper multiple files used the same cleanup function/pattern and several more also created temporary files or directories without reliably cleaning them up. Many used `deleteOnExit()`, unchecked deletion, or teardown methods that did not run after setup failures. Readers, writers, streams, and in-memory file mappings were also not consistently closed on exceptional paths.

This could leave temporary resources behind after failed tests and make cleanup failures invisible, particularly when files remained open or directories had been made non-writable by a permission test.

This is only a cleanup of the tests that used `deleteOnExit()` and/or left temporary directories behind after the failed cleanup. There are more with improper resource usage etc. but I didn't go one by one through all the tests, these were the most clear and easy to fix and diagnose.

## Changes

Replace deferred and unchecked cleanup with deterministic, always-run teardown in the identified BSD tests.

The changes:

- Track temporary fixtures immediately after creation, before later setup or transformation operations can fail.
- Use `alwaysRun = true` for relevant setup and teardown methods.
- Replace silent or unchecked deletion with `Files.deleteIfExists`.
- Aggregate cleanup failures and report them after attempting all cleanup operations.
- Close readers, writers, output streams, and wrapper resources on normal and exceptional paths.
- Clean up temporary `Location` mappings and `ByteArrayHandle` instances in the JPEG-2000 tests.
- Ensure pyramid and tile writers close even when writing fails.
- Preserve the existing test structure, function names, and explanatory comments.

Updated tests include:

- Base model and SPW reader tests
- Conversion, fake reader, file pattern, and JPEG-2000 tests
- ICS and TIFF writer tests
- Large-image and Unicode TIFF tests
- Pyramid and tile-reading tests
- Schema transformation tests
- Sixteen-bit lossless JPEG-2000 tests

`MemoizerTest` remains intentionally excluded from this branch, as it had its fixes added to ome/bioformats#4464 directly.

## Tests

A quick temporary-file audit found no leftovers from the tests changed in this branch. The only remaining resources were from the intentionally excluded `MemoizerTest` permission tests, which leave two non-writable fixture directories and one empty non-writable directory which are cleaned up in ome/bioformats#4464.

The branch passes the complete local `formats-bsd` test suite.