### PR TITLE
Add `omitIniFromUsedFiles` option to `FakeReader`

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -230,6 +230,7 @@ public class FakeReader extends FormatReader {
   private int sleepOpenBytes = 0;
   private int sleepInitFile = 0;
   private boolean labelPlanes = false;
+  private boolean omitIniFromUsedFiles = false;
 
   static void sleep(String msg, int ms) {
     if (ms <= 0) return; // EARLY EXIT
@@ -524,8 +525,12 @@ public class FakeReader extends FormatReader {
       FormatTools.assertId(currentId, true, 1);
       List<String> files = new ArrayList<String>();
       fakeSeries.clear();
-      if (!noPixels) files.addAll(listFakeSeries(currentId));
-      if (iniFile != null) files.add(iniFile);
+      if (!noPixels) {
+        files.addAll(listFakeSeries(currentId));
+      }
+      if (iniFile != null && !omitIniFromUsedFiles) {
+        files.add(iniFile);
+      }
       return files.toArray(new String[files.size()]);
   }
 
@@ -857,6 +862,8 @@ public class FakeReader extends FormatReader {
         sleepInitFile = intValue;
       } else if (key.equals("labelPlanes")) {
         labelPlanes = boolValue;
+      } else if (key.equals("omitIniFromUsedFiles")) {
+        omitIniFromUsedFiles = boolValue;
       }
     }
 


### PR DESCRIPTION
This makes it easy to create a fake dataset that will fail to initialize or have inconsistent dimensions after importing to OMERO.

Options provided in a .fake.ini file override the options provided in the matching .fake file name. Simple example:

```
$ cat "test&sizeX=0.fake"
$ cat "test&sizeX=0.fake.ini"
sizeX=1024
omitIniFromUsedFiles=true
$ showinf -no-upgrade -nopix test\&sizeX\=0.fake
Checking file format [Simulated data]
Initializing reader
FakeReader initializing test&sizeX=0.fake
Initialization took 0.198s

Reading core metadata
filename = test&sizeX=0.fake
Used files = [/home/melissa/bad-test/test&sizeX=0.fake]
Series count = 1
Series #0 :
	Image count = 1
	RGB = false (1) 
	Interleaved = false
	Indexed = false (true color)
	Width = 1024
	Height = 512
	SizeZ = 1
	SizeT = 1
	SizeC = 1
	Tile size = 1024 x 512
	Thumbnail size = 128 x 64
	Endianness = intel (little)
	Dimension order = XYZCT (certain)
	Pixel type = uint8
	Valid bits per pixel = 8
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0


Reading global metadata

Reading metadata
$ rm "test&sizeX=0.fake.ini"
$ showinf -no-upgrade -nopix test\&sizeX\=0.fake
...
loci.formats.FormatException: Invalid sizeX: 0
	at loci.formats.in.FakeReader.initFile(FakeReader.java:874)
	at loci.formats.FormatReader.setId(FormatReader.java:1480)
	at loci.formats.ImageReader.setId(ImageReader.java:864)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:692)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1054)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1165)
```

The idea is that OMERO import should succeed with a dataset like this, but only the .fake file would be put under ManagedRepository. Attempting to initialize the .fake file after import would then throw an exception. This can also be used to get data which would initialize after import, but have different dimensions, pixel type, etc.

Discussed with @knabar in the context of https://github.com/ome/omero-web/issues/657 that something like this might be useful. I was not successful in finding a way to do something similar with other readers, so this is an alternative.