### PR TITLE
TIFF: fix channel unpacking when supplied buffer is too large

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1061,10 +1061,14 @@ public class TiffParser implements Closeable {
           }
         }
       }
+      // buf may be larger than the actual image, so don't use buf.length
+      // to determine the number of bytes per channel
+      // since offset is updated after every tile copy, it reflects the
+      // actual number of bytes that were read and copied into buf
       if (effectiveChannels > 1) {
-        byte[][] split = new byte[effectiveChannels][buf.length / effectiveChannels];
+        byte[][] split = new byte[effectiveChannels][offset / effectiveChannels];
         for (int c=0; c<split.length; c++) {
-          split[c] = ImageTools.splitChannels(buf, c, effectiveChannels, bytes, false, true);
+          split[c] = ImageTools.splitChannels(buf, split[c], c, effectiveChannels, bytes, false, true, split[c].length);
         }
         for (int c=0; c<split.length; c++) {
           System.arraycopy(split[c], 0, buf, c * split[c].length, split[c].length);

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -65,6 +65,13 @@
             <class name="loci.formats.utests.tiff.TiffParserTest"/>
         </classes>
     </test>
+    <test name="RGB48TIFFParserTest">
+        <parameter name="mockClassName"
+                   value="loci.formats.utests.tiff.RGB48TiffMock"/>
+        <classes>
+            <class name="loci.formats.utests.tiff.TiffParserTest"/>
+        </classes>
+    </test>
     <test name="TiffWriterTest">
       <groups/>
       <classes>

--- a/components/formats-bsd/test/loci/formats/utests/tiff/RGB48TiffMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/RGB48TiffMock.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests.tiff;
+
+import java.io.IOException;
+
+import loci.formats.FormatException;
+
+public class RGB48TiffMock extends RGBTiffMock {
+
+  public RGB48TiffMock() throws FormatException, IOException {
+    super();
+  }
+
+  @Override
+  public int[] getBitsPerSample() {
+    return new int[] { 16, 16, 16};
+  }
+
+  @Override
+  public int[] getRowsPerStrip() {
+    return new int[] {1};
+  }
+
+  @Override
+  public int[] getStripOffsets() {
+    return new int[] {0, 36, 72, 108};
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
@@ -198,5 +198,19 @@ public class TiffParserTest {
     mock.close();
   }
 
+  @Test
+  public void testReadPixels() throws IOException, FormatException {
+    int size = mock.getImageLength();
+    int bytesPerPixel = 0;
+    for (int bps : mock.getBitsPerSample()) {
+      bytesPerPixel += (bps / 8);
+    }
+    int minBuf = size * size * bytesPerPixel;
+    for (int i=minBuf; i<minBuf*10; i++) {
+      byte[] buf = new byte[i];
+      tiffParser.getSamples(tiffParser.getFirstIFD(), buf, 0, 0, size, size);
+    }
+  }
+
   // TODO: Test wrong type exceptions
 }


### PR DESCRIPTION
Fixes #4058.

Tested using the file linked from #4058 and slightly modified test code:

```
$ cat BytesTest.java 
import loci.common.DebugTools;
import loci.formats.ImageReader;

class BytesTest {
  public static void main(String[] args) throws Exception {
    DebugTools.enableLogging("WARN");
    var reader = new ImageReader();
    reader.setFlattenedResolutions(false);
    reader.setId("DeltaE_16bit_gamma2_2.tif");
    reader.setResolution(0);

    byte[] correct = reader.openBytes(0, 0, 0, 2048, 2048);

    // minimum 25165824

    int count = 0;
    int start = 25165824;
    int numRuns = Integer.parseInt(args[0]);
    for (int i = start; i < start + numRuns; i++) {
      try {
        byte[] bytes = new byte[i];
        reader.openBytes(0, bytes, 0, 0, 2048, 2048);
        for (int p=0; p<correct.length; p++) {
          if (correct[p] != bytes[p]) {
            System.out.println("incorrect plane @ i=" + i + ", p=" + p);
          }
        }
      } catch (Exception e) {
        if (count == 0) {
          e.printStackTrace();
        }
        System.out.println(i);
        count++;
      }
    }
    System.out.println("total bad: " + count);

  }
}
$ java BytesTest 1000
total bad: 0
```

That checks for exceptions with large buffers (as in the original test), but also compares the returned bytes against a known-good array without a pre-allocated buffer.

I expect this needs a unit test that uses a TIFF generated from fake data, but am opening first to see if any tests fail overnight.