### PR TITLE
Physical sizes for subresolutions

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1677,6 +1677,33 @@ public final class FormatTools {
   }
 
   /**
+   * Calculate a physical size representing a scaled dimension (e.g. subresolution of a pyramid)
+   * using the original physical size and the scale factor between two lengths in pixels.
+   *
+   * @param original physical size of the source dimension
+   * @param originalPixels size in pixels of the source dimension
+   * @param scaledPixels size in pixels of the scaled dimension
+   */
+  public static Length getScaledPhysicalSize(Length original, int originalPixels, int scaledPixels) {
+    if (scaledPixels == 0) {
+      return null;
+    }
+    double scale = (double) originalPixels / scaledPixels;
+    return getScaledPhysicalSize(original, scale);
+  }
+
+  /**
+   * Calculate a physical size representing a scaled dimension (e.g. subresolution of a pyramid)
+   * using the original physical size and the given scale factor.
+   *
+   * @param original physical size of the source dimension
+   * @param scale value by which to multiply the original size
+   */
+  public static Length getScaledPhysicalSize(Length original, double scale) {
+    return new Length(original.value().doubleValue() * scale, original.unit());
+  }
+
+  /**
    * Formats the input value for the physical size in X into a length in
    * microns
    *

--- a/components/formats-bsd/src/loci/formats/in/BDVReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BDVReader.java
@@ -582,9 +582,17 @@ public class BDVReader extends FormatReader {
             }
 
             if (setupSizes != null && setupSizes.size() == 3) {
-              store.setPixelsPhysicalSizeX(setupSizes.get(0), coreIndexToSeries(seriesCount));
-              store.setPixelsPhysicalSizeY(setupSizes.get(1), coreIndexToSeries(seriesCount));
-              store.setPixelsPhysicalSizeZ(setupSizes.get(2), coreIndexToSeries(seriesCount));
+              int seriesIndex = coreIndexToSeries(seriesCount);
+              Length scaledX = FormatTools.getScaledPhysicalSize(setupSizes.get(0),
+                core.get(0).sizeX, core.get(seriesCount).sizeX);
+              Length scaledY = FormatTools.getScaledPhysicalSize(setupSizes.get(1),
+                core.get(0).sizeY, core.get(seriesCount).sizeY);
+              Length scaledZ = FormatTools.getScaledPhysicalSize(setupSizes.get(2),
+                core.get(0).sizeZ, core.get(seriesCount).sizeZ);
+
+              store.setPixelsPhysicalSizeX(scaledX, seriesIndex);
+              store.setPixelsPhysicalSizeY(scaledY, seriesIndex);
+              store.setPixelsPhysicalSizeZ(scaledZ, seriesIndex);
             }
             if (getResolution() == 0) {
               seriesNames.add(String.format("P_%s, W_%s_%s", coord.timepoint, coord.setup, coord.mipmapLevel));

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -81,6 +81,9 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     "yyyy-MM-dd'T'HH:mm:ssZ"
   };
 
+  protected Length physicalSizeX;
+  protected Length physicalSizeY;
+
   // -- Constructors --
 
   /** Constructs a new BaseTiffReader. */
@@ -89,6 +92,18 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
   /** Constructs a new BaseTiffReader. */
   public BaseTiffReader(String name, String[] suffixes) {
     super(name, suffixes);
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      physicalSizeX = null;
+      physicalSizeY = null;
+    }
   }
 
   // -- Internal BaseTiffReader API methods --
@@ -474,14 +489,14 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
         unit = getResolutionUnitFromComment(firstIFD);
       }
 
-      Length sizeX = FormatTools.getPhysicalSizeX(pixX, unit);
-      Length sizeY = FormatTools.getPhysicalSizeY(pixY, unit);
+      physicalSizeX = FormatTools.getPhysicalSizeX(pixX, unit);
+      physicalSizeY = FormatTools.getPhysicalSizeY(pixY, unit);
 
-      if (sizeX != null) {
-        store.setPixelsPhysicalSizeX(sizeX, 0);
+      if (physicalSizeX != null) {
+        store.setPixelsPhysicalSizeX(physicalSizeX, 0);
       }
-      if (sizeY != null) {
-        store.setPixelsPhysicalSizeY(sizeY, 0);
+      if (physicalSizeY != null) {
+        store.setPixelsPhysicalSizeY(physicalSizeY, 0);
       }
       store.setPixelsPhysicalSizeZ(null, 0);
 

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -226,6 +226,9 @@ public class FakeReader extends FormatReader {
   private transient int fields = 0;
   private transient int plateAcqs = 0;
 
+  private transient int resolutionCount = 1;
+  private transient int resolutionScale = DEFAULT_RESOLUTION_SCALE;
+
   // Misc. debugging
   private int sleepOpenBytes = 0;
   private int sleepInitFile = 0;
@@ -586,6 +589,8 @@ public class FakeReader extends FormatReader {
     plateCols = 0;
     fields = 0;
     plateAcqs = 0;
+    resolutionCount = 1;
+    resolutionScale = DEFAULT_RESOLUTION_SCALE;
     labelPlanes = false;
     excitationWavelengths.clear();
     emissionWavelengths.clear();
@@ -690,8 +695,6 @@ public class FakeReader extends FormatReader {
     boolean withInstrument = false;
 
     int seriesCount = 1;
-    int resolutionCount = 1;
-    int resolutionScale = DEFAULT_RESOLUTION_SCALE;
     int lutLength = 3;
 
     String acquisitionDate = null;
@@ -1046,9 +1049,19 @@ public class FakeReader extends FormatReader {
   private void fillPhysicalSizes(MetadataStore store) {
     if (physicalSizeX == null && physicalSizeY == null && physicalSizeZ == null) return;
     for (int s=0; s<getSeriesCount(); s++) {
-      store.setPixelsPhysicalSizeX(physicalSizeX, s);
-      store.setPixelsPhysicalSizeY(physicalSizeY, s);
-      store.setPixelsPhysicalSizeZ(physicalSizeZ, s);
+      Length scaledX = physicalSizeX;
+      Length scaledY = physicalSizeY;
+      Length scaledZ = physicalSizeZ;
+      if (hasFlattenedResolutions()) {
+        int res = s % resolutionCount;
+        double resScale = Math.pow(resolutionScale, res);
+        scaledX = FormatTools.getScaledPhysicalSize(scaledX, resScale);
+        scaledY = FormatTools.getScaledPhysicalSize(scaledY, resScale);
+        scaledZ = FormatTools.getScaledPhysicalSize(scaledZ, resScale);
+      }
+      store.setPixelsPhysicalSizeX(scaledX, s);
+      store.setPixelsPhysicalSizeY(scaledY, s);
+      store.setPixelsPhysicalSizeZ(scaledZ, s);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1030,14 +1030,19 @@ public class CellSensReader extends FormatReader {
           store.setObjectiveSettingsID(MetadataTools.createLSID("Objective", 0, nextPyramid - 1), imageIndex);
           store.setObjectiveSettingsRefractiveIndex(pyramid.refractiveIndex, imageIndex);
 
+          boolean pyramidBasePresent = expectETS && files.size() > 1;
           if (pyramid.physicalSizeX > 0) {
             Length sizeX = FormatTools.getPhysicalSizeX(pyramid.physicalSizeX);
-            sizeX = FormatTools.getScaledPhysicalSize(sizeX, pyramid.width, core.get(i + res).sizeX);
+            if (pyramidBasePresent) {
+              sizeX = FormatTools.getScaledPhysicalSize(sizeX, pyramid.width, core.get(i + res).sizeX);
+            }
             store.setPixelsPhysicalSizeX(sizeX, imageIndex);
           }
           if (pyramid.physicalSizeY > 0) {
             Length sizeY = FormatTools.getPhysicalSizeY(pyramid.physicalSizeY);
-            sizeY = FormatTools.getScaledPhysicalSize(sizeY, pyramid.height, core.get(i + res).sizeY);
+            if (pyramidBasePresent) {
+              sizeY = FormatTools.getScaledPhysicalSize(sizeY, pyramid.height, core.get(i + res).sizeY);
+            }
             store.setPixelsPhysicalSizeY(sizeY, imageIndex);
           }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -56,6 +56,7 @@ import loci.formats.tiff.IFDList;
 import loci.formats.tiff.PhotoInterp;
 import loci.formats.tiff.TiffParser;
 
+import ome.units.quantity.Length;
 import ome.units.UNITS;
 import ome.xml.model.primitives.Timestamp;
 
@@ -922,124 +923,133 @@ public class CellSensReader extends FormatReader {
       }
       int ii = coreIndexToSeries(i);
 
-      if (pyramid != null) {
-        int nextPlane = 0;
-        int effectiveSizeC = core.get(i).rgb ? 1 : core.get(i).sizeC;
-        int[] tzc = new int[] {core.get(i).sizeT, core.get(i).sizeZ, core.get(i).sizeC};
-        for (int c=0; c<effectiveSizeC; c++) {
-          store.setDetectorSettingsID(
-            MetadataTools.createLSID("Detector", 0, nextPyramid - 1), ii, c);
-          store.setDetectorSettingsBinning(
-            MetadataTools.getBinning(pyramid.binningX + "x" + pyramid.binningY), ii, c);
+      int resolutions = hasFlattenedResolutions() ? core.get(i).resolutionCount : 1;
 
-          if (c == 0) {
-            store.setDetectorSettingsGain(pyramid.redGain, ii, c);
-            store.setDetectorSettingsOffset(pyramid.redOffset, ii, c);
-          }
-          else if (c == 1) {
-            store.setDetectorSettingsGain(pyramid.greenGain, ii, c);
-            store.setDetectorSettingsOffset(pyramid.greenOffset, ii, c);
-          }
-          else if (c == 2) {
-            store.setDetectorSettingsGain(pyramid.blueGain, ii, c);
-            store.setDetectorSettingsOffset(pyramid.blueOffset, ii, c);
-          }
+      for (int res=0; res<resolutions; res++) {
+        int imageIndex = ii + res;
+        if (pyramid != null) {
+          int nextPlane = 0;
+          int effectiveSizeC = core.get(i).rgb ? 1 : core.get(i).sizeC;
+          int[] tzc = new int[] {core.get(i).sizeT, core.get(i).sizeZ, core.get(i).sizeC};
+          for (int c=0; c<effectiveSizeC; c++) {
+            store.setDetectorSettingsID(
+              MetadataTools.createLSID("Detector", 0, nextPyramid - 1), imageIndex, c);
+            store.setDetectorSettingsBinning(
+              MetadataTools.getBinning(pyramid.binningX + "x" + pyramid.binningY), imageIndex, c);
 
-          if (c < pyramid.channelNames.size()) {
-            store.setChannelName(pyramid.channelNames.get(c), ii, c);
-          }
-          if (c < pyramid.channelWavelengths.size()) {
-            int wave = pyramid.channelWavelengths.get(c).intValue();
-            if (wave > 0) {
-              store.setChannelEmissionWavelength(
-                FormatTools.getEmissionWavelength((double) wave), ii, c);
+            if (c == 0) {
+              store.setDetectorSettingsGain(pyramid.redGain, imageIndex, c);
+              store.setDetectorSettingsOffset(pyramid.redOffset, imageIndex, c);
             }
-          }
-          for (int z=0; z<core.get(i).sizeZ; z++) {
-            for (int t=0; t<core.get(i).sizeT; t++) {
-              nextPlane = getIndex(z, c, t);
+            else if (c == 1) {
+              store.setDetectorSettingsGain(pyramid.greenGain, imageIndex, c);
+              store.setDetectorSettingsOffset(pyramid.greenOffset, imageIndex, c);
+            }
+            else if (c == 2) {
+              store.setDetectorSettingsGain(pyramid.blueGain, imageIndex, c);
+              store.setDetectorSettingsOffset(pyramid.blueOffset, imageIndex, c);
+            }
 
-              Long exp = pyramid.defaultExposureTime;
-              if (c < pyramid.exposureTimes.size()) {
-                exp = pyramid.exposureTimes.get(c);
-              }
-              else if (c < pyramid.otherExposureTimes.size()) {
-                exp = pyramid.otherExposureTimes.get(c);
-              }
-              if (exp != null) {
-                store.setPlaneExposureTime(
-                  FormatTools.createTime(exp / 1000000.0, UNITS.SECOND), ii, nextPlane);
-              }
-              store.setPlanePositionX(
-                FormatTools.createLength(pyramid.originX, UNITS.MICROMETER), ii, nextPlane);
-              store.setPlanePositionY(
-                FormatTools.createLength(pyramid.originY, UNITS.MICROMETER), ii, nextPlane);
-              if (z < pyramid.zValues.size()) {
-                store.setPlanePositionZ(
-                  FormatTools.createLength(pyramid.zValues.get(z),
-                  UNITS.MICROMETER), ii, nextPlane);
-              }
-              else if (pyramid.zStart != null && pyramid.zIncrement != null) {
-                store.setPlanePositionZ(
-                  FormatTools.createLength(pyramid.zStart + (z * pyramid.zIncrement),
-                  UNITS.MICROMETER), ii, nextPlane);
-              }
-              store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(pyramid.zIncrement), ii);
-
-              // calculate index into timestamp list using TZC order
-              // that matches the plane iteration order here, and seems to work
-              // on the limited data we have that is fully 5D
-              // this approach may need to be re-evaluated for new data though
-              int reorderedPlane = FormatTools.positionToRaster(tzc, new int[] {t, z, c});
-              if (reorderedPlane < pyramid.tValues.size()) {
-                store.setPlaneDeltaT(
-                  FormatTools.createTime(pyramid.tValues.get(reorderedPlane),
-                  UNITS.MILLISECOND), ii, nextPlane);
+            if (c < pyramid.channelNames.size()) {
+              store.setChannelName(pyramid.channelNames.get(c), imageIndex, c);
+            }
+            if (c < pyramid.channelWavelengths.size()) {
+              int wave = pyramid.channelWavelengths.get(c).intValue();
+              if (wave > 0) {
+                store.setChannelEmissionWavelength(
+                  FormatTools.getEmissionWavelength((double) wave), imageIndex, c);
               }
             }
+            for (int z=0; z<core.get(i).sizeZ; z++) {
+              for (int t=0; t<core.get(i).sizeT; t++) {
+                nextPlane = getIndex(z, c, t);
+
+                Long exp = pyramid.defaultExposureTime;
+                if (c < pyramid.exposureTimes.size()) {
+                  exp = pyramid.exposureTimes.get(c);
+                }
+                else if (c < pyramid.otherExposureTimes.size()) {
+                  exp = pyramid.otherExposureTimes.get(c);
+                }
+                if (exp != null) {
+                  store.setPlaneExposureTime(
+                    FormatTools.createTime(exp / 1000000.0, UNITS.SECOND), imageIndex, nextPlane);
+                }
+                store.setPlanePositionX(
+                  FormatTools.createLength(pyramid.originX, UNITS.MICROMETER), imageIndex, nextPlane);
+                store.setPlanePositionY(
+                  FormatTools.createLength(pyramid.originY, UNITS.MICROMETER), imageIndex, nextPlane);
+                if (z < pyramid.zValues.size()) {
+                  store.setPlanePositionZ(
+                    FormatTools.createLength(pyramid.zValues.get(z),
+                    UNITS.MICROMETER), imageIndex, nextPlane);
+                }
+                else if (pyramid.zStart != null && pyramid.zIncrement != null) {
+                  store.setPlanePositionZ(
+                    FormatTools.createLength(pyramid.zStart + (z * pyramid.zIncrement),
+                    UNITS.MICROMETER), imageIndex, nextPlane);
+                }
+                store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(pyramid.zIncrement), imageIndex);
+
+                // calculate index into timestamp list using TZC order
+                // that matches the plane iteration order here, and seems to work
+                // on the limited data we have that is fully 5D
+                // this approach may need to be re-evaluated for new data though
+                int reorderedPlane = FormatTools.positionToRaster(tzc, new int[] {t, z, c});
+                if (reorderedPlane < pyramid.tValues.size()) {
+                  store.setPlaneDeltaT(
+                    FormatTools.createTime(pyramid.tValues.get(reorderedPlane),
+                    UNITS.MILLISECOND), imageIndex, nextPlane);
+                }
+              }
+            }
           }
         }
-      }
 
-      store.setImageInstrumentRef(instrument, ii);
+        store.setImageInstrumentRef(instrument, imageIndex);
 
-      if (pyramid != null) {
-        String imageName = pyramid.name;
-        boolean duplicate = false;
-        for (int q=0; q<pyramids.size(); q++) {
-          if (q != (nextPyramid - 1) &&
-            imageName.equals(pyramids.get(q).name))
-          {
-            duplicate = true;
-            break;
+        if (pyramid != null) {
+          String imageName = pyramid.name;
+          boolean duplicate = false;
+          for (int q=0; q<pyramids.size(); q++) {
+            if (q != (nextPyramid - 1) &&
+              imageName.equals(pyramids.get(q).name))
+            {
+              duplicate = true;
+              break;
+            }
+          }
+
+          if (!imageName.equals("Overview") && !imageName.equals("Label") && duplicate) {
+            imageName += " #" + ii;
+          }
+          if (imageName.equals("Overview") || imageName.equals("Label")) {
+            imageName = imageName.toLowerCase();
+          }
+          store.setImageName(imageName, imageIndex);
+          store.setObjectiveSettingsID(MetadataTools.createLSID("Objective", 0, nextPyramid - 1), imageIndex);
+          store.setObjectiveSettingsRefractiveIndex(pyramid.refractiveIndex, imageIndex);
+
+          if (pyramid.physicalSizeX > 0) {
+            Length sizeX = FormatTools.getPhysicalSizeX(pyramid.physicalSizeX);
+            sizeX = FormatTools.getScaledPhysicalSize(sizeX, pyramid.width, core.get(i + res).sizeX);
+            store.setPixelsPhysicalSizeX(sizeX, imageIndex);
+          }
+          if (pyramid.physicalSizeY > 0) {
+            Length sizeY = FormatTools.getPhysicalSizeY(pyramid.physicalSizeY);
+            sizeY = FormatTools.getScaledPhysicalSize(sizeY, pyramid.height, core.get(i + res).sizeY);
+            store.setPixelsPhysicalSizeY(sizeY, imageIndex);
+          }
+
+          if (pyramid.acquisitionTime != null) {
+            // acquisition time is stored in seconds
+            store.setImageAcquisitionDate(new Timestamp(DateTools.convertDate(
+              pyramid.acquisitionTime * 1000, DateTools.UNIX)), imageIndex);
           }
         }
-
-        if (!imageName.equals("Overview") && !imageName.equals("Label") && duplicate) {
-          imageName += " #" + ii;
+        else {
+          store.setImageName("macro image", imageIndex);
         }
-        if (imageName.equals("Overview") || imageName.equals("Label")) {
-          imageName = imageName.toLowerCase();
-        }
-        store.setImageName(imageName, ii);
-        store.setObjectiveSettingsID(MetadataTools.createLSID("Objective", 0, nextPyramid - 1), ii);
-        store.setObjectiveSettingsRefractiveIndex(pyramid.refractiveIndex, ii);
-
-        if (pyramid.physicalSizeX > 0) {
-          store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(pyramid.physicalSizeX), ii);
-        }
-        if (pyramid.physicalSizeY > 0) {
-          store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(pyramid.physicalSizeY), ii);
-        }
-
-        if (pyramid.acquisitionTime != null) {
-          // acquisition time is stored in seconds
-          store.setImageAcquisitionDate(new Timestamp(DateTools.convertDate(
-            pyramid.acquisitionTime * 1000, DateTools.UNIX)), ii);
-        }
-      }
-      else {
-        store.setImageName("macro image", ii);
       }
 
       i += core.get(i).resolutionCount;

--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -173,6 +173,17 @@ public class PyramidTiffReader extends BaseTiffReader {
 
     for (int i=0; i<getSeriesCount(); i++) {
       store.setImageName("Series " + (i + 1), i);
+
+      if (i > 0) {
+        if (physicalSizeX != null) {
+          store.setPixelsPhysicalSizeX(FormatTools.getScaledPhysicalSize(
+            physicalSizeX, core.get(0, 0).sizeX, core.get(0, i).sizeX), i);
+        }
+        if (physicalSizeY != null) {
+          store.setPixelsPhysicalSizeY(FormatTools.getScaledPhysicalSize(
+            physicalSizeY, core.get(0, 0).sizeY, core.get(0, i).sizeY), i);
+        }
+      }
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -603,6 +603,10 @@ public class SVSReader extends BaseTiffReader {
             }
           }
         }
+        if (ms.pixelSize == null && pos[1] > 0) {
+          SVSCoreMetadata parentResolution = (SVSCoreMetadata) core.get(pos[0], 0);
+          ms.pixelSize = FormatTools.getScaledPhysicalSize(parentResolution.pixelSize, parentResolution.sizeX, ms.sizeX);
+        }
       }
     }
     setSeries(0);

--- a/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TissueFAXSReader.java
@@ -458,6 +458,7 @@ public class TissueFAXSReader extends FormatReader {
       populatedCoreIndexes.add(region.fullResolutionCoreIndex);
       int imageIndex = hasFlattenedResolutions() ? region.fullResolutionCoreIndex : nextImage;
       nextImage++;
+      int resolutions = hasFlattenedResolutions() ? region.resolutions.size() : 1;
 
       String objectiveID = MetadataTools.createLSID("Objective", 0, index);
       store.setObjectiveID(objectiveID, 0, index);
@@ -474,36 +475,48 @@ public class TissueFAXSReader extends FormatReader {
       String objectiveName = region.regionMetadata.getString("ObjectiveName");
       store.setObjectiveModel(objectiveName, 0, index);
 
-      store.setImageName(region.regionMetadata.getString("Name"), imageIndex);
-      store.setObjectiveSettingsID(objectiveID, imageIndex);
+      for (int res=0; res<resolutions; res++) {
+        int resIndex = imageIndex + res;
+        store.setImageName(region.regionMetadata.getString("Name"), resIndex);
+        store.setObjectiveSettingsID(objectiveID, resIndex);
 
-      Double physicalX = region.regionMetadata.getDouble("PhysicalSizeX");
-      Double physicalY = region.regionMetadata.getDouble("PhysicalSizeY");
+        Double physicalX = region.regionMetadata.getDouble("PhysicalSizeX");
+        Double physicalY = region.regionMetadata.getDouble("PhysicalSizeY");
 
-      store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(physicalX), imageIndex);
-      store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(physicalY), imageIndex);
-
-      String acquisitionMode = region.regionMetadata.getString("AcquisitionMode");
-      AcquisitionMode mode = getAcquisitionMode(acquisitionMode);
-
-      for (int c=0; c<region.channels.size(); c++) {
-        Channel ch = region.channels.get(c);
-        store.setChannelName(ch.name, imageIndex, c);
-
-        if (mode != null) {
-          store.setChannelAcquisitionMode(mode, imageIndex, c);
+        double scale = Math.pow(region.scaleFactor, res);
+        Length physicalSizeX = FormatTools.getPhysicalSizeX(physicalX);
+        if (res > 0) {
+          physicalSizeX = FormatTools.getScaledPhysicalSize(physicalSizeX, scale);
         }
+        Length physicalSizeY = FormatTools.getPhysicalSizeY(physicalY);
+        if (res > 0) {
+          physicalSizeY = FormatTools.getScaledPhysicalSize(physicalSizeY, scale);
+        }
+        store.setPixelsPhysicalSizeX(physicalSizeX, resIndex);
+        store.setPixelsPhysicalSizeY(physicalSizeY, resIndex);
 
-        if (ch.emWave >= WAVE_MIN && ch.emWave <= WAVE_MAX) {
-          store.setChannelEmissionWavelength(FormatTools.getWavelength((double) ch.emWave), imageIndex, c);
-        }
-        if (ch.exWave >= WAVE_MIN && ch.exWave <= WAVE_MAX) {
-          store.setChannelExcitationWavelength(FormatTools.getWavelength((double) ch.exWave), imageIndex, c);
-        }
-        // don't set a channel color for brightfield data
-        // the channel color is expected to be white in that case
-        if (!core.get(region.fullResolutionCoreIndex).rgb) {
-          store.setChannelColor(ch.getColor(), imageIndex, c);
+        String acquisitionMode = region.regionMetadata.getString("AcquisitionMode");
+        AcquisitionMode mode = getAcquisitionMode(acquisitionMode);
+
+        for (int c=0; c<region.channels.size(); c++) {
+          Channel ch = region.channels.get(c);
+          store.setChannelName(ch.name, resIndex, c);
+
+          if (mode != null) {
+            store.setChannelAcquisitionMode(mode, resIndex, c);
+          }
+
+          if (ch.emWave >= WAVE_MIN && ch.emWave <= WAVE_MAX) {
+            store.setChannelEmissionWavelength(FormatTools.getWavelength((double) ch.emWave), resIndex, c);
+          }
+          if (ch.exWave >= WAVE_MIN && ch.exWave <= WAVE_MAX) {
+            store.setChannelExcitationWavelength(FormatTools.getWavelength((double) ch.exWave), resIndex, c);
+          }
+          // don't set a channel color for brightfield data
+          // the channel color is expected to be white in that case
+          if (!core.get(region.fullResolutionCoreIndex).rgb) {
+            store.setChannelColor(ch.getColor(), resIndex, c);
+          }
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -794,8 +794,10 @@ public class VentanaReader extends BaseTiffReader {
       store.setObjectiveSettingsID(objective, i);
 
       if (pixelSize != null) {
-        store.setPixelsPhysicalSizeX(pixelSize, i);
-        store.setPixelsPhysicalSizeY(pixelSize, i);
+        int[] pos = core.flattenedIndexes(i);
+        Length scaledSize = FormatTools.getScaledPhysicalSize(pixelSize, core.get(pos[0], 0).sizeX, getSizeX());
+        store.setPixelsPhysicalSizeX(scaledSize, i);
+        store.setPixelsPhysicalSizeY(scaledSize, i);
       }
       if (splitTiles()) {
         for (int p=0; p<getImageCount(); p++) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -392,10 +392,7 @@ public class ZeissCZIReader extends FormatReader {
     int compression = -1;
     try {
       int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
-      int baseResolution = currentIndex;
-      while (baseResolution > 0 && core.get(baseResolution - 1).sizeX > core.get(baseResolution).sizeX) {
-        baseResolution--;
-      }
+      int baseResolution = getBaseResolution();
       for (SubBlock plane : planes) {
         if ((plane.planeIndex == no && ((maxResolution == 0 && plane.coreIndex == currentIndex) ||
           (maxResolution > 0 && plane.coreIndex == baseResolution))) ||
@@ -2055,6 +2052,17 @@ public class ZeissCZIReader extends FormatReader {
     setCoreIndex(previousCoreIndex);
   }
 
+  /**
+   * Get the base resolution index for a pyramid containing the current core index.
+   */
+  private int getBaseResolution() {
+    int baseResolution = getCoreIndex();
+    while (baseResolution > 0 && core.get(baseResolution - 1).sizeX > core.get(baseResolution).sizeX) {
+      baseResolution--;
+    }
+    return baseResolution;
+  }
+
   private void assignPlaneIndices() {
     LOGGER.trace("assignPlaneIndices:");
     // assign plane and series indices to each SubBlock
@@ -2926,14 +2934,30 @@ public class ZeissCZIReader extends FormatReader {
           PositiveFloat size = new PositiveFloat(value);
 
           if (id.equals("X")) {
+            Length sizeX = FormatTools.createLength(size, UNITS.MICROMETER);
+            int baseX = getSizeX();
             for (int series=0; series<getSeriesCount(); series++) {
-              store.setPixelsPhysicalSizeX(FormatTools.createLength(size, UNITS.MICROMETER), series);
+              setSeries(series);
+              if (series == getBaseResolution()) {
+                baseX = getSizeX();
+              }
+              Length scaledX = FormatTools.getScaledPhysicalSize(sizeX, baseX, getSizeX());
+              store.setPixelsPhysicalSizeX(scaledX, series);
             }
+            setSeries(0);
           }
           else if (id.equals("Y")) {
+            Length sizeY = FormatTools.createLength(size, UNITS.MICROMETER);
+            int baseY = getSizeY();
             for (int series=0; series<getSeriesCount(); series++) {
-              store.setPixelsPhysicalSizeY(FormatTools.createLength(size, UNITS.MICROMETER), series);
+              setSeries(series);
+              if (series == getBaseResolution()) {
+                baseY = getSizeY();
+              }
+              Length scaledY = FormatTools.getScaledPhysicalSize(sizeY, baseY, getSizeY());
+              store.setPixelsPhysicalSizeY(scaledY, series);
             }
+            setSeries(0);
           }
           else if (id.equals("Z")) {
             zStep = FormatTools.createLength(size, UNITS.MICROMETER);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2938,7 +2938,9 @@ public class ZeissCZIReader extends FormatReader {
             int baseX = getSizeX();
             for (int series=0; series<getSeriesCount(); series++) {
               setSeries(series);
-              if (series == getBaseResolution()) {
+              if (getSeriesCount() - series <= extraImages.size() ||
+                series == getBaseResolution())
+              {
                 baseX = getSizeX();
               }
               Length scaledX = FormatTools.getScaledPhysicalSize(sizeX, baseX, getSizeX());
@@ -2951,7 +2953,9 @@ public class ZeissCZIReader extends FormatReader {
             int baseY = getSizeY();
             for (int series=0; series<getSeriesCount(); series++) {
               setSeries(series);
-              if (series == getBaseResolution()) {
+              if (getSeriesCount() - series <= extraImages.size() ||
+                series == getBaseResolution())
+              {
                 baseY = getSizeY();
               }
               Length scaledY = FormatTools.getScaledPhysicalSize(sizeY, baseY, getSizeY());

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -195,6 +195,7 @@ public class ZeissCZIReader extends FormatReader {
 
   private transient Length zStep;
 
+  private transient boolean isPALM = false;
   private transient int plateRows;
   private transient int plateColumns;
   private transient ArrayList<String> platePositions = new ArrayList<String>();
@@ -591,6 +592,7 @@ public class ZeissCZIReader extends FormatReader {
       tileHeight = null;
       scaleFactor = 0;
       zStep = null;
+      isPALM = false;
       plateRows = 0;
       plateColumns = 0;
       platePositions.clear();
@@ -1122,7 +1124,6 @@ public class ZeissCZIReader extends FormatReader {
     String firstXML = null;
     boolean canSkipXML = true;
     String currentPath = new Location(currentId).getAbsolutePath();
-    boolean isPALM = false;
     if (planes.size() <= 2 && getImageCount() <= 2) {
       for (Segment segment : segments) {
         String path = new Location(segment.filename).getAbsolutePath();
@@ -2057,7 +2058,11 @@ public class ZeissCZIReader extends FormatReader {
    */
   private int getBaseResolution() {
     int baseResolution = getCoreIndex();
-    while (baseResolution > 0 && core.get(baseResolution - 1).sizeX > core.get(baseResolution).sizeX) {
+    // the check on the ratio between two CoreMetadata's sizeX is to ensure that
+    // slight variations in size between two base resolutions are handled correctly
+    while (baseResolution > 0 && core.get(baseResolution - 1).sizeX > core.get(baseResolution).sizeX &&
+      Math.round((double) core.get(baseResolution - 1).sizeX / core.get(baseResolution).sizeX) > 1)
+    {
       baseResolution--;
     }
     return baseResolution;
@@ -2943,7 +2948,10 @@ public class ZeissCZIReader extends FormatReader {
               {
                 baseX = getSizeX();
               }
-              Length scaledX = FormatTools.getScaledPhysicalSize(sizeX, baseX, getSizeX());
+              Length scaledX = sizeX;
+              if (!isPALM) {
+                scaledX = FormatTools.getScaledPhysicalSize(sizeX, baseX, getSizeX());
+              }
               store.setPixelsPhysicalSizeX(scaledX, series);
             }
             setSeries(0);
@@ -2958,7 +2966,10 @@ public class ZeissCZIReader extends FormatReader {
               {
                 baseY = getSizeY();
               }
-              Length scaledY = FormatTools.getScaledPhysicalSize(sizeY, baseY, getSizeY());
+              Length scaledY = sizeY;
+              if (!isPALM) {
+                scaledY = FormatTools.getScaledPhysicalSize(sizeY, baseY, getSizeY());
+              }
               store.setPixelsPhysicalSizeY(scaledY, series);
             }
             setSeries(0);


### PR DESCRIPTION
Fixes #3797. Opening as draft for now as this needs work, but I wanted to capture current progress before switching to other tasks.

Following discussion of 9.0.0 with @ome/formats earlier this week, I think I feel better about the idea of calculating physical pixel sizes for subresolutions in the case where resolutions are flattened. We also already have one reader (`DicomReader`) that reports a different physical pixel size for each flattened resolution; this is because each resolution's size is stored separately (since one resolution per file).

The current state of this pull request adds some minimal API to `FormatTools` so we don't have to re-implement calculation in each reader, and updates appropriate BSD readers to make use of it. Only readers that need to be updated are ones that meet all 3 criteria:

- make use of pyramids, i.e. set `CoreMetadata.resolutionCount` to something other than 1
- report a physical pixel size, i.e. call `store.setPixelsPhysicalSize*`
- represent a format that does not store a separate physical size for each resolution

I expect the following readers would still need to be updated:

- [x] AFIReader
- [x] CellSensReader
- [x] ~LeicaSCNReader~ already working as intended
- [x] ~NDPIReader~ already working as intended
- [x] PyramidTiffReader
- [x] SVSReader
- [x] TissueFAXSReader
- [x] ~VectraReader~ already working as intended
- [x] VentanaReader
- [x] ZeissCZIReader (#4191)

This will require configuration updates for any datasets that make use of the updated readers. I also note that we don't have a `.fake` example that uses both pyramids and physical sizes, so at least one example of that will need to be added to the test repo.