### PR TITLE
Make no-JHDF tests opt-in

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
             os: 'macos-14'
     runs-on: ${{ matrix.os }}
     env:
-      maven_commands: install # default is install
+      maven_commands: install -Pno-jhdf
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
@@ -97,4 +97,3 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.CI_DEPLOY_USER }}
           MAVEN_PASSWORD: ${{ secrets.CI_DEPLOY_PASS }}
-

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -16,7 +16,7 @@ Type "ant -p" for a list of targets.
   <property name="testng.runWriterTilingTests" value="2"/>
 
   <target name="test" depends="jar,compile-tests,test-long-running,
-      test-no-ome-xml,test-no-exif, test-no-jhdf,
+      test-no-ome-xml,test-no-exif,
       test-spec"
     description="run tests">
     <!-- NOTE: Overrides default "test" target from java.xml -->

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -219,20 +219,6 @@
               </systemPropertyVariables>
             </configuration>
           </execution>
-          <execution>
-            <id>test-no-hdf</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <suiteXmlFiles>
-                <suiteXmlFile>test/loci/formats/utests/testng-no-jhdf.xml</suiteXmlFile>
-              </suiteXmlFiles>
-              <classpathDependencyExcludes>
-                <classpathDependencyExclude>cisd:jhdf5</classpathDependencyExclude>
-              </classpathDependencyExcludes>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -295,6 +281,33 @@
   </developers>
 
   <profiles>
+    <profile>
+      <id>no-jhdf</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>test-no-hdf</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <suiteXmlFiles>
+                    <suiteXmlFile>test/loci/formats/utests/testng-no-jhdf.xml</suiteXmlFile>
+                  </suiteXmlFiles>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExclude>cisd:jhdf5</classpathDependencyExclude>
+                  </classpathDependencyExcludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>only-eclipse</id>
       <activation>


### PR DESCRIPTION
Hej,

While investigating the `MemoizerTest` failures mentioned in ome/bioformats#4464, I found that the problem was caused by the Maven test configuration rather than a problem in the normal Memoizer tests.

`formats-bsd` had two Surefire executions in the default lifecycle: the regular suite and a second execution with JHDF removed from the classpath. When `-Dtest=MemoizerTest` was used, Surefire applied that filter to both executions, so Memoizer tests were unexpectedly run without JHDF.

The normal tests passed with JHDF available. On the stripped classpath, the default `Memoizer` creates an `ImageReader`, which eagerly instantiates all registered readers, including HDF readers. Kryo then inspected the complete reader graph and attempted to resolve `HDF5CompoundDataMap`, causing memo serialization to fail. `saveMemo()` caught the failure and returned `false`, producing the two reported assertion failures.

As far as I can tell the no-JHDF suite was originally intended only to verify that JHDF service discovery fails cleanly when the dependency is absent, but not intended to run arbitrary tests without JHDF.

## Changes

Move the no-JHDF compatibility test into an explicit `no-jhdf` Maven profile.

The changes:

- Remove the dependency-excluded Surefire execution from the default Maven lifecycle.
- Add the execution under the explicit `no-jhdf` profile.
- Remove `test-no-jhdf` from the default Ant test target while retaining the explicit Ant target.
- Update Maven CI to run `mvn install -Pno-jhdf`, preserving coverage of both the normal and missing-JHDF suites.
- Keep the existing `MissingJHDFServiceTest` unchanged.
- Prevent focused normal tests from unexpectedly running on a dependency-excluded classpath.

This change does not alter Memoizer serialization or claim to add Memoizer support for missing JHDF. It isolates the existing compatibility test and makes the test contract explicit. It mostly improves dev experience.

The serializer should still be hardened separately. Even with the no-JHDF suite isolated, users running Bio-Formats without optional HDF dependencies or similar can still lose memoization for otherwise supported non-HDF etc. files because Kryo serializes the entire eagerly discovered ImageReader graph. Unused HDF readers should not make an unrelated memo fail. A future fix should serialize only the active reader and wrapper chain, reconstruct discovery from the current runtime classpath, record or validate required optional dependencies, bump the memo format version, and report unsupported memoization clearly instead of silently returning false. No matter if the separate no-JHDF suite is still needed, this is a central problem with the memoizer.