### PR TITLE
Keep Windows volume identity in memo cache paths

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -836,11 +836,7 @@ public class Memoizer extends ReaderWrapper {
         f = new File(id);
         writeDirectory = new File(f.getParent());
       } else {
-        // this serves to strip off the drive letter on Windows
-        // since we're using the absolute path, 'id' will either start with
-        // File.separator (as on UNIX), or a drive letter (as on Windows)
-        id = id.substring(id.indexOf(File.separator) + 1);
-        f = new File(directory, id);
+        f = new File(directory, getCachePath(id));
         writeDirectory = directory;
       }
 
@@ -857,6 +853,50 @@ public class Memoizer extends ReaderWrapper {
     String p = f.getParent();
     String n = f.getName();
     return new File(p, "." + n + ".bfmemo");
+  }
+
+  /**
+   * Convert an absolute identifier into a relative cache path while retaining
+   * the identity of Windows drives and UNC shares.
+   *
+   * @param absolutePath absolute identifier path
+   * @return path relative to the configured cache directory
+   */
+  protected String getCachePath(String absolutePath) {
+    if (absolutePath.length() >= 3 &&
+      Character.isLetter(absolutePath.charAt(0)) &&
+      absolutePath.charAt(1) == ':' &&
+      isPathSeparator(absolutePath.charAt(2)))
+    {
+      String remainder = normalizeSeparators(absolutePath.substring(3));
+      return Character.toUpperCase(absolutePath.charAt(0)) +
+        File.separator + remainder;
+    }
+
+    if (absolutePath.length() >= 2 &&
+      isPathSeparator(absolutePath.charAt(0)) &&
+      isPathSeparator(absolutePath.charAt(1)))
+    {
+      return "UNC" + File.separator +
+        normalizeSeparators(absolutePath.substring(2));
+    }
+
+    int first = 0;
+    while (first < absolutePath.length() &&
+      absolutePath.charAt(first) == File.separatorChar)
+    {
+      first++;
+    }
+    return absolutePath.substring(first);
+  }
+
+  private boolean isPathSeparator(char character) {
+    return character == '/' || character == '\\';
+  }
+
+  private String normalizeSeparators(String path) {
+    return path.replace('\\', File.separatorChar)
+      .replace('/', File.separatorChar);
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -160,9 +160,8 @@ public class MemoizerTest {
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     directory.mkdirs();
-    String memoDir = idDir.getAbsolutePath();
-    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
+    checkMemoFile(memoizer.getMemoFile(id),
+      getExpectedCacheDirectory(directory));
     checkMemo(memoizer, id);
     recursiveDeleteOnExit(directory);
   }
@@ -183,9 +182,8 @@ public class MemoizerTest {
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     directory.mkdirs();
-    String memoDir = idDir.getAbsolutePath();
-    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
+    checkMemoFile(memoizer.getMemoFile(id),
+      getExpectedCacheDirectory(directory));
     checkMemo(memoizer, id);
     recursiveDeleteOnExit(directory);
   }
@@ -272,6 +270,34 @@ public class MemoizerTest {
     assertFalse(memoFile.exists());
     reader.close();
     checkMemo(memoizer, id);
+  }
+
+  private File getExpectedCacheDirectory(File directory) {
+    String sourcePath = idDir.getAbsolutePath();
+    String cachePath;
+
+    if (sourcePath.length() >= 3 &&
+      Character.isLetter(sourcePath.charAt(0)) &&
+      sourcePath.charAt(1) == ':' &&
+      sourcePath.charAt(2) == File.separatorChar)
+    {
+      cachePath = Character.toUpperCase(sourcePath.charAt(0)) +
+        sourcePath.substring(2);
+    } else if (sourcePath.length() >= 2 &&
+      sourcePath.charAt(0) == File.separatorChar &&
+      sourcePath.charAt(1) == File.separatorChar)
+    {
+      cachePath = "UNC" + sourcePath.substring(1);
+    } else {
+      int first = 0;
+      while (first < sourcePath.length() &&
+        sourcePath.charAt(first) == File.separatorChar)
+      {
+        first++;
+      }
+      cachePath = sourcePath.substring(first);
+    }
+    return new File(directory, cachePath);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerWindowsPathTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerWindowsPathTest.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2026 Open Microscopy Environment
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import loci.formats.Memoizer;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class MemoizerWindowsPathTest {
+
+  private static class CachePathMemoizer extends Memoizer {
+
+    String cachePath(String path) {
+      return getCachePath(path);
+    }
+  }
+
+  private Path directory;
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() throws Exception {
+    if (directory != null && Files.exists(directory)) {
+      Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+
+        @Override
+        public FileVisitResult visitFile(Path file,
+          BasicFileAttributes attributes) throws IOException
+        {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path current,
+          IOException failure) throws IOException
+        {
+          if (failure != null) {
+            throw failure;
+          }
+          Files.delete(current);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    }
+  }
+
+  @Test
+  public void testWindowsDriveIsPartOfCachePath() throws Exception {
+    try (CachePathMemoizer memoizer = new CachePathMemoizer()) {
+      String driveC = memoizer.cachePath("C:\\somedir\\foo.nd2");
+      String driveD = memoizer.cachePath("D:\\somedir\\foo.nd2");
+
+      assertEquals(driveC,
+        new File("C" + File.separator + "somedir", "foo.nd2").getPath());
+      assertEquals(driveD,
+        new File("D" + File.separator + "somedir", "foo.nd2").getPath());
+      assertFalse(driveC.equals(driveD));
+    }
+  }
+
+  @Test
+  public void testUncShareIsPartOfCachePath() throws Exception {
+    try (CachePathMemoizer memoizer = new CachePathMemoizer()) {
+      String first = memoizer.cachePath("\\\\server\\first\\foo.nd2");
+      String second = memoizer.cachePath("\\\\server\\second\\foo.nd2");
+
+      assertTrue(first.startsWith("UNC" + File.separator));
+      assertTrue(second.startsWith("UNC" + File.separator));
+      assertFalse(first.equals(second));
+    }
+  }
+
+  @Test
+  public void testWindowsMemoFilePreservesVolumeIdentity() throws Exception {
+    if (File.separatorChar != '\\') {
+      return;
+    }
+    directory = Files.createTempDirectory(getClass().getName() + ".");
+    try (Memoizer memoizer = new Memoizer(0, directory.toFile())) {
+      File driveC = memoizer.getMemoFile("C:\\somedir\\foo.nd2");
+      File driveD = memoizer.getMemoFile("D:\\somedir\\foo.nd2");
+      File firstShare = memoizer.getMemoFile(
+        "\\\\server\\first\\foo.nd2");
+      File secondShare = memoizer.getMemoFile(
+        "\\\\server\\second\\foo.nd2");
+
+      assertFalse(driveC.equals(driveD));
+      assertFalse(firstShare.equals(secondShare));
+      assertTrue(driveC.toPath().startsWith(directory));
+      assertTrue(driveD.toPath().startsWith(directory));
+      assertTrue(firstShare.toPath().startsWith(directory));
+      assertTrue(secondShare.toPath().startsWith(directory));
+    }
+  }
+}

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -132,6 +132,12 @@
         <class name="loci.formats.utests.MemoizerTest"/>
       </classes>
     </test>
+    <test name="MemoizerWindowsPathTest">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.MemoizerWindowsPathTest"/>
+      </classes>
+    </test>
     <test name="AxisGuesserTest">
       <groups/>
       <classes>


### PR DESCRIPTION
As a continuation of https://github.com/ome/bioformats/pull/4464.
Fixes #3034.

This prevents configured Memoizer cache paths from colliding when source files
have otherwise identical paths on different Windows drives or UNC shares.

The change:

- maps drive-based paths below volume-specific components such as `<cache>/C` and `<cache>/D`;
- maps UNC paths below `<cache>/UNC/<server>/<share>`;
- keeps every generated memo path below the configured cache root; and
- leaves the existing Unix cache layout unchanged.

This intentionally changes the configured cache layout for Windows sources.
Existing memos at the old ambiguous paths will be missed and regenerated.
The new layout prevents state for one volume from being loaded for a different dataset on another volume.