### PR TITLE
Exporter plugin: sanity check bits per pixel fields

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -557,7 +557,14 @@ public class Exporter {
                             originalMetadata.put(key, value);
 
                             if (key.endsWith("BitsPerPixel")) {
-                                w.setValidBitsPerPixel(Integer.parseInt(value));
+                                try {
+                                  int bits = Integer.parseInt(value);
+                                  if (bits > 0 && bits <= FormatTools.getBytesPerPixel(ptype) * 8) {
+                                    w.setValidBitsPerPixel(bits);
+                                  }
+                                }
+                                catch (NumberFormatException e) {
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
See https://forum.image.sc/t/bio-formats-exporter-numberformatexception-on-czi-with-supportedbitsperpixel-8-16/122291.

I was easily able to reproduce the original problem using an artificial dataset:

```
$ ls -gGhl
total 4.0K
-rw-rw-r-- 1  0 Aug 26 13:34 test.fake
-rw-rw-r-- 1 42 Aug 26 13:34 test.fake.ini
$ cat test.fake.ini 
[GlobalMetadata]
InvalidBitsPerPixel=8,16
```

Without this change, import `test.fake` into ImageJ. `Image > Show Info...` should show an `InvalidBitsPerPixel` key. `Plugins > Bio-Formats > Bio-Formats Exporter` should then show a `NumberFormatException` as reported. With this change, the same dataset should export without error.